### PR TITLE
fix parsing if statements without braces

### DIFF
--- a/src/compiler/ast/Node.js
+++ b/src/compiler/ast/Node.js
@@ -112,6 +112,10 @@ class Node {
             return array;
         }
 
+        if (!Array.isArray(array) && array instanceof Node) {
+            array = [array];
+        }
+
         return new ArrayContainer(this, array);
     }
 

--- a/test/compiler/fixtures-html/render-body-call/expected.js
+++ b/test/compiler/fixtures-html/render-body-call/expected.js
@@ -62,6 +62,10 @@ function render(input, out, __component, component, state) {
   let i = 10;
 
   while (i--) marko_dynamicTag(input, {}, out, __component, "16")
+
+  if (z) {
+    marko_dynamicTag(renderD, {}, out, __component, "17");
+  }
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/render-body-call/template.marko
+++ b/test/compiler/fixtures-html/render-body-call/template.marko
@@ -30,3 +30,5 @@ $ let i = 10;
 $ while (i--) {
   input.renderBody(out);
 }
+
+$ if (z) renderD(out);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fix parsing `if` without braces:
```marko
$ if (x) doSomething();
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
