### PR TITLE
add jquery to legacy widgets

### DIFF
--- a/src/components/jquery.js
+++ b/src/components/jquery.js
@@ -2,16 +2,20 @@ var ready = require('./ready');
 
 var idRegExp = /^\#(\S+)( .*)?/;
 
-exports.patchComponent = function(jQuery) {
+exports.patchComponent = function(jQuery, proto, delayThrow) {
     /* globals window */
 
-    if (!(jQuery || (jQuery = window.$))) {
+    if (!(jQuery || (jQuery = window.$)) && !delayThrow) {
         throw new Error('jQuery not found');
     }
 
-    require('./Component').prototype.$ = function jqueryProxy(arg) {
+    (proto || require('./Component').prototype).$ = function jqueryProxy(arg) {
         var args = arguments;
         var self = this;
+
+        if (!jQuery) {
+            throw new Error('jQuery not found');
+        }
 
         if (args.length === 1) {
             //Handle an "ondomready" callback function

--- a/src/components/legacy/defineWidget-legacy-browser.js
+++ b/src/components/legacy/defineWidget-legacy-browser.js
@@ -4,7 +4,8 @@
  var BaseState;
  var BaseComponent;
  var inherit;
-
+ var jQuery = require('../jquery');
+ var ready = require('../ready');
 
 module.exports = function defineWidget(def, renderer) {
     def = def.Widget || def;
@@ -110,6 +111,13 @@ module.exports = function defineWidget(def, renderer) {
     inherit(State, BaseState);
     proto.___State = State;
 
+    jQuery.patchComponent(
+        window.$, 
+        proto, 
+        true /* don't throw error until used if `$` is missing*/
+    );
+
+    ready.patchComponent(proto);
 
     if (!renderer) {
         renderer = ComponentClass.renderer || ComponentClass.prototype.renderer;

--- a/src/components/ready.js
+++ b/src/components/ready.js
@@ -134,8 +134,8 @@ function ready(callback, thisObj, doc) {
 
 module.exports = ready;
 
-module.exports.patchComponent = function() {
-    require('./Component').prototype.ready = function (callback) {
+module.exports.patchComponent = function(proto) {
+    (proto || require('./Component').prototype).ready = function (callback) {
         var document = this.el.ownerDocument;
         ready(callback, this, document);
     };

--- a/test/deprecated-components-browser/index.test.js
+++ b/test/deprecated-components-browser/index.test.js
@@ -8,30 +8,19 @@ if (typeof window !== 'undefined') {
     describe('deprecated-components-browser', function () {
         require('../__util__/autotest').runTests(require('./fixtures/autotests.tests'), function run(testFunc, done) {
             var helpers = new BrowserHelpers();
-
-            require('marko/jquery').patchComponent(window.$);
-            require('marko/ready').patchComponent();
-
-            function cleanup() {
-                delete require('marko/components/Component').prototype.$;
-                delete require('marko/components/Component').prototype.ready;
-            }
-
             try {
                 if (testFunc.length === 1) {
                     testFunc(helpers);
                     helpers._cleanup();
-                    cleanup();
                     done();
                 } else {
                     testFunc(helpers, function (err) {
                         helpers._cleanup();
-                        cleanup();
                         done(err);
                     });
                 }
             } catch (e) {
-                cleanup();
+                helpers._cleanup();
                 throw e;
             }
         });


### PR DESCRIPTION
In Marko 4, we removed `this.$` and `this.ready` from the component prototype.  However, since many widgets were using these in Marko 3 (and Marko Widgets 6), we added support for `marko/jquery` and `marko/ready`to ease the transition.

Enabling these however, patched _all_ components.  This PR includes them by default for legacy widgets only.