### PR TITLE
fixes issue 658 by removing empty style blocks

### DIFF
--- a/src/components/taglib/TransformHelper/handleRootNodes.js
+++ b/src/components/taglib/TransformHelper/handleRootNodes.js
@@ -24,7 +24,7 @@ function handleStyleElement(styleEl, transformHelper) {
         if (name.startsWith('{')) {
             hasStyleBlock = true;
 
-            styleCode = name.slice(1, -1);
+            styleCode = name.slice(1, -1).trim();
         } else if (name === 'class') {
             if (attr.value.type !== 'Literal' || typeof attr.value.value !== 'string') {
                 return;
@@ -39,14 +39,17 @@ function handleStyleElement(styleEl, transformHelper) {
         }
     }
 
-    if (styleCode == null) {
+    if (!styleCode) {
+        if (hasStyleBlock) {
+            styleEl.detach();
+        }
         return;
     }
 
     var context = transformHelper.context;
     context.addDependency({
         type: lang,
-        code: styleCode.trim(),
+        code: styleCode,
         virtualPath: './'+path.basename(context.filename)+'.'+lang,
         path: './'+path.basename(context.filename)
     });

--- a/test/autotests/compiler/style-empty/expected.js
+++ b/test/autotests/compiler/style-empty/expected.js
@@ -1,0 +1,13 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/html").t(__filename);
+
+function render(input, out) {
+  var data = input;
+
+  out.w("<div class=\"test\"></div>");
+}
+
+marko_template._ = render;
+
+marko_template.meta = {};

--- a/test/autotests/compiler/style-empty/template.marko
+++ b/test/autotests/compiler/style-empty/template.marko
@@ -1,0 +1,4 @@
+style.less {
+}
+
+<div class="test"/>


### PR DESCRIPTION
## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] <s>I have updated/added documentation affected by my changes.</s> N/A
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

I think we also need to make a change on the [lasso side](https://github.com/lasso-js/lasso/blob/01dde2dbae025762a98fc09e2306c249eeeb2c19/lib/dependencies/dependency-resource.js#L54-L56): If `code` is an empty string, it doesn't use it and instead tries to read from the filesystem.
