### PR TITLE
Remove extra parenthesis from compiled javascript.

### DIFF
--- a/src/compiler/util/parseJavaScript.js
+++ b/src/compiler/util/parseJavaScript.js
@@ -295,10 +295,7 @@ function parseExpression(src, builder, isExpression) {
 
     let jsAST;
     try {
-        if (isExpression) {
-            src = "(" + src + ")";
-        }
-        jsAST = esprima.parseScript(src);
+        jsAST = esprima.parseScript(isExpression ? "(" + src + ")" : src);
     } catch (e) {
         if (e.index == null) {
             // Doesn't look like an Esprima parse error... just rethrow the exception

--- a/test/components-compilation/fixtures-html/nodejs-8-async-await/expected.js
+++ b/test/components-compilation/fixtures-html/nodejs-8-async-await/expected.js
@@ -1,11 +1,11 @@
 "use strict";
 
 var marko_template = module.exports = require("marko/src/html").t(__filename),
-    marko_component = ({
+    marko_component = {
     test: async function () {
         await Promise.resolve();
     }
-}),
+},
     marko_componentType = "/marko-test$1.0.0/components-compilation/fixtures-html/nodejs-8-async-await/index.marko",
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,

--- a/test/parseFor/fixtures/forEach-invalid-option2/expected.json
+++ b/test/parseFor/fixtures/forEach-invalid-option2/expected.json
@@ -1,3 +1,3 @@
 {
-  "error": "Invalid status-var option: \nUnexpected identifier: (test foo)\n                             ^"
+  "error": "Invalid status-var option: \nUnexpected identifier: test foo\n                             ^"
 }

--- a/test/render/fixtures/error-bad-expression/test.js
+++ b/test/render/fixtures/error-bad-expression/test.js
@@ -13,5 +13,5 @@ exports.checkError = function(e) {
     expect(message).to.contain(
         'Invalid JavaScript expression for attribute "class"'
     );
-    expect(message).to.contain("Unexpected identifier: ((this is not valid))");
+    expect(message).to.contain("Unexpected identifier: (this is not valid)");
 };

--- a/test/render/fixtures/error-invalid-else-if-tag/test.js
+++ b/test/render/fixtures/error-invalid-else-if-tag/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
     var message = e.toString();
     expect(message).to.contain("else-if");
-    expect(message).to.contain("Unexpected identifier: (true invalid)");
+    expect(message).to.contain("Unexpected identifier: true invalid");
 };

--- a/test/render/fixtures/error-invalid-for-attr/test.js
+++ b/test/render/fixtures/error-invalid-for-attr/test.js
@@ -9,6 +9,6 @@ exports.checkError = function(e) {
     );
     expect(message).to.contain('Invalid "in" expression:');
     expect(message).to.contain(
-        "Unexpected identifier: (['red', 'blue', 'green'] foo)"
+        "Unexpected identifier: ['red', 'blue', 'green'] foo"
     );
 };

--- a/test/render/fixtures/error-invalid-for-props/test.js
+++ b/test/render/fixtures/error-invalid-for-props/test.js
@@ -9,6 +9,6 @@ exports.checkError = function(e) {
     );
     expect(message).to.contain('Invalid "in" expression:');
     expect(message).to.contain(
-        "Unexpected identifier: ({'foo': 'low', 'bar': 'high'} foo)"
+        "Unexpected identifier: {'foo': 'low', 'bar': 'high'} foo"
     );
 };

--- a/test/render/fixtures/error-invalid-for-range-step/test.js
+++ b/test/render/fixtures/error-invalid-for-range-step/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
         "An error occurred while trying to compile template at path"
     );
     expect(message).to.contain('Invalid "step" expression:');
-    expect(message).to.contain("Unexpected number: (0 0)");
+    expect(message).to.contain("Unexpected number: 0 0");
 };

--- a/test/render/fixtures/error-invalid-for-range-to-expr/test.js
+++ b/test/render/fixtures/error-invalid-for-range-to-expr/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
         "An error occurred while trying to compile template at path"
     );
     expect(message).to.contain('Invalid "to" expression:');
-    expect(message).to.contain("Unexpected number: ('abc'.length 1)");
+    expect(message).to.contain("Unexpected number: 'abc'.length 1");
 };

--- a/test/render/fixtures/error-invalid-for-range/test.js
+++ b/test/render/fixtures/error-invalid-for-range/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
         "An error occurred while trying to compile template at path"
     );
     expect(message).to.contain('Invalid "from" expression:');
-    expect(message).to.contain("Unexpected identifier: (0 too 9)");
+    expect(message).to.contain("Unexpected identifier: 0 too 9");
 };

--- a/test/render/fixtures/error-invalid-if-attr/test.js
+++ b/test/render/fixtures/error-invalid-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
     var message = e.toString();
-    expect(message).to.contain("Unexpected identifier: (true sdsds)");
+    expect(message).to.contain("Unexpected identifier: true sdsds");
 };

--- a/test/render/fixtures/error-invalid-if-else-attr/test.js
+++ b/test/render/fixtures/error-invalid-if-else-attr/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
     var message = e.toString();
     // expect(message).to.contain('Error: Unable to compile template at path');
-    expect(message).to.contain("Unexpected number: (input.foo === dasda 0)");
+    expect(message).to.contain("Unexpected number: input.foo === dasda 0");
 };

--- a/test/render/fixtures/error-invalid-if-else-if-attr/test.js
+++ b/test/render/fixtures/error-invalid-if-else-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
     var message = e.toString();
-    expect(message).to.contain("Unexpected identifier: (true sds)");
+    expect(message).to.contain("Unexpected identifier: true sds");
 };

--- a/test/render/fixtures/error-invalid-if-else-if-else-attr/test.js
+++ b/test/render/fixtures/error-invalid-if-else-if-else-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
     var message = e.toString();
-    expect(message).to.contain("Unexpected token =: (input.foo ==== 1)");
+    expect(message).to.contain("Unexpected token =: input.foo ==== 1");
 };

--- a/test/render/fixtures/error-invalid-if-else-if-else-tag/test.js
+++ b/test/render/fixtures/error-invalid-if-else-if-else-tag/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
         "An error occurred while trying to compile template at path"
     );
     expect(message).to.contain("Invalid expression for if statement:");
-    expect(message).to.contain("Unexpected identifier: (false foo)");
+    expect(message).to.contain("Unexpected identifier: false foo");
 };

--- a/test/render/fixtures/error-invalid-if-else-if-tag/test.js
+++ b/test/render/fixtures/error-invalid-if-else-if-tag/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
         "An error occurred while trying to compile template at path"
     );
     expect(message).to.contain("Invalid expression for else-if statement:");
-    expect(message).to.contain("Unexpected identifier: (true foo)");
+    expect(message).to.contain("Unexpected identifier: true foo");
 };

--- a/test/render/fixtures/error-invalid-if-tag/test.js
+++ b/test/render/fixtures/error-invalid-if-tag/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
     var message = e.toString();
-    expect(message).to.contain("Unexpected identifier: (true sdsds)");
+    expect(message).to.contain("Unexpected identifier: true sdsds");
 };

--- a/test/render/fixtures/error-invalid-unless-tag/test.js
+++ b/test/render/fixtures/error-invalid-unless-tag/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
     var message = e.toString();
     expect(message).to.contain("unless");
-    expect(message).to.contain("Unexpected identifier: (true sdsds)");
+    expect(message).to.contain("Unexpected identifier: true sdsds");
 };


### PR DESCRIPTION
## Description
Removes added parenthesis for parsed javascript nodes that Marko doesn't understand.

## Motivation and Context
This was making Marko Prettyprint output additional parenthesis. Also it bloats the output a small amount.

- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.