### PR TITLE
fixes #307

### DIFF
--- a/compiler/Parser.js
+++ b/compiler/Parser.js
@@ -56,8 +56,8 @@ function mergeShorthandClassNames(el, shorthandClassNames, context) {
             prevClassName.value += ' ' + className.value;
         } else {
             finalClassNames.push(className);
+            prevClassName = className;
         }
-        prevClassName = className;
     }
 
     if (finalClassNames.length === 1) {

--- a/test/autotests/render/shorthand-classes-many-classes/expected.html
+++ b/test/autotests/render/shorthand-classes-many-classes/expected.html
@@ -1,0 +1,1 @@
+<div class="foo bar baz bat"></div><div class="foo bar test123 baz"></div><div class="foo bar baz test"></div>

--- a/test/autotests/render/shorthand-classes-many-classes/template.marko
+++ b/test/autotests/render/shorthand-classes-many-classes/template.marko
@@ -1,0 +1,3 @@
+.foo.bar.baz.bat
+.foo.bar.${data.cls}.baz
+.foo.bar.baz class="test"

--- a/test/autotests/render/shorthand-classes-many-classes/test.js
+++ b/test/autotests/render/shorthand-classes-many-classes/test.js
@@ -1,0 +1,3 @@
+exports.templateData = {
+    cls: 'test123'
+};


### PR DESCRIPTION
Only set `prevClassName` when the `className` has been pushed to `finalClassNames`, otherwise future `className` values will be appended to a class that doesn't get included in the final output.  This effectively limits the number of classes to 2.