### PR TITLE
add option to revert to old hydrate (pre 4.9) behavior

### DIFF
--- a/src/components/ComponentDef.js
+++ b/src/components/ComponentDef.js
@@ -7,10 +7,9 @@ var extend = require("raptor-util/extend");
 var KeySequence = require("./KeySequence");
 
 var FLAG_WILL_RERENDER_IN_BROWSER = 1;
-/*
-var FLAG_HAS_BODY_EL = 2;
-var FLAG_HAS_HEAD_EL = 4;
-*/
+// var FLAG_HAS_BODY_EL = 2;
+// var FLAG_HAS_HEAD_EL = 4;
+var FLAG_OLD_HYDRATE_NO_CREATE = 8;
 
 /**
  * A ComponentDef is used to hold the metadata collected at runtime for
@@ -106,7 +105,11 @@ ComponentDef.___deserialize = function(o, types, global, registry) {
     // just building it from the server info
     component.___updateQueued = true;
 
-    if (!isLegacy && flags & FLAG_WILL_RERENDER_IN_BROWSER) {
+    if (
+        !isLegacy &&
+        flags & FLAG_WILL_RERENDER_IN_BROWSER &&
+        !(flags & FLAG_OLD_HYDRATE_NO_CREATE)
+    ) {
         if (component.onCreate) {
             component.onCreate(input, { global: global });
         }

--- a/src/components/beginComponent.js
+++ b/src/components/beginComponent.js
@@ -5,6 +5,7 @@ const ComponentDef = require("./ComponentDef");
 var FLAG_WILL_RERENDER_IN_BROWSER = 1;
 // var FLAG_HAS_BODY_EL = 2;
 // var FLAG_HAS_HEAD_EL = 4;
+var FLAG_OLD_HYDRATE_NO_CREATE = 8;
 
 module.exports = function beginComponent(
     componentsContext,
@@ -49,6 +50,10 @@ module.exports = function beginComponent(
 
     if (isSplitComponent === false && out.global.noBrowserRerender !== true) {
         componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER;
+    }
+
+    if (out.global.oldHydrateNoCreate === true) {
+        componentDef.___flags |= FLAG_OLD_HYDRATE_NO_CREATE;
     }
 
     if (ownerComponentDef && key != null) {

--- a/src/taglibs/core/marko-tag.js
+++ b/src/taglibs/core/marko-tag.js
@@ -2,8 +2,10 @@
 
 module.exports = function codeGenerator(elNode, codegen) {
     var builder = codegen.builder;
+    var context = codegen.context;
 
     if (elNode.hasAttribute("no-browser-rerender")) {
+        context.deprecate("no-browser-rerender is deprecated");
         let lhs = builder.memberExpression(
             builder.identifier("out"),
             builder.identifier("global")
@@ -12,6 +14,29 @@ module.exports = function codeGenerator(elNode, codegen) {
         lhs = builder.memberExpression(
             lhs,
             builder.identifier("noBrowserRerender")
+        );
+
+        let rhs = builder.literal(true);
+
+        return builder.assignment(lhs, rhs);
+    }
+
+    if (
+        elNode.hasAttribute(
+            "deprecated-no-create-or-input-lifecycle-for-top-level-hydrate"
+        )
+    ) {
+        context.deprecate(
+            "deprecated-no-create-or-input-lifecycle-for-top-level-hydrate is deprecated"
+        );
+        let lhs = builder.memberExpression(
+            builder.identifier("out"),
+            builder.identifier("global")
+        );
+
+        lhs = builder.memberExpression(
+            lhs,
+            builder.identifier("oldHydrateNoCreate")
         );
 
         let rhs = builder.literal(true);

--- a/src/taglibs/core/marko.json
+++ b/src/taglibs/core/marko.json
@@ -114,7 +114,8 @@
         "deprecated": true,
         "code-generator": "./marko-tag",
         "open-tag-only": true,
-        "@no-browser-rerender": "boolean"
+        "@no-browser-rerender": "boolean",
+        "@deprecated-no-create-or-input-lifecycle-for-top-level-hydrate": "boolean"
     },
     "<marko-preserve-whitespace>": {
         "deprecated": true,

--- a/test/components-pages/fixtures/old-hydrate-no-create-no-input/components/child-component/index.marko
+++ b/test/components-pages/fixtures/old-hydrate-no-create-no-input/components/child-component/index.marko
@@ -1,0 +1,19 @@
+class {
+  onCreate() {
+    if (typeof window !== 'undefined') {
+      window.childCreateCalled = true;
+    }
+  }
+  onInput() {
+    if (typeof window !== 'undefined') {
+      window.childInputCalled = true;
+    }
+  }
+  onRender() {
+    if (typeof window !== 'undefined') {
+      window.childRenderCalled = true;
+    }
+  }
+}
+
+<div/>

--- a/test/components-pages/fixtures/old-hydrate-no-create-no-input/components/test-component/index.marko
+++ b/test/components-pages/fixtures/old-hydrate-no-create-no-input/components/test-component/index.marko
@@ -1,0 +1,30 @@
+class {
+    onCreate(input) {
+        if (typeof window !== 'undefined') {
+            throw new Error('onCreate should not be called in the browser');
+        }
+
+        this.state = { count:input.start }
+    }
+    
+    onInput(input) {
+        if (typeof window !== 'undefined') {
+            throw new Error('onInput should not be called in the browser');
+        }
+
+        this.state = { count:input.start }
+    }
+
+    increment() {
+        this.state.count++;
+    }
+
+    onMount() {
+        window.testComponent = this;
+    }
+}
+
+<div>
+    Hello <span.count>${state.count}</span>!
+    <child-component key="child"/>
+</div>

--- a/test/components-pages/fixtures/old-hydrate-no-create-no-input/template.marko
+++ b/test/components-pages/fixtures/old-hydrate-no-create-no-input/template.marko
@@ -1,0 +1,16 @@
+<marko deprecated-no-create-or-input-lifecycle-for-top-level-hydrate />
+
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <test-component start=10 />
+
+        init-components immediate

--- a/test/components-pages/fixtures/old-hydrate-no-create-no-input/tests.js
+++ b/test/components-pages/fixtures/old-hydrate-no-create-no-input/tests.js
@@ -1,0 +1,25 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it("should mount, not call the onCreate/onInput methods and update", function() {
+        var component = window.testComponent;
+
+        expect(component.input.start).to.equal(10);
+        expect(component.state.count).to.equal(10);
+        expect(component.el.querySelector(".count").innerHTML).to.equal("10");
+
+        component.increment();
+        component.update();
+
+        expect(component.input.start).to.equal(10);
+        expect(component.state.count).to.equal(11);
+        expect(component.el.querySelector(".count").innerHTML).to.equal("11");
+    });
+
+    it("should still call all lifecycle methods on child components", function() {
+        expect(window.childCreateCalled).to.equal(true);
+        expect(window.childInputCalled).to.equal(true);
+        expect(window.childRenderCalled).to.equal(true);
+    });
+});


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Marko 4.9.0 introduced a change to hydration that can cause issues (#1043, #1085).  But the recommended solution (`<marko no-browser-rerender />`) is intended to revert to Pre 4.3.0 behavior and causes a re-render not to happen.

This PR adds the following option to the marko tag.  It is not intended to be used long-term only as a stop-gap.   This PR also adds a deprecation warning for both this new option and `no-browser-rerender`.

```marko
<marko deprecated-no-create-or-input-for-top-level-hydrate /> 
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
