### PR TITLE
Fix node inspect deprecation warning.

### DIFF
--- a/src/compiler/ast/Node.js
+++ b/src/compiler/ast/Node.js
@@ -241,7 +241,7 @@ class Node {
      * of this node that is the same version we use when
      * serializing to JSON.
      */
-    inspect() {
+    [inspect.custom]() {
         // We inspect in the simplified version of this object t
         return this.toJSON();
     }


### PR DESCRIPTION
## Description
Switch to use the node [`util.inspect` symbol](https://nodejs.org/api/util.html#util_util_inspect_custom) for ast nodes.

This symbol is supported in node 6+. Technically this PR could also support node 4, however this still works in node 4 it just doesn't print as pretty. Because it still works I opted to not clutter the codebase for a legacy version of node.

## Motivation and Context

This fixes this deprecation warning `(node:45125) [DEP0079] DeprecationWarning: Custom inspection function on Objects via .inspect() is deprecated`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
