### PR TITLE
better error message when attempting to create a fragment outside of <body>

### DIFF
--- a/src/morphdom/fragment.js
+++ b/src/morphdom/fragment.js
@@ -52,13 +52,22 @@ var fragmentPrototype = {
 
 function createFragmentNode(startNode, nextNode, parentNode) {
     var fragment = Object.create(fragmentPrototype);
+    var detachedContainer = (fragment.detachedContainer = document.createDocumentFragment());
+    parentNode =
+        parentNode || (startNode && startNode.parentNode) || detachedContainer;
+    if (
+        parentNode === document ||
+        parentNode === document.documentElement ||
+        parentNode === document.head
+    ) {
+        throw new Error(
+            "Stateful components cannot contain `<html>`, `<head>` or `<body>` tags. More details: https://github.com/marko-js/marko/wiki/Error:-Stateful-components-cannot-contain--html-,--head--or--body--tags"
+        );
+    }
     fragment.startNode = document.createTextNode("");
     fragment.endNode = document.createTextNode("");
     fragment.startNode.fragment = fragment;
     fragment.endNode.fragment = fragment;
-    var detachedContainer = (fragment.detachedContainer = document.createDocumentFragment());
-    parentNode =
-        parentNode || (startNode && startNode.parentNode) || detachedContainer;
     insertBefore(fragment.startNode, startNode, parentNode);
     insertBefore(fragment.endNode, nextNode, parentNode);
     return fragment;


### PR DESCRIPTION


## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Provides a better error message with a [link to an error wiki](https://github.com/marko-js/marko/wiki/Error:-Stateful-components-cannot-contain--html-,--head--or--body--tags) when a stateful component renders `<html>`, `<head>` or `<body>`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] ~I have added tests to cover my changes.~
