### PR TITLE
add concise syntax example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,23 @@ html lang="en"
             - No colors!
 ```
 
+Alternatively, you can choose to apply rendering logic as separate "tags":
+
+```html
+<!DOCTYPE html>
+html lang="en"
+    head
+        title - Marko Templating Engine
+    body
+        h1 - Hello ${data.name}!
+        if(data.colors.length)
+            ul
+                for(color in data.colors)
+                    li - ${color}
+        else
+            div - No colors!
+```
+
 ## Mixed syntax
 
 You can even mix and match the concise syntax with the HTML syntax within the same document.


### PR DESCRIPTION
## Description
Adds concise syntax example to README.md for applying rendering logic with separate tags.

## Motivation and Context
To make sure the concise syntax is really equivalent to the HTML template I ran this example. I think it makes sense to include it for other new users as another quick introduction to the Marko syntax and the alternative way of applying rendering logic. I would have found it helpful.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.