### PR TITLE
Fixed broken links

### DIFF
--- a/docs/server-side-rendering.md
+++ b/docs/server-side-rendering.md
@@ -24,10 +24,10 @@ module.exports = function(req) {
 
 > **ProTip:** Marko also provides server-side framework integrations:
 >
-> - [express](./express.md)
-> - [hapi](./hapi.md)
-> - [koa](./koa.md)
-> - [huncwot](./huncwot.md)
+> - [express](./express)
+> - [hapi](./hapi)
+> - [koa](./koa)
+> - [huncwot](./huncwot)
 
 ## UI Bootstrapping
 


### PR DESCRIPTION
The links to server-side framework integrations all return 404, so fixed the links to point to the correct pages

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Links were incorrect, giving a 404, so resolved them to the proper pages

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ x ] I have updated/added documentation affected by my changes.
- [ x ] I have added tests to cover my changes.
