### PR TITLE
Remove bluebird as a dev depenency and update tests to vanilla promises.

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "babel-core": "^6.24.1",
     "babel-plugin-minprops": "^2.0.1",
     "benchmark": "^2.1.1",
-    "bluebird": "^3.4.7",
     "browser-refresh": "^1.6.0",
     "browser-refresh-taglib": "^1.1.0",
     "chai": "^3.3.0",

--- a/test/async-render/fixtures/await-promise-error-bluebird/test.js
+++ b/test/async-render/fixtures/await-promise-error-bluebird/test.js
@@ -1,9 +1,5 @@
-var deferred = require('bluebird').defer();
-
-setTimeout(function () {
-    deferred.resolve({});
-}, 200);
-
 exports.templateData = {
-    promiseData: deferred.promise
+    promiseData: new Promise(function (resolve) {
+        setTimeout(resolve, 200);
+    })
 };

--- a/test/deprecated-async-fragments/fixtures/async-fragment-promise-error-bluebird/test.js
+++ b/test/deprecated-async-fragments/fixtures/async-fragment-promise-error-bluebird/test.js
@@ -1,9 +1,5 @@
-var deferred = require('bluebird').defer();
-
-setTimeout(function () {
-    deferred.resolve({});
-}, 200);
-
 exports.templateData = {
-    promiseData: deferred.promise
+    promiseData: new Promise(function (resolve) {
+        setTimeout(resolve, 200);
+    })
 };


### PR DESCRIPTION
## Description
This removes bluebird and updates a couple of tests relying on it.

## Motivation and Context
Cleanup unneeded deps and maintenance.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
