### PR TITLE
Remove object.assign from browser code.

### DIFF
--- a/src/runtime/helpers.js
+++ b/src/runtime/helpers.js
@@ -123,8 +123,12 @@ var helpers = {
                     }, {});
                 if (attrs.renderBody) {
                     var renderBody = attrs.renderBody;
-                    var otherAttrs = Object.assign({}, attrs);
-                    delete otherAttrs.renderBody;
+                    var otherAttrs = {};
+                    for (var attrKey in attrs) {
+                        if (attrKey !== "renderBody") {
+                            otherAttrs[attrKey] = attrs[attrKey];
+                        }
+                    }
                     out.___beginElementDynamic(
                         tag,
                         otherAttrs,

--- a/src/runtime/html/helpers.js
+++ b/src/runtime/html/helpers.js
@@ -155,7 +155,8 @@ var escapeScript = exports.xs;
 var assignPropsFunction = `
     function ap_(p) {
         var s = document.currentScript;
-        Object.assign(s.previousSibling, p);
+        var ps = s.previousSibling;
+        for (var k in p) ps[k] = p[k];
         s.parentNode.removeChild(s);
     }
 `

--- a/src/runtime/vdom/VElement.js
+++ b/src/runtime/vdom/VElement.js
@@ -28,6 +28,14 @@ function convertAttrValue(type, value) {
     }
 }
 
+function assign(a, b) {
+    for (var key in b) {
+        if (b.hasOwnProperty(key)) {
+            a[key] = b[key];
+        }
+    }
+}
+
 function setAttribute(el, namespaceURI, name, value) {
     if (namespaceURI === null) {
         el.setAttribute(name, value);
@@ -194,7 +202,7 @@ VElement.prototype = {
                 : doc.createElement(tagName);
 
         if (flags & FLAG_CUSTOM_ELEMENT) {
-            Object.assign(el, attributes);
+            assign(el, attributes);
         } else {
             for (var attrName in attributes) {
                 var attrValue = attributes[attrName];
@@ -362,7 +370,7 @@ VElement.___morphAttrs = function(fromEl, vFromEl, toEl) {
     var props = toEl.___properties;
 
     if (toFlags & FLAG_CUSTOM_ELEMENT) {
-        return Object.assign(fromEl, attrs);
+        return assign(fromEl, attrs);
     }
 
     var attrName;

--- a/test/render/fixtures/custom-element-assign-props/expected.html
+++ b/test/render/fixtures/custom-element-assign-props/expected.html
@@ -1,1 +1,1 @@
-<ce-test></ce-test><script>function ap_(p){ var s=document.currentScript;Object.assign(s.previousSibling,p);s.parentNode.removeChild(s);}ap_({"attr":{"foo":"bar"}});</script>
+<ce-test></ce-test><script>function ap_(p){ var s=document.currentScript;var ps=s.previousSibling;for(var k in p)ps[k]= p[k];s.parentNode.removeChild(s);}ap_({"attr":{"foo":"bar"}});</script>


### PR DESCRIPTION
## Description

Some object.assign calls made it into the browser code. This removes them.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.