### PR TITLE
Don't set `serializedGlobals` properties to `false` after reading them.

### DIFF
--- a/components/taglib/component-globals-tag.js
+++ b/components/taglib/component-globals-tag.js
@@ -17,7 +17,6 @@ function getSerializedGlobals(outGlobal) {
                         serializedGlobals = {};
                     }
                     serializedGlobals[key] = value;
-                    serializedGlobalsLookup[key] = false;
                 }
             }
         }


### PR DESCRIPTION
Currently, this:
```js
app.locals.foo = 'foo!';
app.locals.serializedGlobals = { foo: true };
```
Doesn't work, because [`component-globals-tag.js`](https://github.com/marko-js/marko/blob/master/components/taglib/component-globals-tag.js#L20) sets each property to `false` after reading them. If there's a reason for doing that, I can't find it, and removing that line fixes the problem.