### PR TITLE
allow loading components by lasso paths, but mark as deprecated

### DIFF
--- a/src/components/registry-browser.js
+++ b/src/components/registry-browser.js
@@ -1,4 +1,6 @@
+var complain = "MARKO_DEBUG" && require("complain");
 var defineComponent = require("./defineComponent");
+var loader = require("../loader");
 
 var registered = {};
 var loaded = {};
@@ -25,6 +27,14 @@ function load(typeName, isLegacy) {
             target = target();
         } else if (isLegacy) {
             target = window.$markoLegacy.load(typeName);
+        } else {
+            target = loader(typeName);
+            // eslint-disable-next-line no-constant-condition
+            if ("MARKO_DEBUG") {
+                complain(
+                    "Looks like you used `require:` in your browser.json to load a component.  This requires that Marko has knowledge of how lasso generates paths and will be removed in a future version.  `marko-dependencies:/path/to/template.marko` should be used instead."
+                );
+            }
         }
 
         if (!target) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Prior to Marko 4.7, if you were using `lasso`, the following was how you would specify components that Marko could not be discovered through static analysis:

_browser.json_
```json
{
    "dependencies": [
        "require: path/to/component"
    ]
}
```

`require:` puts the required dependency into the bundle, but doesn’t load it.  And you need use require it using the lasso generated paths.  Marko currently uses lasso paths as component ids, but it shouldn’t rely on this and it also meant that we were very tied to lasso - certain features didn’t work well with other bundlers.

Marko 4.7 moves away from this coupling, but the intention was not to break existing behavior.  This PR adds back support for loading by lasso-specific urls, but logs a deprecation warning.

`lasso-marko@2.4.0` was released at the same time as Marko 4.7 and introduced the `marko-dependencies:` package type.  This should be used instead.

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] My code follows the code style of this project.
* [ ] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
