### PR TITLE
Add failing test cases from branches.

### DIFF
--- a/test/components-pages/fixtures/preserve-no-update-for-loop/components/root/index.marko
+++ b/test/components-pages/fixtures/preserve-no-update-for-loop/components/root/index.marko
@@ -1,0 +1,22 @@
+class {
+    onCreate() {
+        this.state = { items: [] };
+    }
+
+    onMount() {
+        window.component = this;
+    }
+
+    append(item) {
+        this.state.items.push(item);
+        this.setStateDirty("items");
+    }
+}
+
+<ul key="root">
+    <for(item in state.items)>
+        <li id=item no-update>
+            <span>${item}</span>
+        </li>
+    </for>
+</ul>

--- a/test/components-pages/fixtures/preserve-no-update-for-loop/template.marko
+++ b/test/components-pages/fixtures/preserve-no-update-for-loop/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <root/>
+
+        init-components immediate

--- a/test/components-pages/fixtures/preserve-no-update-for-loop/tests.js
+++ b/test/components-pages/fixtures/preserve-no-update-for-loop/tests.js
@@ -1,0 +1,22 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it.fails("should update correctly", function() {
+        var component = window.component;
+        var $el = component.getEl("root");
+
+        expect($el.innerHTML).to.eql("");
+
+        component.append("a");
+        component.update();
+        expect($el.innerHTML).to.eql('<li id="a"><span>a</span></li>');
+
+        component.append("b");
+        component.update();
+        expect($el.innerHTML).to.eql(
+            '<li id="a"><span>a</span></li><li id="b"><span>b</span></li>'
+        );
+    }).details =
+        "Issue #952";
+});

--- a/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/components/toggle-button/index.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/components/toggle-button/index.marko
@@ -1,0 +1,22 @@
+class {
+  onCreate(){
+    this.state = {
+      active: false
+    }
+  }
+  onMount(){
+    window.component = this;
+  }
+  toggle(evt){
+    this.state.active = !this.state.active
+    this.emit('change')
+  }
+  mousedown(evt){
+    evt.preventDefault()
+  }
+}
+
+div.toggle key="button" class={"toggle--active": state.active} onClick('toggle') onMouseDown('mousedown')
+  include(input.renderBody)
+  if(state.active)
+    -- test

--- a/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/template.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/template.marko
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        toggle-button
+            -- button label
+
+        init-components immediate

--- a/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/tests.js
+++ b/test/components-pages/fixtures/preserve-transcluded-content-on-state-change/tests.js
@@ -1,0 +1,16 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it.fails("should update correctly", function() {
+        var component = window.component;
+        var $button = component.getEl("button");
+        expect($button.textContent).to.eql("button label");
+
+        $button.click();
+        component.update();
+
+        expect($button.textContent).to.eql("button label test");
+    }).details =
+        "issue #912";
+});

--- a/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/child/index.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/child/index.marko
@@ -1,0 +1,5 @@
+class {
+  method () {}
+}
+
+<div>Child</div>

--- a/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/container/index.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/container/index.marko
@@ -1,0 +1,3 @@
+<div class="container">
+    <include (input.renderBody) />
+</div>

--- a/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/root/index.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/components/root/index.marko
@@ -1,0 +1,11 @@
+class {
+    onMount() {
+        window.component = this;
+    }
+}
+
+<container>
+    <@renderBody> 
+        <child key="child"/>
+    </@renderBody>
+</container>

--- a/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/template.marko
+++ b/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Test
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <root/>
+
+        init-components immediate

--- a/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/tests.js
+++ b/test/components-pages/fixtures/preserve-transcluded-key-on-state-change/tests.js
@@ -1,0 +1,18 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it.skip("should update correctly", function() {
+        var component = window.component;
+        var originalChild = component.getComponent("child");
+
+        // Ensure we can find the child reference and that it has the exposed method.
+        expect(originalChild).to.be.have.property("method");
+
+        // Trigger a force re-render and ensure reference still exists.
+        component.forceUpdate();
+        component.update();
+        expect(component.getComponent("child")).to.eql(originalChild);
+    }).details =
+        "issue #947";
+});


### PR DESCRIPTION
## Description

Updates the failing test cases from #952 #947 and #912 to work with `it-fails`.

## Motivation and Context

These tests were sitting in branches and with our new ability to add failing test cases it made sense to bring them into master.

## Checklist:

* [x] My code follows the code style of this project.
* [x] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.
