### PR TITLE
Fixes #755 - Allow diffing of HTML, head, and body.

### DIFF
--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -547,23 +547,31 @@ Component.prototype = componentProto = {
                 var fromEl;
 
                 var targetEl = targetNode.___firstChild;
-                while(targetEl) {
-                    var id = targetEl.id;
+                while (targetEl) {
+                    var nodeName = targetEl.___nodeName;
 
-                    if (id) {
-                        fromEl = fromEls[id];
-                        if (fromEl) {
-                            morphdom(
-                                fromEl,
-                                targetEl,
-                                globalComponentsContext,
-                                onNodeAdded,
-                                onBeforeElUpdated,
-                                onBeforeNodeDiscarded,
-                                onNodeDiscarded,
-                                onBeforeElChildrenUpdated);
-                        }
+                    if (nodeName === 'HTML') {
+                        fromEl = document.documentElement;
+                    } else if (nodeName === 'BODY') {
+                        fromEl = document.body;
+                    } else if (nodeName === 'HEAD') {
+                        fromEl = document.head;
+                    } else {
+                        fromEl = fromEls[targetEl.id];
                     }
+
+                    if (fromEl) {
+                        morphdom(
+                            fromEl,
+                            targetEl,
+                            globalComponentsContext,
+                            onNodeAdded,
+                            onBeforeElUpdated,
+                            onBeforeNodeDiscarded,
+                            onNodeDiscarded,
+                            onBeforeElChildrenUpdated);
+                    }
+
                     targetEl = targetEl.___nextSibling;
                 }
             }

--- a/src/taglibs/async/noop-render.js
+++ b/src/taglibs/async/noop-render.js
@@ -1,0 +1,1 @@
+module.exports = function (input, out) {};

--- a/src/taglibs/async/package.json
+++ b/src/taglibs/async/package.json
@@ -1,5 +1,6 @@
 {
     "browser": {
-        "./client-reorder.js": "./client-reorder-browser.js"
+        "./client-reorder.js": "./client-reorder-browser.js",
+        "./await-reorderer-tag.js": "./noop-render.js"
     }
 }

--- a/src/taglibs/svg/marko.json
+++ b/src/taglibs/svg/marko.json
@@ -71,7 +71,6 @@
     "<symbol>": { "html": true, "htmlType": "svg" },
     "<text>": { "html": true, "htmlType": "svg" },
     "<textPath>": { "html": true, "htmlType": "svg" },
-    "<title>": { "html": true, "htmlType": "svg" },
     "<tref>": { "html": true, "htmlType": "svg" },
     "<tspan>": { "html": true, "htmlType": "svg" },
     "<use>": { "html": true, "htmlType": "svg" },

--- a/test/autotests/components-pages/diff-body-root/template.marko
+++ b/test/autotests/components-pages/diff-body-root/template.marko
@@ -1,0 +1,29 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+body
+    div id="test"
+    div id="mocha"
+    div id="testsTarget"
+    div key="count" -- ${state.count}
+
+    lasso-body
+
+    init-components immediate
+
+    lasso-slot name="mocha-run"
+
+    browser-refresh

--- a/test/autotests/components-pages/diff-body-root/tests.js
+++ b/test/autotests/components-pages/diff-body-root/tests.js
@@ -1,0 +1,15 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing body at the root', function() {
+        var app = window.app;
+        var countEl = app.getEl('count');
+        expect(countEl.innerHTML).to.equal('0');
+
+        app.increment();
+        app.update();
+
+        expect(countEl.innerHTML).to.equal('1');
+    });
+});

--- a/test/autotests/components-pages/diff-body/template.marko
+++ b/test/autotests/components-pages/diff-body/template.marko
@@ -1,0 +1,36 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+<!DOCTYPE html>
+html lang="en" 
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+        div key="count" -- ${state.count}
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/autotests/components-pages/diff-body/tests.js
+++ b/test/autotests/components-pages/diff-body/tests.js
@@ -1,0 +1,15 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing body', function() {
+        var app = window.app;
+        var countEl = app.getEl('count');
+        expect(countEl.innerHTML).to.equal('0');
+
+        app.increment();
+        app.update();
+
+        expect(countEl.innerHTML).to.equal('1');
+    });
+});

--- a/test/autotests/components-pages/diff-head-root/template.marko
+++ b/test/autotests/components-pages/diff-head-root/template.marko
@@ -1,0 +1,33 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+head count=state.count
+    meta charset="UTF-8"
+    title -- Marko Test
+    lasso-head
+body
+
+    div id="test"
+    div id="mocha"
+    div id="testsTarget"
+
+    lasso-body
+
+    init-components immediate
+
+    lasso-slot name="mocha-run"
+
+    browser-refresh

--- a/test/autotests/components-pages/diff-head-root/tests.js
+++ b/test/autotests/components-pages/diff-head-root/tests.js
@@ -1,0 +1,14 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing head at the root', function() {
+        var app = window.app;
+        expect(document.head.getAttribute('count')).to.equal('0');
+
+        app.increment();
+        app.update();
+
+        expect(document.head.getAttribute('count')).to.equal('1');
+    });
+});

--- a/test/autotests/components-pages/diff-head/template.marko
+++ b/test/autotests/components-pages/diff-head/template.marko
@@ -1,0 +1,35 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+<!DOCTYPE html>
+html lang="en"
+    head count=state.count
+        meta charset="UTF-8"
+        title -- Marko Test
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/autotests/components-pages/diff-head/tests.js
+++ b/test/autotests/components-pages/diff-head/tests.js
@@ -1,0 +1,14 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing head', function() {
+        var app = window.app;
+        expect(document.head.getAttribute('count')).to.equal('0');
+
+        app.increment();
+        app.update();
+
+        expect(document.head.getAttribute('count')).to.equal('1');
+    });
+});

--- a/test/autotests/components-pages/diff-html/template.marko
+++ b/test/autotests/components-pages/diff-html/template.marko
@@ -1,0 +1,35 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+<!DOCTYPE html>
+html lang="en" count=state.count
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/autotests/components-pages/diff-html/tests.js
+++ b/test/autotests/components-pages/diff-html/tests.js
@@ -1,0 +1,14 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing html', function() {
+        var app = window.app;
+        expect(document.documentElement.getAttribute('count')).to.equal('0');
+
+        app.increment();
+        app.update();
+
+        expect(document.documentElement.getAttribute('count')).to.equal('1');
+    });
+});

--- a/test/autotests/components-pages/diff-title/template.marko
+++ b/test/autotests/components-pages/diff-title/template.marko
@@ -1,0 +1,35 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+class {
+    onCreate () {
+        this.state = {
+            count: 0
+        }
+    }
+    onMount () {
+        window.app = this;
+    }
+    increment () {
+        this.state.count++;
+    }
+}
+
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Count: ${state.count}
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/autotests/components-pages/diff-title/tests.js
+++ b/test/autotests/components-pages/diff-title/tests.js
@@ -1,0 +1,15 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should allow diffing title inside head', function() {
+        var app = window.app;
+        expect(document.title).to.equal('Count: 0');
+
+        app.increment();
+        app.update();
+
+        expect(app.state.count).to.equal(1);
+        expect(document.title).to.equal('Count: 1');
+    });
+});


### PR DESCRIPTION
Relies on the following PRs:

https://github.com/patrick-steele-idem/warp10/pull/3
https://github.com/lasso-js/lasso/pull/211
