### PR TITLE
Fixes #796 - Fix events for event targets that are SVGElementInstance…

### DIFF
--- a/src/components/event-delegation.js
+++ b/src/components/event-delegation.js
@@ -76,6 +76,11 @@ function attachBubbleEventListeners(doc) {
                 return;
             }
 
+            // event.target of an SVGElementInstance does not have a
+            // `getAttribute` function in IE 11.
+            // See https://github.com/marko-js/marko/issues/796
+            curNode = curNode.correspondingUseElement || curNode;
+
             // Search up the tree looking DOM events mapped to target
             // component methods
             var propName = 'on' + eventType;


### PR DESCRIPTION
… types in IE11.

Not sure of a great way to test this since it only happens in IE11 and `SVGElementInstance` only exists in IE. I manually tested this fix in IE and Edge and validated that it does not break Chrome.