### PR TITLE
Fix `appendTo` bug

### DIFF
--- a/src/morphdom/fragment.js
+++ b/src/morphdom/fragment.js
@@ -46,7 +46,7 @@ var fragmentPrototype = {
     remove: function() {
         this.nodes.forEach(function(node) {
             this.detachedContainer.appendChild(node);
-        });
+        }, this);
     }
 };
 

--- a/src/runtime/dom-insert.js
+++ b/src/runtime/dom-insert.js
@@ -24,7 +24,7 @@ module.exports = function(target, getEl, afterInsert) {
         appendTo: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
-            referenceEl.appendChild(el);
+            el.insertInto(referenceEl);
             return afterInsert(this, referenceEl);
         },
         prependTo: function(referenceEl) {


### PR DESCRIPTION
## Description

In the `4.13.4-1` release, I started getting an error when using `this.appendTo(someEl)` in my component. Upon investigations, I discovered there were a couple of bugs, one related to the recent removal of ES2015 features, and the other with the recent fragment additions.

These two changes are relatively small, but allow `appendTo` to behave as intended. I'd like to add tests for this, but could use some guidance on how best to approach those.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
