### PR TITLE
The `<await>` tag should attempt `.then(undefined, ...)` when resolving a thenable if neither `.catch` nor `.fail` is a function

### DIFF
--- a/taglibs/async/await-tag.js
+++ b/taglibs/async/await-tag.js
@@ -24,7 +24,7 @@ function promiseToCallback(promise, callback, thisObj) {
                 callback(err);
             });
         } else {
-            finalPromise = finalPromise.then(void 0, function(err) {
+            finalPromise = finalPromise.then(null, function(err) {
                 callback(err);
             });
         }

--- a/taglibs/async/await-tag.js
+++ b/taglibs/async/await-tag.js
@@ -23,6 +23,10 @@ function promiseToCallback(promise, callback, thisObj) {
             finalPromise = finalPromise.fail(function(err) {
                 callback(err);
             });
+        } else {
+            finalPromise = finalPromise.then(void 0, function(err) {
+                callback(err);
+            });
         }
 
         if (finalPromise.done) {


### PR DESCRIPTION
As discussed in #439, the `Promises/A+` specification explicitly defines `.then` as accepting at least two arguments: `onResolved` and `onRejected`. The `.catch` method is defined by ECMAScript for *native* implementations, but third-party libraries are under no obligation to include it (though *most* do, for convenience and compatibility).

In the interest of caution, this only calls `.then(undefined, onRejected)` if neither `.catch` nor `.fail` is a function. However, in my opinion, it would be completely safe to remove those two calls altogether, as any implementation which is even *remotely* compliant will handle this as expected.