### PR TITLE
Use parent module to require express patch

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,7 +1,8 @@
 var isDebug = require('./env').isDebug;
+var parentModule = module.parent;
 
 if (isDebug) {
-    module.exports = require('./src/express');
+    module.exports = parentModule.require('marko/src/express');
 } else {
-    module.exports = require('./dist/express');
+    module.exports = parentModule.require('marko/dist/express');
 }


### PR DESCRIPTION
This fixes the issue with `res.marko` not getting properly patched due to recent changes.

## Description
This change allows the module that is calling `require('marko/express')` to be used when requiring the actual module that performs the patching (`./src/express` or `./dist/express` depending on whether debug mode is enabled). This ensures that the correct instance of express used by the app is getting patched.

## Motivation and Context
Recent changes to the project structure caused `res.marko` to not get properly patched onto express. As a result, tests executed via `marko-devtools` failed to start properly.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [x] All new and existing tests passed.
