### PR TITLE
Allow tag name to be set in renderer

### DIFF
--- a/compiler/taglibs/taglib-loader/scanTagsDir.js
+++ b/compiler/taglibs/taglib-loader/scanTagsDir.js
@@ -137,13 +137,13 @@ module.exports = function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, ta
 
                 tagDef.renderer  = rendererJSFile;
                 tag = loader.tagLoader.loadTag(tagDef, tagsConfigPath, taglib, tagDirname);
-                tag.name = tag.name || tagName
+                tag.name = tag.name || tagName;
                 taglib.addTag(tag);
             }
 
             if (tagDef) {
                 tag = loader.tagLoader.loadTag(tagDef, tagsConfigPath, taglib, tagDirname);
-                tag.name = tag.name || tagName
+                tag.name = tag.name || tagName;
                 taglib.addTag(tag);
             }
         }

--- a/compiler/taglibs/taglib-loader/scanTagsDir.js
+++ b/compiler/taglibs/taglib-loader/scanTagsDir.js
@@ -137,13 +137,13 @@ module.exports = function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, ta
 
                 tagDef.renderer  = rendererJSFile;
                 tag = loader.tagLoader.loadTag(tagDef, tagsConfigPath, taglib, tagDirname);
-                tag.name = tagName;
+                tag.name = tag.name || tagName
                 taglib.addTag(tag);
             }
 
             if (tagDef) {
                 tag = loader.tagLoader.loadTag(tagDef, tagsConfigPath, taglib, tagDirname);
-                tag.name = tagName;
+                tag.name = tag.name || tagName
                 taglib.addTag(tag);
             }
         }


### PR DESCRIPTION
It might not be as simple as this, but one can hope, right?

The purpose of this change is to allow this to be written in the renderer

```javascript
module.exports.tag = { name: "my-tag-name" }
```

That would result in the template being named to whatever was specified.