### PR TITLE
Fixes #1219 - transitive widget getEl and events

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -232,6 +232,22 @@ class CompileContext extends EventEmitter {
         }
     }
 
+    setMigrationFlag(name) {
+        var el = this.migrationFlagEl;
+
+        if (!el.hasAttribute(name)) {
+            el.addAttribute({ name });
+        }
+    }
+
+    get migrationFlagEl() {
+        if (!this._mfe) {
+            this._mfe = this.builder.htmlElement("marko-migration-flags");
+            this.root.prependChild(this._mfe);
+        }
+        return this._mfe;
+    }
+
     pushData(key, data) {
         var dataStack = this._dataStacks[key];
         if (!dataStack) {

--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -99,6 +99,14 @@ class Normalizer {
             return;
         }
 
+        if (elNode.tagName === "marko-migration-flags") {
+            elNode.attributes.forEach(attr => {
+                context.setFlag(attr.name);
+            });
+            elNode.detach();
+            return;
+        }
+
         var newNode = this.context.createNodeForEl({
             tagName: elNode.rawTagNameExpression
                 ? builder.parseExpression(elNode.rawTagNameExpression)

--- a/src/components/taglib/components-transformer.js
+++ b/src/components/taglib/components-transformer.js
@@ -18,10 +18,7 @@ module.exports = function transform(el, context) {
 
     if (el.type === "TemplateRoot") {
         transformHelper.handleRootNodes();
-        if (
-            !context.isFlagSet("hasLegacyWidgetBind") &&
-            context.isFlagSet("hasLegacyWidgetAttr")
-        ) {
+        if (context.isFlagSet("legacyWidgetAttrsWithoutBind")) {
             let builder = context.builder;
             let getWidgetFromOut = context.helper("getWidgetFromOut");
             el.prependChild(

--- a/src/taglibs/migrate/all-tags/w-for.js
+++ b/src/taglibs/migrate/all-tags/w-for.js
@@ -1,4 +1,5 @@
 const addIdScopedAttr = require("../util/addIdScopedAttr");
+const findBoundParent = require("../util/findBoundParent");
 
 module.exports = function migrate(el, context) {
     if (
@@ -15,9 +16,16 @@ module.exports = function migrate(el, context) {
                 return;
             }
 
-            context.deprecate(
-                `The "w-for", "for-key" and "for-ref" attributes are deprecated. Please use "for:scoped" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
-            );
+            if (name === "w-for" && !findBoundParent(el)) {
+                context.deprecate(
+                    `Using "w-for" in a template without a "w-bind" is deprecated. The "${name}" attribute is also deprecated. Please use "for:scoped" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+                );
+                context.setMigrationFlag("legacyWidgetAttrsWithoutBind");
+            } else {
+                context.deprecate(
+                    `The "${name}" attribute is deprecated. Please use "for:scoped" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+                );
+            }
 
             if (el.hasAttribute("for:scoped")) {
                 context.addError(

--- a/src/taglibs/migrate/all-tags/w-id.js
+++ b/src/taglibs/migrate/all-tags/w-id.js
@@ -1,12 +1,21 @@
+const findBoundParent = require("../util/findBoundParent");
+
 module.exports = function migrate(el, context) {
     const attr = el.getAttribute("w-id");
     if (!attr) {
         return;
     }
 
-    context.deprecate(
-        `The "w-id" attribute is deprecated. Please use "key" attribute instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
-    );
+    if (findBoundParent(el)) {
+        context.deprecate(
+            `The "w-id" attribute is deprecated. Please use "key" attribute instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+        );
+    } else {
+        context.deprecate(
+            `Using "w-id" in a template without a "w-bind" is deprecated. The "w-id" attribute is also deprecated. Please use "key" attribute instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+        );
+        context.setMigrationFlag("legacyWidgetAttrsWithoutBind");
+    }
 
     el.setAttributeValue("key", attr.value);
     const isHTML = el.tagDef && el.tagDef.html;

--- a/src/taglibs/migrate/all-tags/w-on.js
+++ b/src/taglibs/migrate/all-tags/w-on.js
@@ -1,4 +1,5 @@
 const printJS = require("../util/printJS");
+const findBoundParent = require("../util/findBoundParent");
 
 module.exports = function migrate(el, context) {
     el.forEachAttribute(attr => {
@@ -7,9 +8,16 @@ module.exports = function migrate(el, context) {
             return;
         }
 
-        context.deprecate(
-            `The "w-on*" attributes are deprecated. Please use "on*()" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
-        );
+        if (findBoundParent(el)) {
+            context.deprecate(
+                `The "w-on*" attributes are deprecated. Please use "on*()" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+            );
+        } else {
+            context.deprecate(
+                `Using "w-on*" in a template without a "w-bind" is deprecated. The "w-on*" attributes are also deprecated. Please use "on*()" instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
+            );
+            context.setMigrationFlag("legacyWidgetAttrsWithoutBind");
+        }
 
         name = name.substring("w-on".length);
         if (name.startsWith("-")) name = name.substring("-".length);

--- a/src/taglibs/migrate/util/findBoundParent.js
+++ b/src/taglibs/migrate/util/findBoundParent.js
@@ -1,0 +1,7 @@
+module.exports = function findBoundParent(el) {
+    if (el.type === "HtmlElement" && el.getAttribute("w-bind")) {
+        return el;
+    } else if (el.parentNode) {
+        return findBoundParent(el.parentNode);
+    }
+};

--- a/test/compiler/fixtures-html/invoke/expected.js
+++ b/test/compiler/fixtures-html/invoke/expected.js
@@ -5,11 +5,16 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,
     marko_defineComponent = components_helpers.c,
+    marko_getWidgetFromOut = require("marko/src/components/legacy/helper-getWidgetFromOut"),
     marko_helpers = require("marko/src/runtime/html/helpers"),
     marko_dynamicTag = marko_helpers.d;
 
 function render(input, out, __component, component, state) {
   var data = input;
+
+  var widget = marko_getWidgetFromOut(out),
+      __component = widget,
+      component = __component._c;
 
   marko_dynamicTag(input, {
       x: 1

--- a/test/components-browser/fixtures-deprecated/widget-transitive-event/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-transitive-event/test.js
@@ -12,5 +12,3 @@ module.exports = function(helpers) {
 
     expect(window.transitiveHandled).to.eql(true);
 };
-
-module.exports.fails = "Issue #1219";

--- a/test/components-browser/fixtures-deprecated/widget-transitive-get-el/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-transitive-get-el/test.js
@@ -7,5 +7,3 @@ module.exports = function(helpers) {
 
     expect(el.tagName).to.eql("BUTTON");
 };
-
-module.exports.fails = "Issue #1219";

--- a/test/migrate/fixtures/w-for/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-for/snapshot-expected.marko
@@ -1,4 +1,5 @@
 <!-- test/migrate/fixtures/w-for/template.marko -->
 
+<marko-migration-flags legacyWidgetAttrsWithoutBind/>
 <input key="a" id:scoped="a"/>
 <label for:scoped="a"/>

--- a/test/migrate/fixtures/w-id/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-id/snapshot-expected.marko
@@ -1,5 +1,6 @@
 <!-- test/migrate/fixtures/w-id/template.marko -->
 
+<marko-migration-flags legacyWidgetAttrsWithoutBind/>
 <div key="a" id:scoped="a"/>
 <div key="b" id:scoped="b"/>
 <test key="c"/>

--- a/test/migrate/fixtures/w-on/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-on/snapshot-expected.marko
@@ -1,5 +1,6 @@
 <!-- test/migrate/fixtures/w-on/template.marko -->
 
+<marko-migration-flags legacyWidgetAttrsWithoutBind/>
 <div onClick("handleClick")>
     <input onChange("handleChange")/>
     Hello World

--- a/test/migrate/fixtures/widget-el-id-scoped/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-el-id-scoped/snapshot-expected.marko
@@ -1,4 +1,5 @@
 <!-- test/migrate/fixtures/widget-el-id-scoped/template.marko -->
 
+<marko-migration-flags legacyWidgetAttrsWithoutBind/>
 <label for:scoped="thing"/>
 <input key="thing" id:scoped="thing"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This also adds a new concept of "migration flags".  Migration flags are output in the migrated template as a tag (`<marko-migration-flags flag1 flag2 .../>`) and can influence how the template gets compiled.  

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
