### PR TITLE
Add ability to update globals by setting new input.

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -483,7 +483,7 @@ this.setStateDirty('numbers');
 
 ### `this.input`
 
-The current input for the component.  Setting `this.input` will result in the component being re-rendered.
+The current input for the component. Setting `this.input` will result in the component being re-rendered. If a `$global` property is set the `out.global` will also be updated during the re-render, otherwise the existing `$global` is used.
 
 ## Variables
 

--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -437,6 +437,9 @@ Component.prototype = componentProto = {
 
         if (this.___input === undefined) {
             this.___input = newInput;
+            if (newInput.$global) {
+                this.___global = newInput.$global;
+            }
         }
 
         return newInput;

--- a/test/autotests/components-browser/input-global/index.marko
+++ b/test/autotests/components-browser/input-global/index.marko
@@ -1,0 +1,6 @@
+class {
+}
+
+<div key="current">
+    Pathname: ${out.global.pathname}
+</div>

--- a/test/autotests/components-browser/input-global/test.js
+++ b/test/autotests/components-browser/input-global/test.js
@@ -1,0 +1,20 @@
+var expect = require('chai').expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require('./index.marko'), {
+        $global: {
+            pathname:'/'
+        }
+    });
+
+    expect(component.getEl('current').innerHTML).to.equal('Pathname: /');
+
+    component.input = {
+        $global: {
+            pathname: '/test'
+        }
+    }
+    component.update();
+
+    expect(component.getEl('current').innerHTML).to.equal('Pathname: /test');
+};


### PR DESCRIPTION
Add ability to override the current out.global by setting new $global property on input.


## Description
The change here is small but allows updating the global context without discarding the marko component or using hidden properties like `___global`.

## Motivation and Context
Fixes https://github.com/marko-js/marko/issues/815

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
