### PR TITLE
Improve parity between React and Marko example

### DIFF
--- a/docs/marko-vs-react.md
+++ b/docs/marko-vs-react.md
@@ -39,7 +39,9 @@ JSX using a somewhat contrived UI component as an example:
 
 ```jsx
 class Counter extends React.Component {
-  constructor() {
+  constructor(props) {
+    super(props);
+
     this.state = { count: 0 };
   }
   
@@ -48,8 +50,8 @@ class Counter extends React.Component {
   }
   
   render() {
-    var count = this.state.count;
-    var countClassName = "count";
+    const count = this.state.count;
+    let countClassName = "count";
 
     if (count > 0) {
       countClassName += " positive";
@@ -60,8 +62,8 @@ class Counter extends React.Component {
     return (
       <div className="click-count">
         <div className={countClassName}>{count}</div>
-        <button onClick={() => { this.increment(-1) }.bind(this) }>-1</button>
-        <button onClick={() => { this.increment(1) }.bind(this) }}>+1</button>
+        <button onClick={() => { this.increment(-1) } }>-1</button>
+        <button onClick={() => { this.increment(1) } }>+1</button>
       </div>
     );
   }

--- a/docs/marko-vs-react.md
+++ b/docs/marko-vs-react.md
@@ -39,20 +39,14 @@ JSX using a somewhat contrived UI component as an example:
 
 ```jsx
 class Counter extends React.Component {
-  constructor(props) {
-    super(props);
-
+  constructor() {
     this.state = { count: 0 };
-
-    function doIncrement(delta) {
-      this.setState(prevState => ({
-        count: prevState.count + delta
-      }));
-    }
-
-    this.decrement = doIncrement.bind(this, -1);
-    this.increment = doIncrement.bind(this, 1);
   }
+  
+  increment(delta) {
+    this.setState({ count: this.state.count + delta });
+  }
+  
   render() {
     var count = this.state.count;
     var countClassName = "count";
@@ -66,8 +60,8 @@ class Counter extends React.Component {
     return (
       <div className="click-count">
         <div className={countClassName}>{count}</div>
-        <button onClick={this.decrement}>-1</button>
-        <button onClick={this.increment}>+1</button>
+        <button onClick={() => { this.increment(-1) }.bind(this) }>-1</button>
+        <button onClick={() => { this.increment(1) }.bind(this) }}>+1</button>
       </div>
     );
   }


### PR DESCRIPTION
## Description

The React and Marko examples are not in 100% parity with each other. It gives the impression that the React example requires more boilerplate than the Marko one. This ensures that the two examples are using the same method and argument names and does the same _kind_ of thing (passing functions into `on-click` properties for example).

## Motivation and Context

The hope is this makes it easier to compare the two frameworks and see their differences.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] My code follows the code style of this project.
* [ ] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [ ] I have added tests to cover my changes.
* [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
