### PR TITLE
doc reference for getLength() of loop status-var

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,8 @@ The `for` directive also supports a loop status variable in case you need to kno
 ```xml
 <ul>
     <li for="color in colors; status-var=loop">
-        ${loop.getIndex()+1}) $color
+        $color
+        ${loop.getIndex()+1}) of ${loop.getLength()}
         <if test="loop.isFirst()"> - FIRST</if>
         <if test="loop.isLast()"> - LAST</if>
     </li>


### PR DESCRIPTION
The utility function `getLength()` for loop status variables was previously undocumented.