### PR TITLE
Implement modern arguments support for dynamic tags

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3278,9 +3278,9 @@
             }
         },
         "htmljs-parser": {
-            "version": "2.6.4",
-            "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.4.tgz",
-            "integrity": "sha512-di3GiJ+SfJZZEb9NwEJtyD4MKbRTq4fma8UeZzU/lety9OVgzlIYbCG4fUwlgUd7xNh1/jFxt8C3mFFmDNb4rQ==",
+            "version": "2.6.5",
+            "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.5.tgz",
+            "integrity": "sha512-e5skq04FESLazLExvtEuw+QoF2IbgWbYF0TE3/mCx+hJNmhuyiqdxV0A0z1zQK+Mrpi+Ecr0pB99JQvxI2u8Aw==",
             "requires": {
                 "char-props": "^0.1.5",
                 "complain": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "events": "^1.0.2",
         "events-light": "^1.0.0",
         "he": "^1.1.0",
-        "htmljs-parser": "^2.6.4",
+        "htmljs-parser": "^2.6.5",
         "lasso-caching-fs": "^1.0.1",
         "lasso-modules-client": "^2.0.4",
         "lasso-package-root": "^1.0.1",

--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -416,7 +416,7 @@ class CustomTag extends HtmlElement {
             inputProps = merge(this._additionalProps, inputProps, context);
         }
 
-        if (this.argument) {
+        if (this.argument && !isDynamicTag) {
             let argExpression = builder.parseExpression(this.argument);
             inputProps = merge(argExpression, inputProps, context);
             context.deprecate(
@@ -614,10 +614,16 @@ class CustomTag extends HtmlElement {
                     parentCustomTag.getNestedTagVar(context)
                 ];
             } else if (isDynamicTag) {
+                const argumentNode = this.argument
+                    ? builder.arrayExpression(
+                          [].concat(builder.parseExpression(this.argument))
+                      )
+                    : builder.literalNull();
                 tagVar = context.helper("dynamicTag");
                 tagArgs = [
                     this.tagNameExpression,
                     inputProps,
+                    argumentNode,
                     builder.identifierOut()
                 ];
             } else {

--- a/src/runtime/helpers.js
+++ b/src/runtime/helpers.js
@@ -131,7 +131,15 @@ var helpers = {
     /**
      * Helper to render a dynamic tag
      */
-    d: function dynamicTag(tag, attrs, out, componentDef, key, customEvents) {
+    d: function dynamicTag(
+        tag,
+        attrs,
+        args,
+        out,
+        componentDef,
+        key,
+        customEvents
+    ) {
         if (tag) {
             var component = componentDef && componentDef.___component;
             if (typeof tag === "string") {
@@ -177,13 +185,13 @@ var helpers = {
                     );
                 }
             } else {
-                if (typeof attrs === "object") {
+                if (attrs == null) {
+                    attrs = {};
+                } else if (typeof attrs === "object") {
                     attrs = Object.keys(attrs).reduce(function(r, key) {
                         r[removeDashes(key)] = attrs[key];
                         return r;
                     }, {});
-                } else if (attrs == null) {
-                    attrs = {};
                 }
 
                 if (tag._ || tag.renderer || tag.render) {
@@ -228,7 +236,13 @@ var helpers = {
                                 globalContext
                             );
                             render.toJSON = RENDER_BODY_TO_JSON;
-                            render(out, attrs);
+
+                            if (args) {
+                                render.apply(null, [out].concat(args, attrs));
+                            } else {
+                                render(out, attrs);
+                            }
+
                             componentsContext.___componentDef = parentComponentDef;
                         }
                         out.___endFragment();

--- a/test/__util__/runRenderTest.js
+++ b/test/__util__/runRenderTest.js
@@ -196,7 +196,10 @@ module.exports = function runRenderTest(dir, snapshot, done, options) {
                         let html = fs.readFileSync(expectedHtmlPath, "utf-8");
                         let browser = createBrowser({
                             dir: __dirname,
-                            html: "<html><body>" + html + "</body></html>"
+                            html:
+                                "<html><body>" +
+                                html.replace(/<!--F#\d+-->|<!--F\/-->/g, "") +
+                                "</body></html>"
                         });
 
                         expectedHtml = domToString(

--- a/test/compiler/fixtures-html/dynamic-tag/expected.js
+++ b/test/compiler/fixtures-html/dynamic-tag/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(Target, {}, out, __component, "0");
+  marko_dynamicTag(Target, {}, null, out, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/import-tag-template/expected.js
+++ b/test/compiler/fixtures-html/import-tag-template/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(other, {}, out, __component, "0");
+  marko_dynamicTag(other, {}, null, out, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/include/expected.js
+++ b/test/compiler/fixtures-html/include/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(Target, {}, out, __component, "0");
+  marko_dynamicTag(Target, {}, null, out, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/invoke/expected.js
+++ b/test/compiler/fixtures-html/invoke/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
 
   marko_dynamicTag(input, {
       x: 1
-    }, out, __component, "hi");
+    }, null, out, __component, "hi");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/macros/expected.js
+++ b/test/compiler/fixtures-html/macros/expected.js
@@ -32,7 +32,7 @@ function render(input, out, __component, component, state) {
 
         marko_dynamicTag(macro_renderTree, {
             node: child
-          }, out, __component, "4" + keyscope__2);
+          }, null, out, __component, "4" + keyscope__2);
 
         out.w("</li>");
       });
@@ -43,7 +43,7 @@ function render(input, out, __component, component, state) {
 
   marko_dynamicTag(macro_renderTree, {
       node: input.node
-    }, out, __component, "5");
+    }, null, out, __component, "5");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/render-body-call/expected.js
+++ b/test/compiler/fixtures-html/render-body-call/expected.js
@@ -12,44 +12,44 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(input, {}, out, __component, "0");
+  marko_dynamicTag(input, {}, null, out, __component, "0");
 
-  marko_dynamicTag(input.renderThing, {}, out, __component, "1");
+  marko_dynamicTag(input.renderThing, {}, null, out, __component, "1");
 
-  marko_dynamicTag(input, attrs, out, __component, "2");
+  marko_dynamicTag(input, attrs, null, out, __component, "2");
 
-  marko_dynamicTag(renderBody, {}, out, __component, "3");
+  marko_dynamicTag(renderBody, {}, null, out, __component, "3");
 
   marko_dynamicTag(input.template, {
       x: 1
-    }, out, __component, "4");
+    }, null, out, __component, "4");
 
   marko_dynamicTag(input.template, {
       y: function() {}
-    }, out, __component, "5");
+    }, null, out, __component, "5");
 
   marko_dynamicTag({
       render: input.barRenderer
-    }, {}, out, __component, "6");
+    }, {}, null, out, __component, "6");
 
   marko_dynamicTag(function(out) {
     input.barRenderer({}, true, out);
-  }, {}, out, __component, "7");
+  }, {}, null, out, __component, "7");
 
   if (x) {
-    marko_dynamicTag(renderA, {}, out, __component, "8");
+    marko_dynamicTag(renderA, {}, null, out, __component, "8");
   } else if (y) {
-    marko_dynamicTag(renderB, {}, out, __component, "9");
+    marko_dynamicTag(renderB, {}, null, out, __component, "9");
   } else {
-    marko_dynamicTag(renderC, {}, out, __component, "10");
+    marko_dynamicTag(renderC, {}, null, out, __component, "10");
   }
 
   if (x) {
-    marko_dynamicTag(render, {}, out, __component, "11");
+    marko_dynamicTag(render, {}, null, out, __component, "11");
   }
 
   if (!x) {
-    marko_dynamicTag(render, {}, out, __component, "12");
+    marko_dynamicTag(render, {}, null, out, __component, "12");
   }
 
   var for__13 = 0;
@@ -57,17 +57,17 @@ function render(input, out, __component, component, state) {
   marko_forRange(0, 9, null, function(i) {
     var keyscope__14 = "[" + ((for__13++) + "]");
 
-    marko_dynamicTag(input.items[i], {}, out, __component, "15" + keyscope__14);
+    marko_dynamicTag(input.items[i], {}, null, out, __component, "15" + keyscope__14);
   });
 
   let i = 10;
 
   while (i--) {
-    marko_dynamicTag(input, {}, out, __component, "16");
+    marko_dynamicTag(input, {}, null, out, __component, "16");
   }
 
   if (z) {
-    marko_dynamicTag(renderD, {}, out, __component, "17");
+    marko_dynamicTag(renderD, {}, null, out, __component, "17");
   }
 
   // if.test

--- a/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
+++ b/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
@@ -14,7 +14,7 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(foo ? "foo" : "bar", {}, out, __component, "0");
+  marko_dynamicTag(foo ? "foo" : "bar", {}, null, out, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-vdom/include/expected.js
+++ b/test/compiler/fixtures-vdom/include/expected.js
@@ -17,7 +17,7 @@ function render(input, out, __component, component, state) {
 
   marko_dynamicTag(IncludeTarget, {
       foo: "bar"
-    }, out, __component, "0");
+    }, null, out, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
+++ b/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
@@ -25,7 +25,7 @@ function render(input, out, __component, component, state) {
   marko_dynamicTag(isCircle ? "circle" : "square", {
       width: 200,
       height: 200
-    }, out, __component, "1");
+    }, null, out, __component, "1");
 
   out.ee();
 }

--- a/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, widget, component) {
     "><h1>Header</h1><div>");
 
   if (typeof input.renderBody === "function") {
-    marko_dynamicTag(input, {}, out, __component, "2");
+    marko_dynamicTag(input, {}, null, out, __component, "2");
   } else {
     out.w(marko_escapeXml(input.renderBody));
   }

--- a/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -46,7 +46,7 @@ function render(input, out, __component, component, state) {
 
   out.w("</p></div><span>B</span>");
 
-  marko_dynamicTag(Foo, {}, out, __component, "7");
+  marko_dynamicTag(Foo, {}, null, out, __component, "7");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/components-compilation/fixtures-html/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html/component-include-attr/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
   if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
-    marko_dynamicTag(data.renderBody, {}, out, __component, "3");
+    marko_dynamicTag(data.renderBody, {}, null, out, __component, "3");
   }
 
   out.w("</div></div>");

--- a/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
@@ -20,7 +20,7 @@ function render(input, out, __component, component, state) {
   } else {
     marko_dynamicTag(data.renderBody, {
         test: 1
-      }, out, __component, "1");
+      }, null, out, __component, "1");
   }
 
   out.w("\n</div>");

--- a/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
   if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
-    marko_dynamicTag(data.renderBody, {}, out, __component, "1");
+    marko_dynamicTag(data.renderBody, {}, null, out, __component, "1");
   }
 
   out.w("\n</div>");

--- a/test/components-compilation/fixtures-html/macro-widget/expected.js
+++ b/test/components-compilation/fixtures-html/macro-widget/expected.js
@@ -42,7 +42,7 @@ function render(input, out, __component, component, state) {
 
     marko_dynamicTag(macro_renderButton, {
         color: color
-      }, out, __component, "4" + keyscope__3);
+      }, null, out, __component, "4" + keyscope__3);
   });
 
   out.w("</div>");

--- a/test/render/fixtures/dynamic-tag-arguments/components/layout.marko
+++ b/test/render/fixtures/dynamic-tag-arguments/components/layout.marko
@@ -1,0 +1,1 @@
+<${input.renderBody}("testPage", "http://ebay.com") style="color:green"/>

--- a/test/render/fixtures/dynamic-tag-arguments/expected.html
+++ b/test/render/fixtures/dynamic-tag-arguments/expected.html
@@ -1,0 +1,1 @@
+<!--M#s0--><!--F#0-->testPage http://ebay.com<div style="color:green"></div><!--F/--><!--M/-->

--- a/test/render/fixtures/dynamic-tag-arguments/template.marko
+++ b/test/render/fixtures/dynamic-tag-arguments/template.marko
@@ -1,0 +1,4 @@
+<layout|pageName, href, attrs|>
+    ${pageName} ${href}
+    <div ...attrs/>
+</layout>

--- a/test/render/fixtures/dynamic-tag-arguments/test.js
+++ b/test/render/fixtures/dynamic-tag-arguments/test.js
@@ -1,0 +1,1 @@
+exports.templateData = {};


### PR DESCRIPTION
## Description

This PR makes it so that all arguments passed to the dynamic tag are prepended to the params available as tag params, that is:

```marko
<${input.renderBody}("a", "b") c d/>
```

When provided a render with params could receive:

```marko
<above-tag|firstArg, secondArg, attrs|>
</above-tag>
```

This means that it is possible via the dynamic tag to reimplement things like `<for|item, index, all|` in userland.

> Note: This is only possible and non breaking because previously `<${dynamic}(arguments)>` did not parse properly. This parsing issue has been resolved, adding support for this with custom tags is not possible as it will be breaking but is planned for Marko 5.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.