### PR TITLE
Fixed bug where widgets initialized before the runtime is loaded are lost

### DIFF
--- a/widgets/index.js
+++ b/widgets/index.js
@@ -47,9 +47,9 @@ function writeInitWidgetsCode(widgetsContext, out) {
     var nonceAttr = cspNonce ? ' nonce='+JSON.stringify(cspNonce) : '';
 
     out.write('<script' + nonceAttr + '>' +
-        '(function(){var w=window;(w.$widgets||w.$widgets||(w.$widgets=[])).concat(' +
+        '(function(){var w=window;w.$widgets=((w.$widgets||[]).concat(' +
         warp10.stringify(renderedWidgets).replace(escapeEndingScriptTagRegExp, '\\u003C/') +
-         ')})()</script>');
+         ')||w.$widgets)})()</script>');
 
     widgetsContext.$__clearWidgets();
 }


### PR DESCRIPTION
The widget runtime uses a custom `.concat` method, but the native array `.concat` method returns a new array without modifying the original, which results in `window.$widgets` being an empty array and the init code being lost if the widgets are initialized before the runtime registers its custom method.