### PR TITLE
Reference app should point to "marko-lasso" because "ui-components-pl…

### DIFF
--- a/docs/lasso.md
+++ b/docs/lasso.md
@@ -4,7 +4,7 @@ The [lasso-marko](https://github.com/lasso-js/lasso-marko) plugin for [Lasso.js]
 
 Lasso.js provides Marko custom tags for injecting JavaScript and CSS bundles, images and other resources.
 
-The sample [ui-components-playground](https://github.com/marko-js-samples/ui-components-playground) app demonstrates how to build a production-ready web application using Marko and Lasso.
+The sample [marko-lasso](https://github.com/marko-js-samples/marko-lasso) app demonstrates how to build a production-ready web application using Marko and Lasso.
 
 ## Installation
 


### PR DESCRIPTION
…ayground" does not contain lasso

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
