### PR TITLE
Add node context to errors thrown from a code-generator function

### DIFF
--- a/compiler/CodeGenerator.js
+++ b/compiler/CodeGenerator.js
@@ -4,6 +4,7 @@ const isArray = Array.isArray;
 const Node = require('./ast/Node');
 const Literal = require('./ast/Literal');
 const Identifier = require('./ast/Identifier');
+const HtmlElement = require('./ast/HtmlElement');
 const ok = require('assert').ok;
 const Container = require('./ast/Container');
 const util = require('util');
@@ -195,7 +196,24 @@ class Generator {
         if (node.getCodeGenerator) {
             generateCodeFunc = node.getCodeGenerator(this.outputType);
             if (generateCodeFunc) {
-                finalNode = generateCodeFunc(node, this);
+                try {
+                    finalNode = generateCodeFunc(node, this);
+                } catch(err) {
+                    var contextMessage = 'Generating code for ';
+
+                    if(node instanceof HtmlElement) {
+                        contextMessage += '<'+node.tagName+'> tag';
+                    } else {
+                        contextMessage += node.type + ' node';
+                    }
+
+                    if(node.pos) {
+                        contextMessage += ' ('+this.context.getPosInfo(node.pos)+')';
+                    }
+
+                    err.message = err.message+' -- '+contextMessage;
+                    throw err;
+                }
 
                 if (finalNode === node) {
                     // If the same node was returned then we will generate

--- a/test/autotests/render/error-thrown-in-generator/custom-tag-hyphen-attrs/custom-tag.js
+++ b/test/autotests/render/error-thrown-in-generator/custom-tag-hyphen-attrs/custom-tag.js
@@ -1,0 +1,3 @@
+module.exports = function generator(elNode, generator) {
+    throw new Error('Something Happened!');
+};

--- a/test/autotests/render/error-thrown-in-generator/custom-tag-hyphen-attrs/custom-tag.js
+++ b/test/autotests/render/error-thrown-in-generator/custom-tag-hyphen-attrs/custom-tag.js
@@ -1,3 +1,0 @@
-module.exports = function generator(elNode, generator) {
-    throw new Error('Something Happened!');
-};

--- a/test/autotests/render/error-thrown-in-generator/custom-tag.js
+++ b/test/autotests/render/error-thrown-in-generator/custom-tag.js
@@ -1,0 +1,3 @@
+module.exports = function generator(elNode, generator) {
+    throw new Error('Something Happened!');
+};

--- a/test/autotests/render/error-thrown-in-generator/marko.json
+++ b/test/autotests/render/error-thrown-in-generator/marko.json
@@ -1,0 +1,5 @@
+{
+    "<custom-tag>": {
+        "code-generator": "./custom-tag.js"
+    }
+}

--- a/test/autotests/render/error-thrown-in-generator/template.marko
+++ b/test/autotests/render/error-thrown-in-generator/template.marko
@@ -1,0 +1,3 @@
+<div>
+    <custom-tag/>
+</div>

--- a/test/autotests/render/error-thrown-in-generator/test.js
+++ b/test/autotests/render/error-thrown-in-generator/test.js
@@ -1,0 +1,17 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    //includes the tag it broke on
+    expect(e.message).to.contain('<custom-tag>');
+
+    //includes the line number of the template
+    expect(e.message).to.contain('error-thrown-in-generator/template.marko:2');
+
+    //retains original stack trace
+    expect(e.stack.toString()).to.contain('custom-tag.js:2:11');
+
+    //retains original message
+    expect(e.message).to.contain('Something Happened!');
+};


### PR DESCRIPTION
Ideally, all our errors in generating code would be developer friendly and added through `context.addError`, however, not every case is covered currently.  

This pull request catches errors from code generators, adds context about the node (including line number in the template when available), and rethrows the error while maintaining the original stack trace.

In the ideal case it looks something like this:
```
Error: Something Happened! -- Generating code for <custom-tag> tag (test/autotests/render/error-thrown-in-generator/template.marko:2:4)
```

Even in cases where we don't have the line number, you at least have a better idea of what might be causing the error.  The following is what the error @seangates encountered earlier would have looked like:
```
Error: 
Unexpected token ): (+)
                      ^ -- Generating code for <assign> tag
```
*Note: I'm actually not quite sure why the node doesn't have the line number attached in this case - I may look into this at a later point in time.*


For non-html nodes, the type of node is listed (and will list line number if available):
```
Error: some error message -- Generating code for ForEach node
```