### PR TITLE
Remove unneeded hasRenderBody check

### DIFF
--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -7,7 +7,6 @@ const ok = require("assert").ok;
 const Node = require("./Node");
 
 const CUSTOM_TAG_KEY = Symbol("CustomTag");
-const HAS_RENDER_BODY_PROP_ADDED = Symbol();
 
 function getNestedVariables(elNode, tagDef, codegen) {
     let variableNames = [];
@@ -784,36 +783,6 @@ class CustomTag extends HtmlElement {
             parentCustomTag.addNestedTag(this);
 
             let hasBody = body && body.length;
-
-            if (
-                hasBody &&
-                context.isServerTarget() &&
-                !parentCustomTag.isFlagSet(HAS_RENDER_BODY_PROP_ADDED)
-            ) {
-                parentCustomTag.setFlag(HAS_RENDER_BODY_PROP_ADDED);
-
-                let hasRenderBodyKey = context.addStaticVar(
-                    "hasRenderBodyKey",
-                    builder.functionCall(
-                        builder.memberExpression(
-                            builder.identifier("Symbol"),
-                            builder.identifier("for")
-                        ),
-                        [builder.literal("hasRenderBody")]
-                    )
-                );
-
-                // We flag tags that have a `renderBody` function on the input
-                // since those tags must be handled differently if it happens to
-                // be a top-level UI component since the `input` would not
-                // be serializable (functions are not serializable). If know
-                // that a top-level UI component has non-serializable input
-                // then we won't use it as the browser-side re-render root
-                parentCustomTag.setAttributeValue(
-                    hasRenderBodyKey,
-                    codegen.builder.literal(true)
-                );
-            }
 
             if (
                 checkIfNestedTagCanBeAddedDirectlyToInput(this, parentCustomTag)

--- a/test/compiler/fixtures-html/at-tags-dynamic/expected.js
+++ b/test/compiler/fixtures-html/at-tags-dynamic/expected.js
@@ -7,7 +7,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     marko_defineComponent = components_helpers.c,
     marko_helpers = require("marko/src/runtime/html/helpers"),
     marko_forEach = marko_helpers.f,
-    hasRenderBodyKey = Symbol.for("hasRenderBody"),
     marko_loadNestedTag = require("marko/src/runtime/helper-loadNestedTag"),
     hello_foo_nested_tag = marko_loadNestedTag("foo"),
     marko_mergeNestedTagsHelper = require("marko/src/runtime/helper-mergeNestedTags"),
@@ -32,8 +31,7 @@ function render(input, out, __component, component, state) {
               }
             }, hello0);
         });
-      },
-      [hasRenderBodyKey]: true
+      }
     }), out, __component, "0");
 }
 

--- a/test/compiler/fixtures-html/at-tags/expected.js
+++ b/test/compiler/fixtures-html/at-tags/expected.js
@@ -5,7 +5,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,
     marko_defineComponent = components_helpers.c,
-    hasRenderBodyKey = Symbol.for("hasRenderBody"),
     marko_loadTemplate = require("marko/src/runtime/helper-loadTemplate"),
     hello_template = marko_loadTemplate(require.resolve("./components/hello")),
     marko_helpers = require("marko/src/runtime/html/helpers"),
@@ -20,8 +19,7 @@ function render(input, out, __component, component, state) {
           renderBody: function renderBody(out) {
             out.w("Foo!");
           }
-        },
-      [hasRenderBodyKey]: true
+        }
     }, out, __component, "0");
 }
 

--- a/test/compiler/fixtures-html/nested-tag-if-optimization/expected.js
+++ b/test/compiler/fixtures-html/nested-tag-if-optimization/expected.js
@@ -5,7 +5,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,
     marko_defineComponent = components_helpers.c,
-    hasRenderBodyKey = Symbol.for("hasRenderBody"),
     marko_loadTemplate = require("marko/src/runtime/helper-loadTemplate"),
     test_template = marko_loadTemplate(require.resolve("./components/test")),
     marko_helpers = require("marko/src/runtime/html/helpers"),
@@ -20,8 +19,7 @@ function render(input, out, __component, component, state) {
           renderBody: function renderBody(out) {
             out.w("Hello");
           }
-        },
-      [hasRenderBodyKey]: true
+        }
     }, out, __component, "0");
 
   test_tag({
@@ -29,8 +27,7 @@ function render(input, out, __component, component, state) {
           renderBody: function renderBody(out) {
             out.w("Hello");
           }
-        },
-      [hasRenderBodyKey]: true
+        }
     }, out, __component, "2");
 }
 

--- a/test/compiler/fixtures-html/nested-tag-shorthand-simple-conditional/expected.js
+++ b/test/compiler/fixtures-html/nested-tag-shorthand-simple-conditional/expected.js
@@ -5,7 +5,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,
     marko_defineComponent = components_helpers.c,
-    hasRenderBodyKey = Symbol.for("hasRenderBody"),
     marko_loadTemplate = require("marko/src/runtime/helper-loadTemplate"),
     test_message_template = marko_loadTemplate(require.resolve("./components/test-message/template.marko")),
     marko_helpers = require("marko/src/runtime/html/helpers"),
@@ -20,8 +19,7 @@ function render(input, out, __component, component, state) {
           renderBody: function renderBody(out) {
             out.w("My body");
           }
-        },
-      [hasRenderBodyKey]: true
+        }
     }, out, __component, "0");
 }
 

--- a/test/compiler/fixtures-html/nested-tags/expected.js
+++ b/test/compiler/fixtures-html/nested-tags/expected.js
@@ -5,7 +5,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     components_helpers = require("marko/src/components/helpers"),
     marko_renderer = components_helpers.r,
     marko_defineComponent = components_helpers.c,
-    hasRenderBodyKey = Symbol.for("hasRenderBody"),
     marko_helpers = require("marko/src/runtime/html/helpers"),
     marko_loadTag = marko_helpers.t,
     test_nested_tags_overlay_tag = marko_loadTag(require("./tags/test-nested-tags-overlay/renderer"));
@@ -26,8 +25,7 @@ function render(input, out, __component, component, state) {
           renderBody: function renderBody(out) {
             out.w("Footer content");
           }
-        },
-      [hasRenderBodyKey]: true
+        }
     }, out, __component, "0");
 }
 


### PR DESCRIPTION
## Description

Removes some code that no longer does anything after https://github.com/marko-js/marko/pull/1010/files#diff-896607a8098520717f9f544274619ca2L10 which switched to an alternative solution.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.