### PR TITLE
add error tests for else tag

### DIFF
--- a/test/autotests/render/error-invalid-else-tag-attr-with-if/template.marko
+++ b/test/autotests/render/error-invalid-else-tag-attr-with-if/template.marko
@@ -1,0 +1,6 @@
+<if(input.foo)>
+    A
+</if>
+<else if(input.bar) name="Frank">
+    B
+</else>

--- a/test/autotests/render/error-invalid-else-tag-attr-with-if/test.js
+++ b/test/autotests/render/error-invalid-else-tag-attr-with-if/test.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(err) {
+    expect(err.toString()).to.contain('Invalid <else if> tag. Only the "if" attribute is allowed.');
+};

--- a/test/autotests/render/error-invalid-else-tag-attr/template.marko
+++ b/test/autotests/render/error-invalid-else-tag-attr/template.marko
@@ -1,0 +1,6 @@
+<if(input.foo)>
+    A
+</if>
+<else name="Frank">
+    B
+</else>

--- a/test/autotests/render/error-invalid-else-tag-attr/test.js
+++ b/test/autotests/render/error-invalid-else-tag-attr/test.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(err) {
+    expect(err.toString()).to.contain('Invalid <else> tag. Attributes not allowed.');
+};

--- a/test/autotests/render/error-invalid-else-tag-if-attr/template.marko
+++ b/test/autotests/render/error-invalid-else-tag-if-attr/template.marko
@@ -1,0 +1,6 @@
+<if(input.foo)>
+    A
+</if>
+<else if>
+    B
+</else>

--- a/test/autotests/render/error-invalid-else-tag-if-attr/test.js
+++ b/test/autotests/render/error-invalid-else-tag-if-attr/test.js
@@ -1,0 +1,7 @@
+var expect = require('chai').expect;
+
+exports.templateData = {};
+
+exports.checkError = function(err) {
+    expect(err.toString()).to.contain('Invalid <else if> tag. Invalid "if" attribute.');
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
I've added tests for parts of the `<else>` tag that were missing coverage.

## Description
<!--- Describe your changes in detail -->
Adds tests for the following:
- `else` tag with invalid attribute 
- `else` tag with invalid `if` attribute
- `else` tag with attribute in addition to `if` attribute

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Improving coverage per #468 

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
