### PR TITLE
Fixes #407 - Allow multiple extensions when installing the Node.js re…

### DIFF
--- a/test/node-require-test.js
+++ b/test/node-require-test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const chai = require('chai');
+chai.Assertion.includeStack = true;
+require('chai').should();
+const expect = require('chai').expect;
+const consolidateExtensions = require('../util/consolidateExtensions');
+
+function testConsolidated(options) {
+    let extension = options.extension;
+    let extensions = options.extensions;
+    let markoExtensionFn = options.markoExtensionFn;
+    let expected = options.expected;
+
+    let requireObj = {
+        extensions: {}
+    };
+
+    consolidateExtensions(extension, extensions, requireObj, markoExtensionFn);
+    expect(requireObj.extensions).to.deep.equal(expected);
+}
+
+describe('node-require' , function() {
+
+    it('should consolidate using both extension and extensions', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            extension: '.marko.xml',
+            extensions: ['.marko', '.html'],
+            markoExtensionFn,
+            expected: {
+                '.marko.xml': markoExtensionFn,
+                '.marko': markoExtensionFn,
+                '.html': markoExtensionFn,
+            }
+        });
+    });
+
+    it('should consolidate using only extensions', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            extensions: ['.marko', '.html'],
+            markoExtensionFn,
+            expected: {
+                '.marko': markoExtensionFn,
+                '.html': markoExtensionFn,
+            }
+        });
+    });
+
+    it('should consolidate using only extension', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            extension: '.marko.xml',
+            markoExtensionFn,
+            expected: {
+                '.marko.xml': markoExtensionFn
+            }
+        });
+    });
+
+    it('should consolidate using extension and empty array of extensions', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            extension: '.marko.xml',
+            extensions: [],
+            markoExtensionFn,
+            expected: {
+                '.marko.xml': markoExtensionFn
+            }
+        });
+    });
+
+    it('should consolidate with .marko when neither extension or extensions provided', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            markoExtensionFn,
+            expected: {
+                '.marko': markoExtensionFn
+            }
+        });
+    });
+
+    it('should insert missing period into extensions', function() {
+        let markoExtensionFn = () => {};
+
+        testConsolidated({
+            extension: 'marko.xml',
+            extensions: ['html'],
+            markoExtensionFn,
+            expected: {
+                '.marko.xml': markoExtensionFn,
+                '.html': markoExtensionFn
+            }
+        });
+    });
+});

--- a/util/consolidateExtensions.js
+++ b/util/consolidateExtensions.js
@@ -1,0 +1,30 @@
+function applyPeriodToExtension(extension) {
+    if (extension.charAt(0) !== '.') {
+        extension = '.' + extension;
+    }
+    return extension;
+}
+
+/**
+ * Consolidate extension and extensions properties provided to node-require
+ *
+ * @param  {String} extension - Single extension
+ * @param  {String[]} extensions - Array of extensions
+ * @param  {Object} requireObj - Node.js require
+ * @param  {Function} extensionFn - Function to set the function extension to
+ */
+module.exports = function(extension, extensions, requireObj, extensionFn) {
+    if ((extension || (!extensions || !extensions.length)) && !requireObj.extensions[extension]) {
+        extension = (extension && applyPeriodToExtension(extension)) || '.marko';
+        requireObj.extensions[extension] = extensionFn;
+    }
+
+    if (extensions && extensions.length) {
+        extensions.forEach((extension) => {
+            extension = applyPeriodToExtension(extension);
+            if (!requireObj.extensions[extension]) {
+                requireObj.extensions[extension] = extensionFn;
+            }
+        });
+    }
+};


### PR DESCRIPTION
`extension` and `extensions` properties are both now supported and consolidated. A few things to discuss:

- The consolidation function takes a `requireObj`, which is the Node.js `require` in `node-require.js`. I did this so it was easy to mock in a unit test without having to pollute the actual `require` object.
- I put `consolidateExtensions.js` in a new folder `util/`. I am open to other suggestions as to where to put this module. I do like the idea of having a `util/` folder at the top-level though.