### PR TITLE
Forward error events from nested out of order async outs

### DIFF
--- a/src/runtime/html/AsyncStream.js
+++ b/src/runtime/html/AsyncStream.js
@@ -466,7 +466,10 @@ var proto = (AsyncStream.prototype = {
     },
 
     createOut: function() {
-        return new AsyncStream(this.global);
+        var newOut = new AsyncStream(this.global);
+        // Forward error events to the parent out.
+        newOut.on("error", this.emit.bind(this, "error"));
+        return newOut;
     },
 
     element: function(tagName, elementAttrs, openTagOnly) {

--- a/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/template.marko
+++ b/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/template.marko
@@ -1,0 +1,5 @@
+<div>
+    <await(input.userPromise) client-reorder>
+        <@then|user|>Hello ${user.name}!</@then>
+    </await>
+</div>

--- a/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/test.js
+++ b/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/test.js
@@ -8,7 +8,7 @@ exports.check = function(marko, markoCompiler, expect, snapshot, done) {
         {
             userPromise: new Promise((_, reject) => {
                 setTimeout(function() {
-                    reject(new Error("failed"));
+                    reject(new Error("User Promise Rejected Error"));
                 }, 10);
             })
         },
@@ -16,7 +16,9 @@ exports.check = function(marko, markoCompiler, expect, snapshot, done) {
     );
 
     out.on("error", err => {
-        expect(err.message.startsWith("Render error")).to.equal(true);
+        expect(
+            err.message.indexOf("User Promise Rejected Error") !== -1
+        ).to.equal(true);
         done();
     });
 };

--- a/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/test.js
+++ b/test/api/fixtures/render-await-client-reorder-unhandled-rejected-promise/test.js
@@ -1,0 +1,22 @@
+var nodePath = require("path");
+
+exports.check = function(marko, markoCompiler, expect, snapshot, done) {
+    var template = marko.load(nodePath.join(__dirname, "template.marko"));
+    var out = template.createOut();
+
+    template.render(
+        {
+            userPromise: new Promise((_, reject) => {
+                setTimeout(function() {
+                    reject(new Error("failed"));
+                }, 10);
+            })
+        },
+        out
+    );
+
+    out.on("error", err => {
+        expect(err.message.startsWith("Render error")).to.equal(true);
+        done();
+    });
+};


### PR DESCRIPTION
## Description

Forward `error` events to the parent out with async content with `client-reorder` set.

Fixes: #1274 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
