### PR TITLE
updating location of bindComponent helper

### DIFF
--- a/src/components/taglib/component-tag.js
+++ b/src/components/taglib/component-tag.js
@@ -16,7 +16,7 @@ module.exports = function codeGenerator(el, codegen) {
 
     var bindComponentVar = context.addStaticVar('marko_bindComponent',
         builder.require(
-            builder.literal('marko/components/taglib/helpers/bindComponent')));
+            builder.literal('marko/src/components/taglib/helpers/bindComponent')));
 
     if (context.data[BIND_WIDGET_KEY] == null) {
         context.data[BIND_WIDGET_KEY] = 0;

--- a/src/components/taglib/component-tag.js
+++ b/src/components/taglib/component-tag.js
@@ -13,10 +13,10 @@ module.exports = function codeGenerator(el, codegen) {
 
 
     var componentProps = el.getAttributeValue('props');
-
-    var bindComponentVar = context.addStaticVar('marko_bindComponent',
-        builder.require(
-            builder.literal('marko/src/components/taglib/helpers/bindComponent')));
+    
+    var bindComponentVar = context.importModule(
+        'marko_bindComponent',
+        'marko/components/taglib/helpers/bindComponent');
 
     if (context.data[BIND_WIDGET_KEY] == null) {
         context.data[BIND_WIDGET_KEY] = 0;


### PR DESCRIPTION
Location was missing a `src/` since the structure was updated in https://github.com/marko-js/marko/commit/a602f3cd466ec14468cd8a90e7334299077c329c