### PR TITLE
scan for index/renderer files based on available extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.orig
 .DS_Store
 coverage
+.nvmrc

--- a/compiler/taglib-loader/scanTagsDir.js
+++ b/compiler/taglib-loader/scanTagsDir.js
@@ -35,6 +35,15 @@ function createDefaultTagDef() {
          };
 }
 
+function scanRequireExtensions(dir, childFilename, filename) {
+    var path;
+    for (var extension in require.extensions) {
+        path = nodePath.join(dir, childFilename, filename + extension);
+        if (fs.existsSync(path)) {
+            return path; // short circuit loop
+        }
+    }
+}
 
 /**
  * @param {String} tagsConfigPath path to tag definition file
@@ -70,8 +79,8 @@ module.exports = function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, ta
         var tagDirname = nodePath.join(dir, childFilename);
         var tagFile = nodePath.join(dir, childFilename, 'marko-tag.json');
         var tag = null;
-        var rendererFile = nodePath.join(dir, childFilename, 'renderer.js');
-        var indexFile = nodePath.join(dir, childFilename, 'index.js');
+        var rendererFile = scanRequireExtensions(dir, childFilename, 'renderer');
+        var indexFile = scanRequireExtensions(dir, childFilename, 'index');
         var templateFile = nodePath.join(dir, childFilename, 'template.marko');
         var templateFileAlt = nodePath.join(dir, childFilename, 'template.html');
         var templateFileAlt2 = nodePath.join(dir, childFilename, 'template.marko.html');
@@ -98,9 +107,9 @@ module.exports = function scanTagsDir(tagsConfigPath, tagsConfigDirname, dir, ta
         }
 
         if (!tagDef.renderer && !tagDef.template && !tagDef['code-generator'] && !tagDef['node-factory'] && !tagDef.transformer) {
-            if (fs.existsSync(rendererFile)) {
+            if (rendererFile) {
                 tagDef.renderer = rendererFile;
-            } else if (fs.existsSync(indexFile)) {
+            } else if (indexFile) {
                 tagDef.renderer = indexFile;
             } else if (fs.existsSync(templateFile)) {
                 tagDef.template = templateFile;

--- a/test/taglib-loader-test.js
+++ b/test/taglib-loader-test.js
@@ -4,6 +4,7 @@ chai.config.includeStack = true;
 require('chai').should();
 var expect = require('chai').expect;
 var nodePath = require('path');
+var taglibLoader = require('../compiler').taglibLoader;
 
 describe('taglib-loader' , function() {
 
@@ -18,7 +19,6 @@ describe('taglib-loader' , function() {
     });
 
     it('should load a taglib with shorthand attributes and tags', function() {
-        var taglibLoader = require('../compiler').taglibLoader;
         var taglib = taglibLoader.load(nodePath.join(__dirname, 'fixtures/taglib-shorthand/marko.json'));
         expect(taglib != null).to.equal(true);
 
@@ -37,6 +37,14 @@ describe('taglib-loader' , function() {
         expect(nestedTabTag.attributes.label != null).to.equal(true);
         expect(nestedTabTag.isRepeated).to.equal(true);
         expect(nestedTabTag.targetProperty).to.equal('tabs');
+    });
+
+    it('should load a taglib with index*.js or render*.js', function() {
+        var taglib = taglibLoader.load(nodePath.join(__dirname, 'fixtures/marko.json'));
+
+        console.log(taglib.tags['test-declared-attributes'].renderer);
+        expect(taglib).to.not.be.null;
+        expect(taglib).to.have.deep.property("tags.test-declared-attributes.renderer").to.have.string('renderer.js');
     });
 
 

--- a/test/taglib-loader-test.js
+++ b/test/taglib-loader-test.js
@@ -39,10 +39,9 @@ describe('taglib-loader' , function() {
         expect(nestedTabTag.targetProperty).to.equal('tabs');
     });
 
-    it('should load a taglib with index*.js or render*.js', function() {
+    it('should load a taglib with index.* or render.* extension', function() {
         var taglib = taglibLoader.load(nodePath.join(__dirname, 'fixtures/marko.json'));
 
-        console.log(taglib.tags['test-declared-attributes'].renderer);
         expect(taglib).to.not.be.null;
         expect(taglib).to.have.deep.property("tags.test-declared-attributes.renderer").to.have.string('renderer.js');
     });


### PR DESCRIPTION
With this change, a compile-to-js file such as `index.coffee` can be used in place of the hard coded `index.js` when it comes to custom marko tags.

Refs #235 