### PR TITLE
No longer set scoped attributes as default keys.

### DIFF
--- a/src/components/taglib/TransformHelper/handleScopedAttrs.js
+++ b/src/components/taglib/TransformHelper/handleScopedAttrs.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const removeDashes = require("../../../compiler/util/removeDashes");
-
 const deprecatedKeySuffix = ":key";
 const scopedSuffix = ":scoped";
 const deprecatedAttrs = {
@@ -13,7 +11,6 @@ const deprecatedAttrs = {
 module.exports = function handleComponentKeyAttrs() {
     let el = this.el;
     let context = this.context;
-    let builder = this.builder;
     const filePosition = el.pos ? context.getPosInfo(el.pos) : context.filename;
 
     var attrs = el.attributes.concat([]);
@@ -79,21 +76,9 @@ module.exports = function handleComponentKeyAttrs() {
                 return;
             }
 
-            let uniqueElId = this.nextUniqueId();
-            let idVarName =
-                "marko_" +
-                removeDashes(finalAttributeName) +
-                "_key" +
-                uniqueElId;
-
-            let varNode = builder.var(idVarName, attribute.value);
-
-            el.insertSiblingBefore(varNode);
-            let varIdNode = builder.identifier(idVarName);
-
             el.setAttributeValue(
                 finalAttributeName,
-                this.buildComponentElIdFunctionCall(varIdNode)
+                this.buildComponentElIdFunctionCall(attribute.value)
             );
         }
     });

--- a/src/components/taglib/TransformHelper/handleScopedAttrs.js
+++ b/src/components/taglib/TransformHelper/handleScopedAttrs.js
@@ -95,16 +95,6 @@ module.exports = function handleComponentKeyAttrs() {
                 finalAttributeName,
                 this.buildComponentElIdFunctionCall(varIdNode)
             );
-
-            if (
-                !el.hasAttribute("key") &&
-                !el.hasAttribute("w-id") &&
-                !el.hasAttribute("ref")
-            ) {
-                // The scoped attribute should be suitable for a key
-                el.setAttributeValue("key", varIdNode);
-                el.data.userAssignedKey = false;
-            }
         }
     });
 };

--- a/test/components-browser/fixtures/preserve-nodes-update-scoped-elements/index.marko
+++ b/test/components-browser/fixtures/preserve-nodes-update-scoped-elements/index.marko
@@ -1,0 +1,13 @@
+class {
+    onCreate() {
+        this.state = { show: true };
+    }
+    hide() {
+        this.state.show = false;
+    }
+}
+
+<div>
+    <label for:scoped="abc" if(state.show)/>
+    <input id:scoped="abc"/>
+</div>

--- a/test/components-browser/fixtures/preserve-nodes-update-scoped-elements/test.js
+++ b/test/components-browser/fixtures/preserve-nodes-update-scoped-elements/test.js
@@ -1,0 +1,19 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var rootEl = component.getEl();
+    var inputEl = rootEl.querySelector("input");
+
+    component.hide();
+    component.update();
+
+    expect(
+        null === rootEl.querySelector("label"),
+        "label should have been removed"
+    ).to.equal(true);
+    expect(
+        inputEl === rootEl.querySelector("input"),
+        "input should not have been removed"
+    ).to.equal(true);
+};

--- a/test/components-compilation/fixtures-html/key-suffix/expected.js
+++ b/test/components-compilation/fixtures-html/key-suffix/expected.js
@@ -14,12 +14,8 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  out.w("<div class=\"root\">");
-
-  var marko_for_key1 = "name";
-
-  out.w("<label" +
-    marko_attr("for", __component.elId(marko_for_key1)) +
+  out.w("<div class=\"root\"><label" +
+    marko_attr("for", __component.elId("name")) +
     ">Name</label><input" +
     marko_attr("id", __component.elId("name")) +
     "></div>");

--- a/test/components-compilation/fixtures-html/label-for/expected.js
+++ b/test/components-compilation/fixtures-html/label-for/expected.js
@@ -12,16 +12,10 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  var marko_for_key0 = "submitButton";
-
   out.w("<label" +
-    marko_attr("for", __component.elId(marko_for_key0)) +
-    ">Submit</label>");
-
-  var marko_id_key2 = "submitButton";
-
-  out.w("<button" +
-    marko_attr("id", __component.elId(marko_id_key2)) +
+    marko_attr("for", __component.elId("submitButton")) +
+    ">Submit</label><button" +
+    marko_attr("id", __component.elId("submitButton")) +
     ">Submit</button>");
 }
 

--- a/test/components-compilation/fixtures-html/label-for/expected.js
+++ b/test/components-compilation/fixtures-html/label-for/expected.js
@@ -18,10 +18,10 @@ function render(input, out, __component, component, state) {
     marko_attr("for", __component.elId(marko_for_key0)) +
     ">Submit</label>");
 
-  var marko_id_key1 = "submitButton";
+  var marko_id_key2 = "submitButton";
 
   out.w("<button" +
-    marko_attr("id", __component.elId(marko_id_key1)) +
+    marko_attr("id", __component.elId(marko_id_key2)) +
     ">Submit</button>");
 }
 


### PR DESCRIPTION
## Description

Currently if you have a `:scoped` attribute on an element that scoped attribute will be used as the default key for the element.

IE:

```marko
<label for:scoped="my-input"/>
```

Transforms into:

```marko
<label for:scoped="my-input" key="my-input"/>
```

This causes an issue in a common case where you have a `<label for:scoped` and `<input id:scoped`. This causes both elements to have the same key and cause the matching in the diffing algo to throw away one of them on re-renders.

## Checklist:

- [x] My code follows the code style of this project.
- [x] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.