### PR TITLE
Bug on jQuery Proxy when w-id contains dash/hyphen

### DIFF
--- a/test/autotests/widgets-browser/widget-getEl/template.marko
+++ b/test/autotests/widgets-browser/widget-getEl/template.marko
@@ -1,3 +1,4 @@
 div w-bind
     span.foo w-id="foo"
     span.bar w-id="bar"
+    span.foo-bar w-id="foo-bar"

--- a/test/autotests/widgets-browser/widget-getEl/test.js
+++ b/test/autotests/widgets-browser/widget-getEl/test.js
@@ -4,4 +4,5 @@ module.exports = function(helpers) {
     var widget = helpers.mount(require('./index'), {});
     expect(widget.getEl('foo').className).to.equal('foo');
     expect(widget.getEl('bar').className).to.equal('bar');
+    expect(widget.getEl('foo-bar').className).to.equal('foo-bar');
 };

--- a/test/autotests/widgets-browser/widget-jQuery-proxy/template.marko
+++ b/test/autotests/widgets-browser/widget-jQuery-proxy/template.marko
@@ -1,5 +1,7 @@
 <div class="app-jquery-proxy" w-bind>
     <span w-id="foo">foo</span>
+    <span w-id="foo-text">foo-text</span>
+    <span w-id="fooText">fooText</span>
     <ul w-id="ul">
         <li>red</li>
         <li>green</li>

--- a/test/autotests/widgets-browser/widget-jQuery-proxy/test.js
+++ b/test/autotests/widgets-browser/widget-jQuery-proxy/test.js
@@ -6,6 +6,8 @@ module.exports = function(helpers, done) {
     expect(widget.$().attr('id')).to.equal(widget.id);
     expect(widget.$().attr('class')).to.equal('app-jquery-proxy');
     expect(widget.$('#foo').html()).to.equal('foo');
+    expect(widget.$('#fooText').html()).to.equal('fooText');
+    expect(widget.$('#foo-text').html()).to.equal('foo-text');
     expect(widget.$('#ul li').length).to.equal(3);
     expect(widget.$('button').html()).to.equal('Test Button');
     expect(widget.$('li', 'ul').length).to.equal(3);

--- a/widgets/Widget.js
+++ b/widgets/Widget.js
@@ -33,7 +33,7 @@ var NON_WIDGET_SUBSCRIBE_TO_OPTIONS = {
 
 
 var emit = EventEmitter.prototype.emit;
-var idRegExp = /^\#(\w+)( .*)?/;
+var idRegExp = /^\#(\S+)( .*)?/;
 
 var lifecycleEventMethods = {
     'beforeDestroy': 'onBeforeDestroy',


### PR DESCRIPTION
Bug on jQuery Proxy when w-id contains dash/hyphen, see issue #391 

## Description

Bug on jQuery Proxy when w-id contains dash/hyphen (e.g `w-id="submit-button"`)

## Motivation and Context

This PR contains fix for issue #391 

## Screenshots (if appropriate):
None

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes (comment: not relevant to this issue)
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
