### PR TITLE
Remove direct require of test utils from within the compiler

### DIFF
--- a/widgets/taglib/getRequirePath.js
+++ b/widgets/taglib/getRequirePath.js
@@ -1,6 +1,4 @@
 var resolveFrom = require('resolve-from');
-require('require-self-ref');
-require('~/test/util/patch-module');
 
 module.exports = function getRequirePath(target, context) {
     var resolvedTarget = resolveFrom(context.dirname, target);


### PR DESCRIPTION
Fixes a regression which caused the compiler to `require()` both 'require-self-ref' and '~/test/util/patch-module'. This didn't affect the test suite (which already `require()`s both of those modules), but does throw errors when running `marko` as a module. For example:
```
npm install https://github.com/marko-js/marko
./node_modules/.bin/markoc ./template.marko
```
If `require-self-ref` is also installed:
```
Failed to compile "template.marko". Error: Error: Cannot find module '/path/to/node_modules/marko/test/util/patch-module'
```
Otherwise:
```
Failed to compile "template.marko". Error: Error: Cannot find module 'require-self-ref'
```