### PR TITLE
add failing test for dynamic attributes on custom html tag

### DIFF
--- a/test/autotests/render/dynamic-attributes-custom-html-tag/expected.html
+++ b/test/autotests/render/dynamic-attributes-custom-html-tag/expected.html
@@ -1,0 +1,1 @@
+<div foo="bar" baz>Hello World</div>

--- a/test/autotests/render/dynamic-attributes-custom-html-tag/html-elements.json
+++ b/test/autotests/render/dynamic-attributes-custom-html-tag/html-elements.json
@@ -1,0 +1,3 @@
+{
+    "<custom-html-tag>": {}
+}

--- a/test/autotests/render/dynamic-attributes-custom-html-tag/template.marko
+++ b/test/autotests/render/dynamic-attributes-custom-html-tag/template.marko
@@ -1,0 +1,1 @@
+<custom-html-tag ${input.attrs}>Hello World</custom-html-tag>

--- a/test/autotests/render/dynamic-attributes-custom-html-tag/test.js
+++ b/test/autotests/render/dynamic-attributes-custom-html-tag/test.js
@@ -1,0 +1,5 @@
+exports.templateData = {
+    attrs: {foor: 'bar', baz: true}
+};
+
+exports.vdomSkip = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hi, this is not intended for merge, just to show an issue. Using dynamic attributes with custom html elements leads to the following error:
```
Error: Generating code for TemplateRoot node failed. 
Error: Error: Generating code for <custom-html-tag> tag failed.
Error: AssertionError [ERR_ASSERTION]: "name" should be a string
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
