### PR TITLE
Fallback to regular require if `module.parent.require` is unavailable

### DIFF
--- a/express.js
+++ b/express.js
@@ -1,8 +1,9 @@
 var isDebug = require('./env').isDebug;
 var parentModule = module.parent;
+var parentRequire = parentModule && parentModule.require || require;
 
 if (isDebug) {
-    module.exports = parentModule.require('marko/src/express');
+    module.exports = parentRequire('marko/src/express');
 } else {
-    module.exports = parentModule.require('marko/dist/express');
+    module.exports = parentRequire('marko/dist/express');
 }

--- a/src/express.js
+++ b/src/express.js
@@ -1,7 +1,12 @@
 require('./');
 
 var assign = require('object-assign');
-var express = module.parent.require('express');
+
+var parentModule = module.parent;
+var parentRequire = parentModule && parentModule.require || require;
+
+var express = parentRequire('express');
+
 patchResponse(express.response);
 delete require.cache[__filename];
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Some environments (like jest) don't implement it

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

I'd like to run tests with jest for an app that using marko.

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Tests are failing for some reason, help is appreciated

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
