### PR TITLE
template.stream() is 'error' emitter

### DIFF
--- a/runtime/marko-runtime.js
+++ b/runtime/marko-runtime.js
@@ -189,7 +189,17 @@ Template.prototype = {
 
         // Invoke the compiled template's render function to have it
         // write out strings to the provided out.
-        renderFunc(finalData, finalOut);
+        try {
+          renderFunc(finalData, finalOut);
+        }
+        catch (e) {
+          if (typeof finalOut.on === 'function') {
+            finalOut.emit('error', e);
+          }
+          else {
+            throw e;
+          }
+        }
 
         // Automatically end output stream (the writer) if we
         // had to create an async writer (which might happen

--- a/test/api-tests.js
+++ b/test/api-tests.js
@@ -336,4 +336,15 @@ describe('marko/api' , function() {
             stream);
     });
 
+    it('should emit errors when rendered with stream', function(done) {
+      var template = marko.load(nodePath.join(__dirname, 'fixtures/templates/api-tests/hello-error.marko'));
+
+      template.stream({})
+        .on('error', function (e) {
+          expect(e).to.be.instanceOf(Error);
+          expect(e.message).to.be.equal('Test')
+          done()
+        })
+        .pipe(through(function () {}));
+    });
 });


### PR DESCRIPTION
Marko + koa currently misbehaves due to errors thrown during template stream rendering are uncaught, leading to hard crashes of node.

The sample code below illustrates a very simplied setup, and this patch ensures that errors during template rendering are indeed picked up by the koa error handling system.
```
// Simplified koa usage
app.use(function * () {
  this.type = 'text/plain'
  this.body = require('template.marko').stream({...})
})

app.on('error', function (err) {
  log.error(err) 
})
```

Thanks for an awesome piece of work. Marko+koa is my bread and butter...