### PR TITLE
Fix migrator regressions and misc refactoring

### DIFF
--- a/src/compiler/ast/UnaryExpression.js
+++ b/src/compiler/ast/UnaryExpression.js
@@ -47,7 +47,7 @@ class UnaryExpression extends Node {
     }
 
     isCompoundExpression() {
-        return true;
+        return false;
     }
 
     toJSON() {

--- a/src/taglibs/migrate/all-tags/control-flow-directives.js
+++ b/src/taglibs/migrate/all-tags/control-flow-directives.js
@@ -25,14 +25,7 @@ module.exports = function migrate(el, context) {
             );
             el.removeAttribute(name);
             el.wrapWith(
-                builder.htmlElement(
-                    name,
-                    undefined,
-                    [],
-                    attr.argument,
-                    false,
-                    false
-                )
+                builder.htmlElement(name, undefined, undefined, attr.argument)
             );
         }
     });

--- a/src/taglibs/migrate/all-tags/include-directive.js
+++ b/src/taglibs/migrate/all-tags/include-directive.js
@@ -12,13 +12,6 @@ module.exports = function migrate(el, context) {
 
     el.removeAttribute("include");
     el.appendChild(
-        builder.htmlElement(
-            "include",
-            undefined,
-            [],
-            attr.argument,
-            false,
-            false
-        )
+        builder.htmlElement("include", undefined, undefined, attr.argument)
     );
 };

--- a/src/taglibs/migrate/all-tags/marko-init.js
+++ b/src/taglibs/migrate/all-tags/marko-init.js
@@ -72,15 +72,7 @@ module.exports = function migrate(el, context) {
 };
 
 function toStaticTag(node, context) {
-    const staticTag = context.builder.htmlElement(
-        "static",
-        undefined,
-        undefined,
-        context,
-        true,
-        true
-    );
-
+    const staticTag = context.builder.htmlElement("static");
     let jsStr = printJS(node, context).trim();
 
     if (
@@ -95,15 +87,7 @@ function toStaticTag(node, context) {
 }
 
 function toImportTag(id, from, context) {
-    const importTag = context.builder.htmlElement(
-        "import",
-        undefined,
-        undefined,
-        context,
-        true,
-        true
-    );
-
+    const importTag = context.builder.htmlElement("import");
     let importString = "import";
 
     if (id) {

--- a/src/taglibs/migrate/all-tags/w-body.js
+++ b/src/taglibs/migrate/all-tags/w-body.js
@@ -1,57 +1,46 @@
 const printJS = require("../util/printJS");
 
 module.exports = function migrate(el, context) {
-    if (el.hasAttribute("w-body")) {
-        context.deprecate(
-            'The "w-body" attribute is deprecated. Please use the "<${dynamicTag}/>" tag instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-Widget-body-(w-body)'
-        );
-
-        const builder = context.builder;
-        const bodyValue =
-            el.getAttributeValue("w-body") || builder.identifier("input");
-        let renderBodyValue = bodyValue;
-
-        el.removeAttribute("w-body");
-
-        if (
-            bodyValue.type !== "MemberExpression" ||
-            bodyValue.property.name !== "renderBody"
-        ) {
-            renderBodyValue = builder.memberExpression(
-                bodyValue,
-                builder.identifier("renderBody")
-            );
-        }
-
-        const dynamicTag = builder.htmlElement(
-            undefined,
-            [],
-            undefined,
-            undefined,
-            true,
-            true
-        );
-
-        dynamicTag.rawTagNameExpression = printJS(bodyValue, context);
-
-        el.appendChildren([
-            builder.htmlElement(
-                "if",
-                undefined,
-                [dynamicTag],
-                `typeof ${printJS(renderBodyValue, context)} === 'function'`,
-                context,
-                false,
-                false
-            ),
-            builder.htmlElement(
-                "else",
-                undefined,
-                [builder.text(renderBodyValue)],
-                undefined,
-                false,
-                false
-            )
-        ]);
+    if (!el.hasAttribute("w-body")) {
+        return;
     }
+
+    context.deprecate(
+        'The "w-body" attribute is deprecated. Please use the "<${dynamicTag}/>" tag instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-Widget-body-(w-body)'
+    );
+
+    const builder = context.builder;
+    const defaultValue = builder.identifier("input");
+    const bodyValue = el.getAttributeValue("w-body") || defaultValue;
+    const isDefault = bodyValue.name === defaultValue.name;
+    const dynamicTag = builder.htmlElement();
+    const renderBodyValue = builder.memberExpression(
+        bodyValue,
+        builder.identifier("renderBody")
+    );
+    const condition = builder.binaryExpression(
+        builder.unaryExpression(renderBodyValue, "typeof", true),
+        "===",
+        builder.literal("function")
+    );
+
+    dynamicTag.rawTagNameExpression = printJS(bodyValue, context);
+
+    el.removeAttribute("w-body");
+    el.appendChildren([
+        builder.htmlElement(
+            "if",
+            undefined,
+            [dynamicTag],
+            printJS(
+                isDefault
+                    ? condition
+                    : builder.binaryExpression(bodyValue, "&&", condition),
+                context
+            )
+        ),
+        builder.htmlElement("else", undefined, [
+            builder.text(isDefault ? renderBodyValue : bodyValue)
+        ])
+    ]);
 };

--- a/src/taglibs/migrate/all-templates/render-calls.js
+++ b/src/taglibs/migrate/all-templates/render-calls.js
@@ -81,9 +81,7 @@ module.exports = function migrator(el, context) {
                                     ? node.left
                                     : builder.negate(node.left),
                                 context
-                            ),
-                            false,
-                            false
+                            )
                         );
                         break;
                     case "FunctionCall":
@@ -101,9 +99,7 @@ module.exports = function migrator(el, context) {
                             "if",
                             undefined,
                             replaceScriptlets(node.body, context),
-                            printJS(node.test, context),
-                            false,
-                            false
+                            printJS(node.test, context)
                         );
                         break;
                     case "ElseIf":
@@ -111,19 +107,14 @@ module.exports = function migrator(el, context) {
                             "else-if",
                             undefined,
                             replaceScriptlets(node.body, context),
-                            printJS(node.test, context),
-                            false,
-                            false
+                            printJS(node.test, context)
                         );
                         break;
                     case "Else":
                         node = builder.htmlElement(
                             "else",
                             undefined,
-                            replaceScriptlets(node.body, context),
-                            undefined,
-                            false,
-                            false
+                            replaceScriptlets(node.body, context)
                         );
                         break;
                     case "ForStatement":
@@ -134,9 +125,7 @@ module.exports = function migrator(el, context) {
                             `${printJS(node.init, context)}; ${printJS(
                                 node.test,
                                 context
-                            )}; ${printJS(node.update, context)}`,
-                            false,
-                            false
+                            )}; ${printJS(node.update, context)}`
                         );
                         break;
                     case "WhileStatement":
@@ -144,9 +133,7 @@ module.exports = function migrator(el, context) {
                             "while",
                             undefined,
                             replaceScriptlets(node.body, context),
-                            printJS(node.test, context),
-                            false,
-                            false
+                            printJS(node.test, context)
                         );
                         break;
                     default:

--- a/src/taglibs/migrate/layout-put-tag.js
+++ b/src/taglibs/migrate/layout-put-tag.js
@@ -1,13 +1,13 @@
 const commonTagMigrator = require("./all-tags");
 
 module.exports = function migrator(oldNode, context) {
-    const attributes = oldNode.attributes;
     commonTagMigrator(oldNode, context);
     oldNode.setTransformerApplied(commonTagMigrator);
-
     context.deprecate(
         'The "<layout-put>" tag is deprecated and replaced with first class language support. See: https://github.com/marko-js/marko/wiki/Deprecation:-layout-tag'
     );
+
+    const attributes = oldNode.attributes;
     if (!attributes) {
         context.addError(
             'Invalid <layout-put> tag. Attribute is missing. Example; <layout-put into="body">Some Value</layout-put>'

--- a/src/taglibs/migrate/layout-use-tag.js
+++ b/src/taglibs/migrate/layout-use-tag.js
@@ -3,12 +3,11 @@ const printJS = require("./util/printJS");
 const commonTagMigrator = require("./all-tags");
 
 module.exports = function render(elNode, context) {
+    commonTagMigrator(elNode, context);
+    elNode.setTransformerApplied(commonTagMigrator);
     context.deprecate(
         "The <layout-use> tag is deprecated. Please use a combination of the <${dynamic}> tag and imports instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-layout-tags"
     );
-
-    commonTagMigrator(elNode, context);
-    elNode.setTransformerApplied(commonTagMigrator);
 
     const rawArg = elNode.argument;
     const attributes = elNode.attributes;
@@ -29,21 +28,11 @@ module.exports = function render(elNode, context) {
         attributes.unshift({ spread: true, value: arg });
     }
 
-    const dynamicTag = builder.htmlElement(
-        undefined,
-        attributes,
-        undefined,
-        undefined,
-        true,
-        true
-    );
-
-    if (target.type === "Literal") {
-        dynamicTag.rawTagNameExpression = importTag(target.value, context);
-    } else {
-        dynamicTag.rawTagNameExpression = printJS(target, context);
-    }
-
+    const dynamicTag = builder.htmlElement(undefined, attributes);
+    dynamicTag.rawTagNameExpression =
+        target.type === "Literal"
+            ? importTag(target.value, context)
+            : printJS(target, context);
     elNode.moveChildrenTo(dynamicTag);
     elNode.replaceWith(dynamicTag);
 };

--- a/src/taglibs/migrate/util/import-tag.js
+++ b/src/taglibs/migrate/util/import-tag.js
@@ -30,15 +30,7 @@ module.exports = function importTag(importPath, context) {
         i++;
     }
 
-    const importTag = builder.htmlElement(
-        "import",
-        undefined,
-        undefined,
-        context,
-        true,
-        true
-    );
-
+    const importTag = builder.htmlElement("import");
     importTag.tagString = `import ${identifier} from ${JSON.stringify(
         importPath
     )}`;

--- a/src/taglibs/migrate/util/renderCallToDynamicTag.js
+++ b/src/taglibs/migrate/util/renderCallToDynamicTag.js
@@ -60,15 +60,7 @@ module.exports = function renderCallToDynamicTag(ast, context) {
         );
     }
 
-    const el = builder.htmlElement(
-        undefined,
-        tagAttrs,
-        undefined,
-        undefined,
-        true,
-        true
-    );
-
+    const el = builder.htmlElement(undefined, tagAttrs);
     el.rawTagNameExpression = printJS(tagName, context);
     return el;
 };

--- a/src/taglibs/migrate/var-tag.js
+++ b/src/taglibs/migrate/var-tag.js
@@ -1,7 +1,11 @@
 const isValidJavaScriptVarName = require("../../compiler/util/isValidJavaScriptVarName");
 const printJS = require("./util/printJS");
+const commonTagMigrator = require("./all-tags");
 
 module.exports = function nodeFactory(elNode, context) {
+    commonTagMigrator(elNode, context);
+    elNode.setTransformerApplied(commonTagMigrator);
+
     const attributes = elNode.attributes;
     const builder = context.builder;
     const firstChild = elNode.firstChild;

--- a/test/codegen/fixtures/body-only-if/expected.js
+++ b/test/codegen/fixtures/body-only-if/expected.js
@@ -1,5 +1,5 @@
 if (true) {
-  if (!(!data.url)) {
+  if (!!data.url) {
     out.w("<a" +
       marko_attr("href", data.url) +
       ">");
@@ -7,7 +7,7 @@ if (true) {
 
   out.w("Hello World");
 
-  if (!(!data.url)) {
+  if (!!data.url) {
     out.w("</a>");
   }
 }

--- a/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
@@ -17,7 +17,7 @@ function render(input, out, __component, widget, component) {
     marko_attr("id", __component.elId()) +
     "><h1>Header</h1><div>");
 
-  if ((typeof input.renderBody) === "function") {
+  if (typeof input.renderBody === "function") {
     marko_dynamicTag(input, {}, out, __component, "2");
   } else {
     out.w(marko_escapeXml(input.renderBody));

--- a/test/components-compilation/fixtures-html/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html/component-include-attr/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div><h1>Header</h1><div>");
 
-  if ((typeof data.renderBody) === "string") {
+  if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(data.renderBody, {}, out, __component, "3");

--- a/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>\n    ");
 
-  if ((typeof data.renderBody) === "string") {
+  if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(data.renderBody, {

--- a/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>\n    ");
 
-  if ((typeof data.renderBody) === "string") {
+  if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(data.renderBody, {}, out, __component, "1");

--- a/test/expression-toString/fixtures/UnaryExpression.js/expected.js
+++ b/test/expression-toString/fixtures/UnaryExpression.js/expected.js
@@ -1,1 +1,0 @@
-((typeof foo) && (!i)) && (delete foo.bar)

--- a/test/expression-toString/fixtures/UnaryExpression.js/input.js
+++ b/test/expression-toString/fixtures/UnaryExpression.js/input.js
@@ -1,1 +1,0 @@
-typeof foo && !i && delete foo.bar

--- a/test/expression-toString/fixtures/UnaryExpression/expected.js
+++ b/test/expression-toString/fixtures/UnaryExpression/expected.js
@@ -1,0 +1,1 @@
+((typeof foo && !i) && delete foo.bar) && typeof (x || y)

--- a/test/expression-toString/fixtures/UnaryExpression/input.js
+++ b/test/expression-toString/fixtures/UnaryExpression/input.js
@@ -1,0 +1,1 @@
+typeof foo && !i && delete foo.bar && typeof (x || y)

--- a/test/migrate/fixtures/var-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/var-tag/snapshot-expected.marko
@@ -3,4 +3,7 @@
 $ var firstName = "John";
 $ var lastName = "Smith";
 $ var fullName = firstName + " " + lastName;
+<if(b)>
+    $ var optional = "a";
+</if>
 <div>${fullName}</div>

--- a/test/migrate/fixtures/var-tag/template.marko
+++ b/test/migrate/fixtures/var-tag/template.marko
@@ -1,4 +1,5 @@
 <var firstName="John"/>
 <var lastName="Smith"/>
 <var fullName="${firstName} ${lastName}"/>
+<var optional="a" if(b)/>
 <div>${fullName}</div>

--- a/test/migrate/fixtures/w-body-attr-val/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-body-attr-val/snapshot-expected.marko
@@ -1,8 +1,14 @@
 <!-- test/migrate/fixtures/w-body-attr-val/template.marko -->
 
 <div>
-    <if(typeof input.title.renderBody === 'function')>
+    <if(input.title && (typeof input.title.renderBody === "function"))>
         <${input.title}/>
     </if>
-    <else>${input.title.renderBody}</else>
+    <else>${input.title}</else>
+</div>
+<div>
+    <if((input.a ? input.b : input.c) && (typeof (input.a ? input.b : input.c).renderBody === "function"))>
+        <${input.a ? input.b : input.c}/>
+    </if>
+    <else>${input.a ? input.b : input.c}</else>
 </div>

--- a/test/migrate/fixtures/w-body-attr-val/template.marko
+++ b/test/migrate/fixtures/w-body-attr-val/template.marko
@@ -1,1 +1,2 @@
 <div w-body=input.title />
+<div w-body=(input.a ? input.b : input.c) />

--- a/test/migrate/fixtures/w-body/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-body/snapshot-expected.marko
@@ -1,7 +1,7 @@
 <!-- test/migrate/fixtures/w-body/template.marko -->
 
 <div>
-    <if(typeof input.renderBody === 'function')>
+    <if(typeof input.renderBody === "function")>
         <${input}/>
     </if>
     <else>${input.renderBody}</else>


### PR DESCRIPTION
## Description

* Fixes control flow attributes on var tag.
* Fixes w-body to ensure that value exists.
* Ensures w-body and include properly enclose typeof expressions.
* Improves printing of unary expressions.
* Refactor `builder.htmlElement` calls to omit optional arguments.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
