### PR TITLE
Asyncfragment info

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "mocha": "mocha --ui bdd --reporter spec ./test/",
     "test-coverage": "istanbul cover _mocha --include-all-sources -- --ui bdd --reporter spec ./test && npm run jshint",
     "test-fast": "mocha --ui bdd --reporter spec ./test/render-test",
-    "test-async": "mocha --ui bdd --reporter spec ./test/render-async-test",
+    "test-async": "mocha --ui bdd --reporter spec ./test/async-render-test",
     "test-taglib-loader": "mocha --ui bdd --reporter spec ./test/taglib-loader-test",
     "test-express": "mocha --ui bdd --reporter spec ./test/express-test",
     "jshint": "jshint compiler/ runtime/ taglibs/",

--- a/test/autotests/async-render/async-fragment-client-reorder-mixed/expected-events.json
+++ b/test/autotests/async-render/async-fragment-client-reorder-mixed/expected-events.json
@@ -3,6 +3,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -11,6 +12,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -19,6 +21,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": false
         }
     },
@@ -26,6 +29,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": false
         }
     },
@@ -33,6 +37,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": false
         }
     },
@@ -40,6 +45,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }

--- a/test/autotests/async-render/async-fragment-client-reorder-nested/expected-events.json
+++ b/test/autotests/async-render/async-fragment-client-reorder-nested/expected-events.json
@@ -3,6 +3,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -11,6 +12,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -19,6 +21,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": true,
             "id": 1
         }
@@ -27,6 +30,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.inner2",
+            "finished":true,
             "clientReorder": true,
             "id": 2
         }
@@ -35,6 +39,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -43,6 +48,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": true,
             "id": 1
         }
@@ -51,6 +57,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.inner1",
+            "finished":true,
             "clientReorder": true,
             "id": 1
         }
@@ -59,6 +66,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.inner2",
+            "finished":true,
             "clientReorder": true,
             "id": 2
         }
@@ -67,6 +75,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.inner2",
+            "finished":true,
             "clientReorder": true,
             "id": 2
         }

--- a/test/autotests/async-render/async-fragment-client-reorder/expected-events.json
+++ b/test/autotests/async-render/async-fragment-client-reorder/expected-events.json
@@ -3,6 +3,7 @@
         "event": "asyncFragmentBegin",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -11,6 +12,7 @@
         "event": "asyncFragmentBeforeRender",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }
@@ -19,6 +21,7 @@
         "event": "asyncFragmentFinish",
         "arg": {
             "name": "data.outer",
+            "finished":true,
             "clientReorder": true,
             "id": 0
         }

--- a/test/autotests/async-render/async-fragment-timeout-message/expected.html
+++ b/test/autotests/async-render/async-fragment-timeout-message/expected.html
@@ -1,1 +1,0 @@
-Server is busy!

--- a/test/autotests/async-render/async-fragment-timeout-message/template.marko
+++ b/test/autotests/async-render/async-fragment-timeout-message/template.marko
@@ -1,3 +1,0 @@
-<async-fragment data-provider=data.userInfo var="userInfo" timeout=100 timeout-message="Server is busy!">
-    Hello World
-</async-fragment>

--- a/test/autotests/async-render/async-fragment-timeout-message/test.js
+++ b/test/autotests/async-render/async-fragment-timeout-message/test.js
@@ -1,5 +1,0 @@
-exports.templateData = {
-    userInfo: function(arg, done) {
-        // Do nothing to trigger a timeout
-    }
-};

--- a/test/autotests/async-render/async-fragment-timeout/expected-events.json
+++ b/test/autotests/async-render/async-fragment-timeout/expected-events.json
@@ -1,0 +1,110 @@
+[
+    {
+        "event": "asyncFragmentBegin",
+        "arg": {
+            "name": "userInfo1",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBegin",
+        "arg": {
+            "name": "userInfo2",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBegin",
+        "arg": {
+            "name": "userInfo3",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBegin",
+        "arg": {
+            "name": "userInfo4",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBeforeRender",
+        "arg": {
+            "name": "userInfo1",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentFinish",
+        "arg": {
+            "name": "userInfo1",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBeforeRender",
+        "arg": {
+            "name": "userInfo2",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentFinish",
+        "arg": {
+            "name": "userInfo2",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBeforeRender",
+        "arg": {
+            "name": "userInfo3",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentFinish",
+        "arg": {
+            "name": "userInfo3",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentBeforeRender",
+        "arg": {
+            "name": "userInfo4",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "asyncFragmentFinish",
+        "arg": {
+            "name": "userInfo4",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    }
+]

--- a/test/autotests/async-render/async-fragment-timeout/expected.html
+++ b/test/autotests/async-render/async-fragment-timeout/expected.html
@@ -1,1 +1,1 @@
-1-A timeout has occurred!2-A timeout has occurred!
+BEFORE 1-A timeout has occurred!2-A timeout has occurred!3-A timeout has occurred!4-A timeout has occurred! AFTER

--- a/test/autotests/async-render/async-fragment-timeout/template.marko
+++ b/test/autotests/async-render/async-fragment-timeout/template.marko
@@ -1,6 +1,7 @@
-<async-fragment data-provider=data.userInfo
+- BEFORE
+<async-fragment data-provider=data.userInfoShort
     var="user"
-    timeout=300
+    timeout=500
     name="userInfo1">
 
     <async-fragment-timeout>
@@ -8,10 +9,28 @@
     </async-fragment-timeout>
     1
 </async-fragment>
-<async-fragment data-provider=data.userInfo
+<async-fragment data-provider=data.userInfoShort
     var="user"
     timeout-message="2-A timeout has occurred!"
-    timeout=300
+    timeout=500
     name="userInfo2">
     2
 </async-fragment>
+<async-fragment data-provider=data.userInfoLong
+    var="user"
+    timeout-message="3-A timeout has occurred!"
+    timeout=900
+    name="userInfo3">
+    3
+</async-fragment>
+<async-fragment data-provider=data.userInfoLong
+    var="user"
+    timeout=900
+    name="userInfo4">
+
+    <async-fragment-timeout>
+        4-A timeout has occurred!
+    </async-fragment-timeout>
+    4
+</async-fragment>
+- AFTER

--- a/test/autotests/async-render/async-fragment-timeout/test.js
+++ b/test/autotests/async-render/async-fragment-timeout/test.js
@@ -1,7 +1,32 @@
+var extend = require('raptor-util/extend');
+var expect = require('chai').expect;
+
 exports.templateData = {
-    userInfo: function(done) {
+    userInfoShort: function(done) {
         setTimeout(function() {
             done(null, {});
         }, 600);
+    },
+    userInfoLong: function(done) {
+        setTimeout(function() {
+            done(null, {});
+        }, 1000);
     }
+};
+
+exports.checkEvents = function(events, helpers) {
+    events = events.map(function(eventInfo) {
+        var arg = extend({}, eventInfo.arg);
+        expect(arg.out != null).to.equal(true);
+
+        delete arg.out; // Not serializable
+        delete arg.asyncValue; // Not serializable
+
+        return {
+            event: eventInfo.event,
+            arg: arg
+        };
+    });
+
+    helpers.compare(events, '-events.json');
 };


### PR DESCRIPTION
- Adds additional event info (finished/timedout) to the data emitted from <async-fragment> tags. 
- Ensures that renderBody() is not called again if the fragment has already finished (timed out).
- Fixes `npm run test-async`
- Removes a redundant `async-fragment` timeout related test