### PR TITLE
add warnings for using render methods when you want string output

### DIFF
--- a/docs/javascript-api.md
+++ b/docs/javascript-api.md
@@ -103,7 +103,7 @@ The `Template` type.
 
 ## Methods
 
-### renderSync(templateData) : String
+### renderToString(templateData) : String
 
 Synchronously renders a template to a `String`.
 
@@ -113,8 +113,23 @@ Example usage:
 
 ```javascript
 var template = require('./template.marko');
-var html = template.renderSync({ name: 'Frank' });
+var html = template.renderToString({ name: 'Frank' });
 console.log(html);
+```
+
+### renderToString(templateData, callback)
+
+Asynchronously renders a template and provides the output to the provided callback function.
+
+```javascript
+var template = require('./template.marko');
+template.renderToString({ name: 'Frank' }, function(err, html, out) {
+	if (err) {
+		// Handle the error...
+	}
+
+	console.log(html);
+});
 ```
 
 ### render(templateData, stream.Writable)
@@ -130,7 +145,7 @@ template.render({ name: 'Frank' }, process.stdout);
 
 ### render(templateData, AsyncWriter)
 
-Renders a template to an [AsyncWriter](https://github.com/marko-js/async-writer) instance that wraps an underlying stream.
+Renders a template to an [AsyncWriter](https://github.com/marko-js/async-writer) instance that wraps an underlying stream.  When rendering to an AsyncWriter, the writer will not be ended, automatically.  You must call `out.end()` yourself.
 
 Example usage:
 
@@ -138,21 +153,7 @@ Example usage:
 var template = require('./template.marko');
 var out = require('marko').createWriter(process.stdout);
 template.render({ name: 'Frank' }, out);
-```
-
-### render(templateData, callback)
-
-Asynchronously renders a template and provides the output to the provided callback function.
-
-```javascript
-var template = require('./template.marko');
-template.render({ name: 'Frank' }, function(err, html, out) {
-	if (err) {
-		// Handel the error...
-	}
-
-	console.log(html);
-});
+out.end();
 ```
 
 _NOTE: The `out` argument will rarely be used, but it will be a reference to the [AsyncWriter](https://github.com/marko-js/async-writer) instance that was created to facilitate rendering of the template._
@@ -167,6 +168,12 @@ Example usage:
 var template = require('./template.marko');
 template.stream({ name: 'Frank' }).pipe(process.stdout);
 ```
+
+### renderSync(templateData) : String
+> Deprecated in v3, use `renderToString(templateData)` instead.
+
+### render(templateData, callback)
+> Deprecated in v3, use `renderToString(templateData, callback)` instead.
 
 # require('marko/compiler')
 

--- a/runtime/deprecate.js
+++ b/runtime/deprecate.js
@@ -30,7 +30,7 @@ function warn(message) {
         messageCounts[message]++;
         try {
             stack = new Error().stack.split('\n').slice(4).join('\n');
-        } catch(e) {};
+        } catch(e) {}
         logger.warn(red('WARNING!!') + '\n' + message + '\n' + grey(stack || ''));
     }
 

--- a/runtime/deprecate.js
+++ b/runtime/deprecate.js
@@ -23,12 +23,15 @@ function warn(message) {
     if (!logger) return 0;
 
     var maxWarn = 20;
+    var stack;
     messageCounts[message] = messageCounts[message] || 0;
 
     if (messageCounts[message] < maxWarn) {
         messageCounts[message]++;
-        var stack = new Error().stack.split('\n').slice(4).join('\n');
-        logger.warn(red('WARNING!!') + '\n' + message + '\n' + grey(stack));
+        try {
+            stack = new Error().stack.split('\n').slice(4).join('\n');
+        } catch(e) {};
+        logger.warn(red('WARNING!!') + '\n' + message + '\n' + grey(stack || ''));
     }
 
     return maxWarn - messageCounts[message];

--- a/runtime/deprecate.js
+++ b/runtime/deprecate.js
@@ -1,23 +1,75 @@
 var logger = typeof console !== 'undefined' && console.warn && console;
+var messageCounts = {};
 
 module.exports = function(o, methodName, message) {
-    if (!logger) {
-        return;
-    }
+    if (!logger) return;
 
     var originalMethod = o[methodName];
 
-    var maxWarn = 20;
-    var currentWarn = 0;
-
     o[methodName] = function() {
-        if (currentWarn < maxWarn) {
-            if (++currentWarn === maxWarn) {
-                o[methodName] = originalMethod;
-            }
-            logger.warn(message, 'Stack: ' + new Error().stack);
+        var remainingWarns = warn(message);
+
+        if (!remainingWarns) {
+            o[methodName] = originalMethod;
         }
 
-        return originalMethod.apply(o, arguments);
+        return originalMethod.apply(this, arguments);
     };
 };
+
+module.exports.warn = warn;
+
+function warn(message) {
+    if (!logger) return 0;
+
+    var maxWarn = 20;
+    messageCounts[message] = messageCounts[message] || 0;
+
+    if (messageCounts[message] < maxWarn) {
+        messageCounts[message]++;
+        var stack = new Error().stack.split('\n').slice(4).join('\n');
+        logger.warn(red('WARNING!!') + '\n' + message + '\n' + grey(stack));
+    }
+
+    return maxWarn - messageCounts[message];
+}
+
+var canFormat = (function () {
+    try {
+        if (process.stdout && !process.stdout.isTTY) {
+            return false;
+        }
+
+        if (process.platform === 'win32') {
+            return true;
+        }
+
+        if ('COLORTERM' in process.env) {
+            return true;
+        }
+
+        if (process.env.TERM === 'dumb') {
+            return false;
+        }
+
+        if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
+            return true;
+        }
+    } catch(e){}
+
+    return false;
+})();
+
+function format(str, begin, end) {
+    begin = canFormat ? '\u001b['+begin+'m' : '';
+    end = canFormat ? '\u001b['+end+'m' : '';
+    return begin + str + end;
+}
+
+function red(str) {
+    return format(str, 31, 39);
+}
+
+function grey(str) {
+    return format(str, 90, 39);
+}

--- a/runtime/marko-runtime.js
+++ b/runtime/marko-runtime.js
@@ -157,6 +157,11 @@ Template.prototype = {
         var shouldEnd = false;
 
         if (arguments.length === 3) {
+            require('./deprecate').warn(
+                'Support for `render(data, out, callback)` will be removed in v4. ' +
+                'If you would like to discuss, see: https://github.com/marko-js/marko/issues/451'
+            );
+
             // render(data, out, callback)
             if (!finalOut || !finalOut.isAsyncStream) {
                 finalOut = new AsyncStream(globalData, finalOut);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deprecate `renderSync(data)` and `render(data, callback)` in their current forms.  Use `renderToString` instead as v4 will return a `RenderResult` instead of a string.


## Motivation and Context
With this notice in place, there shouldn't be any breaking changes when moving from v3 to v4 that don't already warn you in the current version.


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] No new tests, changes already covered by existing tests.
- [x] All new and existing tests passed.

