### PR TITLE
Fixes #446 - Normalize the `expected` and `actual` strings during autotests

### DIFF
--- a/test/autotest.js
+++ b/test/autotest.js
@@ -39,11 +39,9 @@ function compareHelper(dir, actual, prefix, suffix) {
         fs.writeFileSync(expectedPath, expectedString, {encoding: 'utf8'});
     }
 
-    if (isObject) {
-        actual = JSON.parse(actualString);
-    }
+    actual = isObject ? JSON.parse(actualString) : actualString.replace(/\r?\n$/, '');
 
-    var expected = isObject ? JSON.parse(expectedString) : expectedString;
+    var expected = isObject ? JSON.parse(expectedString) : expectedString.replace(/\r?\n$/, '');
     assert.deepEqual(actual, expected);
 }
 


### PR DESCRIPTION
The autotest `compareHelper` now normalizes the ending newline of both the `expected` and `actual` strings to avoid test failures when `expected.*` is saved on a POSIX-compliant (non-Windows) OS.