### PR TITLE
update readme header

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-![Marko Logo](https://raw.githubusercontent.com/marko-js/branding/master/marko-logo-small.png)
+<p align="center">
+    <a href="http://markojs.com/"><img src="https://raw.githubusercontent.com/marko-js/branding/master/marko-logo-medium-cropped.png" alt="Marko logo" width="300" /></a><br /><br />
+</p>
+
+Marko is a [_really_ fast](https://github.com/marko-js/templating-benchmarks) and lightweight HTML-based templating engine from eBay. Marko runs on Node.js and in the browser and it supports streaming, async rendering and custom tags. Templates are compiled to readable CommonJS modules. Learn more on [markojs.com](http://markojs.com/), and even [Try Marko Online!](http://markojs.com/try-online/)
 
 [![Build Status](https://travis-ci.org/marko-js/marko.svg?branch=master)](https://travis-ci.org/marko-js/marko)
 [![Coverage Status](https://coveralls.io/repos/github/marko-js/marko/badge.svg?branch=master)](https://coveralls.io/github/marko-js/marko?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/marko-js/marko)
 [![NPM](https://img.shields.io/npm/v/marko.svg)](https://www.npmjs.com/package/marko)
 [![Downloads](https://img.shields.io/npm/dm/marko.svg)](http://npm-stat.com/charts.html?package=marko)
-
-Marko is a [_really_ fast](https://github.com/marko-js/templating-benchmarks) and lightweight HTML-based templating engine from eBay. Marko runs on Node.js and in the browser and it supports streaming, async rendering and custom tags. Templates are compiled to readable CommonJS modules. Learn more on [http://markojs.com/](http://markojs.com/).
-
-You can try out Marko online: [Try Marko Online!](http://markojs.com/try-online/)
 
 # Installation
 


### PR DESCRIPTION
-use retina image for logo
-center logo with html
-move "Try Marko Online" to first paragraph
-move badges below first paragraph

The only way to reliably test this was by putting it on my fork master, so you can see here https://github.com/yomed/marko. Spacing is a bit worse on mobile, but there's only so much customization you can do before github takes over. Let me know of any concerns.


Desktop:
<img width="1044" alt="screen shot 2016-06-28 at 7 25 02 pm" src="https://cloud.githubusercontent.com/assets/3595986/16438603/1b3e4486-3d66-11e6-986c-dbac05f89c0d.png">

Mobile (iPhone 6 size):
<img width="403" alt="screen shot 2016-06-28 at 7 26 11 pm" src="https://cloud.githubusercontent.com/assets/3595986/16438612/363d35e4-3d66-11e6-8fa2-be0c4b3be95f.png">
