### PR TITLE
bug: loop status-var not compiling everytime #904

### DIFF
--- a/src/taglibs/core/util/parseFor.js
+++ b/src/taglibs/core/util/parseFor.js
@@ -36,15 +36,15 @@ var tokenizer = require('../../../compiler/util/tokenizer').create([
     },
     {
         name: 'separator',
-        pattern: /separator=/
+        pattern: /separator\s?=\s?/
     },
     {
         name: 'status-var',
-        pattern: /status\-var=/
+        pattern: /status\-var\s?=\s?/
     },
     {
         name: 'iterator',
-        pattern: /iterator=/
+        pattern: /iterator\s?=\s?/
     },
     {
         name: 'pipe',

--- a/test/autotests/parseFor/forEach-status-var/input.txt
+++ b/test/autotests/parseFor/forEach-status-var/input.txt
@@ -1,1 +1,1 @@
-color in colors | status-var=loop
+color in colors | status-var = loop


### PR DESCRIPTION
Added optional white space between the  equal symbol in separator, status-var and iterator of parseFor.

## Motivation and Context
#904 

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
