### PR TITLE
No longer warn about migrating widget in template when component is used

### DIFF
--- a/src/taglibs/migrate/all-tags/widget-in-attrs.js
+++ b/src/taglibs/migrate/all-tags/widget-in-attrs.js
@@ -44,6 +44,6 @@ function isWidgetMemberExpression(value) {
     return (
         value &&
         value.type === "MemberExpression" &&
-        (value.object.name === "widget" || value.object.name === "component")
+        value.object.name === "widget"
     );
 }


### PR DESCRIPTION
## Description

Currently the `widget` => `component` migrator for templates warns about using `component` as well. This is because originally we wanted to migrate `id=component.elId("test")` => `id:scoped="test"`. However since we are not deprecated that api and we don't want to show these unnecessary warnings this PR removes that migration.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.