### PR TITLE
use the raptor-util behavior for both literals and dynamic values

### DIFF
--- a/compiler/ast/HtmlAttribute.js
+++ b/compiler/ast/HtmlAttribute.js
@@ -3,6 +3,7 @@ var Node = require('./Node');
 var Literal = require('./Literal');
 var ok = require('assert').ok;
 var escapeXmlAttr = require('raptor-util/escapeXml').attr;
+var attr = require('raptor-util/attr');
 var compiler = require('../');
 
 function isStringLiteral(node) {
@@ -158,15 +159,7 @@ class HtmlAttribute extends Node {
         }
 
         if (this.isLiteralValue()) {
-            var literalValue = value.value;
-            if (typeof literalValue === 'boolean' || literalValue === '') {
-                if (literalValue === true || literalValue === '') {
-                    codegen.addWriteLiteral(' ' + name);
-                }
-            } else if (literalValue != null) {
-                codegen.addWriteLiteral(' ' + name + '="' + escapeXmlAttr(literalValue) + '"');
-            }
-
+            codegen.addWriteLiteral(attr(name, value.value));
         } else if (value != null) {
             codegen.isInAttribute = true;
             generateCodeForExpressionAttr(name, value, escape, codegen);

--- a/docs/language-guide.md
+++ b/docs/language-guide.md
@@ -365,7 +365,7 @@ With a value of `false` for `active`, the output would be the following:
 <div>Hello</div>
 ```
 
-_NOTE: If an attribute value expression evaluates to `null`, `false` or an empty string then the attribute is not included in the output._
+_NOTE: If an attribute value expression evaluates to `null` or `false` then the attribute is not included in the output._
 
 A ternary condition can also be used:
 
@@ -381,13 +381,12 @@ With a value of `false` for `active`, the output would be the following:
 
 ## Conditional Attributes
 
-Marko supports conditional attributes when the value of an attribute is an expression. Marko also supports [HTML `boolean` attributes](https://html.spec.whatwg.org/#boolean-attributes) (e.g., `<input type="checkbox" checked>`)  If an attribute value resolves to `null`, `undefined`, `false`  or an empty string then the attribute will not be rendered. If an attribute value resolves to `true` then only the attribute name will rendered.
+Marko supports conditional attributes when the value of an attribute is an expression. Marko also supports [HTML `boolean` attributes](https://html.spec.whatwg.org/#boolean-attributes) (e.g., `<input type="checkbox" checked>`)  If an attribute value resolves to `null`, `undefined`, or `false` then the attribute will not be rendered. If an attribute value resolves to `true` then only the attribute name will rendered.
 
 For example, given the following data:
 
 ```javascript
 {
-    title: '',
     active: true,
     checked: false,
     disabled: true
@@ -397,8 +396,6 @@ For example, given the following data:
 And the following template:
 
 ```xml
-<img src="foo.png" alt=data.title/>
-
 <div class=(data.active && "tab-active")/>
 
 <input type="checkbox" checked=data.checked disabled=data.disabled/>
@@ -407,8 +404,6 @@ And the following template:
 The output HTML will be the following:
 
 ```html
-<img src="foo.png">
-
 <div class="tab-active"></div>
 
 <input type="checkbox" disabled>

--- a/test/autotests/render/attr-empty/expected.html
+++ b/test/autotests/render/attr-empty/expected.html
@@ -1,1 +1,1 @@
-<img alt>
+<img alt=""><img alt="">

--- a/test/autotests/render/attr-empty/template.marko
+++ b/test/autotests/render/attr-empty/template.marko
@@ -1,1 +1,3 @@
+<var empty=""/>
 <img alt="">
+<img alt=empty>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Previously there was a difference in the way empty string (`""`) was handled when it was a literal value.  It now uses the raptor-util behavior for both literals and dynamic values.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #327

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. 

**The tests will fail until raptorjs/raptor-util#4 is merged and published**
