### PR TITLE
Updated Koa docs to version 2.0 signature

### DIFF
--- a/docs/koa.md
+++ b/docs/koa.md
@@ -1,28 +1,54 @@
-Koa + Marko
-=====================
+# Koa + Marko
 
 ## Installation
 
-```
-npm install koa --save
-npm install marko --save
-```
+    npm install koa --save
+    npm install marko --save
 
 ## Usage
 
 ```javascript
 require('marko/node-require');
 
-var koa = require('koa');
+const Koa = require('koa');
 
-var app = koa();
+const app = new Koa();
 
-app.use(function *() {
-    this.body = template.stream({
+app.use((ctx, next) => {
+    ctx.type = 'html';
+    ctx.body = template.stream({
             name: 'Frank',
             count: 30,
             colors: ['red', 'green', 'blue']
         });
+});
+
+app.listen(8080);
+```
+
+You may also easily add `gzip` streaming support without additional dependencies:
+
+```javascript
+require('marko/node-require');
+const { createGzip } = require('zlib');
+
+const Koa = require('koa');
+
+const app = new Koa();
+
+app.use((ctx, next) => {
+    ctx.type = 'html';
+    ctx.body = template.stream({
+            name: 'Frank',
+            count: 30,
+            colors: ['red', 'green', 'blue']
+        });
+    
+    ctx.vary('Accept-Encoding');
+    if (ctx.acceptsEncodings('gzip')) {
+      ctx.set('Content-Encoding', 'gzip');
+      ctx.body = ctx.body.pipe(createGzip());
+    }
 });
 
 app.listen(8080);


### PR DESCRIPTION
Koa 2.0.1 is released as `latest` version, so, these docs needs to be updated. Also added gzip example to feature Koa + Marko streaming flexibility.