### PR TITLE
failing test for for-tag w/ inter-tag spaces

### DIFF
--- a/test/autotests/render/for-tag-spaces/expected.html
+++ b/test/autotests/render/for-tag-spaces/expected.html
@@ -1,0 +1,1 @@
+<div>red</div><div>green</div><div>blue</div>

--- a/test/autotests/render/for-tag-spaces/template.marko
+++ b/test/autotests/render/for-tag-spaces/template.marko
@@ -1,0 +1,5 @@
+<for ( item in ['red', 'green', 'blue'] )>
+    <div>
+        ${item}
+    </div>
+</for>

--- a/test/autotests/render/for-tag-spaces/test.js
+++ b/test/autotests/render/for-tag-spaces/test.js
@@ -1,0 +1,1 @@
+exports.templateData = {};


### PR DESCRIPTION
## Description

marko4 behaviour differs when using `<for ( x in y )>` and currently only supports `<for(x in y)>` (note space differences).

## Motivation and Context

I rarely expect programming languages (and less- templating languages) to be whitespace sensitive.  Whitespace sensitivity in this way requires projects to update all cases of `<for...` and likely would increase adoption / upgrade costs.