### PR TITLE
fix broken methods link

### DIFF
--- a/docs/class-components.md
+++ b/docs/class-components.md
@@ -517,7 +517,7 @@ The root [HTML element](https://developer.mozilla.org/en-US/docs/Web/API/element
 
 An array of the root [HTML elements](https://developer.mozilla.org/en-US/docs/Web/API/element) that the component is bound to.
 
-> `this.el` and `this.els` are deprecated. Please `this.gelEl()` or `this.getEls()` methods. see [Methods](https://markojs.com/docs/components/#getelkey-index)
+> `this.el` and `this.els` are deprecated. Please `this.gelEl()` or `this.getEls()` methods. see [Methods](#getelkey-index)
 
 ### `this.id`
 


### PR DESCRIPTION
## Description
`Methods` link got broken after the page name was recently updated.

https://github.com/marko-js/marko/issues/1287

## Checklist:

- [X] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [X] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes. --> N/A