### PR TITLE
Dynamic class style

### DIFF
--- a/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
+++ b/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
@@ -199,7 +199,11 @@ class HtmlElementVDOM extends Node {
                     if (explicitAttrs) {
                         addAttrs(builder.literal(explicitAttrs));
                     }
-                    addAttrs(attr.value);
+                    addAttrs(
+                        codegen.builder.functionCall(context.helper("attrs"), [
+                            attr.value
+                        ])
+                    );
                     explicitAttrs = null;
                     hasSpreadAttributes = true;
                 } else {

--- a/src/runtime/html/helper-attrs.js
+++ b/src/runtime/html/helper-attrs.js
@@ -2,9 +2,9 @@ module.exports = function attrs(arg) {
     if (typeof arg === "object") {
         var out = "";
         for (var attrName in arg) {
-            if (attrName === STYLE_ATTR) {
+            if (attrName === "style") {
                 out += helpers.sa(arg[attrName]);
-            } else if (attrName === CLASS_ATTR) {
+            } else if (attrName === "class") {
                 out += helpers.ca(arg[attrName]);
             } else {
                 out += attrHelper(attrName, arg[attrName]);
@@ -19,5 +19,3 @@ module.exports = function attrs(arg) {
 
 var attrHelper = require("./helper-attr");
 var helpers = require("./helpers");
-var STYLE_ATTR = helpers.___STYLE_ATTR;
-var CLASS_ATTR = helpers.___CLASS_ATTR;

--- a/src/runtime/html/helper-attrs.js
+++ b/src/runtime/html/helper-attrs.js
@@ -1,16 +1,23 @@
-var attrHelper = require("./helper-attr");
-
-function attrs(arg) {
+module.exports = function attrs(arg) {
     if (typeof arg === "object") {
         var out = "";
         for (var attrName in arg) {
-            out += attrHelper(attrName, arg[attrName]);
+            if (attrName === STYLE_ATTR) {
+                out += helpers.sa(arg[attrName]);
+            } else if (attrName === CLASS_ATTR) {
+                out += helpers.ca(arg[attrName]);
+            } else {
+                out += attrHelper(attrName, arg[attrName]);
+            }
         }
         return out;
     } else if (typeof arg === "string") {
         return arg;
     }
     return "";
-}
+};
 
-module.exports = attrs;
+var attrHelper = require("./helper-attr");
+var helpers = require("./helpers");
+var STYLE_ATTR = helpers.___STYLE_ATTR;
+var CLASS_ATTR = helpers.___CLASS_ATTR;

--- a/src/runtime/html/helpers.js
+++ b/src/runtime/html/helpers.js
@@ -1,14 +1,13 @@
 "use strict";
 var extend = require("raptor-util/extend");
 
-var STYLE_ATTR = "style";
-var CLASS_ATTR = "class";
+var STYLE_ATTR = (exports.___STYLE_ATTR = "style");
+var CLASS_ATTR = (exports.___CLASS_ATTR = "class");
 
 var escape = require("./escape");
 var escapeXml = escape.escapeXml;
 var escapeXmlAttr = escape.escapeXmlAttr;
 var attrHelper = require("./helper-attr");
-var attrsHelper = require("./helper-attrs");
 
 /**
  * Internal method to escape special XML characters
@@ -73,7 +72,7 @@ exports.a = attrHelper;
  * Internal method to render multiple HTML attributes based on the properties of an object
  * @private
  */
-exports.as = attrsHelper;
+exports.as = require("./helper-attrs");
 
 /**
  * Internal helper method to handle the "style" attribute. The value can either
@@ -92,29 +91,31 @@ exports.sa = function(style) {
 
     var type = typeof style;
 
-    if (type === "string") {
-        return attrHelper(STYLE_ATTR, style, false);
-    } else if (type === "object") {
-        var styles = "";
-        for (var name in style) {
-            var value = style[name];
-            if (value != null) {
-                if (typeof value === "number" && value) {
-                    value += "px";
+    if (type !== "string") {
+        if (type === "object") {
+            var styles = "";
+            for (var name in style) {
+                var value = style[name];
+                if (value != null) {
+                    if (typeof value === "number" && value) {
+                        value += "px";
+                    }
+                    var nameDashed = dashedNames[name];
+                    if (!nameDashed) {
+                        nameDashed = dashedNames[name] = name
+                            .replace(/([A-Z])/g, "-$1")
+                            .toLowerCase();
+                    }
+                    styles += nameDashed + ":" + value + ";";
                 }
-                var nameDashed = dashedNames[name];
-                if (!nameDashed) {
-                    nameDashed = dashedNames[name] = name
-                        .replace(/([A-Z])/g, "-$1")
-                        .toLowerCase();
-                }
-                styles += nameDashed + ":" + value + ";";
             }
+            style = styles;
+        } else {
+            return "";
         }
-        return styles ? " " + STYLE_ATTR + '="' + styles + '"' : "";
-    } else {
-        return "";
     }
+
+    return attrHelper(STYLE_ATTR, style);
 };
 
 /**

--- a/src/runtime/html/helpers.js
+++ b/src/runtime/html/helpers.js
@@ -1,13 +1,14 @@
 "use strict";
 var extend = require("raptor-util/extend");
 
-var STYLE_ATTR = (exports.___STYLE_ATTR = "style");
-var CLASS_ATTR = (exports.___CLASS_ATTR = "class");
+var STYLE_ATTR = "style";
+var CLASS_ATTR = "class";
 
 var escape = require("./escape");
 var escapeXml = escape.escapeXml;
 var escapeXmlAttr = escape.escapeXmlAttr;
 var attrHelper = require("./helper-attr");
+var attrsHelper = require("./helper-attrs");
 
 /**
  * Internal method to escape special XML characters
@@ -72,7 +73,7 @@ exports.a = attrHelper;
  * Internal method to render multiple HTML attributes based on the properties of an object
  * @private
  */
-exports.as = require("./helper-attrs");
+exports.as = attrsHelper;
 
 /**
  * Internal helper method to handle the "style" attribute. The value can either

--- a/src/runtime/vdom/AsyncVDOMBuilder.js
+++ b/src/runtime/vdom/AsyncVDOMBuilder.js
@@ -9,6 +9,7 @@ var virtualizeHTML = vdom.___virtualizeHTML;
 var RenderResult = require("../RenderResult");
 var defaultDocument = vdom.___defaultDocument;
 var morphdom = require("../../morphdom");
+var attrsHelper = require("./helper-attrs");
 
 var EVENT_UPDATE = "update";
 var EVENT_FINISH = "finish";
@@ -106,7 +107,7 @@ var proto = (AsyncVDOMBuilder.prototype = {
     ) {
         var element = VElement.___createElementDynamicTag(
             tagName,
-            attrs,
+            attrsHelper(attrs),
             key,
             component,
             childCount,
@@ -196,7 +197,7 @@ var proto = (AsyncVDOMBuilder.prototype = {
     ) {
         var element = VElement.___createElementDynamicTag(
             tagName,
-            attrs,
+            attrsHelper(attrs),
             key,
             component,
             childCount,

--- a/src/runtime/vdom/helper-attrs.js
+++ b/src/runtime/vdom/helper-attrs.js
@@ -1,0 +1,22 @@
+var styleAttr = require("./helper-styleAttr");
+var classAttr = require("./helpers").ca;
+
+/**
+ * Helper for processing dynamic attributes
+ */
+module.exports = function(attributes) {
+    if (attributes.style || attributes.class) {
+        var newAttributes = {};
+        Object.keys(attributes).forEach(function(name) {
+            if (name === "class") {
+                newAttributes[name] = classAttr(attributes[name]);
+            } else if (name === "style") {
+                newAttributes[name] = styleAttr(attributes[name]);
+            } else {
+                newAttributes[name] = attributes[name];
+            }
+        });
+        return newAttributes;
+    }
+    return attributes;
+};

--- a/src/runtime/vdom/helper-attrs.js
+++ b/src/runtime/vdom/helper-attrs.js
@@ -1,6 +1,3 @@
-var styleAttr = require("./helper-styleAttr");
-var classAttr = require("./helpers").ca;
-
 /**
  * Helper for processing dynamic attributes
  */
@@ -20,3 +17,6 @@ module.exports = function(attributes) {
     }
     return attributes;
 };
+
+var styleAttr = require("./helper-styleAttr");
+var classAttr = require("./helpers").ca;

--- a/src/runtime/vdom/helpers.js
+++ b/src/runtime/vdom/helpers.js
@@ -52,7 +52,9 @@ var helpers = extend(
             } else {
                 return classList(classNames);
             }
-        }
+        },
+
+        as: require("./helper-attrs")
     },
     commonHelpers
 );

--- a/test/render/fixtures/dynamic-tag-object-class-style/expected.html
+++ b/test/render/fixtures/dynamic-tag-object-class-style/expected.html
@@ -1,0 +1,1 @@
+<hello-world class="foo bar" style="color:blue;">My nested content</hello-world>

--- a/test/render/fixtures/dynamic-tag-object-class-style/template.marko
+++ b/test/render/fixtures/dynamic-tag-object-class-style/template.marko
@@ -1,0 +1,3 @@
+<${input.myTagName} class=["foo", { bar:true, baz:false }] style={ color:"blue" }>
+    My nested content
+</>

--- a/test/render/fixtures/dynamic-tag-object-class-style/test.js
+++ b/test/render/fixtures/dynamic-tag-object-class-style/test.js
@@ -1,0 +1,3 @@
+exports.templateData = {
+    myTagName: "hello-world"
+};

--- a/test/render/fixtures/spread-attribute-class-style-html-tag/expected.html
+++ b/test/render/fixtures/spread-attribute-class-style-html-tag/expected.html
@@ -1,0 +1,1 @@
+<div class="foo bar" style="color:blue;">Hello spread</div>

--- a/test/render/fixtures/spread-attribute-class-style-html-tag/template.marko
+++ b/test/render/fixtures/spread-attribute-class-style-html-tag/template.marko
@@ -1,0 +1,8 @@
+$ var attrs = {
+    class: ['foo', { bar:true, baz:false }],
+    style: { color:'blue' }
+};
+
+<div ...attrs>
+    Hello spread
+</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Fixes a regression in `<${dynamic}>` tags for object/array class/style attributes:
  ```marko
  $ const style = { color:'blue' };
  <${tagName} style=style/>
  ```
- Allows dynamic attributes defined using `...spread` to include object/array class/style (#933):
  ```marko
  $ const attrs = { style:{ color:'blue' } };
  <tag ...attrs/>
  ```
- Fixes issue where object/array class/style attributes could not be used with `...spread` (#1007):
  ```marko
  $ const attrs = {};
  <tag class=["oops"] ...attrs/>
  ```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] My code follows the code style of this project.
* [x] I have updated/added documentation affected by my changes.
* [x] I have read the **CONTRIBUTING** document.
* [x] I have added tests to cover my changes.
* [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
