### PR TITLE
Fix event collision with multiple runtimes.

### DIFF
--- a/src/components/event-delegation.js
+++ b/src/components/event-delegation.js
@@ -5,7 +5,7 @@ var getMarkoPropsFromEl = componentsUtil.___getMarkoPropsFromEl;
 
 // We make our best effort to allow multiple marko runtimes to be loaded in the
 // same window. Each marko runtime will get its own unique runtime ID.
-var listenersAttachedKey = "$MED" + runtimeId;
+var listenersAttachedKey = "$MDE" + runtimeId;
 
 function getEventFromEl(el, eventName) {
     var virtualProps = getMarkoPropsFromEl(el);

--- a/src/components/util-browser.js
+++ b/src/components/util-browser.js
@@ -1,6 +1,6 @@
 var markoUID = window.$MUID || (window.$MUID = { i: 0 });
 
-var runtimeId = new Date().getTime() + String(Math.random()).slice(2); // slice the non-decimal part of the random output
+var runtimeId = markoUID.i++;
 
 var componentLookup = {};
 
@@ -81,7 +81,7 @@ function nextComponentId() {
     // marko runtimes. This allows multiple instances of marko to be
     // loaded in the same window and they should all place nice
     // together
-    return "b" + markoUID.i++;
+    return "c" + markoUID.i++;
 }
 
 function nextComponentIdProvider() {

--- a/src/components/util-browser.js
+++ b/src/components/util-browser.js
@@ -1,5 +1,4 @@
 var markoUID = window.$MUID || (window.$MUID = { i: 0 });
-
 var runtimeId = markoUID.i++;
 
 var componentLookup = {};

--- a/src/components/util-browser.js
+++ b/src/components/util-browser.js
@@ -1,5 +1,6 @@
 var markoUID = window.$MUID || (window.$MUID = { i: 0 });
-var runtimeId = markoUID.i++;
+
+var runtimeId = new Date().getTime() + String(Math.random()).slice(2); // slice the non-decimal part of the random output
 
 var componentLookup = {};
 


### PR DESCRIPTION

## Description

Verified that this way of getting the runtimeId was not working and this is a
way to have no problems with this.

## Motivation and Context

When injecting marko modules through AJAX (including another marko runtime) there is a collision on the `runtimeId` value. This fixes the event problems by forgetting about runtimeId and just setting the eventKey to a timestamp.

## Screenshots (if appropriate):

## Checklist:

* [x] My code follows the code style of this project.
* [x] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
