### PR TITLE
Fixed typos in components.md

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -10,7 +10,7 @@ With Marko, the DOM output of a UI component is based on input properties and a 
 
 ## Component structure
 
-Marko makes it easy to to co-locate your component's class and styles with the HTML view that they correspond to. The following are the key part of any UI component:
+Marko makes it easy to co-locate your component's class and styles with the HTML view that they correspond to. The following are the key part of any UI component:
 
 - **View** - The HTML template for your UI component. Receives input properties and states and renders to either HTML (server-side) or virtual DOM nodes (browser-side)
 - **Client-side behavior** - Implemented as a JavaScript class with methods and properties to provide initialization, event handling (including DOM events, custom events and lifecycle events) and state management
@@ -69,7 +69,7 @@ style.less {
 }
 ```
 
-> **Note:** The code in the style section is processed in a context that is separate from the rest of the template so so you won't be able to use JavaScript variables inside the style section. If you need variables in your CSS then you will need to use a CSS pre-processor that supports variables.
+> **Note:** The code in the style section is processed in a context that is separate from the rest of the template so you won't be able to use JavaScript variables inside the style section. If you need variables in your CSS then you will need to use a CSS pre-processor that supports variables.
 
 ## Multi-file components
 


### PR DESCRIPTION
Removed two instances of duplicated words, "to to" and "so so"

## Description
Found two typos in the components.md document.
Remove them

<!--- Why is this change required? What problem does it solve? -->
Typos are bad!

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ x ] I have updated/added documentation affected by my changes.
- [ x ] I have added tests to cover my changes.
