### PR TITLE
Prevent logging false positive deprecations for legacy nested tags

### DIFF
--- a/src/taglibs/migrate/all-tags/legacy-nested-tag.js
+++ b/src/taglibs/migrate/all-tags/legacy-nested-tag.js
@@ -1,5 +1,9 @@
 const legacyNestedTagSyntax = /^.*:(.*)$/;
 module.exports = function migrate(el, context) {
+    if (el.rawTagNameExpression) {
+        return;
+    }
+
     const match = el.tagName && el.tagName.match(legacyNestedTagSyntax);
 
     if (!match || !match[1]) {

--- a/test/migrate/fixtures/legacy-nested-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/legacy-nested-tag/snapshot-expected.marko
@@ -2,4 +2,5 @@
 
 <my-tag>
     <@test>Hello</@test>
+    <${should ? be : ignored}>Hello</>
 </my-tag>

--- a/test/migrate/fixtures/legacy-nested-tag/template.marko
+++ b/test/migrate/fixtures/legacy-nested-tag/template.marko
@@ -2,4 +2,8 @@
   <my-tag:test>
     Hello
   </my-tag:test>
+
+  <${should ? be : ignored}>
+    Hello
+  </>
 </my-tag>


### PR DESCRIPTION
## Description

Fixes false positive warning for legacy nested tags (`<a:b>` instead of `<@b>`) where dynamic tags were used that contained `:`. 

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
