### PR TITLE
Fix regression with  function in var/assign tags

### DIFF
--- a/src/compiler/ast/Scriptlet.js
+++ b/src/compiler/ast/Scriptlet.js
@@ -22,7 +22,9 @@ class Scriptlet extends Node {
             return;
         }
 
-        code = adjustIndent(code, writer.currentIndent);
+        if (typeof code === "string") {
+            code = adjustIndent(code, writer.currentIndent);
+        }
 
         writer.write(code);
         writer.write("\n");

--- a/src/taglibs/core/var-tag.js
+++ b/src/taglibs/core/var-tag.js
@@ -1,36 +1,23 @@
-var isValidJavaScriptVarName = require("../../compiler/util/isValidJavaScriptVarName");
+const isValidJavaScriptVarName = require("../../compiler/util/isValidJavaScriptVarName");
+const replacePlaceholderEscapeFuncs = require("../../compiler/util/replacePlaceholderEscapeFuncs");
 
 module.exports = function nodeFactory(elNode, context) {
+    const attributes = elNode.attributes;
     const builder = context.builder;
-    let firstChild = elNode.firstChild;
-    let lastChild = elNode.lastChild;
-    let newNode = null;
-    let hasError = false;
+    const firstChild = elNode.firstChild;
+    const lastChild = elNode.lastChild;
+    let hasError;
+
+    if (!attributes) {
+        context.addError(
+            "Invalid <var> tag. Argument is missing. Example; <var x=123 />"
+        );
+        return elNode;
+    }
 
     context.deprecate(
         'The "<var>" tag is deprecated. Please use "$ <js_code>" for JavaScript in the template. See: https://github.com/marko-js/marko/wiki/Deprecation:-var-assign-invoke-tags'
     );
-
-    elNode.attributes.map(attr => {
-        if (!isValidJavaScriptVarName(attr.name)) {
-            context.addError(
-                "Invalid JavaScript variable name: " + attr.name,
-                "INVALID_VAR_NAME"
-            );
-            hasError = true;
-            return;
-        }
-
-        newNode = builder.scriptlet({
-            value: "var " + attr.name + "=" + attr.rawValue + ";"
-        });
-
-        elNode.insertSiblingBefore(newNode);
-    });
-
-    if (hasError) {
-        return elNode;
-    }
 
     if (
         firstChild &&
@@ -43,14 +30,42 @@ module.exports = function nodeFactory(elNode, context) {
     if (
         lastChild &&
         lastChild.type === "Text" &&
-        /^\s+/.test(lastChild.argument.value)
+        /\s+$/.test(lastChild.argument.value)
     ) {
         lastChild.argument.value = lastChild.argument.value.trimRight();
     }
 
-    elNode.body.forEach(node => {
-        elNode.insertSiblingBefore(node);
+    const vars = elNode.attributes.map(attr => {
+        const name = attr.name;
+        const val = attr.rawValue;
+
+        if (!isValidJavaScriptVarName(attr.name)) {
+            hasError = true;
+            context.addError(
+                "Invalid JavaScript variable name: " + attr.name,
+                "INVALID_VAR_NAME"
+            );
+            return;
+        }
+
+        let parsedExpression = val;
+        if (val != null) {
+            parsedExpression = replacePlaceholderEscapeFuncs(
+                builder.parseExpression(val),
+                context
+            );
+        }
+
+        return builder.variableDeclarator(name, parsedExpression);
     });
 
+    if (hasError) {
+        return;
+    }
+
+    elNode.insertSiblingBefore(
+        builder.scriptlet({ value: builder.vars(vars) })
+    );
+    elNode.forEachChild(node => elNode.insertSiblingBefore(node));
     elNode.detach();
 };

--- a/test/compiler/fixtures-html/class-tag/expected.js
+++ b/test/compiler/fixtures-html/class-tag/expected.js
@@ -12,7 +12,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  var foo=(new Foo());
+  var foo = new Foo()
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/expected.html
+++ b/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/expected.html
@@ -1,0 +1,1 @@
+HELLO WORLD

--- a/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/template.marko
+++ b/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/template.marko
@@ -1,0 +1,4 @@
+<var fullname/>
+<assign fullname="${input.firstName} ${input.lastName}"/>
+
+-- ${fullname.toUpperCase()}

--- a/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/test.js
+++ b/test/render/fixtures-deprecated/assign-tag-with-attribute-placeholder/test.js
@@ -1,0 +1,4 @@
+exports.templateData = {
+    firstName: "Hello",
+    lastName: "World"
+};

--- a/test/render/fixtures-deprecated/var-with-attribute-placeholder/expected.html
+++ b/test/render/fixtures-deprecated/var-with-attribute-placeholder/expected.html
@@ -1,0 +1,1 @@
+HELLO WORLD

--- a/test/render/fixtures-deprecated/var-with-attribute-placeholder/template.marko
+++ b/test/render/fixtures-deprecated/var-with-attribute-placeholder/template.marko
@@ -1,0 +1,3 @@
+<var fullname="${input.firstName} ${input.lastName}"/>
+
+-- ${fullname.toUpperCase()}

--- a/test/render/fixtures-deprecated/var-with-attribute-placeholder/test.js
+++ b/test/render/fixtures-deprecated/var-with-attribute-placeholder/test.js
@@ -1,0 +1,4 @@
+exports.templateData = {
+    firstName: "Hello",
+    lastName: "World"
+};

--- a/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
+++ b/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
@@ -12,7 +12,10 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  var attrs={ foo: 'bar', hello: 'world'  };
+  var attrs = {
+          foo: "bar",
+          hello: "world"
+        }
 
   out.e("DIV", attrs, null, null, 3)
     .t("Hello ")


### PR DESCRIPTION
## Description

Fixes a regression from 4.13.12 where placeholders In `<var>` and `<assign>` tag attributes (eg: `<var x="${y}"/>`).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
