### PR TITLE
Fixes issue #345 - Whitespace preservation should apply to all nested text

### DIFF
--- a/compiler/CodeGenerator.js
+++ b/compiler/CodeGenerator.js
@@ -189,9 +189,15 @@ class Generator {
             beforeAfterEvent = new GeneratorEvent(node, this);
         }
 
+        var isWhitespacePreserved = node.isPreserveWhitespace();
+
         if (beforeAfterEvent) {
             beforeAfterEvent.isBefore = true;
             beforeAfterEvent.node.emit('beforeGenerateCode', beforeAfterEvent);
+
+            if (isWhitespacePreserved) {
+                this.context.beginPreserveWhitespace();
+            }
         }
 
         if (node.getCodeGenerator) {
@@ -268,6 +274,10 @@ class Generator {
         if (beforeAfterEvent) {
             beforeAfterEvent.isBefore = false;
             beforeAfterEvent.node.emit('afterGenerateCode', beforeAfterEvent);
+
+            if (isWhitespacePreserved) {
+                this.context.endPreserveWhitespace();
+            }
         }
 
         this._currentNode = oldCurrentNode;

--- a/compiler/CompileContext.js
+++ b/compiler/CompileContext.js
@@ -14,6 +14,8 @@ var macros = require('./util/macros');
 var extend = require('raptor-util/extend');
 var Walker = require('./Walker');
 
+const FLAG_PRESERVE_WHITESPACE = 'PRESERVE_WHITESPACE';
+
 const deresolveOptions = {
     shouldRemoveExt(ext) {
         return ext === '.js' || ext === '.json' || ext === '.es6';
@@ -392,8 +394,18 @@ class CompileContext {
         this._preserveWhitespace = preserveWhitespace;
     }
 
+    beginPreserveWhitespace() {
+        this.pushFlag(FLAG_PRESERVE_WHITESPACE);
+    }
+
+    endPreserveWhitespace() {
+        this.popFlag(FLAG_PRESERVE_WHITESPACE);
+    }
+
     isPreserveWhitespace() {
-        return this._preserveWhitespace === true;
+        if (this.isFlagSet(FLAG_PRESERVE_WHITESPACE) || this._preserveWhitespace === true) {
+            return true;
+        }
     }
 
     setPreserveComments(preserveComments) {

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -782,6 +782,8 @@ __Option 2)__ Disable whitespace removal using the `marko-preserve-whitespace` a
 </div>
 ```
 
+NOTE: When whitespace preservation is enabled, whitespace will be preserved for text at any level below the tag that the `marko-preserve-whitespace` attribute is attached to.
+
 __Option 3)__ Disable _all_ whitespace removal by changing a compiler option
 
 ```javascript
@@ -799,6 +801,8 @@ Adding the `"preserve-whitespace": true` property to a tag definition will resul
     }
 }
 ```
+
+NOTE: When whitespace preservation is enabled, whitespace will be preserved for text at any level below the tag.
 
 # Helpers
 

--- a/test/autotests/render/bodyText/expected.html
+++ b/test/autotests/render/bodyText/expected.html
@@ -1,1 +1,3 @@
-<script><DIV>FOO</DIV></script>
+<script>
+    <DIV>FOO</DIV>
+</script>

--- a/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/expected.html
+++ b/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/expected.html
@@ -1,0 +1,12 @@
+<div>
+    This
+    whitespace
+    should be
+    preserved
+    <div>
+        This
+        whitespace
+        should also be
+        preserved
+    </div>
+</div>

--- a/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/template.marko
+++ b/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/template.marko
@@ -1,0 +1,14 @@
+<marko-compiler-options preserve-whitespace/>
+
+<div>
+    This
+    whitespace
+    should be
+    preserved
+    <div>
+        This
+        whitespace
+        should also be
+        preserved
+    </div>
+</div>

--- a/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/test.js
+++ b/test/autotests/render/marko-compiler-options-preserve-whitespace-nested/test.js
@@ -1,0 +1,1 @@
+exports.templateData = {};

--- a/test/autotests/render/whitespace-marko-preserve-whitespace-attr/expected.html
+++ b/test/autotests/render/whitespace-marko-preserve-whitespace-attr/expected.html
@@ -1,0 +1,12 @@
+<div>
+    This
+    whitespace
+    should be
+    preserved
+    <div>
+        This
+        whitespace
+        should also be
+        preserved
+    </div>
+</div>

--- a/test/autotests/render/whitespace-marko-preserve-whitespace-attr/template.marko
+++ b/test/autotests/render/whitespace-marko-preserve-whitespace-attr/template.marko
@@ -1,0 +1,12 @@
+<div marko-preserve-whitespace>
+    This
+    whitespace
+    should be
+    preserved
+    <div>
+        This
+        whitespace
+        should also be
+        preserved
+    </div>
+</div>

--- a/test/autotests/render/whitespace-marko-preserve-whitespace-attr/test.js
+++ b/test/autotests/render/whitespace-marko-preserve-whitespace-attr/test.js
@@ -1,0 +1,3 @@
+exports.templateData = {
+    "name": "World"
+};

--- a/test/autotests/render/whitespace-pre-code/expected.html
+++ b/test/autotests/render/whitespace-pre-code/expected.html
@@ -1,0 +1,3 @@
+<pre><code>// Hello World
+
+console.log('Hello World!');</code></pre>

--- a/test/autotests/render/whitespace-pre-code/template.marko
+++ b/test/autotests/render/whitespace-pre-code/template.marko
@@ -1,0 +1,3 @@
+<pre><code>// Hello World
+
+console.log('Hello World!');</code></pre>

--- a/test/autotests/render/whitespace-pre-code/test.js
+++ b/test/autotests/render/whitespace-pre-code/test.js
@@ -1,0 +1,3 @@
+exports.templateData = {
+    "name": "World"
+};


### PR DESCRIPTION
## Description
Currently when a node/tag is marked with "preserve-whitespace", the whitespace is being preserved for only directly nested text. The expected behavior should be that whitespace should be preserved for all directly nested text and any text nested at any level below the node.

## Motivation and Context

[Issue #345](https://github.com/marko-js/marko/issues/345)

## Checklist:

- [X] My code follows the code style of this project.
- [X] I have updated/added documentation affected by my changes.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

