### PR TITLE
Fixes #728 - Do not use module keyword because webpack compiles it to…

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "property-handlers": "^1.0.0",
     "raptor-async": "^1.1.2",
     "raptor-json": "^1.0.1",
-    "raptor-logging": "^1.0.1",
     "raptor-polyfill": "^1.0.0",
     "raptor-promises": "^1.0.1",
     "raptor-regexp": "^1.0.0",

--- a/src/taglibs/async/await-tag.js
+++ b/src/taglibs/async/await-tag.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var logger = require('raptor-logging').logger(module);
 var AsyncValue = require('raptor-async/AsyncValue');
 var isClientReorderSupported = require('./client-reorder').isSupported;
 var nextTick = require('../../runtime/nextTick');
@@ -160,7 +159,7 @@ module.exports = function awaitTag(input, out) {
                 awaitInfo.timedout = true;
 
                 if (renderTimeout) {
-                    logger.error(message);
+                    console.error(message);
                     renderBody(null, null, renderTimeout);
                 } else {
                     renderBody(new Error(message));


### PR DESCRIPTION
See: https://webpack.github.io/docs/api-in-modules.html#module-id 

This is causing https://github.com/raptorjs/raptor-logging/blob/master/lib/raptor-logging-impl.js#L128 to throw an error because it's an object. We should probably add better error handling for this in `raptor-logging`. 

When using `module`, webpack eventually transforms the code to an object that looks like:

```
{ 
  i: 38,
  l: false,
  exports: {},
  deprecate: [Function],
  paths: [],
  children: [],
  loaded: [Getter],
  id: [Getter],
  webpackPolyfill: 1 
}
```

...when a normal Node.js `module` looks like:

```
{
  id: '.',
  exports: {},
  parent: null,
  filename: '/path/to/file.js',
  loaded: false,
  children: [],
  paths: [... ] 
}
```

`raptor-logging` tries to create the logger name based on `module.filename` if the logger passed to the `.logger(module)` function call is an object. Webpack does not expose enough information to create the logger name. We could have `raptor-logging` fall back to `id`, but that's not very helpful and is kind of awkward.

Ultimately, I think the below change should happen anyway. We are not using `raptor-logging` anywhere in the codebase except for this file. Typically we just use `console`.