### PR TITLE
Env var helpers

### DIFF
--- a/src/compiler/Compiler.js
+++ b/src/compiler/Compiler.js
@@ -154,7 +154,9 @@ class Compiler {
         var codeGenerator = new CodeGenerator(context);
 
         // STAGE 1: Parse the template to produce the initial AST
-        var ast = this.parser.parse(src, context, { migrate: true });
+        var ast = this.parser.parse(src, context, {
+            migrate: true && !process.env.MARKO_NO_MIGRATE
+        });
         context._parsingFinished = true;
 
         if (!context.ignoreUnrecognizedTags && context.unrecognizedTags) {

--- a/test/__util__/test-init.js
+++ b/test/__util__/test-init.js
@@ -1,5 +1,9 @@
 require("./patch-module");
-require("complain").log = function() {};
+require("complain").log = function(message) {
+    if (process.env.COMPLAIN_THROWS) {
+        throw new Error(message);
+    }
+};
 require("../../node-require").install({
     compilerOptions: { writeToDisk: false }
 });

--- a/test/autotest.js
+++ b/test/autotest.js
@@ -61,7 +61,12 @@ function runFixtureTest(name, dir, run, mode, context) {
     if (hasMainFile) {
         const main = require(mainPath);
         const skip = main.skip || main["skip_" + mode];
-        const fails = main.fails || main["fails_" + mode];
+        const fails =
+            main.fails ||
+            main["fails_" + mode] ||
+            (dir.includes("deprecated") &&
+                process.env.EXPECT_DEPRECATED_FAILURES &&
+                "this is deprecated");
         if (skip) {
             mochaTestFunction = it.skip;
             mochaDetails = skip;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR adds support for 3 environment variables to change how our tests run and give us better insight.  All 3 are boolean attributes that, when truthy, trigger the following behavior:

- `MARKO_NO_MIGRATE` causes the migration stage to be skipped
- `EXPECT_DEPRECATED_FAILURES` marks all fixtures in a `*-deprecated` directory as expected to fail
- `COMPLAIN_THROWS` turns all deprecation warnings (which are normally suppressed during testing) into errors that will fail a test

## Usage:

#### `MARKO_NO_MIGRATE=1 EXPECT_DEPRECATED_FAILURES=1 npm test`

This will disable migrations and expect deprecated tests to fail.  If there are unexpected failures, this means there are tests which are not marked as deprecated that are relying on migrations.  If there are unexpected passes, this means there is code outside the migration stage that is supporting these deprecated features.

#### `COMPLAIN_THROWS=1 EXPECT_DEPRECATED_FAILURES=1 npm test`

This will throw on deprecation warnings and expect deprecated tests to fail.  If there are unexpected failures, this means there are tests which are not marked as deprecated that are logging deprecation warnings.  If there are unexpected passes, this means there is are tests marked as deprecated that do not log an associated warning for the user.