### PR TITLE
Fixes #1078 - don't mutate spread attributes

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -57,6 +57,7 @@ function requireResolve(builder, path) {
 }
 
 const helpers = {
+    assign: { module: "marko/runtime/helper-assign" },
     attr: "a",
     attrs: "as",
     classAttr: "ca",

--- a/src/runtime/helper-assign.js
+++ b/src/runtime/helper-assign.js
@@ -1,0 +1,22 @@
+/**
+ * Merges object properties
+ * @param  {[type]} object [description]
+ * @param  {[type]} source [description]
+ * @return {[type]}        [description]
+ */
+function assign() {
+    var into = arguments[0];
+    for (var i = 1; i < arguments.length; i++) {
+        var source = arguments[i];
+        if (source != null) {
+            for (var k in source) {
+                if (source.hasOwnProperty(k)) {
+                    into[k] = source[k];
+                }
+            }
+        }
+    }
+    return into;
+}
+
+module.exports = assign;

--- a/test/render/fixtures/spread-attribute-no-mutate/components/test.marko
+++ b/test/render/fixtures/spread-attribute-no-mutate/components/test.marko
@@ -1,0 +1,1 @@
+-- ${JSON.stringify(input)}

--- a/test/render/fixtures/spread-attribute-no-mutate/expected.html
+++ b/test/render/fixtures/spread-attribute-no-mutate/expected.html
@@ -1,0 +1,1 @@
+<div id="dom" class="test"></div>{"hidden":false,"id":"custom","class":"test"}<div id="dom" class="test"></div>

--- a/test/render/fixtures/spread-attribute-no-mutate/template.marko
+++ b/test/render/fixtures/spread-attribute-no-mutate/template.marko
@@ -1,0 +1,13 @@
+import assert from "assert";
+
+$ var before = {
+    hidden: false
+};
+
+$ var after = {
+    class: 'test'
+};
+
+<div ...before id="dom" ...after/>
+<test ...before id="custom" ...after/>
+<div ...before id="dom" ...after/>

--- a/test/render/fixtures/spread-attribute-order-custom-tag/expected.html
+++ b/test/render/fixtures/spread-attribute-order-custom-tag/expected.html
@@ -1,4 +1,4 @@
 <pre>{
-  "id": "override",
-  "class": "test"
+  "class": "test",
+  "id": "override"
 }</pre>

--- a/test/render/fixtures/spread-attribute-order-html-tag/expected.html
+++ b/test/render/fixtures/spread-attribute-order-html-tag/expected.html
@@ -1,1 +1,1 @@
-<div id="override" class="test">Hello spread</div>
+<div class="test" id="override">Hello spread</div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
The spread attribute had been implemented using the `merge` helper, but it works differently to `Object.assign` which is more a `1:1` mapping to the spread concept.  Due in part to this, we were inadvertently causing the spread attributes to have other attributes merged into them - actually mutating the object.

This PR introduces an `assign` helper and uses that instead to merge spread and normal attributes together.  This cleans up the output a bit but also makes the logic around ensuring that we don't mutate simpler.


## Motivation and Context

Fixes #1078 


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
