### PR TITLE
Fix for preserved content in repeated attribute tags.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.6-0",
+    "version": "4.13.6-1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.5",
+    "version": "4.13.6-0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.6-0",
+    "version": "4.13.6-1",
     "license": "MIT",
     "description": "UI Components + streaming, async, high performance, HTML templating for Node.js and the browser.",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "marko",
-    "version": "4.13.5",
+    "version": "4.13.6-0",
     "license": "MIT",
     "description": "UI Components + streaming, async, high performance, HTML templating for Node.js and the browser.",
     "scripts": {

--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -377,8 +377,8 @@ class CustomTag extends HtmlElement {
             }
 
             if (attr.spread) {
-                let isFirstOfMany = i === 0 && this.attributes.length > 1;
-                if (explicitAttrs || isFirstOfMany) {
+                let isFirst = i === 0;
+                if (explicitAttrs || isFirst) {
                     attrs.push(builder.objectExpression(explicitAttrs || {}));
                 }
                 attrs.push(attr.value);

--- a/src/compiler/ast/HtmlElement/index.js
+++ b/src/compiler/ast/HtmlElement/index.js
@@ -181,7 +181,7 @@ class HtmlElement extends Node {
         var attributes = this._attributes.all.concat([]);
 
         for (let i = 0, len = attributes.length; i < len; i++) {
-            callback.call(thisObj, attributes[i]);
+            callback.call(thisObj, attributes[i], i);
         }
     }
 

--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -206,9 +206,16 @@ const getParentForKeyVar = (el, transformHelper) => {
     const keyExpression =
         getChildKey(parentFor) || createIndexKey(parentFor, transformHelper);
     const bracketedKeyExpression = builder.binaryExpression(
-        builder.literal("["),
+        builder.memberExpression(
+            builder.identifier("component"),
+            builder.identifier("id")
+        ),
         "+",
-        builder.binaryExpression(keyExpression, "+", builder.literal("]"))
+        builder.binaryExpression(
+            builder.literal("["),
+            "+",
+            builder.binaryExpression(keyExpression, "+", builder.literal("]"))
+        )
     );
     const varName = "keyscope__" + transformHelper.nextUniqueId();
     const varDeclaration = builder.var(varName, bracketedKeyExpression);

--- a/test/compiler/fixtures-html/at-tags-dynamic/expected.js
+++ b/test/compiler/fixtures-html/at-tags-dynamic/expected.js
@@ -24,7 +24,7 @@ function render(input, out, __component, component, state) {
         var for__1 = 0;
 
         marko_forEach(input.colors, function(color) {
-          var keyscope__2 = "[" + ((for__1++) + "]");
+          var keyscope__2 = component.id + ("[" + ((for__1++) + "]"));
 
           hello_foo_nested_tag({
               renderBody: function renderBody(out) {

--- a/test/compiler/fixtures-html/macros/expected.js
+++ b/test/compiler/fixtures-html/macros/expected.js
@@ -23,7 +23,7 @@ function render(input, out, __component, component, state) {
       var for__1 = 0;
 
       marko_forEach(node.children, function(child) {
-        var keyscope__2 = "[" + ((for__1++) + "]");
+        var keyscope__2 = component.id + ("[" + ((for__1++) + "]"));
 
         out.w("<li>");
 

--- a/test/compiler/fixtures-html/simple/expected.js
+++ b/test/compiler/fixtures-html/simple/expected.js
@@ -22,7 +22,7 @@ function render(input, out, __component, component, state) {
     var for__1 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var keyscope__2 = component.id + ("[" + ((for__1++) + "]"));
 
       out.w("<li>" +
         marko_escapeXml(color) +
@@ -40,7 +40,7 @@ function render(input, out, __component, component, state) {
     var for__6 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__7 = "[" + ((for__6++) + "]");
+      var keyscope__7 = component.id + ("[" + ((for__6++) + "]"));
 
       out.w("<li>" +
         marko_escapeXml(color) +

--- a/test/compiler/fixtures-vdom/simple/expected.js
+++ b/test/compiler/fixtures-vdom/simple/expected.js
@@ -37,7 +37,7 @@ function render(input, out, __component, component, state) {
     var for__1 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var keyscope__2 = component.id + ("[" + ((for__1++) + "]"));
 
       out.e("LI", null, "3" + keyscope__2, component, 1)
         .t(color);
@@ -54,7 +54,7 @@ function render(input, out, __component, component, state) {
     var for__6 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__7 = "[" + ((for__6++) + "]");
+      var keyscope__7 = component.id + ("[" + ((for__6++) + "]"));
 
       out.e("LI", null, "8" + keyscope__7, component, 1)
         .t(color);

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/index.marko
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/index.marko
@@ -1,0 +1,5 @@
+<ul>
+  <for(item in input.items)>
+    <li><${item}/></li>
+  </for>
+</ul>

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/marko-tag.json
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/marko-tag.json
@@ -1,0 +1,6 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    },
+    "@*": "expression"
+}

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/index.marko
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/index.marko
@@ -1,0 +1,14 @@
+class {
+    onCreate() {
+        this.data = { a: 1 };
+    }
+    onMount() {
+        window.component = this;
+    }
+}
+
+<menu ...component.data>
+    <for(i from 1 to 3)>
+        <@item>${i}</@item>
+    </for>
+</menu>

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/test.js
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/test.js
@@ -1,0 +1,6 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    expect(component.data).to.deep.equal({ a: 1 });
+};

--- a/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -23,7 +23,7 @@ function render(input, out, __component, component, state) {
   var for__2 = 0;
 
   marko_forEach(colors, function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var keyscope__3 = component.id + ("[" + ((for__2++) + "]"));
 
     out.w("<li>" +
       marko_escapeXml(color) +

--- a/test/components-compilation/fixtures-html/macro-widget/expected.js
+++ b/test/components-compilation/fixtures-html/macro-widget/expected.js
@@ -35,7 +35,7 @@ function render(input, out, __component, component, state) {
       "green",
       "blue"
     ], function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var keyscope__3 = component.id + ("[" + ((for__2++) + "]"));
 
     macro_renderButton(color, out);
   });

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/index.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/index.marko
@@ -1,0 +1,9 @@
+class {}
+
+<ul>
+    <for(item in input.items)>
+        <li>
+            <include(item)/>
+        </li>
+    </for>
+</ul>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/marko-tag.json
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/marko-tag.json
@@ -1,0 +1,5 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    }
+}

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/index.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/index.marko
@@ -1,0 +1,7 @@
+class {}
+
+<child>
+    <@item for(item in input.items)>
+        <include(item)/>
+    </@item>
+</child>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/marko-tag.json
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/marko-tag.json
@@ -1,0 +1,5 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    }
+}

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/template.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/template.marko
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Marko Test</title>
+    </head>
+    <body>
+
+        <div id="test"/>
+        <div id="mocha"/>
+        <div id="testsTarget"/>
+
+        <div id="root">
+            <root>
+                <@item>A</@item>
+                <@item>B</@item>
+                <@item>C</@item>
+            </root>
+        </div>
+
+        <init-components immediate/>
+    </body>
+</html>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
@@ -1,0 +1,10 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it.fails("should update correctly", function() {
+        var $el = document.getElementById("root");
+        expect($el.innerHTML).to.eql("<ul><li>A</li><li>B</li><li>C</li></ul>");
+    }).details =
+        "issue #1134";
+});

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
@@ -2,9 +2,8 @@ var path = require("path");
 var expect = require("chai").expect;
 
 describe(path.basename(__dirname), function() {
-    it.fails("should update correctly", function() {
+    it("should update correctly", function() {
         var $el = document.getElementById("root");
         expect($el.innerHTML).to.eql("<ul><li>A</li><li>B</li><li>C</li></ul>");
-    }).details =
-        "issue #1134";
+    });
 });


### PR DESCRIPTION
## Description

Adds a test case and potential fix for issue #1134.

This fix is to include the owner key in loop keyscopes. It seems the main issue is that the attribute tag was being keyed relative to the parent not the owner and the keyscope var (which was in the owner) was colliding with one in the parent.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
