### PR TITLE
Fixes #778 - Fix Marko compiler generating incorrect path for require…

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -313,7 +313,7 @@ class CompileContext extends EventEmitter {
             if (ext === '.js') {
                 deresolved = deresolved.slice(0, 0 - ext.length);
             }
-            return deresolved;
+            return deresolved.replace(/\\/g, '/');
         }
 
         return markoModules.deresolve(targetFilename, this.dirname);


### PR DESCRIPTION
…s on Windows.