### PR TITLE
Prevent input mutation when repeated attribute tags and spread attributes

### DIFF
--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -377,8 +377,8 @@ class CustomTag extends HtmlElement {
             }
 
             if (attr.spread) {
-                let isFirstOfMany = i === 0 && this.attributes.length > 1;
-                if (explicitAttrs || isFirstOfMany) {
+                let isFirst = i === 0;
+                if (explicitAttrs || isFirst) {
                     attrs.push(builder.objectExpression(explicitAttrs || {}));
                 }
                 attrs.push(attr.value);

--- a/src/compiler/ast/HtmlElement/index.js
+++ b/src/compiler/ast/HtmlElement/index.js
@@ -181,7 +181,7 @@ class HtmlElement extends Node {
         var attributes = this._attributes.all.concat([]);
 
         for (let i = 0, len = attributes.length; i < len; i++) {
-            callback.call(thisObj, attributes[i]);
+            callback.call(thisObj, attributes[i], i);
         }
     }
 

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/index.marko
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/index.marko
@@ -1,0 +1,5 @@
+<ul>
+  <for(item in input.items)>
+    <li><${item}/></li>
+  </for>
+</ul>

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/marko-tag.json
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/components/menu/marko-tag.json
@@ -1,0 +1,6 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    },
+    "@*": "expression"
+}

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/index.marko
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/index.marko
@@ -1,0 +1,14 @@
+class {
+    onCreate() {
+        this.data = { a: 1 };
+    }
+    onMount() {
+        window.component = this;
+    }
+}
+
+<menu ...component.data>
+    <for(i from 1 to 3)>
+        <@item>${i}</@item>
+    </for>
+</menu>

--- a/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/test.js
+++ b/test/components-browser/fixtures/prevent-input-mutation-repeated-at-tags/test.js
@@ -1,0 +1,6 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    expect(component.data).to.deep.equal({ a: 1 });
+};


### PR DESCRIPTION
## Description

This PR removes the optimization that reused a spread attribute object if it is the only attribute.
This caused issues around repeated @tags which change the input after this optimization takes place and causes the original input to be mutated.

Partial fix of #1134

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.