### PR TITLE
Remove legacy invoke and ref code

### DIFF
--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -35,11 +35,6 @@ module.exports = function assignComponentId(isRepeated) {
     var isHtmlElement = el.type === "HtmlElement";
     var isCustomTag = el.type === "CustomTag";
 
-    // LEGACY -- Remove in Marko 5.0
-    if (!isCustomTag && el.tagName === "invoke") {
-        isCustomTag = true;
-    }
-
     if (!isCustomTag && !isHtmlElement) {
         return;
     }
@@ -47,12 +42,6 @@ module.exports = function assignComponentId(isRepeated) {
     if (el.hasAttribute("key")) {
         assignedKey = el.getAttributeValue("key");
         el.removeAttribute("key");
-    } else if (el.hasAttribute("ref")) {
-        context.deprecate(
-            'The "ref" attribute is deprecated. Please use "key" instead.'
-        );
-        assignedKey = el.getAttributeValue("ref");
-        el.removeAttribute("ref");
     }
 
     if (assignedKey) {


### PR DESCRIPTION
## Description

This PR removes two pieces of unreachable leftover code from the `ref` attribute migration and the `invoke` tag migration.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
