### PR TITLE
Fix 'marko is using deprecated features' message

### DIFF
--- a/compiler-browser.marko
+++ b/compiler-browser.marko
@@ -1,7 +1,7 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/compiler");\n`;
-});
+})/>
 
 // What's going on here? We are using Marko to do JavaScript code generation
 // during the module bundling phase to conditionally export either the

--- a/components-browser.marko
+++ b/components-browser.marko
@@ -1,7 +1,7 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components");\n`;
-});
+})/>
 
 // What's going on here? We are using Marko to do JavaScript code generation
 // during the module bundling phase to conditionally export either the

--- a/index-browser.marko
+++ b/index-browser.marko
@@ -1,7 +1,7 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/index");\n`;
-});
+})/>
 
 // What's going on here? We are using Marko to do JavaScript code generation
 // during the module bundling phase to conditionally export either the

--- a/jquery.marko
+++ b/jquery.marko
@@ -1,4 +1,10 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components/jquery");\n`;
-});
+})/>
+
+// What's going on here? We are using Marko to do JavaScript code generation
+// during the module bundling phase to conditionally export either the
+// "src" or the "dist" folder based on whether or not we are doing a
+// debug or non-debug build. We are using Marko since we know the Marko compiler
+// is enabled already (no extra babel transform required).

--- a/legacy-components-browser.marko
+++ b/legacy-components-browser.marko
@@ -1,7 +1,7 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components/legacy");\n`;
-});
+})/>
 
 // What's going on here? We are using Marko to do JavaScript code generation
 // during the module bundling phase to conditionally export either the

--- a/ready.marko
+++ b/ready.marko
@@ -1,4 +1,10 @@
-module-code(function(require) {
+<module-code(function(require) {
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components/ready");\n`;
-});
+})/>
+
+// What's going on here? We are using Marko to do JavaScript code generation
+// during the module bundling phase to conditionally export either the
+// "src" or the "dist" folder based on whether or not we are doing a
+// debug or non-debug build. We are using Marko since we know the Marko compiler
+// is enabled already (no extra babel transform required).


### PR DESCRIPTION
## Description

Currently the entry points with `module-code` tags are being incorrectly parsed to have an additional empty attribute. This converts them to not use concise mode which is a work around until the parsing can be fixed in this edge case.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.