### PR TITLE
Fix regression with dynamic attributes as a string on server side

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -60,6 +60,7 @@ const helpers = {
     assign: { module: "marko/runtime/helper-assign" },
     attr: "a",
     attrs: "as",
+    mergeAttrs: "am",
     classAttr: "ca",
     classList: "cl",
     const: "const",

--- a/src/compiler/ast/HtmlElement/html/StartTag.js
+++ b/src/compiler/ast/HtmlElement/html/StartTag.js
@@ -56,18 +56,16 @@ class StartTag extends Node {
                     attrs.push(builder.objectExpression(explicitAttrs));
                 }
 
-                let attrsFunctionCall = builder.functionCall(
-                    context.helper("attrs"),
-                    [
-                        attrs.length > 1
-                            ? builder.functionCall(
-                                  context.helper("assign"),
-                                  attrs
-                              )
-                            : attrs[0]
-                    ]
+                nodes.push(
+                    builder.html(
+                        builder.functionCall(
+                            context.helper(
+                                attrs.length === 1 ? "attrs" : "mergeAttrs"
+                            ),
+                            attrs
+                        )
+                    )
                 );
-                nodes.push(builder.html(attrsFunctionCall));
             }
         }
 

--- a/src/runtime/html/helper-merge-attrs.js
+++ b/src/runtime/html/helper-merge-attrs.js
@@ -1,0 +1,36 @@
+var complain = "MARKO_DEBUG" && require("complain");
+var attrsHelper = require("./helper-attrs");
+
+/**
+ * Merges attribute objects into a string
+ * @param  {[type]} object [description]
+ * @param  {[type]} source [description]
+ * @return {[type]}        [description]
+ */
+function mergeAttrs() {
+    var result = "";
+    var currentAttrs = {};
+    for (var i = 0; i < arguments.length; i++) {
+        var source = arguments[i];
+        if (typeof source === "string") {
+            // eslint-disable-next-line no-constant-condition
+            if ("MARKO_DEBUG") {
+                complain(
+                    "Passing a string as dynamic attributes ('<div ${string}>' or '<div ...string>') is deprecated, use an object instead."
+                );
+            }
+            result += attrsHelper(currentAttrs) + source;
+            currentAttrs = {};
+        } else if (source != null) {
+            for (var k in source) {
+                if (source.hasOwnProperty(k)) {
+                    currentAttrs[k] = source[k];
+                }
+            }
+        }
+    }
+
+    return result + attrsHelper(currentAttrs);
+}
+
+module.exports = mergeAttrs;

--- a/src/runtime/html/helpers.js
+++ b/src/runtime/html/helpers.js
@@ -9,6 +9,7 @@ var escapeXml = escape.escapeXml;
 var escapeXmlAttr = escape.escapeXmlAttr;
 var attrHelper = require("./helper-attr");
 var attrsHelper = require("./helper-attrs");
+var mergeAttrsHelper = require("./helper-merge-attrs");
 var styleHelper = require("../vdom/helper-styleAttr");
 
 /**
@@ -75,6 +76,12 @@ exports.a = attrHelper;
  * @private
  */
 exports.as = attrsHelper;
+
+/**
+ * Internal method to merge multiple attribute objects together
+ * @private
+ */
+exports.am = mergeAttrsHelper;
 
 /**
  * Internal helper method to handle the "style" attribute. The value can either

--- a/test/render/fixtures-deprecated/dynamic-attrs-string/expected.html
+++ b/test/render/fixtures-deprecated/dynamic-attrs-string/expected.html
@@ -1,0 +1,1 @@
+<div x=1 class="a" id="b"></div>

--- a/test/render/fixtures-deprecated/dynamic-attrs-string/template.marko
+++ b/test/render/fixtures-deprecated/dynamic-attrs-string/template.marko
@@ -1,0 +1,1 @@
+<div class="a" ${" x=1"} id="b"/>

--- a/test/render/fixtures-deprecated/dynamic-attrs-string/test.js
+++ b/test/render/fixtures-deprecated/dynamic-attrs-string/test.js
@@ -1,0 +1,2 @@
+exports.templateData = {};
+exports.fails_vdom = true;


### PR DESCRIPTION
## Description

Previously passing a string as a dynamic attribute (`<div ${string}>`) would work on the server side (not client side). A recent migration made it so that this behavior broke server side as well. This PR adds this back on the server with a deprecation warning.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.