### PR TITLE
Fix regression with w-body migration

### DIFF
--- a/src/taglibs/migrate/all-tags/w-body.js
+++ b/src/taglibs/migrate/all-tags/w-body.js
@@ -18,11 +18,7 @@ module.exports = function migrate(el, context) {
         bodyValue,
         builder.identifier("renderBody")
     );
-    const condition = builder.binaryExpression(
-        builder.unaryExpression(renderBodyValue, "typeof", true),
-        "===",
-        builder.literal("function")
-    );
+    const condition = buildTypeOfFunction(renderBodyValue, context);
 
     dynamicTag.rawTagNameExpression = printJS(bodyValue, context);
 
@@ -35,7 +31,15 @@ module.exports = function migrate(el, context) {
             printJS(
                 isDefault
                     ? condition
-                    : builder.binaryExpression(bodyValue, "&&", condition),
+                    : builder.binaryExpression(
+                          bodyValue,
+                          "&&",
+                          builder.binaryExpression(
+                              buildTypeOfFunction(bodyValue, context),
+                              "||",
+                              condition
+                          )
+                      ),
                 context
             )
         ),
@@ -44,3 +48,12 @@ module.exports = function migrate(el, context) {
         ])
     ]);
 };
+
+function buildTypeOfFunction(node, context) {
+    const builder = context.builder;
+    return builder.binaryExpression(
+        builder.unaryExpression(node, "typeof", true),
+        "===",
+        builder.literal("function")
+    );
+}

--- a/test/migrate/fixtures/w-body-attr-val/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-body-attr-val/snapshot-expected.marko
@@ -1,13 +1,13 @@
 <!-- test/migrate/fixtures/w-body-attr-val/template.marko -->
 
 <div>
-    <if(input.title && (typeof input.title.renderBody === "function"))>
+    <if(input.title && ((typeof input.title === "function") || (typeof input.title.renderBody === "function")))>
         <${input.title}/>
     </if>
     <else>${input.title}</else>
 </div>
 <div>
-    <if((input.a ? input.b : input.c) && (typeof (input.a ? input.b : input.c).renderBody === "function"))>
+    <if((input.a ? input.b : input.c) && ((typeof (input.a ? input.b : input.c) === "function") || (typeof (input.a ? input.b : input.c).renderBody === "function")))>
         <${input.a ? input.b : input.c}/>
     </if>
     <else>${input.a ? input.b : input.c}</else>


### PR DESCRIPTION
## Description

This fixes a regression in w-body where passing the renderBody function directly (eg: `<div w-body=item.renderBody>`) stopped working.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
