### PR TITLE
Fix client reordering when having multiple children

### DIFF
--- a/src/taglibs/async/client-reorder-runtime.js
+++ b/src/taglibs/async/client-reorder-runtime.js
@@ -24,7 +24,7 @@ function $af(
         len = childNodes.length;
 
         for (; i < len; i++) {
-            docFragment.appendChild(childNodes.item(0));
+            docFragment.appendChild(childNodes.item(i));
         }
 
         targetEl.parentNode.replaceChild(docFragment, targetEl);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

I was looking at the client-reorder functionality and I'm sure that there is a bug in this code where it will continue appending the first element to the docFragment when there are modules with many children

## Motivation and Context

When using the await tag with code that renders multiple children we'll have problems reordering the content.

## Screenshots (if appropriate):

## Checklist:

- [X] My code follows the code style of this project.
- [NA] I have updated/added documentation affected by my changes.
- [X] I have read the **CONTRIBUTING** document.
- [in progress?] I have added tests to cover my changes.
- [X] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
