### PR TITLE
fixes #1022 - transcluded keys don't match, stateful component not preserved

### DIFF
--- a/src/components/renderer.js
+++ b/src/components/renderer.js
@@ -22,7 +22,7 @@ function resolveComponentKey(
         return key.substring(1);
     } else {
         parentComponentDef = parentComponentDef || ownerComponentDef;
-        return ownerComponentDef.id + "-" + parentComponentDef.___nextKey(key);
+        return parentComponentDef.___nextKey(ownerComponentDef.id + "-" + key);
     }
 }
 

--- a/src/components/renderer.js
+++ b/src/components/renderer.js
@@ -12,11 +12,17 @@ var endComponent = require("./endComponent");
 
 var COMPONENT_BEGIN_ASYNC_ADDED_KEY = "$wa";
 
-function resolveComponentKey(globalComponentsContext, key, parentComponentDef) {
+function resolveComponentKey(
+    globalComponentsContext,
+    key,
+    ownerComponentDef,
+    parentComponentDef
+) {
     if (key[0] === "#") {
         return key.substring(1);
     } else {
-        return parentComponentDef.id + "-" + parentComponentDef.___nextKey(key);
+        parentComponentDef = parentComponentDef || ownerComponentDef;
+        return ownerComponentDef.id + "-" + parentComponentDef.___nextKey(key);
     }
 }
 
@@ -73,7 +79,7 @@ function createRendererFunc(
         var customEvents;
         var scope;
         var parentComponentDef = componentsContext.___componentDef;
-        var componentDefFromArgs = out.___assignedComponentDef;
+        var ownerComponentDef = out.___assignedComponentDef;
 
         if (component) {
             // If component is provided then we are currently rendering
@@ -87,9 +93,9 @@ function createRendererFunc(
             // DOM (if any) so we will need to resolve the component ID from
             // the assigned key. We also need to handle any custom event bindings
             // that were provided.
-            if (componentDefFromArgs) {
+            if (ownerComponentDef) {
                 // console.log('componentArgs:', componentArgs);
-                scope = componentDefFromArgs.id;
+                scope = ownerComponentDef.id;
                 out.___assignedComponentDef = null;
 
                 customEvents = out.___assignedCustomEvents;
@@ -99,10 +105,11 @@ function createRendererFunc(
                     id = resolveComponentKey(
                         globalComponentsContext,
                         key.toString(),
-                        componentDefFromArgs
+                        ownerComponentDef,
+                        parentComponentDef
                     );
                 } else {
-                    id = componentDefFromArgs.___nextComponentId();
+                    id = ownerComponentDef.___nextComponentId();
                 }
             } else {
                 id = globalComponentsContext.___nextComponentId();
@@ -206,7 +213,7 @@ function createRendererFunc(
             componentsContext,
             component,
             isSplit,
-            componentDefFromArgs,
+            ownerComponentDef,
             isImplicitComponent
         );
 

--- a/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/components/container/index.marko
+++ b/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/components/container/index.marko
@@ -1,0 +1,9 @@
+class {
+    onCreate() {
+        this.state = { hideOwnCounter:false };
+    }
+}
+
+<div>
+    <counter key="counter" if(!state.hideOwnCounter)/>|<include(input.renderBody)/>
+</div>

--- a/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/components/counter/index.marko
+++ b/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/components/counter/index.marko
@@ -1,0 +1,11 @@
+class {
+    onCreate() {
+        this.state = { count:0 };
+    }
+
+    increment() {
+        this.state.count++;
+    }
+}
+
+-- ${state.count}

--- a/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/index.marko
+++ b/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/index.marko
@@ -1,0 +1,5 @@
+class {}
+
+<container key="container">
+    <counter key="counter"/>
+</container>

--- a/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/test.js
+++ b/test/components-browser/fixtures/transclusion-rerender-stateful-shared-key/test.js
@@ -1,0 +1,19 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var root = helpers.mount(require.resolve("./index"));
+    var container = root.getComponent("container");
+    var counter = root.getComponent("counter");
+
+    expect(helpers.targetEl.textContent).to.equal("0|0");
+
+    counter.increment();
+    counter.update();
+
+    expect(helpers.targetEl.textContent).to.equal("0|1");
+
+    container.state.hideOwnCounter = true;
+    container.update();
+
+    expect(helpers.targetEl.textContent).to.equal("|1");
+};

--- a/test/components-browser/fixtures/transclusion-rerender-stateful/test.js
+++ b/test/components-browser/fixtures/transclusion-rerender-stateful/test.js
@@ -5,17 +5,15 @@ module.exports = function(helpers) {
     var container = root.getComponent("container");
     var counter = root.getComponent("counter");
 
-    expect(document.body.textContent).to.equal("0");
+    expect(helpers.targetEl.textContent).to.equal("0");
 
     counter.increment();
     counter.update();
 
-    expect(document.body.textContent).to.equal("1");
+    expect(helpers.targetEl.textContent).to.equal("1");
 
     container.forceUpdate();
     container.update();
 
-    expect(document.body.textContent).to.equal("1");
+    expect(helpers.targetEl.textContent).to.equal("1");
 };
-
-module.exports.fails = "issue #1022";


### PR DESCRIPTION
## Description

Fixes Issue #1022: Because keys can be repeated in Marko, a component has a KeySequence that keeps track of the number of times a key has been rendered.  This gets reset each time the component is re-rendered, but in the case of transcluded content, the owner component (the component in which a node is defined) is not the only cause of re-renders.  The immediate parent can cause a rerender and in this case, the owner component's KeySequence picks up where it left off, generating incorrect keys.

In practice, this means nodes get thrown away that shouldn't be.  And this is especially problematic when the node that gets thrown away is a stateful component as its internal state gets lost.

This PR fixes this issue by using the immediate parent's KeySequence instead of the owner component's.  Keys are still scoped to the owner component, so `getComponent` still works.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
