### PR TITLE
fix dynamic attribute priority

### DIFF
--- a/src/taglibs/migrate/all-tags/dynamic-attributes.js
+++ b/src/taglibs/migrate/all-tags/dynamic-attributes.js
@@ -4,11 +4,9 @@ module.exports = function migrate(el, context) {
             context.deprecate(
                 'The "${attributes}" is deprecated. Please use "...attributes" modifier instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes'
             );
-            el.attributes.splice(index, 1);
-            el.addAttribute({
-                value: attr.value,
-                spread: true
-            });
+            const attribute = el.attributes.splice(index, 1)[0];
+            attribute.spread = true;
+            el.attributes.unshift(attribute);
         }
     });
 };

--- a/test/migrate/fixtures/dynamic-attributes/snapshot-expected.marko
+++ b/test/migrate/fixtures/dynamic-attributes/snapshot-expected.marko
@@ -1,3 +1,3 @@
 <!-- test/migrate/fixtures/dynamic-attributes/template.marko -->
 
-<div test="blah" ...input.attr>Hello World</div>
+<div ...input.attr test="blah">Hello World</div>

--- a/test/migrate/fixtures/dynamic-attributes/template.marko
+++ b/test/migrate/fixtures/dynamic-attributes/template.marko
@@ -1,1 +1,1 @@
-<div ${input.attr} test="blah">Hello World</div>
+<div test="blah" ${input.attr}>Hello World</div>

--- a/test/render/fixtures/attrs/expected.html
+++ b/test/render/fixtures/attrs/expected.html
@@ -1,1 +1,1 @@
-<div data-encoding="&quot;hello&quot;" style="background-color: #FF0000; &lt;test>" class="my-div" checked>Hello World!</div>
+<div style="background-color: #FF0000; &lt;test>" class="my-div" checked data-encoding="&quot;hello&quot;">Hello World!</div>

--- a/test/render/fixtures/script-nonce/expected.html
+++ b/test/render/fixtures/script-nonce/expected.html
@@ -1,3 +1,3 @@
-<script foo="bar" hello="world" nonce="foo">
+<script hello="world" foo="bar" nonce="foo">
 console.log('foo')
 </script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

No matter where the dynamic `${attrs}` are defined, they always have lowest priority.  In the following example, both explicit `foo` and `bar` attributes would overwrite any values in `attrs`.

```marko
<div foo=123 ${attrs} bar=456>Hello World</div>
```

The current migration gives highest priority to these dynamic attributes rather than lowest.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
