### PR TITLE
Proposition: add docs for Marko + Huncwot integration

### DIFF
--- a/docs/huncwot.md
+++ b/docs/huncwot.md
@@ -1,0 +1,23 @@
+# Huncwot + Marko
+
+See the [marko-huncwot](https://github.com/zaiste/marko-huncwot) sample
+project for a working example.
+
+## Installation
+
+    yarn add huncwot marko
+
+## Usage
+
+```javascript
+require('marko/node-require');
+
+const Huncwot = require('huncwot');
+
+const app = new Huncwot();
+const template = require('./index.marko');
+
+app.get('/', request => template.stream({ name: 'Frank' }))
+
+app.listen(3000);
+```

--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -26,6 +26,7 @@ module.exports = function(req) {
 > - [express](/docs/express)
 > - [hapi](/docs/hapi)
 > - [koa](/docs/koa)
+> - [huncwot](/docs/huncwot)
 
 ## UI Bootstrapping
 

--- a/docs/structure.json
+++ b/docs/structure.json
@@ -23,7 +23,8 @@
     "docs": [
         "Express",
         "Koa",
-        "Hapi"
+        "Hapi",
+        "Huncwot"
     ]
 },{
     "title": "Tooling",


### PR DESCRIPTION
A piece of documentation describing how to use Marko alongside [Huncwot](https://github.com/zaiste/huncwot). I'd be happy to hear your feedback.

## Description
I'm building a library similar to Express and Koa called Huncwot. I'm planning to use Marko as its default (and only) view engine. Huncwot is inspired by Clojure's ring with routes as (pure) functions returning *data* describing responses. In this pull request I'm describing how to use Marko with Huncwot.

## Motivation and Context
Server-side integration example using Huncwot is simpler and requires less code for the same result as in Koa or Express.

## Screenshots (if appropriate):

## Checklist:
- [x] My code follows the code style of this project.
- [X] I have updated/added documentation affected by my changes.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. (N/A)
- [ ] All new and existing tests passed.
