### PR TITLE
Fix component dom insert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.4",
+    "version": "4.13.4-4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.4",
+    "version": "4.13.4-4",
     "license": "MIT",
     "description": "UI Components + streaming, async, high performance, HTML templating for Node.js and the browser.",
     "scripts": {

--- a/src/morphdom/fragment.js
+++ b/src/morphdom/fragment.js
@@ -40,13 +40,13 @@ var fragmentPrototype = {
     insertInto: function(newParentNode, referenceNode) {
         this.nodes.forEach(function(node) {
             insertBefore(node, referenceNode, newParentNode);
-        });
+        }, this);
         return this;
     },
     remove: function() {
         this.nodes.forEach(function(node) {
             this.detachedContainer.appendChild(node);
-        });
+        }, this);
     }
 };
 

--- a/src/runtime/dom-insert.js
+++ b/src/runtime/dom-insert.js
@@ -2,6 +2,11 @@ var extend = require("raptor-util/extend");
 var componentsUtil = require("../components/util");
 var destroyComponentForNode = componentsUtil.___destroyComponentForNode;
 var destroyNodeRecursive = componentsUtil.___destroyNodeRecursive;
+var helpers = require("../morphdom/helpers");
+
+var insertBefore = helpers.___insertBefore;
+var insertAfter = helpers.___insertAfter;
+var removeChild = helpers.___removeChild;
 
 function resolveEl(el) {
     if (typeof el == "string") {
@@ -24,20 +29,21 @@ module.exports = function(target, getEl, afterInsert) {
         appendTo: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
-            referenceEl.appendChild(el);
+            insertBefore(el, null, referenceEl);
             return afterInsert(this, referenceEl);
         },
         prependTo: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
-            referenceEl.insertBefore(el, referenceEl.firstChild || null);
+            insertBefore(el, referenceEl.firstChild || null, referenceEl);
             return afterInsert(this, referenceEl);
         },
         replace: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
             beforeRemove(referenceEl);
-            referenceEl.parentNode.replaceChild(el, referenceEl);
+            insertBefore(el, referenceEl, referenceEl.parentNode);
+            removeChild(referenceEl);
             return afterInsert(this, referenceEl);
         },
         replaceChildrenOf: function(referenceEl) {
@@ -52,25 +58,19 @@ module.exports = function(target, getEl, afterInsert) {
             }
 
             referenceEl.innerHTML = "";
-            referenceEl.appendChild(el);
+            insertBefore(el, null, referenceEl);
             return afterInsert(this, referenceEl);
         },
         insertBefore: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
-            referenceEl.parentNode.insertBefore(el, referenceEl);
+            insertBefore(el, referenceEl, referenceEl.parentNode);
             return afterInsert(this, referenceEl);
         },
         insertAfter: function(referenceEl) {
             referenceEl = resolveEl(referenceEl);
             var el = getEl(this, referenceEl);
-            var nextSibling = referenceEl.nextSibling;
-            var parentNode = referenceEl.parentNode;
-            if (nextSibling) {
-                parentNode.insertBefore(el, nextSibling);
-            } else {
-                parentNode.appendChild(el);
-            }
+            insertAfter(el, referenceEl, referenceEl.parentNode);
             return afterInsert(this, referenceEl);
         }
     });

--- a/test/components-browser/fixtures/component-api-move-root/component.js
+++ b/test/components-browser/fixtures/component-api-move-root/component.js
@@ -1,0 +1,3 @@
+module.exports = {
+    onMount: function() {}
+};

--- a/test/components-browser/fixtures/component-api-move-root/index.marko
+++ b/test/components-browser/fixtures/component-api-move-root/index.marko
@@ -1,0 +1,1 @@
+-- Hello World

--- a/test/components-browser/fixtures/component-api-move-root/test.js
+++ b/test/components-browser/fixtures/component-api-move-root/test.js
@@ -1,0 +1,9 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var newTarget = document.createElement("div");
+    document.body.appendChild(newTarget);
+    component.appendTo(newTarget);
+    expect(newTarget.innerHTML).to.equal("Hello World");
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #1126 

Two changes here: 
- Fix detaching a fragment.  When we switched from `() =>` to `function` we lost the lexical `this`.
- Use the morphdom helper methods in the `dom-insert` mixin.  This allows us to insert fragments as well.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
