### PR TITLE
Increase mocha timeout to avoid CI build's failing

### DIFF
--- a/test/server-tests-runner/cli.js
+++ b/test/server-tests-runner/cli.js
@@ -7,7 +7,7 @@ const testDir = path.join(rootDir, isDebug ? 'test' : 'test-dist');
 const spawnSync = require('child_process').spawnSync;
 const mochaPath = path.join(rootDir, 'node_modules/.bin/mocha');
 
-var result = spawnSync(mochaPath, ['--ui', 'bdd', '--reporter', 'spec', testDir], {
+var result = spawnSync(mochaPath, ['--ui', 'bdd', '--reporter', 'spec', '--timeout', '3000', testDir], {
     stdio: 'inherit'
 });
 


### PR DESCRIPTION
## Description
Increase the allowed time for tests to run with mocha. Some tests were occasionally exceeding the 2s threshold.

## Motivation and Context
During my past few PR's occasionally the CI build's have been failing due to timeouts in mocha.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.