### PR TITLE
Key scope fix

### DIFF
--- a/src/compiler/Parser.js
+++ b/src/compiler/Parser.js
@@ -266,10 +266,9 @@ class Parser {
                 }
 
                 if (attrDef.rawValue) {
-                    let match = /^component\.(?:getE|e)lId\((?:"|')(.*)(?:"|')\)$/.exec(attrDef.rawValue);
-                    if (match) {
-                        context.data.imperativeComponentIds = context.data.imperativeComponentIds || [];
-                        context.data.imperativeComponentIds.push(match[1]);
+                    if (/^component\.(?:getE|e)lId\(.*\)$/.test(attrDef.rawValue)) {
+                        // TODO: add complain call here
+                        context.data.hasImperativeComponentIds = true;
                     }
                 }
 

--- a/src/compiler/Parser.js
+++ b/src/compiler/Parser.js
@@ -265,6 +265,14 @@ class Parser {
                     }
                 }
 
+                if (attrDef.rawValue) {
+                    let match = /^component\.(?:getE|e)lId\((?:"|')(.*)(?:"|')\)$/.exec(attrDef.rawValue);
+                    if (match) {
+                        context.data.imperativeComponentIds = context.data.imperativeComponentIds || [];
+                        context.data.imperativeComponentIds.push(match[1]);
+                    }
+                }
+
                 parsedAttributes.push(attrDef);
             });
         }

--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -100,7 +100,7 @@ module.exports = function assignComponentId(isRepeated) {
             }
 
             if (context.data.imperativeComponentIds &&  el.data.userAssignedKey !== false) {
-                if (context.data.imperativeComponentIds.includes(assignedKey.value)) {
+                if (context.data.imperativeComponentIds.indexOf(assignedKey.value) !== -1) {
                     el.setAttributeValue('id', this.buildComponentElIdFunctionCall(assignedKey));
                 }
             }

--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -99,6 +99,12 @@ module.exports = function assignComponentId(isRepeated) {
                 el.setAttributeValue('id', this.buildComponentElIdFunctionCall(assignedKey));
             }
 
+            if (context.data.imperativeComponentIds &&  el.data.userAssignedKey !== false) {
+                if (context.data.imperativeComponentIds.includes(assignedKey.value)) {
+                    el.setAttributeValue('id', this.buildComponentElIdFunctionCall(assignedKey));
+                }
+            }
+
             if (context.isServerTarget()) {
                 var markoKeyAttrVar = context.importModule('marko_keyAttr',
                     this.getMarkoComponentsRequirePath('marko/components/taglib/helpers/markoKeyAttr'));

--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -95,12 +95,8 @@ module.exports = function assignComponentId(isRepeated) {
             this.getComponentArgs().setKey(nestedIdExpression);
         } else {
             idExpression = assignedKey;
-            if (context.data.hasLegacyForKey && el.data.userAssignedKey !== false) {
-                el.setAttributeValue('id', this.buildComponentElIdFunctionCall(assignedKey));
-            }
-
-            if (context.data.imperativeComponentIds &&  el.data.userAssignedKey !== false) {
-                if (context.data.imperativeComponentIds.indexOf(assignedKey.value) !== -1) {
+            if (el.data.userAssignedKey !== false) {
+                if (context.data.hasLegacyForKey || context.data.hasImperativeComponentIds) {
                     el.setAttributeValue('id', this.buildComponentElIdFunctionCall(assignedKey));
                 }
             }

--- a/src/components/taglib/TransformHelper/handleScopedAttrs.js
+++ b/src/components/taglib/TransformHelper/handleScopedAttrs.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const removeDashes = require('../../../compiler/util/removeDashes');
+
 const deprecatedKeySuffix = ':key';
 const scopedSuffix = ':scoped';
 const deprecatedAttrs = {
@@ -55,8 +57,7 @@ module.exports = function handleComponentKeyAttrs() {
             }
 
             let uniqueElId = this.nextUniqueId();
-            let idVarName = 'marko_' + finalAttributeName + '_key' + uniqueElId;
-
+            let idVarName = 'marko_' + removeDashes(finalAttributeName) + '_key' + uniqueElId;
 
             let varNode = builder.var(idVarName, attribute.value);
 

--- a/test/autotests/render-deprecated/component-aria-key/expected.html
+++ b/test/autotests/render-deprecated/component-aria-key/expected.html
@@ -1,0 +1,1 @@
+<!--M#s0--><div id="s0-buttonDescription">Submit the form thing</div><button aria-described-by="s0-buttonDescription">Submit</button><!--M/s0-->

--- a/test/autotests/render-deprecated/component-aria-key/template.marko
+++ b/test/autotests/render-deprecated/component-aria-key/template.marko
@@ -1,0 +1,3 @@
+class {}
+<div key="buttonDescription">Submit the form thing</div>
+<button aria-described-by:key="buttonDescription">Submit</button>

--- a/test/autotests/render-deprecated/component-aria-key/test.js
+++ b/test/autotests/render-deprecated/component-aria-key/test.js
@@ -1,0 +1,1 @@
+exports.vdomSkip = true;

--- a/test/autotests/render/component-aria-key/expected.html
+++ b/test/autotests/render/component-aria-key/expected.html
@@ -1,0 +1,1 @@
+<!--M#s0--><div id="s0-buttonDescription">Submit the form thing</div><button aria-described-by="s0-buttonDescription">Submit</button><!--M/s0-->

--- a/test/autotests/render/component-aria-key/template.marko
+++ b/test/autotests/render/component-aria-key/template.marko
@@ -1,0 +1,3 @@
+class {}
+<div id:scoped="buttonDescription">Submit the form thing</div>
+<button aria-described-by:scoped="buttonDescription">Submit</button>

--- a/test/autotests/render/component-aria-key/test.js
+++ b/test/autotests/render/component-aria-key/test.js
@@ -1,0 +1,1 @@
+exports.vdomSkip = true;

--- a/test/autotests/render/component-elId/expected.html
+++ b/test/autotests/render/component-elId/expected.html
@@ -1,1 +1,1 @@
-<!--M#s0--><div><input><label for="s0-checkbox"></label></div><!--M/s0-->
+<!--M#s0--><div><input id="s0-checkbox"><label for="s0-checkbox"></label></div><!--M/s0-->

--- a/test/autotests/render/component-getElId/expected.html
+++ b/test/autotests/render/component-getElId/expected.html
@@ -1,1 +1,1 @@
-<!--M#s0--><div><input><label for="s0-checkbox"></label></div><!--M/s0-->
+<!--M#s0--><div><input id="s0-checkbox"><label for="s0-checkbox"></label></div><!--M/s0-->


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- fixes scoped/keyed attributes with dashes causing compile-time error (`aria-described-by:scoped`)
- maintains behavior prior to the current beta with a `key` being used alongside `component.elId` or `component.getElId`

```marko
<label for=component.getElId('name')>Name</label>
<input key="name"/>
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
