### PR TITLE
Add shorter .mark extension support to taglib-loader.

### DIFF
--- a/src/compiler/taglib-loader/scanTagsDir.js
+++ b/src/compiler/taglib-loader/scanTagsDir.js
@@ -19,9 +19,11 @@ const tagFileTypes = [
 
 const searchFiles = [
     { name: "index.marko", type: "template" },
+    { name: "index.mark", type: "template" },
     { name: "renderer", type: "renderer" },
     { name: "index", type: "renderer" },
     { name: "template.marko", type: "template" },
+    { name: "template.mark", type: "template" },
     { name: "template.html", type: "template" },
     { name: "code-generator", type: "code-generator" },
     { name: "node-factory", type: "node-factory" },
@@ -133,7 +135,7 @@ module.exports = function scanTagsDir(
         let tagJsonPath;
 
         let ext = nodePath.extname(childFilename);
-        if (ext === ".marko") {
+        if (ext === ".marko" || ext === ".mark") {
             tagName = childFilename.slice(0, 0 - ext.length);
             tagDirname = dir;
             tagDef = createDefaultTagDef();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
I configure Webpack to recognize .mark files as marko templates, but it's impossible to use other extensions than .marko with custom tags, excepts with marko.json(maybe).
<!--- If it fixes an open issue, please link to the issue here. -->

## Screenshots (if appropriate):

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

_Disclaimer: Contributions via GitHub pull requests are gladly accepted from their original author. Along with any pull requests, please state that the contribution is your original work and that you license the work to the project under the project's open source license. Whether or not you state this explicitly, by submitting any copyrighted material via pull request, email, or other means you agree to license the material under the project's open source license and warrant that you have the legal authority to do so._
