### PR TITLE
Make jquery optional for legacy components.

### DIFF
--- a/src/components/legacy/defineWidget-legacy-browser.js
+++ b/src/components/legacy/defineWidget-legacy-browser.js
@@ -156,5 +156,3 @@ module.exports = function defineWidget(def, renderer) {
 BaseState = require('./State-legacy');
 BaseComponent = require('../Component');
 inherit = require('raptor-util/inherit');
-
-require('../jquery').patchComponent();


### PR DESCRIPTION
## Description
Currently when using a legacy component it is required that jQuery exists.
This change makes jQuery optional.

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
