### PR TITLE
Fix walkers into some ast nodes

### DIFF
--- a/src/compiler/ast/Scriptlet.js
+++ b/src/compiler/ast/Scriptlet.js
@@ -22,12 +22,16 @@ class Scriptlet extends Node {
             return;
         }
 
-        if (typeof code === "string") {
+        if (typeof code === "string" && this.block) {
             code = adjustIndent(code, writer.currentIndent);
         }
 
         writer.write(code);
         writer.write("\n");
+    }
+
+    walk(walker) {
+        this.code = walker.walk(this.code);
     }
 }
 

--- a/src/compiler/ast/TemplateLiteral.js
+++ b/src/compiler/ast/TemplateLiteral.js
@@ -49,6 +49,10 @@ class TemplateLiteral extends Node {
         writer.write(quote + code + quote);
         writer.write("\n");
     }
+
+    walk(walker) {
+        this.expressions = walker.walk(this.expressions);
+    }
 }
 
 function escapeQuasi(quasi, quote) {

--- a/src/compiler/ast/Vars.js
+++ b/src/compiler/ast/Vars.js
@@ -63,7 +63,7 @@ class Vars extends Node {
     }
 
     walk(walker) {
-        this.argument = walker.walk(this.argument);
+        this.declarations = walker.walk(this.declarations);
     }
 
     /**

--- a/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
@@ -3,4 +3,5 @@
 <div aria-describedby=(a && component.id)/>
 <div aria-describedby=(a && component.elId("x"))/>
 <div aria-describedby=(a && component.anything())/>
+<div aria-describedby=`${a} ${component.id}`/>
 $ var widgetId = a ? component.id : component.elId("b");

--- a/test/migrate/fixtures/widget-in-attrs/template.marko
+++ b/test/migrate/fixtures/widget-in-attrs/template.marko
@@ -1,4 +1,5 @@
 <div aria-describedby=(a && widget.id)/>
 <div aria-describedby=(a && widget.elId('x'))/>
 <div aria-describedby=(a && widget.anything())/>
+<div aria-describedby=`${a} ${widget.id}`/>
 <var widgetId=(a ? widget.id : widget.elId("b"))/>

--- a/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
+++ b/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
@@ -15,9 +15,9 @@ function render(input, out, __component, component, state) {
   var data = input;
 
   var attrs = {
-      foo: "bar",
-      hello: "world"
-    }
+    foo: "bar",
+    hello: "world"
+  }
 
   out.e("DIV", marko_attrs(attrs), null, null, 3)
     .t("Hello ")


### PR DESCRIPTION
## Description

`Vars`, `TemplateLiteral` and `Scriptlet` ast nodes did not have a walker implemented which caused some migrations to not work as expected. This PR adds walkers to those nodes.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.