### PR TITLE
<macro> must have a name

### DIFF
--- a/taglibs/core/macro-tag.js
+++ b/taglibs/core/macro-tag.js
@@ -1,13 +1,10 @@
 module.exports = function codeGenerator(elNode, codegen) {
 
     var attributes = elNode.attributes;
-    if (!attributes.length) {
-        return;
-    }
-
     var defAttr = attributes[0];
-    if (defAttr.argument == null) {
-        return;
+
+    if(!defAttr || defAttr.value !== undefined) {
+        return codegen.addError('The <macro> tag must contain a name as its first attribute, example: <macro greeting()>');
     }
 
     var body = elNode.body;

--- a/test/autotests/render/error-macro-no-name/marko.json
+++ b/test/autotests/render/error-macro-no-name/marko.json
@@ -1,5 +1,0 @@
-{
-    "<test-open-tag-only>": {
-        "open-tag-only": true
-    }
-}

--- a/test/autotests/render/error-macro-no-name/marko.json
+++ b/test/autotests/render/error-macro-no-name/marko.json
@@ -1,0 +1,5 @@
+{
+    "<test-open-tag-only>": {
+        "open-tag-only": true
+    }
+}

--- a/test/autotests/render/error-macro-no-name/template.marko
+++ b/test/autotests/render/error-macro-no-name/template.marko
@@ -1,0 +1,7 @@
+<macro>
+    This is bad.
+</macro>
+
+<macro test=123>
+    This is also bad.
+</macro>

--- a/test/autotests/render/error-macro-no-name/test.js
+++ b/test/autotests/render/error-macro-no-name/test.js
@@ -1,0 +1,11 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    expect(Array.isArray(e.errors)).to.equal(true);
+    expect(e.errors.length).to.equal(2);
+
+    var message = e.toString();
+    expect(message).to.contain('The <macro> tag must contain a name as its first attribute, example: <macro greeting()>');
+};

--- a/test/autotests/render/macro-no-args/expected.html
+++ b/test/autotests/render/macro-no-args/expected.html
@@ -1,1 +1,1 @@
-Marko is awesomeMarko is awesome
+Marko is awesomeMarko is awesomeMarko is really awesomeMarko is really awesome

--- a/test/autotests/render/macro-no-args/template.marko
+++ b/test/autotests/render/macro-no-args/template.marko
@@ -2,5 +2,11 @@
     Marko is awesome
 </macro>
 
+<macro greeting2>
+    Marko is really awesome
+</macro>
+
 <greeting/>
-<greeting/>
+<greeting()/>
+<greeting2/>
+<greeting2()/>


### PR DESCRIPTION
`<macro>` now expects its first attribute to be its name (regardless of whether it has arguments or not), if there are no attributes or the first attribute has a value (ex. `test=123`), then it throws an error.

✅ good:
```xml
<macro greeting>
    Hello!
</macro>

<macro greeting()>
    Hello!
</macro>

<macro greeting(name)>
    Hello ${name}!
</macro>
```

:x: bad:
```xml
<macro async=true>
    Uh-oh!
</macro>

<macro test=123 greeting(name)>
    Uh-oh ${name}!
</macro>

<macro>
    Uh-oh!
</macro>
```