### PR TITLE
Add back abiity to get child component element from getEl

### DIFF
--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -223,7 +223,24 @@ Component.prototype = componentProto = {
     },
     getEl: function(key, index) {
         if (key) {
-            return this.___keyedElements["@" + resolveKeyHelper(key, index)];
+            var resolvedKey = resolveKeyHelper(key, index);
+            var keyedElement = this.___keyedElements["@" + resolvedKey];
+
+            if (!keyedElement) {
+                var keyedComponent = this.getComponent(resolvedKey);
+
+                if (keyedComponent) {
+                    // eslint-disable-next-line no-constant-condition
+                    if ("MARKO_DEBUG") {
+                        complain(
+                            "Accessing the elements of a child component using 'component.getEl' is deprecated."
+                        );
+                    }
+                    return keyedComponent.___rootNode.firstChild;
+                }
+            }
+
+            return keyedElement;
         } else {
             return this.___rootNode && this.___rootNode.firstChild;
         }

--- a/test/components-browser/fixtures-deprecated/get-el-nested-component/components/child.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-component/components/child.marko
@@ -1,0 +1,1 @@
+<span>Text</span>

--- a/test/components-browser/fixtures-deprecated/get-el-nested-component/template.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-component/template.marko
@@ -1,0 +1,5 @@
+class {}
+
+<div>
+	<child key="child"/>
+</div>

--- a/test/components-browser/fixtures-deprecated/get-el-nested-component/test.js
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-component/test.js
@@ -1,0 +1,7 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./template.marko"));
+
+    expect(component.getEl("child").tagName).to.equal("SPAN");
+};


### PR DESCRIPTION
## Description

Somewhere in 4.5 we removed the ability to get a child components element from `getEl` without deprecating it. This changes brings it back with a deprecation warning.

Fixes #1112 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
