### PR TITLE
add additional reference to fragment

### DIFF
--- a/src/morphdom/index.js
+++ b/src/morphdom/index.js
@@ -359,6 +359,9 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                                     );
                                     fragment.___markoKey = curToNodeKey;
                                     fragment.___markoVElement = curToNodeChild;
+                                    referenceComponent.___keyedElements[
+                                        curToNodeKey
+                                    ] = fragment;
                                     removeChild(curFromNodeChild);
                                     removeChild(endNode);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #1122 

This issue is caused by a fragment's startNode (an empty `Text` node) missing a property that refers to the fragment itself.  It turns out that this property from the DOM Text node is the only reference to the fragment.  That should be fine, but apparently IE11 is treating this as a weak reference and garbage collection the fragment anyways.

The fix is to provide an additional reference to the fragment so it doesn't get garbage collected.  Fortunately, we have a good place to put this: the `keyedElements` lookup on the component.  In fact, for non-hydrated (client-rendered) fragments, they already are put there.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
