### PR TITLE
Update Docs: Fix framework integrations' doc links

### DIFF
--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -23,10 +23,10 @@ module.exports = function(req) {
 ```
 
 > **ProTip:** Marko also provides server-side framework integrations:
-> - [express](/docs/express)
-> - [hapi](/docs/hapi)
-> - [koa](/docs/koa)
-> - [huncwot](/docs/huncwot)
+> - [express](/docs/express.md)
+> - [hapi](/docs/hapi.md)
+> - [koa](/docs/koa.md)
+> - [huncwot](/docs/huncwot.md)
 
 ## UI Bootstrapping
 


### PR DESCRIPTION
## Description
The links for express, hapi, koa, huncwot in the Server-Side Rendering Doc were not working. Appended '.md' to them. They now work.

## Motivation and Context
Was browsing the docs, found a broken link. Fixed it.

## Checklist:
- [ ] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
