### PR TITLE
Fix issue with include tag hydration.

### DIFF
--- a/src/morphdom/index.js
+++ b/src/morphdom/index.js
@@ -252,6 +252,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
             } else if (curToNodeKey) {
                 curVFromNodeChild = undefined;
                 curFromNodeKey = undefined;
+                let curToNodeKeyOriginal = curToNodeKey;
 
                 if (isAutoKey(curToNodeKey)) {
                     if (ownerComponent !== parentComponent) {
@@ -354,7 +355,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                                 curFromNodeChild.nodeType === COMMENT_NODE
                             ) {
                                 var content = curFromNodeChild.nodeValue;
-                                if (content == "F#" + curToNodeKey) {
+                                if (content == "F#" + curToNodeKeyOriginal) {
                                     var endNode = curFromNodeChild;
                                     while (
                                         endNode.nodeType !== COMMENT_NODE ||

--- a/src/taglibs/core/include-tag.js
+++ b/src/taglibs/core/include-tag.js
@@ -33,7 +33,8 @@ function doInclude(input, out, throwError) {
     if (renderBody) {
         var componentsContext = out.___components;
         var componentDef =
-            componentsContext && componentsContext.___componentDef;
+            out.___assignedComponentDef ||
+            (componentsContext && componentsContext.___componentDef);
         var willRerenderInBrowser =
             componentDef &&
             componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER;

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/index.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/index.marko
@@ -1,0 +1,9 @@
+class {}
+
+<ul>
+    <for(item in input.items)>
+        <li>
+            <include(item)/>
+        </li>
+    </for>
+</ul>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/marko-tag.json
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/child/marko-tag.json
@@ -1,0 +1,5 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    }
+}

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/index.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/index.marko
@@ -1,0 +1,7 @@
+class {}
+
+<child>
+    <@item for(item in input.items)>
+        <include(item)/>
+    </@item>
+</child>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/marko-tag.json
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/components/root/marko-tag.json
@@ -1,0 +1,5 @@
+{
+    "@items <item>[]": {
+        "@*": "expression"
+    }
+}

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/template.marko
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/template.marko
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Marko Test</title>
+    </head>
+    <body>
+
+        <div id="test"/>
+        <div id="mocha"/>
+        <div id="testsTarget"/>
+
+        <div id="root">
+            <root>
+                <@item>A</@item>
+                <@item>B</@item>
+                <@item>C</@item>
+            </root>
+        </div>
+
+        <init-components immediate/>
+    </body>
+</html>

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
@@ -1,0 +1,10 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it.fails("should update correctly", function() {
+        var $el = document.getElementById("root");
+        expect($el.innerHTML).to.eql("<ul><li>A</li><li>B</li><li>C</li></ul>");
+    }).details =
+        "issue #1134";
+});

--- a/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
+++ b/test/components-pages/fixtures/preserve-looped-attribute-tag/tests.js
@@ -2,9 +2,8 @@ var path = require("path");
 var expect = require("chai").expect;
 
 describe(path.basename(__dirname), function() {
-    it.fails("should update correctly", function() {
+    it("should update correctly", function() {
         var $el = document.getElementById("root");
         expect($el.innerHTML).to.eql("<ul><li>A</li><li>B</li><li>C</li></ul>");
-    }).details =
-        "issue #1134";
+    });
 });


### PR DESCRIPTION
## Description

In this PR the include tag is updated to get the proper owner component.
Fragments being matched also use an unmodified key.

Partially fixes #1134.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
