### PR TITLE
Prevent implicit components with tag params

### DIFF
--- a/src/compiler/Parser.js
+++ b/src/compiler/Parser.js
@@ -405,7 +405,7 @@ class Parser {
         var tagDef = node.tagDef;
         if (tagDef && tagDef.featureFlags) {
             if (tagDef.featureFlags.includes("params")) {
-                enableTagParams(node, this.context.builder);
+                enableTagParams(node, this.context);
             }
         }
     }

--- a/src/compiler/util/enableTagParams.js
+++ b/src/compiler/util/enableTagParams.js
@@ -1,12 +1,15 @@
-module.exports = function enableTagParams(el, builder) {
+module.exports = function enableTagParams(el, context) {
     if (el.argument) {
+        var builder = context.builder;
         el.params = builder.parseJavaScriptParams(el.argument);
         el.params.forEach(param => el.addNestedVariable(param));
         delete el.argument;
+        context.setFlag("hasTagParams");
+        context.exampleTagParam = el;
     }
     el.forEachChild(childNode => {
         if (isNestedTag(childNode)) {
-            enableTagParams(childNode, builder);
+            enableTagParams(childNode, context);
         }
     });
 };

--- a/src/components/taglib/TransformHelper/convertToComponent.js
+++ b/src/components/taglib/TransformHelper/convertToComponent.js
@@ -19,18 +19,29 @@ module.exports = function handleComponentBind(options) {
     let rootNodes = options.rootNodes;
     let isLegacyInnerBind = options.isLegacyInnerBind;
     var isImplicitComponent = options.isImplicitComponent === true;
-
+    var hasTagParams = context.isFlagSet("hasTagParams");
     var isSplit = false;
 
     if (
         (rendererModule && rendererModule !== componentModule) ||
         (!rendererModule && componentModule)
     ) {
-        componentProps.___split = isSplit = true;
+        if (hasTagParams) {
+            context.addError(
+                context.exampleTagParam,
+                "Cannot use tag params within a split component."
+            );
+        } else {
+            componentProps.___split = isSplit = true;
+        }
     }
 
     if (isImplicitComponent) {
-        componentProps.___implicit = true;
+        if (hasTagParams) {
+            isImplicitComponent = false;
+        } else {
+            componentProps.___implicit = true;
+        }
     }
 
     if (componentModule) {

--- a/test/compiler/fixtures-html/split-component-root-tag-params-error/components/name/index.marko
+++ b/test/compiler/fixtures-html/split-component-root-tag-params-error/components/name/index.marko
@@ -1,0 +1,17 @@
+class {
+    onCreate() {
+        this.state = {
+            name:'Anna'
+        }
+    }
+    changeName() {
+        this.state.name = 'Vickie';
+    }
+}
+
+<div>
+    <${input} name=state.name/>
+    <button on-click('changeName')>
+        Change
+    </button>
+</div>

--- a/test/compiler/fixtures-html/split-component-root-tag-params-error/components/name/marko-tag.json
+++ b/test/compiler/fixtures-html/split-component-root-tag-params-error/components/name/marko-tag.json
@@ -1,0 +1,3 @@
+{
+    "featureFlags": ["params"]
+}

--- a/test/compiler/fixtures-html/split-component-root-tag-params-error/template.component-browser.js
+++ b/test/compiler/fixtures-html/split-component-root-tag-params-error/template.component-browser.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/compiler/fixtures-html/split-component-root-tag-params-error/template.marko
+++ b/test/compiler/fixtures-html/split-component-root-tag-params-error/template.marko
@@ -1,0 +1,3 @@
+<name({ name }) key="name">
+    Hello, ${name}!
+</name>

--- a/test/compiler/fixtures-html/split-component-root-tag-params-error/test.js
+++ b/test/compiler/fixtures-html/split-component-root-tag-params-error/test.js
@@ -1,0 +1,5 @@
+var expect = require("chai").expect;
+
+exports.checkError = function(e) {
+    expect(e.toString()).to.contain("tag params within a split component");
+};

--- a/test/components-pages/fixtures/implicit-component-root-tag-params/components/hello-implicit-component/index.marko
+++ b/test/components-pages/fixtures/implicit-component-root-tag-params/components/hello-implicit-component/index.marko
@@ -1,0 +1,6 @@
+$ if (typeof window !== "undefined") {
+  window.helloImplicitComponentSent = true;
+}
+<name({ name }) key="name">
+    Hello, ${name}!
+</name>

--- a/test/components-pages/fixtures/implicit-component-root-tag-params/components/name/index.marko
+++ b/test/components-pages/fixtures/implicit-component-root-tag-params/components/name/index.marko
@@ -1,0 +1,17 @@
+class {
+    onCreate() {
+        this.state = {
+            name:'Anna'
+        }
+    }
+    changeName() {
+        this.state.name = 'Vickie';
+    }
+}
+
+<div>
+    <${input} name=state.name/>
+    <button on-click('changeName')>
+        Change
+    </button>
+</div>

--- a/test/components-pages/fixtures/implicit-component-root-tag-params/components/name/marko-tag.json
+++ b/test/components-pages/fixtures/implicit-component-root-tag-params/components/name/marko-tag.json
@@ -1,0 +1,3 @@
+{
+    "featureFlags": ["params"]
+}

--- a/test/components-pages/fixtures/implicit-component-root-tag-params/template.marko
+++ b/test/components-pages/fixtures/implicit-component-root-tag-params/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <hello-implicit-component/>
+
+        init-components

--- a/test/components-pages/fixtures/implicit-component-root-tag-params/tests.js
+++ b/test/components-pages/fixtures/implicit-component-root-tag-params/tests.js
@@ -1,0 +1,8 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it("should mount implicit components with tag params", function() {
+        expect(window.helloImplicitComponentSent).to.equal(true);
+    });
+});


### PR DESCRIPTION
## Description

Currently we just check if there is a component class when we determine if something is an implicit component. This breaks down with tag params which are typically always stateful and pass new data back up to the parent (the parent renderBody needs to be sent down to the browser).

This PR adds a check for tagParams and bails out of being an implicit component if they exist.
For split components this now throws an error since that typically doesn't make sense with tag params.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.