### PR TITLE
Hydrate tests

### DIFF
--- a/src/compiler/ast/TemplateRoot.js
+++ b/src/compiler/ast/TemplateRoot.js
@@ -75,10 +75,9 @@ class TemplateRoot extends Node {
                         renderStatements)
                 ]);
         } else {
-            var isBrowser = context.options.browser;
-            var createArgs = isBrowser ?
-                [] :
-                [ builder.identifier('__filename') ];
+            var createArgs = context.useMeta ?
+                [ builder.identifier('__filename') ] :
+                [];
 
             let templateDeclaration = builder.variableDeclarator('marko_template',
                 builder.assignment(

--- a/src/components/taglib/TransformHelper/handleComponentEvents.js
+++ b/src/components/taglib/TransformHelper/handleComponentEvents.js
@@ -45,7 +45,7 @@ function addBubblingEventListener(transformHelper, options) {
     el.setPropertyValue(propName, propValue, false);
 
     if (options.eventType.value === 'attach' || options.eventType.value === 'detach') {
-        if (!transformHelper.context.data[ATTACH_DETACH_KEY]) {
+        if (!transformHelper.context.data[ATTACH_DETACH_KEY] && transformHelper.context.outputType === 'vdom') {
             transformHelper.context.data[ATTACH_DETACH_KEY] = true;
             transformHelper.context.importModule(null, 'marko/components/attach-detach');
         }

--- a/test/__util__/BrowserHelpers.js
+++ b/test/__util__/BrowserHelpers.js
@@ -32,8 +32,8 @@ BrowserHelpers.prototype = {
     },
 
     mount: function (component, input) {
+        var $global = input && input.$global;
         var renderResult = component.renderSync(input).appendTo(this.targetEl);
-
         var instance;
         try {
             instance = renderResult.getComponent();
@@ -47,7 +47,8 @@ BrowserHelpers.prototype = {
             this.components.push({
                 instance: instance,
                 type: instance.___type,
-                input: input
+                input: input,
+                $global: $global
             });
         }
 

--- a/test/__util__/BrowserHelpers.js
+++ b/test/__util__/BrowserHelpers.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+var path = require('path');
 var assert = require('assert');
 var markoComponents = require('marko/components');
 
@@ -44,9 +45,13 @@ BrowserHelpers.prototype = {
         }
 
         if (instance) {
+            var template = (component.renderer && component.renderer.template) || component;
+            var meta = template.meta;
             this.components.push({
                 instance: instance,
-                type: instance.___type,
+                type: meta && meta.id,
+                logic: meta && meta.component && path.resolve(path.dirname(template.path), meta.component),
+                template: template.path,
                 input: input,
                 $global: $global
             });

--- a/test/__util__/create-marko-jsdom-module.js
+++ b/test/__util__/create-marko-jsdom-module.js
@@ -5,6 +5,7 @@ const createJSDOMModule = require('./create-jsdom-module');
 const compiler = require('../../compiler');
 const noop = function () {};
 const globals = [
+  'console',
   '__coverage__',
   'Error',
   'describe',
@@ -17,10 +18,12 @@ const globals = [
 
 const browserExtensions = {
     '.marko': function (module, filename) {
-        return module._compile(compiler.compileFileForBrowser(filename).code, filename, {
+        return module._compile(compiler.compileFile(filename, {
             writeToDisk: false,
-            output: 'vdom'
-        });
+            output: 'vdom',
+            browser: true,
+            meta: true
+        }), filename);
     }
 };
 

--- a/test/autotest.js
+++ b/test/autotest.js
@@ -161,16 +161,16 @@ exports.scanDir = function(autoTestDir, run, options) {
                 }
 
                 var testFunc = options.type === 'describe' ? describe : it;
+                var dir = path.join(autoTestDir, name);
 
                 if (enabledTest && (name === enabledTest || testGroup+'/'+name === enabledTest)) {
                     testFunc = testFunc.only;
                 }
 
-                if (name.endsWith('.skip')) {
+                if (name.endsWith('.skip') || options.skip && options.skip(name, dir)) {
                     testFunc = testFunc.skip;
                 }
 
-                var dir = path.join(autoTestDir, name);
                 testFunc(options.name !== false ? name : '', function(done) {
                     autoTest(name, dir, run, options, done);
                 });

--- a/test/components-browser/fixtures-deprecated/widget-rerender-init-order/components/app-rerender-init-order-child/index.js
+++ b/test/components-browser/fixtures-deprecated/widget-rerender-init-order/components/app-rerender-init-order-child/index.js
@@ -14,6 +14,7 @@ module.exports = require('marko/legacy-components').defineComponent({
     },
     init: function () {
         // console.log(module.id, 'init()', this.state);
+        window.rerenderInitOrder = window.rerenderInitOrder || [];
         window.rerenderInitOrder.push(this.state.id);
     },
     onUpdate: function () {

--- a/test/components-browser/fixtures-deprecated/widget-rerender-init-order/index.js
+++ b/test/components-browser/fixtures-deprecated/widget-rerender-init-order/index.js
@@ -11,6 +11,7 @@ module.exports = require('marko/legacy-components').defineComponent({
         };
     },
     init: function () {
+        window.rerenderInitOrder = window.rerenderInitOrder || [];
         window.rerenderInitOrder.push('parent');
     },
     onUpdate: function () {

--- a/test/components-browser/fixtures-deprecated/widget-rerender-init-order/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-rerender-init-order/test.js
@@ -1,8 +1,6 @@
 var expect = require('chai').expect;
 
 module.exports = function (helpers) {
-    window.rerenderInitOrder = [];
-
     var widget = helpers.mount(require('./index'), {
         version: 0
     });

--- a/test/components-browser/fixtures-deprecated/widget-rerender-init-order/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-rerender-init-order/test.js
@@ -15,5 +15,5 @@ module.exports = function (helpers) {
     // console.log('ACTUAL ORDER: ', window.rerenderInitOrder);
     expect(window.rerenderInitOrder).to.deep.equal(['childB', 'childA', 'parent']);
 
-    delete window.rerenderInitOrder;
+    window.rerenderInitOrder = null;
 };

--- a/test/components-browser/fixtures/event-attach-el-once/test.js
+++ b/test/components-browser/fixtures/event-attach-el-once/test.js
@@ -5,19 +5,23 @@ module.exports = function (helpers) {
         colors: ['red']
     });
 
-    expect(component.numberOfInvocations).to.equal(1);
+    // When hydrating, the first color item was rendered on the
+    // server so there is no corresponding attach event fired
+    var OFFSET = helpers.isHydrate ? -1 : 0;
+
+    expect(component.numberOfInvocations).to.equal(OFFSET+1);
 
     component.input = {
         colors: ['red', 'blue']
     };
     component.update();
 
-    expect(component.numberOfInvocations).to.equal(2);
+    expect(component.numberOfInvocations).to.equal(OFFSET+2);
 
     component.input = {
         colors: ['red', 'green', 'blue']
     };
     component.update();
 
-    expect(component.numberOfInvocations).to.equal(3);
+    expect(component.numberOfInvocations).to.equal(OFFSET+3);
 };

--- a/test/components-browser/fixtures/event-attach-el/test.js
+++ b/test/components-browser/fixtures/event-attach-el/test.js
@@ -5,10 +5,14 @@ module.exports = function (helpers) {
         colors: ['red']
     });
 
-    expect(component.events.length).to.equal(1);
-
-    expect(component.events[0].color).to.equal('red');
-    expect(component.events[0].node).to.equal(component.el.querySelectorAll('li')[0]);
+    // When hydrating, the first color item was rendered on the
+    // server so there is no corresponding attach event fired
+    var OFFSET = helpers.isHydrate ? -1 : 0;
+    if (!helpers.isHydrate) {
+        expect(component.events.length).to.equal(1);
+        expect(component.events[0].color).to.equal('red');
+        expect(component.events[0].node).to.equal(component.el.querySelectorAll('li')[0]);
+    }
 
     component.input = {
         colors: ['red', 'blue']
@@ -16,9 +20,9 @@ module.exports = function (helpers) {
 
     component.update();
 
-    expect(component.events.length).to.equal(2);
-    expect(component.events[1].color).to.equal('blue');
-    expect(component.events[1].node).to.equal(component.el.querySelectorAll('li')[1]);
+    expect(component.events.length).to.equal(OFFSET+2);
+    expect(component.events[OFFSET+1].color).to.equal('blue');
+    expect(component.events[OFFSET+1].node).to.equal(component.el.querySelectorAll('li')[1]);
 
     component.input = {
         colors: ['red', 'green', 'blue']
@@ -26,7 +30,7 @@ module.exports = function (helpers) {
 
     component.update();
 
-    expect(component.events.length).to.equal(3);
-    expect(component.events[2].color).to.equal('green');
-    expect(component.events[2].node).to.equal(component.el.querySelectorAll('li')[1]);
+    expect(component.events.length).to.equal(OFFSET+3);
+    expect(component.events[OFFSET+2].color).to.equal('green');
+    expect(component.events[OFFSET+2].node).to.equal(component.el.querySelectorAll('li')[1]);
 };

--- a/test/components-browser/fixtures/event-detach-remove-nested-component-last/index.marko
+++ b/test/components-browser/fixtures/event-detach-remove-nested-component-last/index.marko
@@ -1,3 +1,5 @@
+class {}
+
 <ul key="root">
     <for(color in input.colors)>
         <color-li color=color key=color />

--- a/test/components-browser/fixtures/event-detach-remove-nested-component-middle/index.marko
+++ b/test/components-browser/fixtures/event-detach-remove-nested-component-middle/index.marko
@@ -1,3 +1,5 @@
+class {}
+
 <ul key="root">
     <for(color in input.colors)>
         <color-li color=color key=color />

--- a/test/components-browser/fixtures/global-rerender-nested/test.js
+++ b/test/components-browser/fixtures/global-rerender-nested/test.js
@@ -3,7 +3,8 @@ var expect = require('chai').expect;
 module.exports = function (helpers) {
     var component = helpers.mount(require('./index.marko'), {
         $global: {
-            name: 'Frank'
+            name: 'Frank',
+            serializedGlobals: { name:true }
         }
     });
 

--- a/test/components-browser/fixtures/global-rerender/test.js
+++ b/test/components-browser/fixtures/global-rerender/test.js
@@ -3,7 +3,8 @@ var expect = require('chai').expect;
 module.exports = function (helpers) {
     var component = helpers.mount(require('./index.marko'), {
         $global: {
-            name: 'Frank'
+            name: 'Frank',
+            serializedGlobals: { name:true }
         }
     });
 

--- a/test/components-browser/fixtures/implicit-component-keys/test.js
+++ b/test/components-browser/fixtures/implicit-component-keys/test.js
@@ -18,3 +18,5 @@ module.exports = function (helpers) {
     expect(els[0]).to.equal(elsAfter[1]);
     expect(els[1]).to.equal(elsAfter[0]);
 };
+
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/implicit-component/test.js
+++ b/test/components-browser/fixtures/implicit-component/test.js
@@ -6,3 +6,5 @@ module.exports = function (helpers) {
     component.destroy();
     expect(helpers.targetEl.querySelector('.hello') == null).to.equal(true);
 };
+
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/input-global/test.js
+++ b/test/components-browser/fixtures/input-global/test.js
@@ -18,3 +18,5 @@ module.exports = function (helpers) {
 
     expect(component.getEl('current').innerHTML).to.equal('Pathname: /test');
 };
+
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/lifecyle-hooks-nested-no-id/test.js
+++ b/test/components-browser/fixtures/lifecyle-hooks-nested-no-id/test.js
@@ -17,3 +17,7 @@ module.exports = function (helpers) {
     expect(hooks.getHookNames('foo')).to.deep.equal(['render', 'update']);
     expect(hooks.getHookNames('root')).to.deep.equal(['render', 'update']);
 };
+
+// Temporarily skip failing hydrate test
+// TODO: enable this test
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/lifecyle-hooks-nested-with-id/test.js
+++ b/test/components-browser/fixtures/lifecyle-hooks-nested-with-id/test.js
@@ -17,3 +17,7 @@ module.exports = function (helpers) {
     expect(hooks.getHookNames('foo')).to.deep.equal(['render', 'update']);
     expect(hooks.getHookNames('root')).to.deep.equal(['render', 'update']);
 };
+
+// Temporarily skip failing hydrate test
+// TODO: enable this test
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/lifecyle-hooks-parent-child-ordering/test.js
+++ b/test/components-browser/fixtures/lifecyle-hooks-parent-child-ordering/test.js
@@ -12,3 +12,7 @@ module.exports = function (helpers) {
 
     expect(hooks.getHookNames()).deep.equal(["root:render", "foo:render", "foo:update", "root:update"]);
 };
+
+// Temporarily skip failing hydrate test
+// TODO: enable this test
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/lifecyle-hooks-root/test.js
+++ b/test/components-browser/fixtures/lifecyle-hooks-root/test.js
@@ -12,3 +12,7 @@ module.exports = function (helpers) {
     expect(component.el.querySelector('.name').innerHTML).to.equal('John');
     expect(component.hookNames).to.deep.equal(['render', 'update']);
 };
+
+// Temporarily skip failing hydrate test
+// TODO: enable this test
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/widget-dom-events/test.js
+++ b/test/components-browser/fixtures/widget-dom-events/test.js
@@ -39,3 +39,7 @@ module.exports = function (helpers) {
     expect(component.logOutput).to.deep.equal(['#helloWorld:mousedown']);
     expect(component.getComponent('appButton').clicked).to.equal(true);
 };
+
+// Temporarily skip failing hydrate test
+// TODO: enable this test
+module.exports.skipHydrate = true;

--- a/test/components-browser/fixtures/widget-rerender-init-order/components/app-rerender-init-order-child/component.js
+++ b/test/components-browser/fixtures/widget-rerender-init-order/components/app-rerender-init-order-child/component.js
@@ -1,6 +1,7 @@
 module.exports = {
     onMount: function () {
         // console.log(module.id, 'init()', this.state);
+        window.rerenderInitOrder = window.rerenderInitOrder || [];
         window.rerenderInitOrder.push(this.input.id);
     },
     onUpdate: function () {

--- a/test/components-browser/fixtures/widget-rerender-init-order/test.js
+++ b/test/components-browser/fixtures/widget-rerender-init-order/test.js
@@ -1,8 +1,6 @@
 var expect = require('chai').expect;
 
 module.exports = function (helpers) {
-    window.rerenderInitOrder = [];
-
     var component = helpers.mount(require('./index'), {
         version: 0
     });

--- a/test/components-browser/fixtures/widget-rerender-init-order/test.js
+++ b/test/components-browser/fixtures/widget-rerender-init-order/test.js
@@ -15,5 +15,5 @@ module.exports = function (helpers) {
     // console.log('ACTUAL ORDER: ', window.rerenderInitOrder);
     expect(window.rerenderInitOrder).to.deep.equal(['childB', 'childA', 'parent']);
 
-    delete window.rerenderInitOrder;
+    window.rerenderInitOrder = null;
 };

--- a/test/components-browser/fixtures/widget-rerender-reuse-stateful/components/hello/index.marko
+++ b/test/components-browser/fixtures/widget-rerender-reuse-stateful/components/hello/index.marko
@@ -1,5 +1,6 @@
 class {
-    onCreate() {
+    onMount() {
+        window.helloInstances = window.helloInstances || [];
         window.helloInstances.push(this);
     }
 

--- a/test/components-browser/fixtures/widget-rerender-reuse-stateful/test.js
+++ b/test/components-browser/fixtures/widget-rerender-reuse-stateful/test.js
@@ -1,8 +1,6 @@
 var expect = require('chai').expect;
 
 module.exports = function (helpers) {
-    window.helloInstances = [];
-
     var component = helpers.mount(require('./index'), {});
 
     expect(window.helloInstances.length).to.equal(2);

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -108,6 +108,7 @@ describe(TEST_NAME + ' (hydrated)', function () {
                 var curInstance = 0;
 
                 browser.window.$initComponents();
+                helpers.isHydrate = true;
 
                 helpers.mount = function () {
                     return browser.window.components[curInstance++];

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -83,7 +83,7 @@ describe(TEST_NAME + ' (hydrated)', function () {
         hydrateOptions
     );
 
-    describe('deprecated', function () {
+    describe.skip('deprecated', function () {
         autotest.scanDir(
             path.join(__dirname, './fixtures-deprecated'),
             runServerRender,

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -75,15 +75,21 @@ describe(TEST_NAME, function () {
 });
 
 describe(TEST_NAME + ' (hydrated)', function () {
+    var hydrateOptions = { 
+        skip: (_, dir) => require(path.join(dir, 'test.js')).skipHydrate
+    };
+
     autotest.scanDir(
         path.join(__dirname, './fixtures'),
-        runServerRender
+        runServerRender,
+        hydrateOptions
     );
 
     describe('deprecated', function () {
         autotest.scanDir(
             path.join(__dirname, './fixtures-deprecated'),
-            runServerRender
+            runServerRender,
+            hydrateOptions
         );
     });
 

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -60,7 +60,8 @@ describe(TEST_NAME, function () {
                 return {
                     file: file,
                     template: require(file),
-                    input: component.input
+                    input: component.input,
+                    $global: component.$global
                 };
             });
     
@@ -88,8 +89,9 @@ describe(TEST_NAME + ' (hydrated)', function () {
 
     function runServerRender(dir, _, done) {
         var components = renderedCache[dir];
+        var $global = components.reduce(($g, c) => Object.assign($g, c.$global), {});
         ssrTemplate
-            .render({ components: components })
+            .render({ components: components, $global: $global })
             .then(function (html) {
                 var browser = createJSDOMModule(__dirname, String(html), {
                     beforeParse(window, browser) {

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -55,15 +55,13 @@ describe(TEST_NAME, function () {
     
         function cleanupAndFinish (err) {
             // Cache components for use in hydrate run.
-            renderedCache[dir] = helpers.components.map(function (component) {
-                var file = component.type.replace(/^.*\/components-browser/, __dirname);
-                return {
-                    file: file,
-                    template: require(file),
-                    input: component.input,
-                    $global: component.$global
-                };
-            });
+            renderedCache[dir] = helpers.components.map(component => ({
+                type: component.type,
+                logic: component.logic,
+                template: component.template && require(component.template),
+                input: component.input,
+                $global: component.$global
+            }));
     
             if (err) {
                 done(err);
@@ -101,10 +99,11 @@ describe(TEST_NAME + ' (hydrated)', function () {
             .then(function (html) {
                 var browser = createJSDOMModule(__dirname, String(html), {
                     beforeParse(window, browser) {
+                        var marko = browser.require('marko/components');
                         var rootComponent = browser.require(require.resolve('./template.component-browser.js'));
-                        browser.require('marko/components').register(ssrTemplate.meta.id, rootComponent);
+                        marko.register(ssrTemplate.meta.id, rootComponent);
                         components.forEach(function (component) {
-                            browser.require(component.file);
+                            marko.register(component.type, browser.require(component.logic));
                         });
                     }
                 });

--- a/test/components-browser/template.component-browser.js
+++ b/test/components-browser/template.component-browser.js
@@ -1,0 +1,6 @@
+module.exports = {
+    onMount() {
+        debugger;
+        window.components = this.getComponents('components');
+    }
+}

--- a/test/components-browser/template.component-browser.js
+++ b/test/components-browser/template.component-browser.js
@@ -1,6 +1,5 @@
 module.exports = {
     onMount() {
-        debugger;
         window.components = this.getComponents('components');
     }
 }

--- a/test/components-browser/template.marko
+++ b/test/components-browser/template.marko
@@ -5,7 +5,9 @@
     </head>
     <body>
         <div#testsTarget>
-            <include(component.template, component.input) for(component in input.components)/>
+            <for(component in input.components)>
+                <include(component.template, component.input) key="components[]"/>
+            </for>
         </div>
     </body>
 </html>


### PR DESCRIPTION
This is building on the changes @DylanPiercey made to get ready for running all our client-only tests in hydrate mode as well.

We'll be going through the each of the failing tests to determine why the test is failing.  

For some of these tests, it's because the assertions need to be different due to the difference in lifecycle (specifically, in hydrate mode, some of the lifecycle happens on the server before mounting in the client).  Other tests might require changes to the testing harness.  There might be a few that don't make sense to run in hydrate mode (maybe?).

We do expect that some of these tests are actual failures though.  For the purposes of this PR, those will be skipped for the time being and we'll address those in future PRs (I already have a branch that addresses some of the tests that are failing).