### PR TITLE
Provide hidden hook for `<context>` tag.

### DIFF
--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -20,6 +20,7 @@ var morphdom = require("../morphdom");
 var eventDelegation = require("./event-delegation");
 var domData = require("./dom-data");
 var componentsByDOMNode = domData.___componentByDOMNode;
+var CONTEXT_KEY = "__subtree_context__";
 
 var slice = Array.prototype.slice;
 
@@ -403,6 +404,7 @@ Component.prototype = componentProto = {
 
         var oldInput = this.___input;
         this.___input = undefined;
+        this.___context = (out && out[CONTEXT_KEY]) || this.___context;
 
         if (onInput) {
             // We need to set a flag to preview `this.input = foo` inside
@@ -521,6 +523,7 @@ Component.prototype = componentProto = {
             var out = createOut(globalData);
             out.sync();
             out.___document = self.___document;
+            out[CONTEXT_KEY] = self.___context;
 
             var componentsContext = getComponentsContext(out);
             var globalComponentsContext = componentsContext.___globalContext;


### PR DESCRIPTION
## Description
This PR updates the component rendering logic to preserve a `out["__subtree_context__"]` variable across renders. This is not meant to be used in user land but is used by the upcoming [`<context>`](https://github.com/marko-js/tags/pull/6) tag in [marko-js/tags](https://github.com/marko-js/tags). Currently it is impossible to implement this behavior in user land without this patch, however we do not want to tie Marko to this specific context implementation right away and so it will be trialed in [marko-js/tags](https://github.com/marko-js/tags).

Note:
This PR does not have any tests as those exist in the [marko-js/tags](https://github.com/marko-js/tags) repo.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
