### PR TITLE
Costomize default await timeout

### DIFF
--- a/compiler/config.js
+++ b/compiler/config.js
@@ -26,9 +26,13 @@ if (g.__MARKO_CONFIG) {
         writeToDisk: true,
 
         /**
+         * Default timeout for await tag
+         */
+        awaitTimeout: process.env.MARKO_TIMEOUT || 10000,
+        /**
          * If true, then the compiled template on disk will assumed to be up-to-date if it exists.
          */
-        assumeUpToDate: process.env.MARKO_CLEAN != null || process.env.hasOwnProperty('MARKO_HOT_RELOAD') ? false : ( NODE_ENV == null ? false : (NODE_ENV !== 'development' && NODE_ENV !== 'dev')),
+        assumeUpToDate: process.env.MARKO_CLEAN != null || process.env.hasOwnProperty('MARKO_HOT_RELOAD') ? false : (NODE_ENV == null ? false : (NODE_ENV !== 'development' && NODE_ENV !== 'dev')),
 
         /**
          * If true, whitespace will be preserved in templates. Defaults to false.

--- a/taglibs/async/await-tag.js
+++ b/taglibs/async/await-tag.js
@@ -4,6 +4,7 @@ var logger = require('raptor-logging').logger(module);
 var AsyncValue = require('raptor-async/AsyncValue');
 var isClientReorderSupported = require('./client-reorder').isSupported;
 var nextTick = require('../../runtime/nextTick');
+var awaitTimeout = require('../../compiler/config').awaitTimeout;
 
 function isPromise(o) {
     return o && typeof o.then === 'function';
@@ -12,7 +13,7 @@ function isPromise(o) {
 function safeRenderBody(renderBody, targetOut, data) {
     try {
         renderBody(targetOut, data);
-    } catch(err) {
+    } catch (err) {
         return err;
     }
 }
@@ -52,8 +53,7 @@ function requestData(provider, args, callback, thisObj) {
         if (data !== undefined) {
             if (isPromise(data)) {
                 promiseToCallback(data, callback);
-            }
-            else {
+            } else {
                 callback(null, data);
             }
         }
@@ -148,7 +148,7 @@ module.exports = function awaitTag(input, out) {
         var renderPlaceholder = input.renderPlaceholder;
 
         if (timeout == null) {
-            timeout = 10000;
+            timeout = awaitTimeout;
         } else if (timeout <= 0) {
             timeout = null;
         }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding option to customize default timeout for await tags

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We use await a lot and we need to customize the default await timeout for all await tags and we think this will help us to fix the timeout problem

I've opened an issue asking about this thing #621 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
