### PR TITLE
better error reporting during compilation of template

### DIFF
--- a/compiler/Builder.js
+++ b/compiler/Builder.js
@@ -282,6 +282,8 @@ class Builder {
     }
 
     ifStatement(test, body, elseStatement) {
+        test = makeNode(test);
+
         return new If({test, body, else: elseStatement});
     }
 

--- a/compiler/util/parseJavaScript.js
+++ b/compiler/util/parseJavaScript.js
@@ -1,6 +1,5 @@
 'use strict';
 var ok = require('assert').ok;
-var charProps = require('char-props');
 
 const esprima = require('esprima');
 
@@ -219,19 +218,15 @@ function parseExpression(src, builder, isExpression) {
         jsAST = esprima.parse(src);
     } catch(e) {
         var errorIndex = e.index;
-
-        var errorMessage = e.toString();
+        var errorMessage = '\n' + e.description;
         if (errorIndex != null && errorIndex >= 0) {
-            var srcCharProps = charProps(src);
             if (isExpression) {
                 errorIndex--; // Account for extra paren added to start
             }
-
-            let line = srcCharProps.lineAt(errorIndex)+1;
-            let column = srcCharProps.columnAt(errorIndex)+1;
-            errorMessage += ' [Line ' + line + ', Col: ' + column + ']';
+            errorMessage += ': ';
+            errorMessage += src + '\n'+ new Array(errorMessage.length + errorIndex + 1).join(" ") + '^';
         }
-        var wrappedError = new Error('Invalid JavaScript expression: ' + src + ' - ' + errorMessage);
+        var wrappedError = new Error(errorMessage);
         wrappedError.index = errorIndex;
         wrappedError.src = src;
         wrappedError.code = 'ERR_INVALID_JAVASCRIPT_EXPRESSION';

--- a/test/fixtures/parseFor/autotest/forEach-invalid-option2/expected.json
+++ b/test/fixtures/parseFor/autotest/forEach-invalid-option2/expected.json
@@ -1,3 +1,3 @@
 {
-  "error": "Invalid status-var option: Invalid JavaScript expression: (test foo) - Error: Line 1: Unexpected identifier [Line 1, Col: 6]"
+  "error": "Invalid status-var option: \nUnexpected identifier: (test foo)\n                             ^"
 }

--- a/test/fixtures/render/autotest/error-bad-expression/test.js
+++ b/test/fixtures/render/autotest/error-bad-expression/test.js
@@ -7,7 +7,7 @@ exports.checkError = function(e) {
     expect(e.errors.length).to.equal(1);
 
     var message = e.toString();
-    expect(message).to.contain('Invalid JavaScript expression: ((this is not valid))');
+    expect(message).to.contain('Error: An error occurred while trying to compile template at path');
     expect(message).to.contain('Invalid JavaScript expression for attribute "class"');
-    expect(message).to.contain('Unexpected identifier');
+    expect(message).to.contain('Unexpected identifier: ((this is not valid))');
 };

--- a/test/fixtures/render/autotest/error-invalid-for-attr-separator/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-for-attr-separator/template.marko
@@ -1,0 +1,3 @@
+<b for(item in ['red', 'green', 'blue'] | separator=', ' foo)>
+    ${item}
+</b>

--- a/test/fixtures/render/autotest/error-invalid-for-attr-separator/test.js
+++ b/test/fixtures/render/autotest/error-invalid-for-attr-separator/test.js
@@ -1,0 +1,10 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('An error occurred while trying to compile template at path');
+    expect(message).to.contain('Invalid "separator" expression:');
+    expect(message).to.contain('Unexpected identifier');
+};

--- a/test/fixtures/render/autotest/error-invalid-for-attr/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-for-attr/template.marko
@@ -1,0 +1,3 @@
+<div for(color in ['red', 'blue', 'green'] foo)>
+  ${color}
+</div>

--- a/test/fixtures/render/autotest/error-invalid-for-attr/test.js
+++ b/test/fixtures/render/autotest/error-invalid-for-attr/test.js
@@ -1,0 +1,10 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('An error occurred while trying to compile template at path');
+    expect(message).to.contain('Invalid "in" expression:');
+    expect(message).to.contain("Unexpected identifier: (['red', 'blue', 'green'] foo)");
+};

--- a/test/fixtures/render/autotest/error-invalid-for-props/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-for-props/template.marko
@@ -1,0 +1,3 @@
+<for(name,value in {'foo': 'low', 'bar': 'high'} foo)>
+    [${name}=${value}]
+</for>

--- a/test/fixtures/render/autotest/error-invalid-for-props/test.js
+++ b/test/fixtures/render/autotest/error-invalid-for-props/test.js
@@ -1,0 +1,10 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('An error occurred while trying to compile template at path');
+    expect(message).to.contain('Invalid "in" expression:');
+    expect(message).to.contain("Unexpected identifier: ({'foo': 'low', 'bar': 'high'} foo)");
+};

--- a/test/fixtures/render/autotest/error-invalid-if-attr/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-if-attr/template.marko
@@ -1,0 +1,3 @@
+<if(true sdsds)>
+    A
+</if>

--- a/test/fixtures/render/autotest/error-invalid-if-attr/test.js
+++ b/test/fixtures/render/autotest/error-invalid-if-attr/test.js
@@ -1,0 +1,8 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('Unexpected identifier: (true sdsds)');
+};

--- a/test/fixtures/render/autotest/error-invalid-if-else-attr/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-if-else-attr/template.marko
@@ -1,0 +1,6 @@
+<div if(data.foo === dasda 0)>
+    A
+</div>
+<div else>
+    B
+</div>

--- a/test/fixtures/render/autotest/error-invalid-if-else-attr/test.js
+++ b/test/fixtures/render/autotest/error-invalid-if-else-attr/test.js
@@ -1,0 +1,9 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('Error: Unable to compile template at path');
+    expect(message).to.contain('Unexpected number: (data.foo === dasda 0)');
+};

--- a/test/fixtures/render/autotest/error-invalid-if-else-if-attr/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-if-else-if-attr/template.marko
@@ -1,0 +1,6 @@
+<div if(data.foo === 0)>
+    A
+</div>
+<div else-if(true sds)>
+    B
+</div>

--- a/test/fixtures/render/autotest/error-invalid-if-else-if-attr/test.js
+++ b/test/fixtures/render/autotest/error-invalid-if-else-if-attr/test.js
@@ -1,0 +1,9 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('Error: Unable to compile template at path');
+    expect(message).to.contain('Unexpected identifier: (true sds)');
+};

--- a/test/fixtures/render/autotest/error-invalid-if-else-if-else-attr/template.marko
+++ b/test/fixtures/render/autotest/error-invalid-if-else-if-else-attr/template.marko
@@ -1,0 +1,9 @@
+<div if(data.foo === 0)>
+    A
+</div>
+<div else-if(data.foo ==== 1)>
+    B
+</div>
+<div else foo asasa sasa>
+    C
+</div>

--- a/test/fixtures/render/autotest/error-invalid-if-else-if-else-attr/test.js
+++ b/test/fixtures/render/autotest/error-invalid-if-else-if-else-attr/test.js
@@ -1,0 +1,9 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain('Error: Unable to compile template at path');
+    expect(message).to.contain('Unexpected token =: (data.foo ==== 1)');
+};

--- a/test/fixtures/walker/autotest/remove-attrs/expected.json
+++ b/test/fixtures/walker/autotest/remove-attrs/expected.json
@@ -3,7 +3,27 @@
   "body": [
     {
       "type": "If",
-      "test": "notEmpty(data.colors)",
+      "test": {
+        "type": "FunctionCall",
+        "callee": {
+          "type": "Identifier",
+          "name": "notEmpty"
+        },
+        "args": [
+          {
+            "type": "MemberExpression",
+            "object": {
+              "type": "Identifier",
+              "name": "data"
+            },
+            "property": {
+              "type": "Identifier",
+              "name": "colors"
+            },
+            "computed": false
+          }
+        ]
+      },
       "body": [
         {
           "type": "HtmlElement",


### PR DESCRIPTION
Changes includes

- Better error reporting Ex: Unexpected identifier: (['red', 'blue', 'green'] foo)
- 'If statement' was not parsing the javascript expression, it is fixed now
- Added more negative tests
- Fixed the existing tests which broke due to changes with this PR