### PR TITLE
Fixes #495 - Support import destructuring using a colon.

### DIFF
--- a/taglibs/core/util/parseImport.js
+++ b/taglibs/core/util/parseImport.js
@@ -34,16 +34,16 @@ function getVariableName(moduleSpecifier) {
 }
 
 function getNames(importSpecifier) {
-       var names = importSpecifier.split(/\bas\b/);
+   var names = importSpecifier.split(/\s*(?:\bas\b|:)\s*/);
 
-       if (names.length == 1) {
-            names[1] = names[0];
-       }
+   if (names.length == 1) {
+        names[1] = names[0];
+   }
 
-       return {
-            exported: names[0].trim(),
-            local: names[1].trim()
-       };
+   return {
+        exported: names[0].trim(),
+        local: names[1].trim()
+   };
 }
 
 module.exports = function importToAssignments(tagString) {

--- a/test/autotests/parseImport/parseImport-colon-destructuring-colon-with-alias/expected.json
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-colon-with-alias/expected.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "greetings_module",
+        "value": "./greetings",
+        "module": true
+    },
+    {
+        "name": "hi",
+        "value":{
+            "object": "greetings_module",
+            "property": "hello"
+        }
+    }
+]

--- a/test/autotests/parseImport/parseImport-colon-destructuring-colon-with-alias/input.txt
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-colon-with-alias/input.txt
@@ -1,0 +1,1 @@
+import { hello : hi } from "./greetings"

--- a/test/autotests/parseImport/parseImport-colon-destructuring-no-space/expected.json
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-no-space/expected.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "greetings_module",
+        "value": "./greetings",
+        "module": true
+    },
+    {
+        "name": "hi",
+        "value":{
+            "object": "greetings_module",
+            "property": "hello"
+        }
+    }
+]

--- a/test/autotests/parseImport/parseImport-colon-destructuring-no-space/input.txt
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-no-space/input.txt
@@ -1,0 +1,1 @@
+import { hello:hi } from "./greetings"

--- a/test/autotests/parseImport/parseImport-colon-destructuring-space-after-property/expected.json
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-space-after-property/expected.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "greetings_module",
+        "value": "./greetings",
+        "module": true
+    },
+    {
+        "name": "hi",
+        "value":{
+            "object": "greetings_module",
+            "property": "hello"
+        }
+    }
+]

--- a/test/autotests/parseImport/parseImport-colon-destructuring-space-after-property/input.txt
+++ b/test/autotests/parseImport/parseImport-colon-destructuring-space-after-property/input.txt
@@ -1,0 +1,1 @@
+import { hello :hi } from "./greetings"

--- a/test/autotests/parseImport/parseImport-colon-destructuring/expected.json
+++ b/test/autotests/parseImport/parseImport-colon-destructuring/expected.json
@@ -1,0 +1,14 @@
+[
+    {
+        "name": "greetings_module",
+        "value": "./greetings",
+        "module": true
+    },
+    {
+        "name": "hi",
+        "value":{
+            "object": "greetings_module",
+            "property": "hello"
+        }
+    }
+]

--- a/test/autotests/parseImport/parseImport-colon-destructuring/input.txt
+++ b/test/autotests/parseImport/parseImport-colon-destructuring/input.txt
@@ -1,0 +1,1 @@
+import { hello: hi } from "./greetings"

--- a/test/autotests/render/import-colon/bar.js
+++ b/test/autotests/render/import-colon/bar.js
@@ -1,0 +1,4 @@
+module.exports = {
+    foo: "Foo",
+    b: "Bar"
+};

--- a/test/autotests/render/import-colon/expected.html
+++ b/test/autotests/render/import-colon/expected.html
@@ -1,0 +1,1 @@
+Foo Bar Foo

--- a/test/autotests/render/import-colon/template.marko
+++ b/test/autotests/render/import-colon/template.marko
@@ -1,0 +1,3 @@
+<import mod, { b: bar } from "./bar" />
+<import test from './bar' />
+-- ${mod.foo} ${bar} ${test.foo}


### PR DESCRIPTION
Introduces colon alias destructuring support for `import`:

```javascript
<import { test: testAlias } from './test' } />
```