### PR TITLE
Use new travis infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 node_js:
 - "0.10"
 - "0.12"


### PR DESCRIPTION
Travis upgraded its infrastructure which allows CI tests to be ran in docker containers. The result is faster tests. 

To use it you just have to specify `sudo: false` in the travis CI.