### PR TITLE
Optional migrations & basic w-bind migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,9 @@
 /work
 /build
-/.idea/
-/npm-debug.log
-/node_modules
-/*.sublime-workspace
+.idea/
+npm-debug.log
+node_modules
+*.sublime-workspace
 *.orig
 .DS_Store
 .vscode

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,66 @@
                 "@babel/highlight": "^7.0.0"
             }
         },
+        "@babel/core": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.0.tgz",
+            "integrity": "sha512-7pvAdC4B+iKjFFp9Ztj0QgBndJ++qaMeonT185wAqUnhipw8idm9Rv1UMyBuKtYjfl6ORNkgEgcsYLfHX/GpLw==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "^7.0.0",
+                "@babel/generator": "^7.2.0",
+                "@babel/helpers": "^7.2.0",
+                "@babel/parser": "^7.2.0",
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.6",
+                "@babel/types": "^7.2.0",
+                "convert-source-map": "^1.1.0",
+                "debug": "^4.1.0",
+                "json5": "^2.1.0",
+                "lodash": "^4.17.10",
+                "resolve": "^1.3.2",
+                "semver": "^5.4.1",
+                "source-map": "^0.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                },
+                "json5": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+                    "dev": true,
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "minimist": {
+                    "version": "1.2.0",
+                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                }
+            }
+        },
         "@babel/generator": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
@@ -69,6 +129,17 @@
                 "@babel/types": "^7.0.0"
             }
         },
+        "@babel/helpers": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
+            "integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+            "dev": true,
+            "requires": {
+                "@babel/template": "^7.1.2",
+                "@babel/traverse": "^7.1.5",
+                "@babel/types": "^7.2.0"
+            }
+        },
         "@babel/highlight": {
             "version": "7.0.0",
             "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
@@ -122,6 +193,23 @@
             "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.0.tgz",
             "integrity": "sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==",
             "dev": true
+        },
+        "@babel/runtime": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
+            "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+            "dev": true,
+            "requires": {
+                "regenerator-runtime": "^0.12.0"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.12.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
+                    "dev": true
+                }
+            }
         },
         "@babel/template": {
             "version": "7.1.2",
@@ -193,6 +281,78 @@
                 }
             }
         },
+        "@marko/migrate": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@marko/migrate/-/migrate-1.2.0.tgz",
+            "integrity": "sha512-UbzOgxhJJBhfW2Y5xozJgqWBsZUqcunQFq689DZlMerlKxpTNhsQprQghPS4YWTay4BLRhGEgbDHczhwxt5vag==",
+            "dev": true,
+            "requires": {
+                "@babel/runtime": "^7.2.0",
+                "@marko/migrate-v3-widget": "^1.0.1",
+                "@marko/prettyprint": "^1.2.0",
+                "argly": "^1.2.0",
+                "enquirer": "^2.1.1",
+                "glob": "^7.1.3",
+                "lasso-package-root": "^1.0.1",
+                "mz": "^2.7.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
+        "@marko/migrate-v3-widget": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@marko/migrate-v3-widget/-/migrate-v3-widget-1.0.1.tgz",
+            "integrity": "sha512-luWXWYUPlStF0OFeB8NbBm5w59khC2dLgRcoXlj1N6QejZ1+ZVd2xlrkTj88XJavS+cZxWtObHvG77xRePp9aQ==",
+            "dev": true,
+            "requires": {
+                "@babel/core": "^7.1.5",
+                "@babel/traverse": "^7.1.6",
+                "mz": "^2.7.0",
+                "recast": "^0.16.1",
+                "tslib": "^1.9.3"
+            }
+        },
+        "@marko/prettyprint": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@marko/prettyprint/-/prettyprint-1.2.0.tgz",
+            "integrity": "sha512-YXm5nW0koZ36cXkmlJyG9WMfMK0NkjzE3H6Svz/01vCwMMtuj2zDcYvJm3V1ql0bW0Nwc960zOB5raN3kKVrBQ==",
+            "dev": true,
+            "requires": {
+                "argly": "^1.2.0",
+                "editorconfig": "^0.15.2",
+                "lasso-package-root": "^1.0.1",
+                "marko": "^4.14.3",
+                "minimatch": "^3.0.4",
+                "prettier": "^1.15.3",
+                "redent": "^2.0.0",
+                "resolve-from": "^4.0.0"
+            },
+            "dependencies": {
+                "redent": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+                    "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+                    "dev": true,
+                    "requires": {
+                        "indent-string": "^3.0.0",
+                        "strip-indent": "^2.0.0"
+                    }
+                },
+                "resolve-from": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+                    "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+                    "dev": true
+                }
+            }
+        },
         "@samverschueren/stream-to-observable": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -201,6 +361,18 @@
             "requires": {
                 "any-observable": "^0.3.0"
             }
+        },
+        "@types/node": {
+            "version": "10.12.15",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.15.tgz",
+            "integrity": "sha512-9kROxduaN98QghwwHmxXO2Xz3MaWf+I1sLVAA6KJDF5xix+IyXVhds0MAfdNwtcpSrzhaTsNB0/jnL86fgUhqA==",
+            "dev": true
+        },
+        "@types/semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
+            "dev": true
         },
         "abab": {
             "version": "2.0.0",
@@ -283,6 +455,12 @@
             "integrity": "sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=",
             "dev": true
         },
+        "ansi-colors": {
+            "version": "3.2.3",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "dev": true
+        },
         "ansi-escapes": {
             "version": "3.1.0",
             "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -305,6 +483,12 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.3.0.tgz",
             "integrity": "sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==",
+            "dev": true
+        },
+        "any-promise": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+            "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8=",
             "dev": true
         },
         "anymatch": {
@@ -434,6 +618,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
             "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+            "dev": true
+        },
+        "ast-types": {
+            "version": "0.11.6",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.6.tgz",
+            "integrity": "sha512-nHiuV14upVGl7MWwFUYbzJ6YlfwWS084CU9EA8HajfYQjMSli5TQi3UTRygGF58LFWVkXxS1rbgRhROEqlQkXg==",
             "dev": true
         },
         "async-each": {
@@ -1610,6 +1800,20 @@
                 "safer-buffer": "^2.1.0"
             }
         },
+        "editorconfig": {
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.2.tgz",
+            "integrity": "sha512-GWjSI19PVJAM9IZRGOS+YKI8LN+/sjkSjNyvxL5ucqP9/IqtYNXBaQ/6c/hkPNYQHyOHra2KoXZI/JVpuqwmcQ==",
+            "dev": true,
+            "requires": {
+                "@types/node": "^10.11.7",
+                "@types/semver": "^5.5.0",
+                "commander": "^2.19.0",
+                "lru-cache": "^4.1.3",
+                "semver": "^5.6.0",
+                "sigmund": "^1.0.1"
+            }
+        },
         "ee-first": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -1627,6 +1831,15 @@
             "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
             "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
             "dev": true
+        },
+        "enquirer": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.1.1.tgz",
+            "integrity": "sha512-Ky4Uo7q/dY9jSJIDkPf+y5nM+9F4ESINZaWJSSJbJqOVY15kVXIa/goQR6XmHNcS/MQ38wZT/N2+1pBwQeC2wQ==",
+            "dev": true,
+            "requires": {
+                "ansi-colors": "^3.2.1"
+            }
         },
         "entities": {
             "version": "1.1.2",
@@ -4147,6 +4360,45 @@
                 "object-visit": "^1.0.0"
             }
         },
+        "marko": {
+            "version": "4.14.4",
+            "resolved": "https://registry.npmjs.org/marko/-/marko-4.14.4.tgz",
+            "integrity": "sha512-GyIDRYWe9cPolvqEFSaGRmSGSzdcvL4L/s64AdBd1YMbTdhAT2vQzqkl23LpiFzc5r2FBB+kgvaK8carqlwTPw==",
+            "dev": true,
+            "requires": {
+                "app-module-path": "^2.2.0",
+                "argly": "^1.0.0",
+                "browser-refresh-client": "^1.0.0",
+                "char-props": "~0.1.5",
+                "complain": "^1.3.0",
+                "deresolve": "^1.1.2",
+                "escodegen": "^1.8.1",
+                "esprima": "^4.0.0",
+                "estraverse": "^4.2.0",
+                "events": "^1.0.2",
+                "events-light": "^1.0.0",
+                "he": "^1.1.0",
+                "htmljs-parser": "^2.5.0",
+                "lasso-caching-fs": "^1.0.1",
+                "lasso-modules-client": "^2.0.4",
+                "lasso-package-root": "^1.0.1",
+                "listener-tracker": "^2.0.0",
+                "minimatch": "^3.0.2",
+                "object-assign": "^4.1.0",
+                "property-handlers": "^1.0.0",
+                "raptor-json": "^1.0.1",
+                "raptor-polyfill": "^1.0.0",
+                "raptor-promises": "^1.0.1",
+                "raptor-regexp": "^1.0.0",
+                "raptor-util": "^3.2.0",
+                "resolve-from": "^2.0.0",
+                "shorthash": "0.0.2",
+                "simple-sha1": "^2.1.0",
+                "strip-json-comments": "^2.0.1",
+                "try-require": "^1.2.1",
+                "warp10": "^1.0.0"
+            }
+        },
         "marko-widgets": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/marko-widgets/-/marko-widgets-7.0.1.tgz",
@@ -4630,6 +4882,17 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
             "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
             "dev": true
+        },
+        "mz": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+            "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "thenify-all": "^1.0.0"
+            }
         },
         "nan": {
             "version": "2.11.1",
@@ -6544,6 +6807,18 @@
                 "readable-stream": "^2.0.2"
             }
         },
+        "recast": {
+            "version": "0.16.1",
+            "resolved": "https://registry.npmjs.org/recast/-/recast-0.16.1.tgz",
+            "integrity": "sha512-ZUQm94F3AHozRaTo4Vz6yIgkSEZIL7p+BsWeGZ23rx+ZVRoqX+bvBA8br0xmCOU0DSR4qYGtV7Y5HxTsC4V78A==",
+            "dev": true,
+            "requires": {
+                "ast-types": "0.11.6",
+                "esprima": "~4.0.0",
+                "private": "~0.1.5",
+                "source-map": "~0.6.1"
+            }
+        },
         "rechoir": {
             "version": "0.6.2",
             "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
@@ -6943,6 +7218,12 @@
             "resolved": "https://registry.npmjs.org/shorthash/-/shorthash-0.0.2.tgz",
             "integrity": "sha1-WbJo7sveWQOLMNogK8+93rLEpOs="
         },
+        "sigmund": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+            "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+            "dev": true
+        },
         "signal-exit": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
@@ -7089,8 +7370,7 @@
         "source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-            "optional": true
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "source-map-resolve": {
             "version": "0.5.2",
@@ -7444,6 +7724,24 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
             "dev": true
+        },
+        "thenify": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
+            "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+            "dev": true,
+            "requires": {
+                "any-promise": "^1.0.0"
+            }
+        },
+        "thenify-all": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+            "integrity": "sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=",
+            "dev": true,
+            "requires": {
+                "thenify": ">= 3.1.0 < 4"
+            }
         },
         "through": {
             "version": "2.3.8",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "warp10": "^1.0.0"
     },
     "devDependencies": {
+        "@marko/migrate": "^1.2.0",
         "babel-cli": "^6.24.1",
         "babel-core": "^6.24.1",
         "babel-plugin-minprops": "^2.0.1",

--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -952,6 +952,10 @@ class CompileContext extends EventEmitter {
     isServerTarget() {
         return this.target === "server";
     }
+
+    addMigration() {
+        // Actual functionality implemented by marko migrate cli command.
+    }
 }
 
 CompileContext.prototype.util = {

--- a/src/compiler/index.js
+++ b/src/compiler/index.js
@@ -220,6 +220,10 @@ function parse(templateSrc, filename, options) {
         filename,
         Builder.DEFAULT_BUILDER
     );
+
+    if (options.onContext) {
+        options.onContext(context);
+    }
     var parsed = defaultParser.parse(templateSrc, context, options);
 
     if (context.hasErrors()) {

--- a/src/components/taglib/TransformHelper/convertToComponent.js
+++ b/src/components/taglib/TransformHelper/convertToComponent.js
@@ -11,8 +11,11 @@ module.exports = function handleComponentBind(options) {
 
     context.firstBind = true;
 
-    let isLegacyComponent = (this.isLegacyComponent =
-        options.isLegacyComponent === true);
+    if (options.isLegacyComponent) {
+        context.setMeta("legacy", true);
+    }
+
+    let isLegacyComponent = this.isLegacyComponent;
     let componentModule = options.componentModule;
     let rendererModule = options.rendererModule;
     let componentProps = options.componentProps || {};

--- a/src/components/taglib/TransformHelper/index.js
+++ b/src/components/taglib/TransformHelper/index.js
@@ -139,6 +139,10 @@ class TransformHelper {
         return this.context.data[MARKO_WIDGETS_VAR_KEY];
     }
 
+    get isLegacyComponent() {
+        return this.context.meta.legacy;
+    }
+
     buildComponentElIdFunctionCall(id) {
         var builder = this.builder;
 

--- a/src/components/taglib/widget-types-tag.js
+++ b/src/components/taglib/widget-types-tag.js
@@ -8,7 +8,7 @@ module.exports = function codeGenerator(el, codegen) {
     var context = codegen.context;
     var transformHelper = getTransformHelper(el, context);
 
-    transformHelper.isLegacyComponent = true;
+    context.setMeta("legacy", true);
 
     var builder = codegen.builder;
 

--- a/src/taglibs/migrate/common/w-bind.js
+++ b/src/taglibs/migrate/common/w-bind.js
@@ -1,0 +1,117 @@
+const resolveFrom = require("resolve-from");
+
+module.exports = function migrate(el, context) {
+    const attr = el.getAttribute("w-bind");
+
+    if (!attr) {
+        return;
+    }
+
+    const value = attr.value;
+    const hasWidgetTypes = context.isFlagSet("hasWidgetTypes");
+    let componentModule;
+    let rendererModule;
+
+    context.setMeta("legacy", true);
+
+    context.deprecate(
+        "Legacy components using w-bind and defineRenderer/defineComponent or defineComponent are deprecated. See: https://github.com/marko-js/marko/issues/421"
+    );
+
+    if (value == null) {
+        componentModule = getDefaultWidgetFile(context.dirname);
+
+        if (!componentModule) {
+            context.addError(
+                'No corresponding JavaScript module found in the same directory (either "widget.js", "component.js" or "index.js").'
+            );
+            return;
+        }
+
+        if (componentModule.requirePath === "./") {
+            rendererModule = componentModule;
+        }
+    } else if (attr.isLiteralValue()) {
+        const literalValue = attr.literalValue;
+
+        if (typeof literalValue !== "string") {
+            context.addError(
+                'The value for the "w-bind" attribute should be a string. Actual: ' +
+                    literalValue
+            );
+            return;
+        }
+
+        const filename = resolveFrom(context.dirname, literalValue);
+
+        if (!filename) {
+            this.addError(
+                "Target file not found: " +
+                    literalValue +
+                    " (from: " +
+                    context.dirname +
+                    ")"
+            );
+            return;
+        }
+
+        componentModule = {
+            legacy: true,
+            filename,
+            requirePath: literalValue
+        };
+    }
+
+    context.legacyComponentModule = componentModule;
+    context.legacyRendererModule = rendererModule;
+
+    context.addMigration({
+        description: "Migrate legacy widget with w-bind",
+        apply(helpers) {
+            if (hasWidgetTypes) {
+                return;
+            }
+
+            return helpers
+                .confirm({
+                    message:
+                        "A widget file was discovered, would you like to migrate that as well?\n" +
+                        "Note: widget migrations are not 100% safe and should be tested after migration.",
+                    initial: true
+                })
+                .then(shouldMigrate => {
+                    if (shouldMigrate) {
+                        el.removeAttribute("w-bind");
+                        return helpers.run("componentFile", componentModule);
+                    }
+                });
+        }
+    });
+};
+
+function getDefaultWidgetFile(dirname) {
+    var filename;
+    var legacy = true;
+
+    if ((filename = resolveFrom(dirname, "./widget"))) {
+        return {
+            filename,
+            requirePath: "./widget",
+            legacy
+        };
+    } else if ((filename = resolveFrom(dirname, "./component"))) {
+        return {
+            filename,
+            requirePath: "./component",
+            legacy
+        };
+    } else if ((filename = resolveFrom(dirname, "./"))) {
+        return {
+            filename,
+            requirePath: "./",
+            legacy
+        };
+    } else {
+        return null;
+    }
+}

--- a/src/taglibs/migrate/common/w-bind.js
+++ b/src/taglibs/migrate/common/w-bind.js
@@ -73,7 +73,8 @@ module.exports = function migrate(el, context) {
             }
 
             return helpers
-                .confirm({
+                .prompt({
+                    type: "confirm",
                     message:
                         "A widget file was discovered, would you like to migrate that as well?\n" +
                         "Note: widget migrations are not 100% safe and should be tested after migration.",

--- a/test/__util__/patch-module.js
+++ b/test/__util__/patch-module.js
@@ -25,7 +25,8 @@ Module._resolveFilename = function(request, parent, isMain) {
             request === "marko/components" ||
             request === "marko/jquery" ||
             request === "marko/legacy-components" ||
-            request === "marko/ready"
+            request === "marko/ready" ||
+            request === "marko/env"
         ) {
             request = nodePath.join(
                 rootDir,

--- a/test/migrate/fixtures/w-bind-prompt-n/index.js
+++ b/test/migrate/fixtures/w-bind-prompt-n/index.js
@@ -1,0 +1,3 @@
+module.exports = require("marko-widgets").defineComponent({
+    template: require("./template")
+});

--- a/test/migrate/fixtures/w-bind-prompt-n/prompt-answers.js
+++ b/test/migrate/fixtures/w-bind-prompt-n/prompt-answers.js
@@ -1,1 +1,0 @@
-module.exports = [false];

--- a/test/migrate/fixtures/w-bind-prompt-n/prompt-answers.js
+++ b/test/migrate/fixtures/w-bind-prompt-n/prompt-answers.js
@@ -1,0 +1,1 @@
+module.exports = [false];

--- a/test/migrate/fixtures/w-bind-prompt-n/prompts.js
+++ b/test/migrate/fixtures/w-bind-prompt-n/prompts.js
@@ -1,0 +1,7 @@
+module.exports = [
+    {
+        question:
+            "A widget file was discovered, would you like to migrate that as well?\nNote: widget migrations are not 100% safe and should be tested after migration.",
+        answer: false
+    }
+];

--- a/test/migrate/fixtures/w-bind-prompt-n/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-bind-prompt-n/snapshot-expected.marko
@@ -1,0 +1,3 @@
+<!-- test/migrate/fixtures/w-bind-prompt-n/template.marko -->
+
+<div w-bind/>

--- a/test/migrate/fixtures/w-bind-prompt-n/template.marko
+++ b/test/migrate/fixtures/w-bind-prompt-n/template.marko
@@ -1,0 +1,1 @@
+<div w-bind/>

--- a/test/migrate/fixtures/w-bind-prompt-y/index.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/index.js
@@ -1,0 +1,3 @@
+module.exports = require("marko-widgets").defineComponent({
+    template: require("./template")
+});

--- a/test/migrate/fixtures/w-bind-prompt-y/prompt-answers.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/prompt-answers.js
@@ -1,1 +1,0 @@
-module.exports = [true];

--- a/test/migrate/fixtures/w-bind-prompt-y/prompt-answers.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/prompt-answers.js
@@ -1,0 +1,1 @@
+module.exports = [true];

--- a/test/migrate/fixtures/w-bind-prompt-y/prompts.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/prompts.js
@@ -1,0 +1,7 @@
+module.exports = [
+    {
+        question:
+            "A widget file was discovered, would you like to migrate that as well?\nNote: widget migrations are not 100% safe and should be tested after migration.",
+        answer: true
+    }
+];

--- a/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.js
@@ -1,0 +1,3 @@
+// test/migrate/fixtures/w-bind-prompt-y/index.js
+
+module.exports = {}

--- a/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.js
+++ b/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.js
@@ -1,3 +1,3 @@
 // test/migrate/fixtures/w-bind-prompt-y/index.js
 
-module.exports = {}
+module.exports = {};

--- a/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-bind-prompt-y/snapshot-expected.marko
@@ -1,0 +1,3 @@
+<!-- test/migrate/fixtures/w-bind-prompt-y/template.marko -->
+
+<div/>

--- a/test/migrate/fixtures/w-bind-prompt-y/template.marko
+++ b/test/migrate/fixtures/w-bind-prompt-y/template.marko
@@ -1,0 +1,1 @@
+<div w-bind/>

--- a/test/migrate/index.test.js
+++ b/test/migrate/index.test.js
@@ -1,0 +1,79 @@
+"use strict";
+
+require("../__util__/test-init");
+
+var path = require("path");
+var chai = require("chai");
+chai.config.includeStack = true;
+var cp = require("child_process");
+var autotest = require("../autotest");
+var migrate = require("@marko/migrate").default;
+var CWD = process.cwd();
+
+cp.execSync("npm i --no-package-lock", { cwd: __dirname });
+
+autotest("fixtures", fixture => {
+    let test = fixture.test;
+    let resolve = fixture.resolve;
+    let snapshot = fixture.snapshot;
+    let answersPath;
+    let answers = [];
+
+    try {
+        answersPath = resolve("prompt-answers");
+    } catch (_) {
+        // Ignore
+    }
+
+    if (answersPath) {
+        answers = require(answersPath).slice();
+    }
+
+    test(() => {
+        return migrate({
+            dir: __dirname,
+            files: [resolve("template.marko")],
+            prompt() {
+                if (!answers.length) {
+                    throw new Error(
+                        "Prompt occurred during migration test but no answer provided."
+                    );
+                }
+                return answers.shift();
+            }
+        }).then(outputs => {
+            const byExtension = Object.entries(outputs)
+                .sort(([a], [b]) => a.localeCompare(b))
+                .reduce((r, [file, source]) => {
+                    const ext = path.extname(file);
+                    const parts = (r[ext] = r[ext] || []);
+                    parts.push(
+                        `${toComment(
+                            ext,
+                            path.relative(CWD, file)
+                        )}\n\n${source}`
+                    );
+                    return r;
+                }, {});
+
+            Object.entries(byExtension).forEach(([ext, files]) => {
+                snapshot(files.join("\n\n"), {
+                    ext,
+                    name: "snapshot"
+                });
+            });
+        });
+    });
+});
+
+function toComment(ext, str) {
+    switch (ext) {
+        case ".marko":
+            return `<!-- ${str} -->`;
+        case ".js":
+        case ".json":
+            return `// ${str}`;
+        default:
+            return `# ${str}`;
+    }
+}

--- a/test/migrate/index.test.js
+++ b/test/migrate/index.test.js
@@ -16,30 +16,28 @@ autotest("fixtures", fixture => {
     let test = fixture.test;
     let resolve = fixture.resolve;
     let snapshot = fixture.snapshot;
-    let answersPath;
-    let answers = [];
+    let expectedPrompts = [];
 
     try {
-        answersPath = resolve("prompt-answers");
+        expectedPrompts = require(resolve("./prompts.js")).slice();
     } catch (_) {
         // Ignore
-    }
-
-    if (answersPath) {
-        answers = require(answersPath).slice();
     }
 
     test(() => {
         return migrate({
             dir: __dirname,
             files: [resolve("template.marko")],
-            prompt() {
-                if (!answers.length) {
+            prompt(opts) {
+                if (!expectedPrompts.length) {
                     throw new Error(
                         "Prompt occurred during migration test but no answer provided."
                     );
                 }
-                return answers.shift();
+
+                const currentPrompt = expectedPrompts.shift();
+                chai.expect(opts.message).to.eql(currentPrompt.question);
+                return currentPrompt.answer;
             }
         }).then(outputs => {
             const byExtension = Object.entries(outputs)

--- a/test/migrate/index.test.js
+++ b/test/migrate/index.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-if (!/^v6\.*/.test(process.version)) {
+if (!/^v6\..*/.test(process.version)) {
     require("../__util__/test-init");
 
     var path = require("path");

--- a/test/migrate/index.test.js
+++ b/test/migrate/index.test.js
@@ -1,68 +1,70 @@
 "use strict";
 
-require("../__util__/test-init");
+if (!/^v6\.*/.test(process.version)) {
+    require("../__util__/test-init");
 
-var path = require("path");
-var chai = require("chai");
-chai.config.includeStack = true;
-var cp = require("child_process");
-var autotest = require("../autotest");
-var migrate = require("@marko/migrate").default;
-var CWD = process.cwd();
+    var path = require("path");
+    var chai = require("chai");
+    chai.config.includeStack = true;
+    var cp = require("child_process");
+    var autotest = require("../autotest");
+    var migrate = require("@marko/migrate").default;
+    var CWD = process.cwd();
 
-cp.execSync("npm i --no-package-lock", { cwd: __dirname });
+    cp.execSync("npm i --no-package-lock", { cwd: __dirname });
 
-autotest("fixtures", fixture => {
-    let test = fixture.test;
-    let resolve = fixture.resolve;
-    let snapshot = fixture.snapshot;
-    let expectedPrompts = [];
+    autotest("fixtures", fixture => {
+        let test = fixture.test;
+        let resolve = fixture.resolve;
+        let snapshot = fixture.snapshot;
+        let expectedPrompts = [];
 
-    try {
-        expectedPrompts = require(resolve("./prompts.js")).slice();
-    } catch (_) {
-        // Ignore
-    }
+        try {
+            expectedPrompts = require(resolve("./prompts.js")).slice();
+        } catch (_) {
+            // Ignore
+        }
 
-    test(() => {
-        return migrate({
-            dir: __dirname,
-            files: [resolve("template.marko")],
-            prompt(opts) {
-                if (!expectedPrompts.length) {
-                    throw new Error(
-                        "Prompt occurred during migration test but no answer provided."
-                    );
+        test(() => {
+            return migrate({
+                dir: __dirname,
+                files: [resolve("template.marko")],
+                prompt(opts) {
+                    if (!expectedPrompts.length) {
+                        throw new Error(
+                            "Prompt occurred during migration test but no answer provided."
+                        );
+                    }
+
+                    const currentPrompt = expectedPrompts.shift();
+                    chai.expect(opts.message).to.eql(currentPrompt.question);
+                    return currentPrompt.answer;
                 }
+            }).then(outputs => {
+                const byExtension = Object.entries(outputs)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .reduce((r, [file, source]) => {
+                        const ext = path.extname(file);
+                        const parts = (r[ext] = r[ext] || []);
+                        parts.push(
+                            `${toComment(
+                                ext,
+                                path.relative(CWD, file)
+                            )}\n\n${source}`
+                        );
+                        return r;
+                    }, {});
 
-                const currentPrompt = expectedPrompts.shift();
-                chai.expect(opts.message).to.eql(currentPrompt.question);
-                return currentPrompt.answer;
-            }
-        }).then(outputs => {
-            const byExtension = Object.entries(outputs)
-                .sort(([a], [b]) => a.localeCompare(b))
-                .reduce((r, [file, source]) => {
-                    const ext = path.extname(file);
-                    const parts = (r[ext] = r[ext] || []);
-                    parts.push(
-                        `${toComment(
-                            ext,
-                            path.relative(CWD, file)
-                        )}\n\n${source}`
-                    );
-                    return r;
-                }, {});
-
-            Object.entries(byExtension).forEach(([ext, files]) => {
-                snapshot(files.join("\n\n"), {
-                    ext,
-                    name: "snapshot"
+                Object.entries(byExtension).forEach(([ext, files]) => {
+                    snapshot(files.join("\n\n"), {
+                        ext,
+                        name: "snapshot"
+                    });
                 });
             });
         });
     });
-});
+}
 
 function toComment(ext, str) {
     switch (ext) {

--- a/test/migrate/package.json
+++ b/test/migrate/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "marko": "file:../../"
+  }
+}


### PR DESCRIPTION
## Description

In this PR hooks are added to work closer with the [marko migrate](https://github.com/marko-js/cli/blob/master/packages/migrate/README.md) cli, especially around optional / cross file migrations.

Specifically a hook is added to get the compiler context while parsing and a noop function is added to the context which in marko migrate is overwritten to run additional migrations.

This PR also calls out to another optional `componentFile` migration when w-bind is detected with the widget file to migrate. Part of the `w-bind` transformer was moved into a migrator to allow getting the widget file in the migration stage. 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.