### PR TITLE
provide hook to get serialized globals before component init

### DIFF
--- a/src/components/index-browser.js
+++ b/src/components/index-browser.js
@@ -7,6 +7,8 @@ require("./ComponentsContext").___initClientRendered =
 
 exports.getComponentForEl = componentsUtil.___getComponentForEl;
 exports.init = window.$initComponents = initComponents.___initServerRendered;
+exports.initGlobals = window.$initGlobals =
+    initComponents.___initServerRenderedGlobals;
 
 exports.register = function(id, component) {
     registry.___register(id, function() {

--- a/src/components/init-components-browser.js
+++ b/src/components/init-components-browser.js
@@ -252,6 +252,15 @@ function initClientRendered(componentDefs, doc) {
  * This method initializes all components that were rendered on the server by iterating over all
  * of the component IDs.
  */
+
+function initServerRenderedGlobals() {
+    var globals = window.$MG;
+    if (globals) {
+        serverRenderedGlobals = warp10Finalize(globals);
+        delete window.$MG;
+    }
+    return serverRenderedGlobals;
+}
 function initServerRendered(renderedComponents, doc) {
     if (!renderedComponents) {
         renderedComponents = win.$components;
@@ -282,11 +291,7 @@ function initServerRendered(renderedComponents, doc) {
     indexServerComponentBoundaries(doc, runtimeId);
     eventDelegation.___init(doc);
 
-    var globals = window.$MG;
-    if (globals) {
-        serverRenderedGlobals = warp10Finalize(globals);
-        delete window.$MG;
-    }
+    initServerRenderedGlobals();
 
     componentDefs.forEach(function(componentDef) {
         componentDef = ComponentDef.___deserialize(
@@ -332,3 +337,4 @@ function hydrateComponent(componentDef, doc) {
 
 exports.___initClientRendered = initClientRendered;
 exports.___initServerRendered = initServerRendered;
+exports.___initServerRenderedGlobals = initServerRenderedGlobals;


### PR DESCRIPTION
this PR exposes a new method require("marko/components").initGlobals() which allows access to the serialized globals before a call to require("marko/components").init()

I need this hook so that I can do some initialization client side, using my server side state, before marko builds the client side component tree. Part of which may be fetching a lazy loaded webpack module that is required to render the components