### PR TITLE
Fix grammar errors in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ module.exports = {
 
 ## Concise Syntax
 
-Marko also support a beautiful concise syntax as an alternative to the HTML
+Marko also supports a beautifully concise syntax as an alternative to HTML
 syntax. Find out more about the [concise syntax here](http://markojs.com/docs/concise/).
 
 ```marko


### PR DESCRIPTION
## Description

I corrected three things in the Readme that I perceive as grammar errors. 
1) This one I am most confident about. I believe the original author meant to say 'Marko also supports' instead of 'Marko also support'.
2) The original author use two adjectives back to back ('beautiful concise'). I believe this is incorrect. Either a comma must be inserted between the two adjectives or the first adjective must become an adverb.
3) I think 'HTML syntax' sounds better than 'The HTML syntax'.

## Motivation and Context

I think having a more pleasing README helps build up a good first impression which helps build a user base. People think that a repo with a good README will have quality maintainers. (and quality maintainers are attracted to repos with good READMEs)

I agree to license this under the terms of this projects open source license.