### PR TITLE
Issue 938

### DIFF
--- a/src/morphdom/index.js
+++ b/src/morphdom/index.js
@@ -245,8 +245,13 @@ function morphdom(
                         }
 
                         // We need to move the existing component into
-                        // the correct location
+                        // the correct location and preserve focus.
+                        var activeElement = doc.activeElement;
                         insertBefore(matchingFromComponent.___detach(), curFromNodeChild, parentFromNode);
+                        // This focus patch should be a temporary fix.
+                        if (activeElement !== doc.activeElement && activeElement.focus) {
+                            activeElement.focus();
+                        }
                     }
 
                     if (curToNodeChild.___preserve) {

--- a/test/components-pages/fixtures/include-input-preserve-focus/components/container/index.marko
+++ b/test/components-pages/fixtures/include-input-preserve-focus/components/container/index.marko
@@ -1,0 +1,3 @@
+<div>
+  <include(input.renderBody)/>
+</div>

--- a/test/components-pages/fixtures/include-input-preserve-focus/components/root/index.marko
+++ b/test/components-pages/fixtures/include-input-preserve-focus/components/root/index.marko
@@ -1,0 +1,14 @@
+class {
+    onMount() {
+        window.component = this;
+    }
+    onCreate () {
+        this.state = {
+            text: ""
+        };
+    }
+}
+
+<include("../container/index.marko")>
+    <input key="input" value=state.text/>
+</include>

--- a/test/components-pages/fixtures/include-input-preserve-focus/template.marko
+++ b/test/components-pages/fixtures/include-input-preserve-focus/template.marko
@@ -1,0 +1,23 @@
+lasso-page dependencies=input.browserDependencies lasso=input.lasso
+
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+        lasso-head
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <root/>
+
+        lasso-body
+
+        init-components immediate
+
+        lasso-slot name="mocha-run"
+
+        browser-refresh

--- a/test/components-pages/fixtures/include-input-preserve-focus/tests.js
+++ b/test/components-pages/fixtures/include-input-preserve-focus/tests.js
@@ -1,0 +1,22 @@
+var path = require('path');
+var expect = require('chai').expect;
+
+describe.skip(path.basename(__dirname), function() {
+    it('should update correctly', function() {
+        var component = window.component;
+        var input = component.getEl('input');
+
+        document.addEventListener("focusout", (e) => {
+            console.log("FOCUS OUT", e);
+            debugger;
+        })
+        input.focus();
+        expect(document.activeElement).to.eql(input);
+
+        component.state.text = "Updated";
+        component.forceUpdate();
+        component.update();
+
+        expect(document.activeElement).to.eql(input);
+    });
+});

--- a/test/components-pages/fixtures/include-input-preserve-focus/tests.js
+++ b/test/components-pages/fixtures/include-input-preserve-focus/tests.js
@@ -1,15 +1,11 @@
 var path = require('path');
 var expect = require('chai').expect;
 
-describe.skip(path.basename(__dirname), function() {
+describe(path.basename(__dirname), function() {
     it('should update correctly', function() {
         var component = window.component;
         var input = component.getEl('input');
 
-        document.addEventListener("focusout", (e) => {
-            console.log("FOCUS OUT", e);
-            debugger;
-        })
         input.focus();
         expect(document.activeElement).to.eql(input);
 


### PR DESCRIPTION
## Description
Currently there is a part of the diffing algorithm that temporarily removes a component from the Dom that causes it to loose focus. This patch keeps track of the focused element and refocuses if needed.

## Motivation and Context
#938 

## Checklist:
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
