### PR TITLE
Fix regression with escaped sequences in non standard template literals

### DIFF
--- a/src/compiler/HtmlJsParser.js
+++ b/src/compiler/HtmlJsParser.js
@@ -31,7 +31,7 @@ class HtmlJsParser {
                             value += "${" + part.value + "}";
                         } else {
                             value += part.replace(
-                                /`|\\|\${/g,
+                                /`|\${/g,
                                 match => "\\" + match
                             );
                         }

--- a/test/migrate/fixtures/non-standard-template-literals/snapshot-expected.marko
+++ b/test/migrate/fixtures/non-standard-template-literals/snapshot-expected.marko
@@ -16,3 +16,4 @@
 <test value={
     a: `${b} ${c}`
 }/>
+<test class=`something\n  ${data.first ? " first" : ""}\n  ${data.last ? " last" : ""}`/>

--- a/test/migrate/fixtures/non-standard-template-literals/template.marko
+++ b/test/migrate/fixtures/non-standard-template-literals/template.marko
@@ -6,3 +6,6 @@
 <test value="${a} ${b}"/>
 <test value={ a: "${b}" }/>
 <test value={ a: "${b} ${c}" }/>
+<test class="something
+  ${data.first ? ' first' : ''}
+  ${data.last ? ' last' : ''}"/>


### PR DESCRIPTION
## Description

Currently code using non standard template literals can have values such as `\n` double escaped:

```
<div class="a
b"/>
```

becomes

```
<div class=`a\\nb`/>
```

This PR fixes that issue.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
