### PR TITLE
extend marko globals with defaults

### DIFF
--- a/components/util-browser.js
+++ b/components/util-browser.js
@@ -1,6 +1,10 @@
-var markoGlobal = window.$MG || (window.$MG = {
-    uid: 0
+var extend = require('raptor-util/extend');
+
+var markoGlobal = extend(window.$MG, {
+  uid: 0
 });
+
+window.$MG = markoGlobal;
 
 var runtimeId = markoGlobal.uid++;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Marko global defaults and user globals aren't merged. If user globals exists the `defaults` are ignored.


## Motivation and Context
Look at https://github.com/marko-js/marko/issues/677

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tests suite doesn't works on windows! I will open an issue for this.