### PR TITLE
Fixed a typo for rendererFunc in helpers.js

### DIFF
--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -54,7 +54,7 @@ function createDeferredRenderer(handler) {
     // the renderer with the actual renderer func on the first render
     deferredRenderer.renderer = function(input, out) {
         var rendererFunc = handler.renderer || handler.render;
-        if (typeof renderFunc !== 'function') {
+        if (typeof rendererFunc !== 'function') {
             throw new Error('Invalid tag handler: ' + handler);
         }
         // Use the actual renderer from now on


### PR DESCRIPTION
This should resolve issues with circular dependency rendering. Previously, whenever this function was called, it would throw an error because `typeof renderFunc` was always `undefined`. With this fix, `rendererFunc` will (in valid cases) be a function.