### PR TITLE
Fix debug mode eval class name

### DIFF
--- a/src/components/registry-browser.js
+++ b/src/components/registry-browser.js
@@ -76,16 +76,21 @@ function getComponentClass(typeName, isLegacy) {
         });
         className = className
             .replace(/\$\d+\.\d+\.\d+$/, "")
-            .replace(/[^\w]+/g, "_");
+            .replace(/^[^a-z$_]/i, "_$&")
+            .replace(/[^0-9a-z$_]+/gi, "_");
         className = className[0].toUpperCase() + className.slice(1);
         // eslint-disable-next-line no-unused-vars
-        var OldComponentClass = ComponentClass;
-        eval(
-            "ComponentClass = function " +
-                className +
-                "(id, doc) { OldComponentClass.call(this, id, doc); }"
-        );
-        ComponentClass.prototype = OldComponentClass.prototype;
+        try {
+            var OldComponentClass = ComponentClass;
+            eval(
+                "ComponentClass = function " +
+                    className +
+                    "(id, doc) { OldComponentClass.call(this, id, doc); }"
+            );
+            ComponentClass.prototype = OldComponentClass.prototype;
+        } catch (e) {
+            /** ignore error */
+        }
     }
 
     componentTypes[typeName] = ComponentClass;


### PR DESCRIPTION
## Description

Currently the dev mode `eval`'d component class name can cause a syntax error for components which start with and invalid identifier character (ie: `11-my-item`). This PR helps ensures that the first character is a valid and also wraps the eval in a try catch which falls back to the old behavior.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.