### PR TITLE
Fix for class attribute so empty arrays are null;

### DIFF
--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -52,7 +52,7 @@ function classListHelper(arg, classNames) {
 function classList(classList) {
     var classNames = [];
     classListHelper(classList, classNames);
-    return classNames.join(' ');
+    return classNames.join(' ') || null;
 }
 
 function createDeferredRenderer(handler) {

--- a/test/autotests/compiler/attr-escape/expected.js
+++ b/test/autotests/compiler/attr-escape/expected.js
@@ -19,7 +19,15 @@ function create(__helpers) {
       str(data.foo) +
       " b\" nested=\"a " +
       str(data.foo + ("nested " + data.bar)) +
-      " b\"></div>");
+      " b\"></div><div" +
+      classAttr([
+        "non",
+        "empty",
+        "array"
+      ]) +
+      "></div><div" +
+      classAttr([]) +
+      "></div>");
   };
 }
 

--- a/test/autotests/compiler/attr-escape/template.marko
+++ b/test/autotests/compiler/attr-escape/template.marko
@@ -5,3 +5,5 @@
     baz="a $!{data.foo} b"
     nested="a $!{data.foo + 'nested ${data.bar}'} b">
 </div>
+<div class=['non','empty','array']></div>
+<div class=[]></div>

--- a/test/autotests/render/class-attr-array/expected.html
+++ b/test/autotests/render/class-attr-array/expected.html
@@ -1,1 +1,1 @@
-<div class="a c"></div>
+<div class="a c"></div><div></div>

--- a/test/autotests/render/class-attr-array/template.marko
+++ b/test/autotests/render/class-attr-array/template.marko
@@ -1,1 +1,2 @@
 div class=['a', null, 'c']
+div class=[]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This fix will ensure that an empty array does not output a an empty class attribute: `class=""`.

## Description
- modified helpers.js line 55 adds ` || null` when the array is empty (because a joined empty array is falsy);
- fixed tests to accommodate

## Motivation and Context
I was attempting to use arrays for class names because of the utility of concatenating them together was taken up by Marko. But, when the array was ever empty, I would have the `class=""` throughout my app, and my tests. This issue added unnecessary bloat. Therefore, the motivation for this fix.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [X] I have updated/added documentation affected by my changes.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
