### PR TITLE
updated render api. fixes #389.

### DIFF
--- a/runtime/html/AsyncStream.js
+++ b/runtime/html/AsyncStream.js
@@ -2,8 +2,8 @@
 var EventEmitter = require('events').EventEmitter;
 var StringWriter = require('./StringWriter');
 var BufferedWriter = require('./BufferedWriter');
-var extend = require('raptor-util/extend');
 var documentProvider = require('../document-provider');
+var RenderResult = require('../RenderResult');
 var helpers;
 
 var voidWriter = { write:function(){} };
@@ -471,6 +471,22 @@ var proto = AsyncStream.prototype = {
         return this.getOutput();
     },
 
+    then: function(fn, fnErr) {
+        var out = this;
+        var promise = new Promise(function(resolve, reject) {
+            out.on('error', reject);
+            out.on('finish', function() {
+                resolve(new RenderResult(out));
+            });
+        });
+
+        return Promise.resolve(promise).then(fn, fnErr);
+    },
+
+    catch: function(fnErr) {
+        return this.then(undefined, fnErr);
+    },
+
     // END DOM METHODS
 
     // Deprecated BEGIN:
@@ -497,8 +513,6 @@ var proto = AsyncStream.prototype = {
 
 // alias:
 proto.w = proto.write;
-
-extend(proto, require('../OutMixins'));
 
 module.exports = AsyncStream;
 

--- a/runtime/html/index.js
+++ b/runtime/html/index.js
@@ -1,6 +1,7 @@
 'use strict';
 // helpers provide a core set of various utility methods to compiled templates
 var helpers;
+var RenderResult = require('../RenderResult');
 
 /**
  * Method is for internal usage only. This method
@@ -49,7 +50,7 @@ Template.prototype = {
         out.sync();
 
         this._(localData, out);
-        return out.getOutput();
+        return new RenderResult(out);
     },
 
     /**
@@ -94,7 +95,7 @@ Template.prototype = {
                 if (callback) {
                     out
                         .on('finish', function() {
-                            callback(null, out.getOutput(), out);
+                            callback(null, new RenderResult(out), out);
                         })
                         .once('error', callback);
                 }
@@ -119,7 +120,7 @@ Template.prototype = {
         if (callback) {
             finalOut
                 .on('finish', function() {
-                    callback(null, finalOut.getOutput(), finalOut);
+                    callback(null, new RenderResult(finalOut), finalOut);
                 })
                 .once('error', callback);
         }

--- a/runtime/vdom/index.js
+++ b/runtime/vdom/index.js
@@ -2,6 +2,7 @@
 // helpers provide a core set of various utility methods
 // that are available in every template
 var helpers;
+var RenderResult = require('../RenderResult');
 
 /**
  * Method is for internal usage only. This method
@@ -9,7 +10,7 @@ var helpers;
  * it is used to create a new Template instance.
  * @private
  */
- exports.c = function createTemplate(path) {
+exports.c = function createTemplate(path) {
      return new Template(path);
 };
 
@@ -45,7 +46,7 @@ Template.prototype = {
         var out = new AsyncVDOMBuilder(globalData);
         out.sync();
         this._(localData, out);
-        return out.getOutput();
+        return new RenderResult(out);
     },
 
     /**
@@ -90,7 +91,7 @@ Template.prototype = {
                 if (callback) {
                     out
                         .on('finish', function() {
-                            callback(null, out.getOutput(), out);
+                            callback(null, new RenderResult(out), out);
                         })
                         .once('error', callback);
                 }
@@ -113,7 +114,7 @@ Template.prototype = {
         if (callback) {
             finalOut
                 .on('finish', function() {
-                    callback(null, finalOut.getOutput(), finalOut);
+                    callback(null, new RenderResult(finalOut), out);
                 })
                 .once('error', callback);
         }

--- a/test/AsyncStream-test.js
+++ b/test/AsyncStream-test.js
@@ -31,7 +31,7 @@ function createAsyncStream(options) {
     }
 }
 
-describe('async-writer' , function() {
+describe('AsyncStream', function() {
 
     beforeEach(function(done) {
         // for (var k in require.cache) {
@@ -63,10 +63,10 @@ describe('async-writer' , function() {
         out.write('1');
         out.write('2');
 
-        return out.end().then((data) => {
+        return out.end().then((result) => {
             const output = out.getOutput();
             expect(output).to.equal('12');
-            expect(data.getOutput()).to.equal('12');
+            expect(result.toString()).to.equal('12');
         });
     });
 

--- a/test/AsyncVDOMBuilder-test.js
+++ b/test/AsyncVDOMBuilder-test.js
@@ -2,128 +2,133 @@ var AsyncVDOMBuilder = require('../runtime/vdom/AsyncVDOMBuilder');
 var HTMLElement = require('../runtime/vdom/HTMLElement');
 var expect = require('chai').expect;
 
-it('sync', function() {
-    var out = new AsyncVDOMBuilder();
-    out.element('div', {}, 0);
-    var tree = out.getOutput();
-    expect(tree.childNodes.length).to.equal(1);
-});
-
-it('end, then listen for finish', function(done) {
-    var out = new AsyncVDOMBuilder();
-    out.element('div', {}, 0);
-    out.end();
-    out.on('finish', function(tree) {
-        expect(tree.childNodes.length).to.equal(1);
-        done();
-    });
-});
-
-it('async', function(done) {
-    var out = new AsyncVDOMBuilder();
-    out.element('div', {}, 0);
-    var asyncOut = out.beginAsync();
-
-    setTimeout(function() {
-        asyncOut.element('span', {}, 0);
-        asyncOut.end();
-    }, 10);
-
-    out.element('section', {}, 0);
-
-    out.end();
-    out.on('finish', function(tree) {
-        expect(tree.childNodes.length).to.equal(3);
-        expect(tree.firstChild.nodeName).to.equal('div');
-        expect(tree.firstChild.nextSibling.nodeName).to.equal('span');
-        expect(tree.firstChild.nextSibling.nextSibling.nodeName).to.equal('section');
-        done();
-    });
-});
-
-it('promise', function(done) {
-    const out = new AsyncVDOMBuilder();
-    out.element('div', {}, 0);
-    out.end().then((tree) => {
-        expect(tree.childNodes.length).to.equal(1);
-        done();
-    });
-});
-
-it('async flush', function(done) {
-    var out = new AsyncVDOMBuilder();
-    out.on('update', function(tree) {
+describe('AsyncVDOMBuilder', function() {
+    it('sync', function() {
+        var out = new AsyncVDOMBuilder();
+        out.element('div', {}, 0);
+        var tree = out.getOutput();
         expect(tree.childNodes.length).to.equal(1);
     });
-    out.once('finish', function(tree) {
-        expect(tree.childNodes.length).to.equal(2);
-        done();
+
+    it('end, then listen for finish', function(done) {
+        var out = new AsyncVDOMBuilder();
+        out.element('div', {}, 0);
+        out.end();
+        out.on('finish', function(result) {
+            expect(result.getOutput().childNodes.length).to.equal(1);
+            done();
+        });
     });
 
-    out.element('div', {}, 0);
-    out.flush();
+    it('async', function(done) {
+        var out = new AsyncVDOMBuilder();
+        out.element('div', {}, 0);
+        var asyncOut = out.beginAsync();
 
-    var asyncOut = out.beginAsync();
+        setTimeout(function() {
+            asyncOut.element('span', {}, 0);
+            asyncOut.end();
+        }, 10);
 
-    setTimeout(function() {
-        asyncOut.element('span', {}, 0);
-        asyncOut.end();
-    }, 10);
+        out.element('section', {}, 0);
 
-    out.end();
-});
-
-it('for loop', function(done) {
-    var out = new AsyncVDOMBuilder();
-    out.once('finish', function(tree) {
-        var header = tree.childNodes[0];
-        var list = tree.childNodes[1];
-        var paragraph = tree.childNodes[2];
-        expect(header.nodeName).to.equal('h1');
-        expect(list.nodeName).to.equal('ul');
-        expect(list.childNodes.length).to.equal(10);
-        expect(paragraph.nodeName).to.equal('p');
-        done();
+        out.end();
+        out.on('finish', function(result) {
+            var tree = result.getOutput();
+            expect(tree.childNodes.length).to.equal(3);
+            expect(tree.firstChild.nodeName).to.equal('div');
+            expect(tree.firstChild.nextSibling.nodeName).to.equal('span');
+            expect(tree.firstChild.nextSibling.nextSibling.nodeName).to.equal('section');
+            done();
+        });
     });
 
-    out.element('h1', {}, 0);
-
-    out.beginElement('ul', {});
-
-    for(var i = 0; i < 10; i++) {
-        out.element('li', {}, 1).t(i);
-    }
-
-    out.endElement();
-
-    out.element('p', {}, 0);
-
-    out.end();
-});
-
-it('staticNode, text, comment', function(done) {
-    var staticNode = new HTMLElement('div', {}, 0, 'f891ea3');
-    var out = new AsyncVDOMBuilder();
-
-    out.node(staticNode);
-    out.text('Hello <em>World</em>');
-    out.comment('TODO: make this work');
-    out.end();
-
-    out.once('finish', function(tree) {
-        expect(tree.childNodes[0].nodeName).to.equal('div');
-        expect(tree.childNodes[1].nodeValue).to.equal('Hello <em>World</em>');
-        expect(tree.childNodes[2].nodeValue).to.equal('TODO: make this work');
-        done();
+    it('promise', function(done) {
+        const out = new AsyncVDOMBuilder();
+        out.element('div', {}, 0);
+        out.end().then((result) => {
+            expect(result.getOutput().childNodes.length).to.equal(1);
+            done();
+        }).catch(done);
     });
-});
 
-// it('should handle timeouts correctly');
-//
-// it('should handle sync errors correctly');
-//
-// it('should handle timeout errors correctly');
-//
-// it('should avoid writes after end');
-//
-// it('globals');
+    it('async flush', function(done) {
+        var out = new AsyncVDOMBuilder();
+        out.on('update', function(result) {
+            expect(result.getOutput().childNodes.length).to.equal(1);
+        });
+        out.once('finish', function(result) {
+            expect(result.getOutput().childNodes.length).to.equal(2);
+            done();
+        });
+
+        out.element('div', {}, 0);
+        out.flush();
+
+        var asyncOut = out.beginAsync();
+
+        setTimeout(function() {
+            asyncOut.element('span', {}, 0);
+            asyncOut.end();
+        }, 10);
+
+        out.end();
+    });
+
+    it('for loop', function(done) {
+        var out = new AsyncVDOMBuilder();
+        out.once('finish', function(result) {
+            var tree = result.getOutput();
+            var header = tree.childNodes[0];
+            var list = tree.childNodes[1];
+            var paragraph = tree.childNodes[2];
+            expect(header.nodeName).to.equal('h1');
+            expect(list.nodeName).to.equal('ul');
+            expect(list.childNodes.length).to.equal(10);
+            expect(paragraph.nodeName).to.equal('p');
+            done();
+        });
+
+        out.element('h1', {}, 0);
+
+        out.beginElement('ul', {});
+
+        for(var i = 0; i < 10; i++) {
+            out.element('li', {}, 1).t(i);
+        }
+
+        out.endElement();
+
+        out.element('p', {}, 0);
+
+        out.end();
+    });
+
+    it('staticNode, text, comment', function(done) {
+        var staticNode = new HTMLElement('div', {}, 0, 'f891ea3');
+        var out = new AsyncVDOMBuilder();
+
+        out.node(staticNode);
+        out.text('Hello <em>World</em>');
+        out.comment('TODO: make this work');
+        out.end();
+
+        out.once('finish', function(result) {
+            var tree = result.getOutput();
+            expect(tree.childNodes[0].nodeName).to.equal('div');
+            expect(tree.childNodes[1].nodeValue).to.equal('Hello <em>World</em>');
+            expect(tree.childNodes[2].nodeValue).to.equal('TODO: make this work');
+            done();
+        });
+    });
+
+    // it('should handle timeouts correctly');
+    //
+    // it('should handle sync errors correctly');
+    //
+    // it('should handle timeout errors correctly');
+    //
+    // it('should avoid writes after end');
+    //
+    // it('globals');
+});

--- a/test/async-fragments-deprecated-test.js
+++ b/test/async-fragments-deprecated-test.js
@@ -67,10 +67,12 @@ describe('async-fragments (deprecated)', function() {
                 addEventListener('asyncFragmentBeforeRender');
                 addEventListener('asyncFragmentFinish');
 
-                template.render(templateData, out, function(err, html) {
+                template.render(templateData, out, function(err, result) {
                     if (err) {
                         return done(err);
                     }
+
+                    var html = result.toString();
 
                     if (main.checkHtml) {
                         main.checkHtml(html);

--- a/test/autotests/api/load-render-callback/test.js
+++ b/test/autotests/api/load-render-callback/test.js
@@ -5,13 +5,13 @@ exports.check = function(marko, markoCompiler, expect, done) {
     template.render({
             name: 'John'
         },
-        function(err, html, out) {
+        function(err, result, out) {
             if (err) {
                 return done(err);
             }
 
-            expect(html).to.equal(out.getOutput());
-            expect(html).to.equal('Hello John!');
+            expect(result.toString()).to.equal(out.getOutput());
+            expect(result.toString()).to.equal('Hello John!');
             done();
         });
 };

--- a/test/autotests/api/load-render-promise/test.js
+++ b/test/autotests/api/load-render-promise/test.js
@@ -7,8 +7,8 @@ exports.check = function(marko, markoCompiler, expect, done) {
 
     template.render({
         name: 'John'
-    }).then((out) => {
-        expect(out.getOutput()).to.equal('Hello John!');
+    }).then((result) => {
+        expect(result.toString()).to.equal('Hello John!');
         done();
     }).catch((err) => {
         done(err);

--- a/test/autotests/api/load-source/test.js
+++ b/test/autotests/api/load-source/test.js
@@ -8,12 +8,12 @@ exports.check = function(marko, markoCompiler, expect, done) {
     // Make sure calling load with templatePath:String, templateSrc:String arguments works
     templatePath = nodePath.join(__dirname, 'dummy.marko');
     template = marko.load(templatePath, '- Hello $!{data.name}!');
-    expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
 
     // Make sure calling load with templatePath:String, templateSrc:String, options:Object arguments works
     templatePath = nodePath.join(__dirname, 'dummy.marko');
     template = marko.load(templatePath, '- Hello $!{data.name}!', {});
-    expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
 
     // Make sure calling load with templatePath:String, options:Object arguments works
     delete markoCompiler.defaultOptions.writeToDisk;
@@ -30,6 +30,6 @@ exports.check = function(marko, markoCompiler, expect, done) {
     template = marko.load(templatePath, {writeToDisk: false});
     expect(fs.existsSync(compiledPath)).to.equal(false);
     expect(template.render).to.be.a('function');
-    expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
     done();
 };

--- a/test/autotests/api/no-write-to-disk-load/test.js
+++ b/test/autotests/api/no-write-to-disk-load/test.js
@@ -9,7 +9,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
         var template = marko.load(templatePath);
         expect(fs.existsSync(compiledPath)).to.equal(false);
         expect(template.render).to.be.a('function');
-        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+        expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
     } finally {
         markoCompiler.defaultOptions.writeToDisk = true;
     }

--- a/test/autotests/api/no-write-to-disk-require/test.js
+++ b/test/autotests/api/no-write-to-disk-require/test.js
@@ -9,7 +9,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
         var template = require(templatePath);
         expect(fs.existsSync(compiledPath)).to.equal(false);
         expect(template.render).to.be.a('function');
-        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+        expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
     } finally {
         markoCompiler.defaultOptions.writeToDisk = true;
     }

--- a/test/autotests/api/render-callback-args/test.js
+++ b/test/autotests/api/render-callback-args/test.js
@@ -3,8 +3,8 @@ exports.check = function(marko, markoCompiler, expect, done) {
     var data = {
         name: 'John'
     };
-    template.render(data, function(error, html, out) {
-        expect(html).to.equal('Hello John!');
+    template.render(data, function(error, result, out) {
+        expect(result.toString()).to.equal('Hello John!');
         expect(out != null).to.equal(true);
         done();
     });

--- a/test/autotests/api/render-callback-global-data/test.js
+++ b/test/autotests/api/render-callback-global-data/test.js
@@ -8,8 +8,8 @@ exports.check = function(marko, markoCompiler, expect, done) {
             greeting: 'Greetings'
         }
     };
-    template.render(data, function(error, output) {
-        expect(output).to.equal('Greetings John!');
+    template.render(data, function(error, result) {
+        expect(result.toString()).to.equal('Greetings John!');
         done();
     });
 };

--- a/test/autotests/api/renderSync-global-data/test.js
+++ b/test/autotests/api/renderSync-global-data/test.js
@@ -8,7 +8,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
           greeting: 'Greetings'
       }
     };
-    var output = template.renderSync(data);
-    expect(output).to.equal('Greetings John!');
+    var result = template.renderSync(data);
+    expect(result.toString()).to.equal('Greetings John!');
     done();
 };

--- a/test/autotests/api/renderSync-no-data/test.js
+++ b/test/autotests/api/renderSync-no-data/test.js
@@ -2,7 +2,7 @@ var nodePath = require('path');
 
 exports.check = function(marko, markoCompiler, expect, done) {
     var template = marko.load(nodePath.join(__dirname, 'template.marko'));
-    var output = template.renderSync();
-    expect(output).to.equal('Hello!');
+    var result = template.renderSync();
+    expect(result.toString()).to.equal('Hello!');
     done();
 };

--- a/test/autotests/api/renderSync/test.js
+++ b/test/autotests/api/renderSync/test.js
@@ -2,7 +2,7 @@ var nodePath = require('path');
 
 exports.check = function(marko, markoCompiler, expect, done) {
     var template = marko.load(nodePath.join(__dirname, 'template.marko'));
-    var output = template.renderSync({ name: 'John' });
-    expect(output).to.equal('Hello John!');
+    var result = template.renderSync({ name: 'John' });
+    expect(result.toString()).to.equal('Hello John!');
     done();
 };

--- a/test/autotests/api/require-compiled-template/test.js
+++ b/test/autotests/api/require-compiled-template/test.js
@@ -10,12 +10,12 @@ exports.check = function(marko, markoCompiler, expect, done) {
     template.render({
             name: 'John'
         },
-        function(err, output) {
+        function(err, result) {
             if (err) {
                 return done(err);
             }
 
-            expect(output).to.equal('Hello John!');
+            expect(result.toString()).to.equal('Hello John!');
             done();
         });
 };

--- a/test/autotests/api/require-render-callback/test.js
+++ b/test/autotests/api/require-render-callback/test.js
@@ -7,12 +7,12 @@ exports.check = function(marko, markoCompiler, expect, done) {
         {
             name: 'John'
         },
-        function(err, output) {
+        function(err, result) {
             if (err) {
                 return done(err);
             }
 
-            expect(output).to.equal('Hello John!');
+            expect(result.toString()).to.equal('Hello John!');
             done();
         });
 };

--- a/test/autotests/api/write-to-disk-load/test.js
+++ b/test/autotests/api/write-to-disk-load/test.js
@@ -8,7 +8,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
     compiledPath = nodePath.join(__dirname, 'template.marko.js');
     var template = marko.load(templatePath);
     expect(fs.existsSync(compiledPath)).to.equal(true);
-    expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
 
     done();
 };

--- a/test/autotests/api/write-to-disk-require/test.js
+++ b/test/autotests/api/write-to-disk-require/test.js
@@ -10,7 +10,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
         var template = require(templatePath);
         delete require.cache[templatePath];
         expect(fs.existsSync(compiledPath)).to.equal(true);
-        expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+        expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
     } finally {
         fs.unlinkSync(compiledPath);
     }

--- a/test/autotests/api/writeToDisk-false-include/test.js
+++ b/test/autotests/api/writeToDisk-false-include/test.js
@@ -9,7 +9,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
 
     var templatePath = nodePath.join(__dirname, 'template.marko');
     var template = marko.load(templatePath);
-    expect(template.renderSync({name: 'Frank'})).to.equal('Hello Frank!');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('Hello Frank!');
 
     markoCompiler.configure({
         writeToDisk: false

--- a/test/autotests/api/writeToDisk-false-layout/test.js
+++ b/test/autotests/api/writeToDisk-false-layout/test.js
@@ -9,7 +9,7 @@ exports.check = function(marko, markoCompiler, expect, done) {
 
     var templatePath = nodePath.join(__dirname, 'template.marko');
     var template = marko.load(templatePath);
-    expect(template.renderSync({name: 'Frank'})).to.equal('<div>Hello Frank!</div>');
+    expect(template.renderSync({name: 'Frank'}).toString()).to.equal('<div>Hello Frank!</div>');
 
     markoCompiler.configure({
         writeToDisk: false

--- a/test/autotests/hot-reload/load/test.js
+++ b/test/autotests/hot-reload/load/test.js
@@ -10,13 +10,13 @@ exports.check = function(marko, hotReload, expect) {
 
     var template = marko.load(tempTemplatePath);
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!');
 
     fs.writeFileSync(tempTemplatePath, templateSrc + '!', { encoding: 'utf8' });
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!');
 
     hotReload.handleFileModified(tempTemplatePath);
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!!');
 };

--- a/test/autotests/hot-reload/require/test.js
+++ b/test/autotests/hot-reload/require/test.js
@@ -10,13 +10,13 @@ exports.check = function(marko, hotReload, expect) {
 
     var template = require(tempTemplatePath);
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!');
 
     fs.writeFileSync(tempTemplatePath, templateSrc + '!', { encoding: 'utf8' });
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!');
 
     hotReload.handleFileModified(tempTemplatePath);
 
-    expect(template.renderSync({ name: 'John' })).to.equal('Hello John!!');
+    expect(template.renderSync({ name: 'John' }).toString()).to.equal('Hello John!!');
 };

--- a/test/autotests/inline/multiple-templates-custom-tags/index.js
+++ b/test/autotests/inline/multiple-templates-custom-tags/index.js
@@ -9,5 +9,5 @@ module.exports = function() {
         test-bar
         test-bar`;
 
-    return template1.renderSync() + '\n' + template2.renderSync();
+    return template1.renderSync().toString() + '\n' + template2.renderSync().toString();
 };

--- a/test/autotests/widgets-browser-deprecated/widget-render-to-iframe/index.js
+++ b/test/autotests/widgets-browser-deprecated/widget-render-to-iframe/index.js
@@ -5,7 +5,7 @@ module.exports = require('marko/widgets').defineComponent({
 
 	renderIntoIframe: function() {
 		var frameEl = this.getFrameEl();
-		return iframeContentComponent.render({})
+		return iframeContentComponent.renderSync({})
             .appendTo(frameEl.contentWindow.document.body)
             .getWidget();
 	},

--- a/test/autotests/widgets-browser/widget-render-to-iframe/index.js
+++ b/test/autotests/widgets-browser/widget-render-to-iframe/index.js
@@ -5,7 +5,7 @@ module.exports = require('marko/widgets').defineComponent({
 
 	renderIntoIframe: function() {
 		var frameEl = this.getFrameEl();
-		return iframeContentComponent.render({})
+		return iframeContentComponent.renderSync({})
             .appendTo(frameEl.contentWindow.document.body)
             .getWidget();
 	},

--- a/test/autotests/widgets-pages/server-browser-unique-ids/tests.js
+++ b/test/autotests/widgets-pages/server-browser-unique-ids/tests.js
@@ -6,7 +6,7 @@ describe(path.basename(__dirname), function() {
     it('should generate a unique ID that is different for a UI component rendered on the server and browser', function() {
 
         var serverFooWidget = window.fooWidget;
-        var browserFooWidget = appFooComponent.render({}).appendTo(document.body).getWidget();
+        var browserFooWidget = appFooComponent.renderSync({}).appendTo(document.body).getWidget();
         expect(browserFooWidget.id).to.be.a('string');
         expect(serverFooWidget.id).to.be.a('string');
         expect(serverFooWidget.id).to.not.equal(browserFooWidget.id);

--- a/test/inline-test.js
+++ b/test/inline-test.js
@@ -35,22 +35,22 @@ describe('inline', function() {
 
         var func = require(outputFile);
 
-        function handleOutput(html) {
-            helpers.compare(html, '.html');
+        function handleOutput(result) {
+            helpers.compare(result.toString(), '.html');
             done();
         }
 
         if (func.length === 1) {
-            func((err, html) => {
+            func((err, result) => {
                 if (err) {
                     return done(err);
                 }
 
-                handleOutput(html);
+                handleOutput(result);
             });
         } else {
-            let outputHtml = func();
-            handleOutput(outputHtml);
+            let result = func();
+            handleOutput(result);
         }
 
 

--- a/test/util/BrowserHelpers.js
+++ b/test/util/BrowserHelpers.js
@@ -29,7 +29,7 @@ BrowserHelpers.prototype = {
     },
 
     mount: function(component, input) {
-        var renderResult = component.render(input)
+        var renderResult = component.renderSync(input)
             .appendTo(this.targetEl);
 
         var widget;

--- a/test/util/runRenderTest.js
+++ b/test/util/runRenderTest.js
@@ -140,10 +140,12 @@ module.exports = function runRenderTest(dir, helpers, done, options) {
                 asyncEventsVerifier = createAsyncVerifier(main, helpers, out);
             }
 
-            template.render(templateData, out, function(err, renderOutput) {
+            template.render(templateData, out, function(err, renderResult) {
                 if (err) {
                     return done(err);
                 }
+
+                var renderOutput = renderResult.getOutput();
 
                 if (isVDOM) {
                     let vdomTree = renderOutput;

--- a/widgets/Widget.js
+++ b/widgets/Widget.js
@@ -3,6 +3,7 @@ var inherit = require('raptor-util/inherit');
 var dom = require('./dom');
 var markoWidgets = require('./');
 var EventEmitter = require('events').EventEmitter;
+var RenderResult = require('../runtime/RenderResult');
 var listenerTracker = require('listener-tracker');
 var arrayFromArguments = require('raptor-util/arrayFromArguments');
 var extend = require('raptor-util/extend');
@@ -551,6 +552,7 @@ Widget.prototype = widgetProto = {
             var createOut = renderer.createOut || marko.createOut;
             var out = createOut(globalData);
             renderer(templateData, out);
+            var result = new RenderResult(out);
 
             var targetNode;
 
@@ -633,7 +635,7 @@ Widget.prototype = widgetProto = {
             });
 
             // Trigger any 'onUpdate' events for all of the rendered widgets
-            out.afterInsert(elToReplace);
+            result.afterInsert(elToReplace);
 
             self.__lifecycleState = null;
 

--- a/widgets/defineWidget-browser.js
+++ b/widgets/defineWidget-browser.js
@@ -26,6 +26,7 @@ module.exports = function defineWidget(def, renderer) {
         return {
             renderer: renderer,
             render: renderer.render,
+            renderSync: renderer.renderSync,
             extendWidget: function(widget) {
                 extendWidget(widget);
                 widget.renderer = renderer;
@@ -105,6 +106,7 @@ module.exports = function defineWidget(def, renderer) {
         // new widget constructor function
         Widget.renderer = proto.renderer = renderer;
         Widget.render = renderer.render;
+        Widget.renderSync = renderer.renderSync;
     }
 
     return Widget;

--- a/widgets/defineWidget.js
+++ b/widgets/defineWidget.js
@@ -23,7 +23,8 @@ module.exports = function defineWidget(def, renderer) {
         return {
             _isWidget: true,
             renderer: renderer,
-            render: renderer.render
+            render: renderer.render,
+            renderSync: renderer.renderSync
         };
     } else {
         return {_isWidget: true};

--- a/widgets/renderable.js
+++ b/widgets/renderable.js
@@ -1,13 +1,34 @@
 var marko = require('marko');
+var RenderResult = require('../runtime/RenderResult');
 
 module.exports = function(target, renderer) {
     var rendererFunc = renderer.renderer || renderer.render || renderer;
     var createOut = renderer.createOut || marko.createOut;
 
     target.renderer = rendererFunc;
-    target.render = function(input) {
+
+    target.render = function(input, cb) {
         var out = createOut();
         rendererFunc(input, out);
-        return out.end();
+        out.end();
+
+        if(cb) {
+            out.on('finished', function() {
+                cb(null, new RenderResult(out));
+            });
+            out.on('error', function(err) {
+                cb(err);
+            });
+        }
+
+        return out;
+    };
+
+    target.renderSync = function(input) {
+        var out = createOut();
+        out.sync();
+        rendererFunc(input, out);
+        out.end();
+        return new RenderResult(out);
     };
 };


### PR DESCRIPTION
## Description

Making the render api consistent.

### Sync Render
Rendering synchronously now returns a RenderResult:
```js
var result = template.renderSync({});
result.appendTo(document.body);
result.getWidgets();
// etc.
```

**Differences:**
In v3, we return a string.  In order to make this a more painless switch, I will introduce a `renderToString` method in v3 and prompt users to switch to using that if they need that string output.

### Async Render

Calling `.render()` still returns an out:
```js
var out = template.render({});
out.on('finished', function(out) {
    
});
```

**Differences:**
In v3, there is no value passed to the `finished` event.  No breaking change here.


### Callback 

```js
template.render({}, function(err, result, out) {

});
```

**Differences:**
In v3, the callback is passed the `html` string instead of a RenderResult.  The third parameter, `out` is only passed for legacy reasons.  You can also access it from `result.out`.

### Promise

See also #439, #442.

```js
template.render({}).then(result => result.appendTo(document.body));
```

**Differences:**
In v3, then was not available.  No breaking change here.

### Widgets

`defineRenderer` and `makeRenderable`/`renderable` now include both `render` and `renderSync` that function similarly to above.  I plan to add `renderSync` to `marko-widgets@6` and warn users that are using the api like:

```js
widget.render({}).appendTo(document.body);
```

to switch to 

```js
widget.renderSync({}).appendTo(document.body);
```
or
```js
widget.render({}, function(err, result) {
    result.appendTo(document.body);
});
```

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


@patrick-steele-idem I'd like some eyes on this and the plan described above before merging.
@Hesulan How does the Promise implementation look?
