### PR TITLE
Fix function as event handler when server side rendering

### DIFF
--- a/src/compiler/ast/HtmlElement/html/generateCode.js
+++ b/src/compiler/ast/HtmlElement/html/generateCode.js
@@ -16,7 +16,7 @@ module.exports = function generateCode(node, codegen) {
 
     var properties = node.getProperties();
 
-    if (properties) {
+    if (properties && !codegen.context.isStatefulComponent) {
         var objectProps = Object.keys(properties).map(propName => {
             return builder.property(
                 builder.literal(propName),

--- a/test/components-browser/fixtures/event-handler-function/index.marko
+++ b/test/components-browser/fixtures/event-handler-function/index.marko
@@ -1,0 +1,11 @@
+class {}
+
+static function handleClick(component) {
+    if (component.clickCount === undefined) {
+        component.clickCount = 0;
+    }
+
+    component.clickCount++;
+}
+
+<button key="button" on-click(handleClick, component)/>

--- a/test/components-browser/fixtures/event-handler-function/test.js
+++ b/test/components-browser/fixtures/event-handler-function/test.js
@@ -1,0 +1,19 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers, done) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var button = component.getEl("button");
+
+    expect(component.clickCount).to.equal(undefined);
+    button.click();
+
+    setTimeout(() => {
+        expect(component.clickCount).to.equal(1);
+        button.click();
+
+        setTimeout(() => {
+            expect(component.clickCount).to.equal(2);
+            done();
+        }, 100);
+    }, 100);
+};

--- a/test/components-compilation/fixtures-html/macro-widget/expected.js
+++ b/test/components-compilation/fixtures-html/macro-widget/expected.js
@@ -8,7 +8,6 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
     marko_defineComponent = components_helpers.c,
     marko_helpers = require("marko/src/runtime/html/helpers"),
     marko_escapeXml = marko_helpers.x,
-    marko_attr = marko_helpers.a,
     marko_forEach = marko_helpers.f,
     marko_dynamicTag = marko_helpers.d;
 
@@ -18,13 +17,7 @@ function render(input, out, __component, component, state) {
   function macro_renderButton(out, macroInput) {
     var color = macroInput.color
 
-    out.w("<button" +
-      marko_attr("data-marko", {
-        onclick: __component.d("click", "handleColorClick", false, [
-            color
-          ])
-      }, false) +
-      ">" +
+    out.w("<button>" +
       marko_escapeXml(color) +
       "</button>");
   }


### PR DESCRIPTION
## Description

Currently `data-marko` is serialized more than it is needed. It is only needed when we have SSR only / split components. This caused an issue where event handlers that were functions could not be serialized properly and failed to hydrate.

This PR fixes this by only serializing data-marko when needed.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.