### PR TITLE
Fix issue with <title> namespace inside an svg

### DIFF
--- a/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
+++ b/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
@@ -47,7 +47,8 @@ function finalizeCreateArgs(createArgs, builder) {
 const MAYBE_SVG = {
     a: true,
     script: true,
-    style: true
+    style: true,
+    title: true
 };
 
 const SIMPLE_ATTRS = {

--- a/test/compiler/fixtures-vdom/svg-title/expected.js
+++ b/test/compiler/fixtures-vdom/svg-title/expected.js
@@ -1,0 +1,36 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/vdom").t(),
+    components_helpers = require("marko/src/components/helpers"),
+    marko_registerComponent = components_helpers.rc,
+    marko_componentType = marko_registerComponent("/marko-test$1.0.0/compiler/fixtures-vdom/svg-title/template.marko", function() {
+      return module.exports;
+    }),
+    marko_renderer = components_helpers.r,
+    marko_defineComponent = components_helpers.c,
+    marko_helpers = require("marko/src/runtime/vdom/helpers"),
+    marko_createElement = marko_helpers.e,
+    marko_const = marko_helpers.const,
+    marko_const_nextId = marko_const("a0adc5"),
+    marko_node0 = marko_createElement("svg", {
+        width: "140",
+        height: "30"
+      }, "0", null, 1, 1, {
+        i: marko_const_nextId()
+      })
+      .e("g", null, null, null, 1, 1)
+        .e("title", null, null, null, 1, 1)
+          .t("This is a tool tip");
+
+function render(input, out, __component, component, state) {
+  var data = input;
+
+  out.n(marko_node0, component);
+}
+
+marko_template._ = marko_renderer(render, {
+    ___implicit: true,
+    ___type: marko_componentType
+  });
+
+marko_template.Component = marko_defineComponent({}, marko_template._);

--- a/test/compiler/fixtures-vdom/svg-title/template.marko
+++ b/test/compiler/fixtures-vdom/svg-title/template.marko
@@ -1,0 +1,5 @@
+<svg width="140" height="30">
+    <g>
+        <title>This is a tool tip</title>
+    </g>
+</svg>


### PR DESCRIPTION
## Description

There is currently a whitelist of tags which can be rendered in the SVG namespace if they are within an SVG. This list was missing `<title>`.

Fixes https://github.com/marko-js/marko/issues/1272

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.