### PR TITLE
Added `escapeAtTags` option to compiler in order to render `<@tags>` as they are;

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -137,6 +137,7 @@ class CompileContext extends EventEmitter {
         this.compilerVersion = this.options.compilerVersion || markoPkgVersion;
         this.writeVersionComment = writeVersionComment !== 'undefined' ? writeVersionComment : true;
         this.ignoreUnrecognizedTags = this.options.ignoreUnrecognizedTags || false;
+        this.escapeAtTags = this.options.escapeAtTags || false;
 
         this._vars = {};
         this._uniqueVars = new UniqueVars();
@@ -458,6 +459,13 @@ class CompileContext extends EventEmitter {
             throw new Error('Invalid attributes');
         }
 
+        var isAtTag = typeof tagName === 'string' && tagName.startsWith('@');
+
+        if (isAtTag && this.options.escapeAtTags) {
+            tagName = tagName.replace(/^@/, 'at_');
+            elDef.tagName = tagName;
+        }
+
         var node;
         var elNode = builder.htmlElement(elDef);
         elNode.pos = elDef.pos;
@@ -468,7 +476,7 @@ class CompileContext extends EventEmitter {
 
         var taglibLookup = this.taglibLookup;
 
-        if (typeof tagName === 'string' && tagName.startsWith('@')) {
+        if (isAtTag && !this.options.escapeAtTags) {
             // NOTE: The tag definition can't be determined now since it will be
             //       determined by the parent custom tag.
             node = builder.customTag(elNode);

--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -461,7 +461,7 @@ class CompileContext extends EventEmitter {
 
         var isAtTag = typeof tagName === 'string' && tagName.startsWith('@');
 
-        if (isAtTag && this.options.escapeAtTags) {
+        if (isAtTag && this.escapeAtTags) {
             tagName = tagName.replace(/^@/, 'at_');
             elDef.tagName = tagName;
         }
@@ -476,7 +476,7 @@ class CompileContext extends EventEmitter {
 
         var taglibLookup = this.taglibLookup;
 
-        if (isAtTag && !this.options.escapeAtTags) {
+        if (isAtTag && !this.escapeAtTags) {
             // NOTE: The tag definition can't be determined now since it will be
             //       determined by the parent custom tag.
             node = builder.customTag(elNode);

--- a/src/compiler/config.js
+++ b/src/compiler/config.js
@@ -60,7 +60,12 @@ if (g.__MARKO_CONFIG) {
          * Whether unrecognized tags should be ignored or not. This flag will
          * be enabled by default when compiling XML.
          */
-        ignoreUnrecognizedTags: false
+        ignoreUnrecognizedTags: false,
+
+        /**
+         * Whether <@tags> should error when are used outside a custom component.
+         */
+        escapeAtTags: false
     };
 
     if (process.env.MARKO_CONFIG) {

--- a/test/autotests/render/escape-at-tag/expected.html
+++ b/test/autotests/render/escape-at-tag/expected.html
@@ -1,0 +1,1 @@
+<div><at_hello></at_hello></div>

--- a/test/autotests/render/escape-at-tag/template.marko
+++ b/test/autotests/render/escape-at-tag/template.marko
@@ -1,0 +1,1 @@
+<div><@hello></@hello></div>

--- a/test/autotests/render/escape-at-tag/test.js
+++ b/test/autotests/render/escape-at-tag/test.js
@@ -1,0 +1,5 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+exports.ignoreUnrecognizedTags = true;
+exports.escapeAtTags = true;

--- a/test/util/runRenderTest.js
+++ b/test/util/runRenderTest.js
@@ -107,6 +107,10 @@ module.exports = function runRenderTest(dir, helpers, done, options) {
         require('marko/compiler').defaultOptions.ignoreUnrecognizedTags = true;
     }
 
+    if (main.escapeAtTags) {
+        require('marko/compiler').defaultOptions.escapeAtTags = true;
+    }
+
     var oldDone = done;
     done = function(err) {
         require('marko/compiler').configure();


### PR DESCRIPTION
## Description
When `escapeAtTags` options is being passed to the compiler - it will escape `<@whatever></@whatever>` tags with `<at_whatever></at_whatever>`.

## Motivation and Context
During tests, if we isolate tested component from its nested dependencies, we may find ourselves in place where we have `<@whatever></@whatever>` tag sitting not within a custom component element.

*Desired result*: if we're isolating dependencies during tests, we want to render the transclusion code as it is.

## Checklist:
- [ x ] My code follows the code style of this project.
- [ - ] I have updated/added documentation affected by my changes.
- [ x ] I have read the **CONTRIBUTING** document.
- [ x ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
