### PR TITLE
Add better interop for importing modules with default exports

### DIFF
--- a/src/taglibs/core/import-tag.js
+++ b/src/taglibs/core/import-tag.js
@@ -15,14 +15,21 @@ module.exports = function codeGenerator(el, codegen) {
         }
 
         if (arg.module) {
-            // needs to be require()'d
-            var result = builder.require(builder.literal(arg.value));
+            var requireExpression = builder.require(builder.literal(arg.value));
+            var moduleName = 'module_' + varName;
 
             if (varName) {
-                // saves identifier
-                vars[varName] = codegen.addStaticVar(varName, result);
+                // saves identifier under a module alias.
+                vars[varName] = codegen.addStaticVar(moduleName, requireExpression);
+                // extracts out the default export.
+                codegen.addStaticVar(varName, builder.logicalExpression(
+                    builder.memberExpression(moduleName, builder.identifier('default')),
+                    '||',
+                    moduleName
+                ));
             } else {
-                codegen.addStaticCode(result);
+                // require without saving var.
+                codegen.addStaticCode(requireExpression);
             }
         } else {
             // ie: { bar } from "./bar"

--- a/test/autotests/compiler/import-tag-conflict/expected.js
+++ b/test/autotests/compiler/import-tag-conflict/expected.js
@@ -1,10 +1,11 @@
 "use strict";
 
 var marko_template = module.exports = require("marko/src/html").t(__filename),
-    asset_module = require("./test1/asset"),
-    test = asset_module.asset,
-    asset_module2 = require("./test2/asset"),
-    asset = asset_module2.asset;
+    module_asset_module = require("./test1/asset"),
+    asset_module = module_asset_module.default || module_asset_module,
+    test = module_asset_module.asset,
+    module_asset_module2 = require("./test2/asset"),
+    asset = module_asset_module2.asset;
 
 function render(input, out) {
   var data = input;

--- a/test/autotests/compiler/import-tag/expected.js
+++ b/test/autotests/compiler/import-tag/expected.js
@@ -1,8 +1,9 @@
 "use strict";
 
 var marko_template = module.exports = require("marko/src/html").t(__filename),
-    bar = require("./bar"),
-    foo = bar.f;
+    module_bar = require("./bar"),
+    bar = module_bar.default || module_bar,
+    foo = module_bar.f;
 
 require("./foo");
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Currently when using the import tag to import es6 modules with default exports you instead get the entire exports object like `{ default: ..., }`.

<!--- Describe your changes in detail -->
This change checks to see if the default export is set and tries to use it if possible like so:

```js
import myThing from './myfile.js'
```
becomes

```js
var module_myThing = require('./myfile.js')
var myThing = module_myThing.default || module_myThing
```

## Motivation and Context
Resolves https://github.com/marko-js/marko/issues/802.
Currently users have to manually access the default export which is not in line with the modules spec.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.