### PR TITLE
added scoped link feature

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -422,6 +422,18 @@ The above code will produce output HTML similar to the following:
 </div>
 ```
 
+**`href:scoped`**
+
+```marko
+<a href:scoped="#anchor">Go to Anchor</a>
+<div id:scoped="anchor"></div>
+```
+
+```html
+<a href="#c0-anchor">Go to Anchor</a>
+<div id="c0-anchor"></div>
+```
+
 ### `no-update`
 
 Preserves the DOM subtree associated with the DOM element or component such that

--- a/src/components/ComponentDef.js
+++ b/src/components/ComponentDef.js
@@ -63,6 +63,10 @@ ComponentDef.prototype = {
         if (nestedId == null) {
             return id;
         } else {
+            if (nestedId.startsWith("#")) {
+                id = "#" + id;
+                nestedId = nestedId.substring(1);
+            }
             if (typeof nestedId == "string" && repeatedRegExp.test(nestedId)) {
                 return this.___globalComponentsContext.___nextRepeatedId(
                     id,

--- a/test/components-browser/fixtures/scoped-link/component.js
+++ b/test/components-browser/fixtures/scoped-link/component.js
@@ -1,0 +1,3 @@
+module.exports = {
+    onMount: function() {}
+};

--- a/test/components-browser/fixtures/scoped-link/index.marko
+++ b/test/components-browser/fixtures/scoped-link/index.marko
@@ -1,0 +1,3 @@
+<div key="root">
+	<a href:scoped="#anchor">Go to anchor</a>
+</div>

--- a/test/components-browser/fixtures/scoped-link/test.js
+++ b/test/components-browser/fixtures/scoped-link/test.js
@@ -1,0 +1,10 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var link = component.getEl("root").querySelector("a");
+    var linkHref = link.getAttribute("href");
+    expect(!!linkHref).to.equal(true);
+    expect(linkHref).to.match(/^#.*anchor$/);
+    expect(link.getAttribute("href:scoped")).to.equal(null);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

If you add a '#' at the beginning of a scoped attribute the generated id will start with a '#'

I added this functionality because when you use external libraries sometime you need scoped attribute starts with a '#'

## Example

```
<div>
	<a href:scoped="#anchor">Go to anchor</a>
	<div id:scoped="anchor"></div>
</div>
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
