### PR TITLE
Fix onBeforeUpdate call timing for legacy components.

### DIFF
--- a/src/components/legacy/renderer-legacy.js
+++ b/src/components/legacy/renderer-legacy.js
@@ -230,7 +230,7 @@ function createRendererFunc(templateRenderFunc, componentProps) {
             }
         };
 
-        if (component && isExisting) {
+        if (!isFakeComponent && !registry.___isServer) {
             component.___emitLifecycleEvent("___legacyRender");
         }
 


### PR DESCRIPTION
## Description
Currently `onBeforeUpdate` is called after updating on legacy components in the compatibility layer.
This changes it to be emitted after rendering but before updating the dom.

## Motivation and Context
Improves legacy compatibility.

## Checklist:

* [x] My code follows the code style of this project.
* [ ] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.
