### PR TITLE
Add events for timeout and error

### DIFF
--- a/docs/async-taglib.md
+++ b/docs/async-taglib.md
@@ -73,6 +73,17 @@ The marko-async taglib also supports out-of-order flushing. Enabling out-of-orde
 
 If `client-reorder` is `true` then a placeholder element will be rendered to the output instead of the final HTML for the await instance. The instance will be instead rendered at the end of the page and client-side JavaScript code will be used to move the await's contents into the proper place in the DOM. The `<await-reorderer>` will be where the out-of-order instances are rendered before they are moved into place. If there are any out-of-order instances then inline JavaScript code will be injected into the page at this location to move the DOM nodes into the proper place in the DOM.
 
+# Events
+
+You may listen to these events on the AsyncStream returned from a template's render
+method or the wrapped stream if it is an event emitter (like node's http `res` stream).
+
+- **`await:begin`** - emits an object with the keys `name`, `dataProvider`, and `clientReorder` when the `<await>` tag begins awaiting its promise/callback.
+- **`await:beforeRender`** - emits the same object with the key `out` (the async output stream) added once the promise/callback has returned and the `<await>` tag is about to render its contents.
+- **`await:error`** - emits the same object with the key `error` (the `Error`) added, if an error occurs
+- **`await:timeout`** - emits the same object with the key `timedout` (a boolean set to `true`) added, if a timeout occurs
+- **`await:finish`** - emits the same the key `finished` (a boolean set to `true`) added once the `<await>` tag finishes
+
 # Taglib API
 
 ## `<await>`

--- a/taglibs/async/await-tag.js
+++ b/taglibs/async/await-tag.js
@@ -106,6 +106,8 @@ module.exports = function render(input, out) {
         }
 
         if (err) {
+            awaitInfo.error = err;
+            out.emit('await:error', awaitInfo);
             if (input.renderError) {
                 console.error('Await (' + name + ') failed. Error:', (err.stack || err));
                 input.renderError(targetOut);
@@ -113,6 +115,8 @@ module.exports = function render(input, out) {
                 targetOut.error(err);
             }
         } else if (renderTimeout) {
+            awaitInfo.timedout = true;
+            out.emit('await:timeout', awaitInfo);
             renderTimeout(targetOut);
         } else {
             if (input.renderBody) {

--- a/taglibs/async/await-tag.js
+++ b/taglibs/async/await-tag.js
@@ -115,8 +115,6 @@ module.exports = function render(input, out) {
                 targetOut.error(err);
             }
         } else if (renderTimeout) {
-            awaitInfo.timedout = true;
-            out.emit('await:timeout', awaitInfo);
             renderTimeout(targetOut);
         } else {
             if (input.renderBody) {
@@ -160,6 +158,7 @@ module.exports = function render(input, out) {
                 var message = 'Await (' + name + ') timed out after ' + timeout + 'ms';
 
                 awaitInfo.timedout = true;
+                out.emit('await:timeout', awaitInfo);
 
                 if (renderTimeout) {
                     logger.error(message);

--- a/test/async-render-test.js
+++ b/test/async-render-test.js
@@ -64,6 +64,8 @@ describe('async render', function() {
 
                 addEventListener('await:begin');
                 addEventListener('await:beforeRender');
+                addEventListener('await:error');
+                addEventListener('await:timeout');
                 addEventListener('await:finish');
 
                 template.render(templateData, out, function(err, html) {
@@ -84,11 +86,9 @@ describe('async render', function() {
                     // Make sure all of the await instances were correctly ended
                     Object.keys(eventsByAwaitInstance).forEach(function(name) {
                         var events = eventsByAwaitInstance[name];
-                        expect(events).to.deep.equal([
-                            'await:begin',
-                            'await:beforeRender',
-                            'await:finish'
-                        ]);
+                        expect(events).to.include('await:begin');
+                        expect(events).to.include('await:beforeRender');
+                        expect(events).to.include('await:finish');
                     });
 
                     done();

--- a/test/autotests/async-render/await-error/expected-events.json
+++ b/test/autotests/async-render/await-error/expected-events.json
@@ -1,0 +1,38 @@
+[
+    {
+        "event": "await:begin",
+        "arg": {
+            "name": "data.testDataProvider",
+            "clientReorder": false,
+            "error": {},
+            "finished": true
+        }
+    },
+    {
+        "event": "await:beforeRender",
+        "arg": {
+            "name": "data.testDataProvider",
+            "clientReorder": false,
+            "error": {},
+            "finished": true
+        }
+    },
+    {
+        "event": "await:error",
+        "arg": {
+            "name": "data.testDataProvider",
+            "clientReorder": false,
+            "error": {},
+            "finished": true
+        }
+    },
+    {
+        "event": "await:finish",
+        "arg": {
+            "name": "data.testDataProvider",
+            "clientReorder": false,
+            "error": {},
+            "finished": true
+        }
+    }
+]

--- a/test/autotests/async-render/await-error/test.js
+++ b/test/autotests/async-render/await-error/test.js
@@ -1,3 +1,6 @@
+var extend = require('raptor-util/extend');
+var expect = require('chai').expect;
+
 exports.templateData = {
     testDataProvider: function(done) {
         setTimeout(function() {
@@ -5,4 +8,21 @@ exports.templateData = {
             done(err, null);
         }, 200);
     }
+};
+
+exports.checkEvents = function(events, helpers) {
+    events = events.map(function(eventInfo) {
+        var arg = extend({}, eventInfo.arg);
+        expect(arg.out != null).to.equal(true);
+
+        delete arg.out; // Not serializable
+        delete arg.asyncValue; // Not serializable
+
+        return {
+            event: eventInfo.event,
+            arg: arg
+        };
+    });
+
+    helpers.compare(events, '-events.json');
 };

--- a/test/autotests/async-render/await-timeout/expected-events.json
+++ b/test/autotests/async-render/await-timeout/expected-events.json
@@ -36,7 +36,7 @@
         }
     },
     {
-        "event": "await:beforeRender",
+        "event": "await:timeout",
         "arg": {
             "name": "userInfo1",
             "clientReorder": false,
@@ -45,7 +45,7 @@
         }
     },
     {
-        "event": "await:timeout",
+        "event": "await:beforeRender",
         "arg": {
             "name": "userInfo1",
             "clientReorder": false,
@@ -63,7 +63,7 @@
         }
     },
     {
-        "event": "await:beforeRender",
+        "event": "await:timeout",
         "arg": {
             "name": "userInfo2",
             "clientReorder": false,
@@ -72,7 +72,7 @@
         }
     },
     {
-        "event": "await:timeout",
+        "event": "await:beforeRender",
         "arg": {
             "name": "userInfo2",
             "clientReorder": false,
@@ -90,7 +90,7 @@
         }
     },
     {
-        "event": "await:beforeRender",
+        "event": "await:timeout",
         "arg": {
             "name": "userInfo3",
             "clientReorder": false,
@@ -99,7 +99,7 @@
         }
     },
     {
-        "event": "await:timeout",
+        "event": "await:beforeRender",
         "arg": {
             "name": "userInfo3",
             "clientReorder": false,
@@ -117,7 +117,7 @@
         }
     },
     {
-        "event": "await:beforeRender",
+        "event": "await:timeout",
         "arg": {
             "name": "userInfo4",
             "clientReorder": false,
@@ -126,7 +126,7 @@
         }
     },
     {
-        "event": "await:timeout",
+        "event": "await:beforeRender",
         "arg": {
             "name": "userInfo4",
             "clientReorder": false,

--- a/test/autotests/async-render/await-timeout/expected-events.json
+++ b/test/autotests/async-render/await-timeout/expected-events.json
@@ -45,6 +45,15 @@
         }
     },
     {
+        "event": "await:timeout",
+        "arg": {
+            "name": "userInfo1",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
         "event": "await:finish",
         "arg": {
             "name": "userInfo1",
@@ -63,6 +72,15 @@
         }
     },
     {
+        "event": "await:timeout",
+        "arg": {
+            "name": "userInfo2",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
         "event": "await:finish",
         "arg": {
             "name": "userInfo2",
@@ -81,6 +99,15 @@
         }
     },
     {
+        "event": "await:timeout",
+        "arg": {
+            "name": "userInfo3",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
         "event": "await:finish",
         "arg": {
             "name": "userInfo3",
@@ -91,6 +118,15 @@
     },
     {
         "event": "await:beforeRender",
+        "arg": {
+            "name": "userInfo4",
+            "clientReorder": false,
+            "timedout": true,
+            "finished": true
+        }
+    },
+    {
+        "event": "await:timeout",
         "arg": {
             "name": "userInfo4",
             "clientReorder": false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Opening this for feedback & discussion.  This PR adds `await:error` and `await:timeout` events.  I will add documentation for these before we merge.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To allow applications to listen for errors that occur in an `<await>` tag, even if the error is handled by the template. For logging purposes and such.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

