### PR TITLE
Fix regression with the include tag migration & parent paths

### DIFF
--- a/src/taglibs/migrate/util/import-tag.js
+++ b/src/taglibs/migrate/util/import-tag.js
@@ -1,5 +1,5 @@
 const camelCase = require("camelcase");
-const nameReg = /\/([^/]+?)(?:\/index)?(?:\..*)?$/;
+const nameReg = /\/([^/]+?)(?:\/index)?(?:\.[^/]+)?$/;
 
 module.exports = function importTag(importPath, context) {
     const builder = context.builder;
@@ -13,13 +13,14 @@ module.exports = function importTag(importPath, context) {
     }
 
     const match = nameReg.exec(importPath);
+
+    // Create a camelcased tagName identifier based off of the matched file name.
+    // Replace any invalid JS chars (We don't need to worry about reserved words because of camelcase).
     const requestedTagName = camelCase((match && match[1]) || "Template", {
         pascalCase: true
-    });
+    }).replace(/^[^$A-Z_]|[^0-9A-Z_$]/gi, "_");
 
-    // Replace any invalid JS chars.
-    // We don't need to worry about reserved words because of camelcase.
-    let identifier = requestedTagName.replace(/^[^$A-Z_]|[^0-9A-Z_$]/gi, "_");
+    let identifier = requestedTagName;
     let i = 1;
 
     while (

--- a/test/migrate/fixtures/include-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/include-tag/snapshot-expected.marko
@@ -5,6 +5,9 @@ import ExampleB from "./example-b.marko"
 import ExampleC from "./example-c/index.marko"
 import ExampleD_1 from "./example-d.marko"
 import ExampleE from "./example-e/index.marko"
+import ExampleF from "../../../hello/example-f.marko"
+import ExampleF_1 from "../../../hello2/example-f.marko"
+import ExampleH from "../../../hello/example-h/index.marko"
 
 <!-- Import: basic -->
 <${ExampleA}/>
@@ -23,6 +26,12 @@ $ const ExampleD = undefined;
 <${ExampleE}>
     <div>Hi</div>
 </>
+<!-- Import: complex path -->
+<${ExampleF}/>
+<!-- Import: complex path name conflict -->
+<${ExampleF_1}/>
+<!-- Import: complex path index -->
+<${ExampleH}/>
 <!-- Dynamic: basic -->
 <if(typeof input.x === "string")>${input.x}</if>
 <else>

--- a/test/migrate/fixtures/include-tag/template.marko
+++ b/test/migrate/fixtures/include-tag/template.marko
@@ -13,6 +13,12 @@ $ const ExampleD = undefined;
 <include("./example-e/index.marko")>
     <div>Hi</div>
 </include>
+<!-- Import: complex path -->
+<include("../../../hello/example-f.marko")/>
+<!-- Import: complex path name conflict -->
+<include("../../../hello2/example-f.marko")/>
+<!-- Import: complex path index -->
+<include("../../../hello/example-h/index.marko")/>
 <!-- Dynamic: basic -->
 <include(input.x)/>
 <!-- Dynamic: with attributes -->


### PR DESCRIPTION
## Description
Fixes a regression which caused invalid identifiers to be output when generating `import` tags during migration.

Fixes #1230 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
