### PR TITLE
Remove uneeded command from installation docs

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -13,7 +13,6 @@ get you going quickly. To get started:
 npm install marko-cli --global
 marko create hello-world
 cd hello-world
-npm install # or yarn
 npm start
 ```
 


### PR DESCRIPTION
It looks like the marks-cli automatically installs node modules.

## Description
Currently in the docs it mentions that after `marko create hello-world` that users must install dependencies. It looks like this is now handled automatically and should be removed from the docs.

## Motivation and Context
Consistency/accuracy of docs.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.