### PR TITLE
Deprecate some tags, and add notes for future deprecations

### DIFF
--- a/bin/markoc.js
+++ b/bin/markoc.js
@@ -1,3 +1,5 @@
+// TODO: Should deprecate and move into marko/cli
+
 /* eslint-disable no-console */
 
 var fs = require("fs");

--- a/browser-refresh.js
+++ b/browser-refresh.js
@@ -1,3 +1,5 @@
+// TODO: Should deprecate and extract into @marko/browser-refresh
+
 var isDebug = require("./env").isDebug;
 
 if (isDebug) {

--- a/express.js
+++ b/express.js
@@ -1,3 +1,5 @@
+// TODO: Should deprecate and extract into @marko/express
+
 var isDebug = require("./env").isDebug;
 var target = isDebug ? "marko/src/express" : "marko/dist/express";
 

--- a/helpers/notEmpty.js
+++ b/helpers/notEmpty.js
@@ -1,3 +1,4 @@
+// TODO: deprecate this (and empty).
 module.exports = function notEmpty(o) {
     if (o == null) {
         return false;

--- a/hot-reload.js
+++ b/hot-reload.js
@@ -1,3 +1,5 @@
+// TODO: Should deprecate?
+
 var isDebug = require("./env").isDebug;
 
 if (isDebug) {

--- a/jquery.marko
+++ b/jquery.marko
@@ -1,4 +1,5 @@
 <module-code(function(require) {
+    require("complain")("marko/jquery is deprecated.");
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components/jquery");\n`;
 })/>

--- a/node-require.js
+++ b/node-require.js
@@ -1,3 +1,4 @@
+// TODO: Should deprecate and extract into @marko/register
 var isDebug = require("./env").isDebug;
 
 if (isDebug) {

--- a/ready.marko
+++ b/ready.marko
@@ -1,4 +1,5 @@
 <module-code(function(require) {
+    require("complain")("marko/ready is deprecated.");
     var isDebug = require('./env').isDebug;
     return `module.exports = require("./${isDebug ? 'src' : 'dist'}/components/ready");\n`;
 })/>

--- a/src/compiler/Parser.js
+++ b/src/compiler/Parser.js
@@ -163,6 +163,8 @@ class Parser {
         }
 
         if (tagName === "marko-compiler-options") {
+            context.deprecate("<marko-compiler-options> is deprecated.");
+
             this.parentNode.setTrimStartEnd(true);
 
             attributes.forEach(function(attr) {

--- a/src/taglibs/cache/marko.json
+++ b/src/taglibs/cache/marko.json
@@ -1,5 +1,6 @@
 {
     "<cached-fragment>": {
+        "deprecated": true,
         "renderer": "./cached-fragment-tag",
         "@cache-key": "string",
         "@cache-name": "string",

--- a/src/taglibs/core/marko.json
+++ b/src/taglibs/core/marko.json
@@ -111,11 +111,13 @@
         "no-output": true
     },
     "<marko>": {
+        "deprecated": true,
         "code-generator": "./marko-tag",
         "open-tag-only": true,
         "@no-browser-rerender": "boolean"
     },
     "<marko-preserve-whitespace>": {
+        "deprecated": true,
         "code-generator": "./marko-preserve-whitespace-tag",
         "preserve-whitespace": true,
         "autocomplete": [


### PR DESCRIPTION
## Description

This PR deprecates some entry points (`jquery` and `ready`) as well as some core tags which will be removed in Marko 5. Comments are added for some additional migrations.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
