### PR TITLE
Convert imperative rendering inside scriptlets to dynamic tags

### DIFF
--- a/src/taglibs/core/invoke-tag.js
+++ b/src/taglibs/core/invoke-tag.js
@@ -1,70 +1,9 @@
+const renderCallToDynamicTag = require("./util/renderCallToDynamicTag");
+
 module.exports = function codeGenerator(elNode, context) {
+    const builder = context.builder;
     const functionAttr = elNode.attributes[0];
-    const attrs = elNode.attributes;
-    const args = context.builder.parseJavaScriptArgs(functionAttr.argument);
-    const argsLength = args.length;
-    const functionName = functionAttr.name;
-
-    let outIsFirstIndex = false;
-    let argsContainsOut = false;
-    let functionCallExpression = null;
-    let newNode = null;
-
-    args.map((arg, i) => {
-        if (arg.name === "out") {
-            if (i === 0) {
-                outIsFirstIndex = true;
-            }
-
-            argsContainsOut = true;
-        }
-    });
-
-    // Removes HtmlAtrribute
-    attrs.splice(0, 1);
-
-    if (
-        (functionName === "data.renderBody" ||
-            functionName === "input.renderBody") &&
-        argsContainsOut &&
-        outIsFirstIndex
-    ) {
-        // Handles cases for the following:
-        // 1. <invoke data.renderBody(out) w-id="barTest"/> --> <${data.renderBody} w-id="barTest"/>
-
-        attrs.unshift({
-            value: args[0],
-            spread: true
-        });
-
-        newNode = context.createNodeForEl(
-            context.builder.parseExpression(functionName),
-            attrs
-        );
-    } else if (argsLength > 1 && argsContainsOut && !outIsFirstIndex) {
-        // Handles cases for the following:
-        // 1. <invoke data.barRenderer({}, out) w-id="barTest"/> --> <${{ render:data.barRenderer }} ...{} w-id="barTest"/>
-        // 2. <invoke data.template.render({}, out) w-id="barTest"/> --> <${{ render: data.template.render }} ...{} w-id="barTest"/>
-        // 3. <invoke data.template.renderer({}, out) w-id="barTest"/> --> <${{ render: data.template.renderer }} ...{} w-id="barTest"/>
-
-        attrs.unshift({
-            value: args[0],
-            spread: true
-        });
-
-        newNode = context.createNodeForEl(
-            context.builder.parseExpression("{renderer:" + functionName + "}"),
-            attrs
-        );
-    } else {
-        // Handles all other cases:
-        // 1. e.g. <invoke console.log('hello') /> --> console.log(arguement/s)
-
-        functionCallExpression = functionName + "(" + args + ");";
-        newNode = context.builder.scriptlet({
-            value: functionCallExpression
-        });
-    }
+    const functionArgs = functionAttr.argument;
 
     context.deprecate(
         'The "<invoke>" tag is deprecated. Please use "$ <js_code>" for JavaScript in the template. See: https://github.com/marko-js/marko/wiki/Deprecation:-var-assign-invoke-tags'
@@ -77,13 +16,28 @@ module.exports = function codeGenerator(elNode, context) {
         return;
     }
 
-    if (args === undefined) {
+    if (functionArgs === undefined) {
         context.addError(
             'Invalid <invoke> tag. Missing function arguments. Expected: <invoke console.log("Hello World")'
         );
         return;
     }
 
-    elNode.insertSiblingBefore(newNode);
-    elNode.detach();
+    const functionCallExpression = `${functionAttr.name}(${functionArgs})`;
+    const functionAst = context.builder.parseExpression(functionCallExpression);
+    let replacement = renderCallToDynamicTag(functionAst, context);
+
+    if (replacement) {
+        elNode.forEachAttribute(attr => {
+            if (attr !== functionAttr) {
+                replacement.addAttribute(attr);
+            }
+        });
+    } else {
+        replacement = builder.scriptlet({
+            value: functionCallExpression
+        });
+    }
+
+    elNode.replaceWith(replacement);
 };

--- a/src/taglibs/core/marko.json
+++ b/src/taglibs/core/marko.json
@@ -1,4 +1,5 @@
 {
+    "transformer": "./root-transformer",
     "<assign>": {
         "transformer": "./assign-tag",
         "open-tag-only": true,

--- a/src/taglibs/core/root-transformer.js
+++ b/src/taglibs/core/root-transformer.js
@@ -1,0 +1,76 @@
+"use strict";
+
+const OUT_IDENTIFIER_REG = /[(,] *out *[,)]/;
+const renderCallToDynamicTag = require("./util/renderCallToDynamicTag");
+
+module.exports = function transform(el, context) {
+    const walker = context.createWalker({
+        enter(node) {
+            if (
+                node.type !== "Scriptlet" ||
+                !OUT_IDENTIFIER_REG.test(node.code)
+            ) {
+                return;
+            }
+
+            const replacement = replaceScriptlets(
+                context.builder.parseStatement(node.code),
+                context
+            );
+
+            node.replaceWith(replacement);
+        }
+    });
+    walker.walk(el);
+};
+
+function replaceScriptlets(node, context) {
+    const builder = context.builder;
+    if (!node.type) {
+        if (node.replaceChild) {
+            node.forEach(child => {
+                const replacement = replaceScriptlets(child, context);
+                if (child !== replacement) {
+                    node.replaceChild(replacement, child);
+                }
+            });
+        } else if (node.body) {
+            node.body.forEach(child => {
+                const replacement = replaceScriptlets(child, context);
+                if (child !== replacement) {
+                    node.body.replaceChild(replacement, child);
+                }
+            });
+        }
+
+        return node;
+    }
+
+    switch (node.type) {
+        case "LogicalExpression":
+            node = builder.ifStatement(
+                node.operator === "&&" ? node.left : builder.negate(node.left),
+                [replaceScriptlets(node.right, context)]
+            );
+            break;
+        case "FunctionCall":
+            node = renderCallToDynamicTag(node, context) || node;
+            break;
+        case "If":
+        case "ElseIf":
+            node.body = replaceScriptlets(node.body, context);
+            if (node.else) {
+                replaceScriptlets(node.else, context);
+            }
+            break;
+        case "Else":
+        case "ForStatement":
+        case "WhileStatement":
+            node.body = replaceScriptlets(node.body, context);
+            break;
+        default:
+            break;
+    }
+
+    return node;
+}

--- a/src/taglibs/core/util/renderCallToDynamicTag.js
+++ b/src/taglibs/core/util/renderCallToDynamicTag.js
@@ -1,0 +1,89 @@
+module.exports = function renderCallToDynamicTag(ast, context) {
+    const builder = context.builder;
+    const args = ast.args;
+    const callee = ast.callee;
+    const argsLength = args.length;
+    const outIndex = args.findIndex(arg => arg.name === "out");
+    const calleeProperty = callee.property && callee.property.name;
+
+    if (outIndex === -1) {
+        return false;
+    }
+
+    let tagName;
+    let tagAttrs;
+
+    if (argsLength <= 2) {
+        if (outIndex === 0) {
+            // Handles cases for the following:
+            // 1. input.renderBody(out) --> <${input}/>
+            // 2. input.renderThing(out) --> <${input.renderThing}/>
+            // 3. input.renderBody(out, attrs) --> <${input} ...attrs/>
+            // 4. renderBody(out) --> <${renderBody}/>
+            if (argsLength === 2) {
+                tagName = callee;
+                tagAttrs = toAttributesOrSpread(args[1]);
+            }
+
+            // Removes `.renderBody` which is optional.
+            if (calleeProperty === "renderBody") {
+                tagName = callee.object;
+            } else {
+                tagName = callee;
+            }
+        } else if (outIndex === 1) {
+            // Handles cases for the following:
+            // 1. input.template.render({}, out) --> <${input.template} ...{}/>
+            // 2. input.template.renderer({}, out) --> <${input.template} ...{}/>
+            // 3. input.barRenderer({}, out) --> <${{ render:input.barRenderer }} ...{}/>
+
+            tagAttrs = toAttributesOrSpread(args[0]);
+
+            // Removes `.render` or `.renderer` which are optional.
+            if (calleeProperty === "render" || calleeProperty === "renderer") {
+                tagName = callee.object;
+            } else {
+                tagName = builder.objectExpression({
+                    render: callee
+                });
+            }
+        }
+    } else {
+        // Handles worst case scenario:
+        // 1. input.barRenderer({}, true, out) --> <${(out) => input.barRenderer({}, true, out)}/>
+        tagName = builder.functionDeclaration(
+            null,
+            [builder.identifier("out")],
+            [ast]
+        );
+    }
+
+    return context.createNodeForEl(tagName, tagAttrs, null, true, true);
+};
+
+function toAttributesOrSpread(val) {
+    if (
+        !val ||
+        (val.type === "Literal" && val.value === null) ||
+        (val.type === "Identifier" && val.name === "undefined")
+    ) {
+        return [];
+    }
+
+    if (
+        val.type === "ObjectExpression" &&
+        val.properties.every(prop => !prop.computed)
+    ) {
+        return val.properties.map(prop => ({
+            name: prop.literalKeyValue,
+            value: prop.value
+        }));
+    }
+
+    return [
+        {
+            value: val,
+            spread: true
+        }
+    ];
+}

--- a/test/compiler/fixtures-html/invoke-if/expected.js
+++ b/test/compiler/fixtures-html/invoke-if/expected.js
@@ -10,7 +10,7 @@ function render(input, out, __component, component, state) {
   var data = input;
 
   if (true) {
-    console.log("hello");
+    console.log('hello')
   }
 }
 

--- a/test/compiler/fixtures-html/invoke/expected.js
+++ b/test/compiler/fixtures-html/invoke/expected.js
@@ -11,7 +11,9 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(input.renderBody, out, out, __component, "0");
+  marko_dynamicTag(input, {
+      x: 1
+    }, out, __component, "hi");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/invoke/template.marko
+++ b/test/compiler/fixtures-html/invoke/template.marko
@@ -1,1 +1,1 @@
-<invoke input.renderBody(out)/>
+<invoke input.renderBody(out) w-id="hi" x=1/>

--- a/test/compiler/fixtures-html/render-body-call/expected.js
+++ b/test/compiler/fixtures-html/render-body-call/expected.js
@@ -1,0 +1,76 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/html").t(__filename),
+    marko_componentType = "/marko-test$1.0.0/compiler/fixtures-html/render-body-call/template.marko",
+    components_helpers = require("marko/src/components/helpers"),
+    marko_renderer = components_helpers.r,
+    marko_defineComponent = components_helpers.c,
+    marko_helpers = require("marko/src/runtime/html/helpers"),
+    marko_dynamicTag = marko_helpers.d;
+
+function render(input, out, __component, component, state) {
+  var data = input;
+
+  marko_dynamicTag(input, {}, out, __component, "0");
+
+  marko_dynamicTag(input.renderThing, {}, out, __component, "1");
+
+  marko_dynamicTag(input, attrs, out, __component, "2");
+
+  marko_dynamicTag(renderBody, {}, out, __component, "3");
+
+  marko_dynamicTag(input.template, {
+      x: 1
+    }, out, __component, "4");
+
+  marko_dynamicTag(input.template, {
+      y: function() {}
+    }, out, __component, "5");
+
+  marko_dynamicTag({
+      render: input.barRenderer
+    }, {}, out, __component, "6");
+
+  marko_dynamicTag(function(out) {
+    input.barRenderer({}, true, out);
+  }, {}, out, __component, "7");
+
+  if (x) {
+    marko_dynamicTag(renderA, {}, out, __component, "8");
+  } else if (y) {
+    marko_dynamicTag(renderB, {}, out, __component, "9");
+  } else {
+    marko_dynamicTag(renderC, {}, out, __component, "10");
+  }
+
+  if (x) {
+    marko_dynamicTag(render, {}, out, __component, "11");
+  }
+
+  if (!x) {
+    marko_dynamicTag(render, {}, out, __component, "12");
+  }
+
+  var for__13 = 0;
+
+  for (let i = 0; i < 10; i++) {
+    var keyscope__14 = "[" + ((for__13++) + "]");
+
+    marko_dynamicTag(input.items[i], {}, out, __component, "15" + keyscope__14);
+  }
+
+  let i = 10;
+
+  while (i--) marko_dynamicTag(input, {}, out, __component, "16")
+}
+
+marko_template._ = marko_renderer(render, {
+    ___implicit: true,
+    ___type: marko_componentType
+  });
+
+marko_template.Component = marko_defineComponent({}, marko_template._);
+
+marko_template.meta = {
+    id: "/marko-test$1.0.0/compiler/fixtures-html/render-body-call/template.marko"
+  };

--- a/test/compiler/fixtures-html/render-body-call/template.marko
+++ b/test/compiler/fixtures-html/render-body-call/template.marko
@@ -1,0 +1,32 @@
+$ {
+  input.renderBody(out);
+  input.renderThing(out);
+  input.renderBody(out, attrs);
+  renderBody(out);
+}
+
+$ input.template.render({ x: 1 }, out);
+$ input.template.renderer({ y() {} }, out);
+$ input.barRenderer(null, out);
+
+$ input.barRenderer({}, true, out);
+
+$ if (x) {
+  renderA(out);
+} else if (y) {
+  renderB(out);
+} else {
+  renderC(out);
+}
+
+$ x && render(out);
+$ x || render(out);
+
+$ for (let i = 0; i < 10; i++) {
+  input.items[i].renderBody(out);
+}
+
+$ let i = 10;
+$ while (i--) {
+  input.renderBody(out);
+}


### PR DESCRIPTION
## Description

This builds on top of #1165 and adds the same [imperative rendering]() => [dynamic tag](
https://github.com/marko-js/marko/compare/scriptlet-imperative-rendering-migration?expand=1#diff-0caeb97613de4af96608ae0dd05369a3) transform within scriptlets where possible. This does not account for every scenario but the most prominent ones.

1. `$ input.renderBody(out)` => `<${input}/>`
2. `$ input.renderThing(out)` => `<${input.renderThing}/>`
3. `$ input.renderBody(out, attrs)` => `<${input} ...attrs/>`
4. `$ renderBody(out)` => `<${renderBody}/>`
5. `$ input.template.render({}, out)` => `<${input.template} ...{}/>`
6. `$ input.template.renderer({}, out)` => `<${input.template} ...{}/>`
7. `$ input.barRenderer({}, out)` => `<${{ render:input.barRenderer }} ...{}/>`
8. `$ input.barRenderer({}, true, out)` => `<${(out) => input.barRenderer({}, true, out)}/>`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.