### PR TITLE
Fix widget el id migration

### DIFF
--- a/src/taglibs/migrate/all-tags/widget-elId.js
+++ b/src/taglibs/migrate/all-tags/widget-elId.js
@@ -1,18 +1,23 @@
 module.exports = function migrate(el, context) {
     el.forEachAttribute(attr => {
-        let name = attr.name;
-        const value = attr.value ? attr.value.toString() : undefined;
-        if (!value || !value.startsWith("widget.elId")) {
+        const value = attr.value;
+
+        if (
+            !value ||
+            value.type !== "FunctionCall" ||
+            value.callee.type !== "MemberExpression" ||
+            (value.callee.object.name !== "widget" &&
+                value.callee.object.name !== "component") ||
+            value.callee.property.name !== "elId"
+        ) {
             return;
         }
 
-        const argument = attr.argument;
         context.deprecate(
             `The "*=widget.elId("someId")" is deprecated. Please use "*:scoped="someId"" modifier instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
         );
 
-        name = `${attr.name}:scoped`;
-        el.setAttributeValue(name, argument);
-        el.removeAttribute(attr.name);
+        attr.name += ":scoped";
+        attr.value = value.args[0];
     });
 };

--- a/test/migrate/fixtures/widget-el-id-scoped/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-el-id-scoped/snapshot-expected.marko
@@ -1,0 +1,4 @@
+<!-- test/migrate/fixtures/widget-el-id-scoped/template.marko -->
+
+<label for:scoped="thing"/>
+<input key="thing" id:scoped="thing"/>

--- a/test/migrate/fixtures/widget-el-id-scoped/template.marko
+++ b/test/migrate/fixtures/widget-el-id-scoped/template.marko
@@ -1,0 +1,2 @@
+<label for=widget.elId('thing')/>
+<input w-id="thing"/>


### PR DESCRIPTION
## Description

Fixes a regression from #1190 where the `widget.elId('name')` migration was not including the `'name'`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
