### PR TITLE
Make loading template from String template source easier

### DIFF
--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -7,21 +7,68 @@ JavaScript API
 
 ## Methods
 
-### load(templatePath[, options]) : Template
+### load(templatePath[, templateSrc][, options]) : Template
 
 Loads a template instance for the given template path.
+Both `templateSrc` and `options` are optional.
 
-Example usage:
+Template loading is supported in the browser and on
+the server but the behavior differs slightly.
+
+**On the server,**
+if `templateSrc` is not provided then `templatePath` is expected
+to be the path to a Marko template file. If `templateSrc`
+is provided then it is expected to be a `String` and its value
+will be the raw template. The `templatePath`
+argument is only used for reporting error stack traces if
+`templateSrc` is provided.
+
+**In the browser,**
+`templatePath` is expected to path to be the module name
+of the compiled template and the module will be loaded
+via `require(templatePath)`. The `templateSrc` argument
+is ignored if the `load` function is called in the browser.
+
+If `options` is provided then it is expected to be the last argument
+and should be an `Object`.
+
+Example usage for browser and server:
 
 ```javascript
 var templatePath = require.resolve('./template.marko');
-var template = require('marko')require('marko')(templatePath);
+var template = require('marko').load(templatePath);
+template.render({ name: 'Frank' }, process.stdout);
+```
+
+Example **server-side** template loading with `writeToDisk: false` option:
+
+```javascript
+var templatePath = './sample.marko';
+var template = require('marko').load(templatePath, {writeToDisk: false});
+template.render({ name: 'Frank' }, process.stdout);
+```
+
+Example **server-side** template compilation from string:
+
+```javascript
+var templatePath = 'sample.marko';
+var templateSrc = 'Hello $!{data.name}';
+var template = require('marko').load(templatePath, templateSrc);
 template.render({ name: 'Frank' }, process.stdout);
 ```
 
 Supported `options`:
 
-- `buffer` (`boolean`) - If `true` (default) then rendered output will be buffered until `out.flush()` is called or until rendering is completed. Otherwise, the output will be written to the underlying stream as soon as it is produced.
+- `buffer` (`Boolean`) - If `true` (default) then rendered output will be
+buffered until `out.flush()` is called or until rendering is completed.
+Otherwise, the output will be written to the underlying stream as soon as
+it is produced.
+
+- `writeToDisk` (`Boolean`) - This option is only applicable to server-side
+template loading. If `true` then compiled template will be written to disk.
+If `false`, template will be compiled and loaded but the compiled source
+will not be written to disk.
+
 
 ### createWriter([stream]) : AsyncWriter
 

--- a/runtime/marko-runtime.js
+++ b/runtime/marko-runtime.js
@@ -268,22 +268,38 @@ function initTemplate(rawTemplate, templatePath) {
     return template;
 }
 
-function load(templatePath, options) {
+function load(templatePath, templateSrc, options) {
     if (!templatePath) {
         throw new Error('"templatePath" is required');
+    }
+
+    if (arguments.length === 1) {
+        // templateSrc and options not provided
+    } else if (arguments.length === 2) {
+        // see if second argument is templateSrc (a String)
+        // or options (an Object)
+        var lastArg = arguments[arguments.length - 1];
+        if (typeof lastArg !== 'string') {
+            options = arguments[1];
+            templateSrc = undefined;
+        }
+    } else if (arguments.length === 3) {
+        // assume function called according to function signature
+    } else {
+        throw new Error('Illegal arguments');
     }
 
     var template;
 
     if (typeof templatePath === 'string') {
-        template = initTemplate(loader(templatePath), templatePath);
+        template = initTemplate(loader(templatePath, templateSrc, options), templatePath);
     } else if (templatePath.render) {
         template = templatePath;
     } else {
         template = initTemplate(templatePath);
     }
 
-    if (options) {
+    if (options && (options.buffer != null)) {
         template = new Template(
             template.path,
             createRenderProxy(template),

--- a/test/api-tests.js
+++ b/test/api-tests.js
@@ -394,4 +394,36 @@ describe('marko/api' , function() {
         }
     });
 
+    it('should allow a template to be loaded from source', function() {
+        var template;
+        var templatePath;
+
+        // Make sure calling load with templatePath:String, templateSrc:String arguments works
+        templatePath = nodePath.join(__dirname, 'dummy.marko');
+        template = marko.load(templatePath, 'Hello $!{data.name}!');
+        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+
+        // Make sure calling load with templatePath:String, templateSrc:String, options:Object arguments works
+        templatePath = nodePath.join(__dirname, 'dummy.marko');
+        template = marko.load(templatePath, 'Hello $!{data.name}!', {});
+        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+
+        // Make sure calling load with templatePath:String, options:Object arguments works
+        delete require('../compiler').defaultOptions.writeToDisk;
+
+        templatePath = nodePath.join(__dirname, 'fixtures/write-to-disk/template.marko');
+        var compiledPath = nodePath.join(__dirname, 'fixtures/write-to-disk/template.marko.js');
+
+        try {
+            fs.unlinkSync(compiledPath);
+        } catch(e) {
+            // ignore
+        }
+
+        template = marko.load(templatePath, {writeToDisk: false});
+        expect(fs.existsSync(compiledPath)).to.equal(false);
+        expect(template.render).to.be.a('function');
+        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    });
+
 });


### PR DESCRIPTION
- Allow loading of template from template source on server-side
- Fix documentation for JavaScript API
- Allow `writeToDisk` option to be passed to load function (e.g. `require('marko').load(templatePath, {writeToDisk: false})`)