### PR TITLE
Fixes #848 browser-refresh does not reload marko files if a static reference is held

### DIFF
--- a/src/runtime/html/index.js
+++ b/src/runtime/html/index.js
@@ -1,8 +1,4 @@
 'use strict';
-require('../../');
-
-var AsyncStream = require('./AsyncStream');
-var Template = require('./Template');
 
 /**
  * Method is for internal usage only. This method
@@ -13,6 +9,13 @@ var Template = require('./Template');
 exports.t = function createTemplate(path) {
      return new Template(path);
 };
+
+require('../../');
+
+var AsyncStream = require('./AsyncStream');
+var Template = require('./Template');
+
+
 
 function createOut(globalData, parent, state, buffer) {
     return new AsyncStream(globalData, parent, state, buffer);

--- a/src/runtime/html/index.js
+++ b/src/runtime/html/index.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Template;
+
 /**
  * Method is for internal usage only. This method
  * is invoked by code in a compiled Marko template and
@@ -13,9 +15,7 @@ exports.t = function createTemplate(path) {
 require('../../');
 
 var AsyncStream = require('./AsyncStream');
-var Template = require('./Template');
-
-
+Template = require('./Template');
 
 function createOut(globalData, parent, state, buffer) {
     return new AsyncStream(globalData, parent, state, buffer);


### PR DESCRIPTION
The main change is to move the following block above any requires:

```javascript
exports.t = function createTemplate(path) {
     return new Template(path);
};
```

This avoids issue with circular dependency which broke the hot-reload code because the `t` function was not exported right away.