### PR TITLE
Fix regression with undefined spread attributes

### DIFF
--- a/src/runtime/vdom/helper-attrs.js
+++ b/src/runtime/vdom/helper-attrs.js
@@ -2,7 +2,7 @@
  * Helper for processing dynamic attributes
  */
 module.exports = function(attributes) {
-    if (attributes.style || attributes.class) {
+    if (attributes && (attributes.style || attributes.class)) {
         var newAttributes = {};
         Object.keys(attributes).forEach(function(name) {
             if (name === "class") {

--- a/test/render/fixtures/spread-attribute-undefined/expected.html
+++ b/test/render/fixtures/spread-attribute-undefined/expected.html
@@ -1,0 +1,1 @@
+<div>Hello spread</div>

--- a/test/render/fixtures/spread-attribute-undefined/template.marko
+++ b/test/render/fixtures/spread-attribute-undefined/template.marko
@@ -1,0 +1,5 @@
+$ var attrs = undefined;
+
+<div ...attrs>
+    Hello spread
+</div>


### PR DESCRIPTION
## Description
Currently `<div ...undefined>` throws an error as it try's to check for `style` and `class` properties to normalize. I believe this is a regression from https://github.com/marko-js/marko/pull/1058. This PR adds a check for undefined values which fixes the issue.


## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.