### PR TITLE
Fix issue with multiple top level elements being removed twice.

### DIFF
--- a/src/morphdom/index.js
+++ b/src/morphdom/index.js
@@ -532,7 +532,7 @@ function morphdom(
             var componentToDestroy = node.___markoComponent;
             if (componentToDestroy) {
                 componentToDestroy.destroy();
-            } else {
+            } else if (node.parentNode) {
                 destroyNodeRecursive(node, detachedFromComponent !== true && detachedFromComponent);
 
                 if (eventDelegation.___handleNodeDetach(node) != false) {

--- a/test/components-browser/fixtures/remove-last-multi-root-component/child.marko
+++ b/test/components-browser/fixtures/remove-last-multi-root-component/child.marko
@@ -1,0 +1,2 @@
+<div>A</div>
+<div>B</div>

--- a/test/components-browser/fixtures/remove-last-multi-root-component/index.marko
+++ b/test/components-browser/fixtures/remove-last-multi-root-component/index.marko
@@ -1,0 +1,13 @@
+class {
+  onCreate () {
+    this.state = { display: true };
+  }
+
+  toggle () {
+    this.state.display = !this.state.display;
+  }
+}
+
+<div key="root">
+    <include('./child') if(state.display)/>
+</div>

--- a/test/components-browser/fixtures/remove-last-multi-root-component/test.js
+++ b/test/components-browser/fixtures/remove-last-multi-root-component/test.js
@@ -1,0 +1,16 @@
+var expect = require('chai').expect;
+
+module.exports = function (helpers) {
+    var component = helpers.mount(require('./index'), {});
+    var el = component.getEl('root');
+
+    expect(el.children.length).to.equal(2);
+    component.toggle();
+    component.forceUpdate();
+    component.update();
+    expect(el.children.length).to.equal(0);
+    component.toggle();
+    component.forceUpdate();
+    component.update();
+    expect(el.children.length).to.equal(2);
+};

--- a/test/components-pages/fixtures/remove-last-multi-root-component/components/child/index.marko
+++ b/test/components-pages/fixtures/remove-last-multi-root-component/components/child/index.marko
@@ -1,0 +1,2 @@
+<div>A</div>
+<div>B</div>

--- a/test/components-pages/fixtures/remove-last-multi-root-component/components/root/index.marko
+++ b/test/components-pages/fixtures/remove-last-multi-root-component/components/root/index.marko
@@ -1,0 +1,17 @@
+class {
+  onCreate () {
+    this.state = { display: true };
+  }
+
+  onMount () {
+    window.testComponent = this;
+  }
+
+  toggle () {
+    this.state.display = !this.state.display;
+  }
+}
+
+<div key="root">
+    <include('../child') if(state.display)/>
+</div>

--- a/test/components-pages/fixtures/remove-last-multi-root-component/template.marko
+++ b/test/components-pages/fixtures/remove-last-multi-root-component/template.marko
@@ -1,0 +1,23 @@
+lasso-page dependencies=data.browserDependencies lasso=data.lasso
+
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <root/>
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/components-pages/fixtures/remove-last-multi-root-component/tests.js
+++ b/test/components-pages/fixtures/remove-last-multi-root-component/tests.js
@@ -1,0 +1,19 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe(path.basename(__dirname), function() {
+    it('should remove the child nodes', function() {
+        var component = window.testComponent;
+        var el = component.getEl('root');
+    
+        expect(el.children.length).to.equal(2);
+        component.toggle();
+        component.forceUpdate();
+        component.update();
+        expect(el.children.length).to.equal(0);
+        component.toggle();
+        component.forceUpdate();
+        component.update();
+        expect(el.children.length).to.equal(2);
+    });
+});


### PR DESCRIPTION
## Description
Prevent attempted to remove dom elements twice (once at component level and once by morphdom).

## Motivation and Context
See https://github.com/marko-js/marko/issues/939 .

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
