### PR TITLE
move legacy api into guarded block so it's not included in a server bundle

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 "use strict";
-require("./components/legacy/dependencies/html");
 
+// the following development and legacy apis should not be included
+// when bundling the server with a tool like webpack
 if (!process.env.BUNDLE) {
     if (process.env.MARKO_HOT_RELOAD) {
         require("./hot-reload").enable();
@@ -9,6 +10,9 @@ if (!process.env.BUNDLE) {
     // If process was launched with browser refresh then automatically
     // enable browser-refresh
     require("./browser-refresh").enable();
+
+    // Adds the template.getDependencies() method needed by older versions of lasso-marko
+    require("./components/legacy/dependencies/html");
 }
 
 function fixFlush() {


### PR DESCRIPTION

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Moves the legacy dependencies api (used by older versions of `lasso-marko`) into a block that's guarded by `!process.env.BUNDLE`.  APIs inside this block use dynamic requires and are either intended for development or are legacy apis.  This is needed so that webpack does not throw warnings or errors when building a bundle for node.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [ ] ~I have added tests to cover my changes.~
