### PR TITLE
Fix regression for no-update on dynamic tag html attributes

### DIFF
--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -619,12 +619,23 @@ class CustomTag extends HtmlElement {
                           [].concat(builder.parseExpression(this.argument))
                       )
                     : builder.literalNull();
+                const properties = this.getProperties();
                 tagVar = context.helper("dynamicTag");
                 tagArgs = [
+                    builder.identifierOut(),
                     this.tagNameExpression,
                     inputProps,
                     argumentNode,
-                    builder.identifierOut()
+                    properties
+                        ? builder.objectExpression(
+                              Object.keys(properties).map(propName => {
+                                  return builder.property(
+                                      builder.literal(propName),
+                                      properties[propName]
+                                  );
+                              })
+                          )
+                        : builder.literalNull()
                 ];
             } else {
                 loadTag = builder.functionCall(context.helper("loadTag"), [

--- a/src/runtime/helpers.js
+++ b/src/runtime/helpers.js
@@ -132,10 +132,11 @@ var helpers = {
      * Helper to render a dynamic tag
      */
     d: function dynamicTag(
+        out,
         tag,
         attrs,
         args,
-        out,
+        props,
         componentDef,
         key,
         customEvents
@@ -143,17 +144,21 @@ var helpers = {
         if (tag) {
             var component = componentDef && componentDef.___component;
             if (typeof tag === "string") {
-                var events =
-                    customEvents &&
-                    customEvents.reduce(function(events, eventArray) {
-                        events["on" + eventArray[0]] = componentDef.d(
+                if (customEvents) {
+                    if (!props) {
+                        props = {};
+                    }
+
+                    customEvents.forEach(function(eventArray) {
+                        props["on" + eventArray[0]] = componentDef.d(
                             eventArray[0],
                             eventArray[1],
                             eventArray[2],
                             eventArray[3]
                         );
-                        return events;
-                    }, {});
+                    });
+                }
+
                 if (attrs.renderBody) {
                     var renderBody = attrs.renderBody;
                     var otherAttrs = {};
@@ -169,7 +174,7 @@ var helpers = {
                         component,
                         0,
                         0,
-                        events
+                        props
                     );
                     renderBody(out);
                     out.___endElement();
@@ -181,7 +186,7 @@ var helpers = {
                         component,
                         0,
                         0,
-                        events
+                        props
                     );
                 }
             } else {

--- a/test/compiler/fixtures-html/dynamic-tag/expected.js
+++ b/test/compiler/fixtures-html/dynamic-tag/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(Target, {}, null, out, __component, "0");
+  marko_dynamicTag(out, Target, {}, null, null, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/import-tag-template/expected.js
+++ b/test/compiler/fixtures-html/import-tag-template/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(other, {}, null, out, __component, "0");
+  marko_dynamicTag(out, other, {}, null, null, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/include/expected.js
+++ b/test/compiler/fixtures-html/include/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(Target, {}, null, out, __component, "0");
+  marko_dynamicTag(out, Target, {}, null, null, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/invoke/expected.js
+++ b/test/compiler/fixtures-html/invoke/expected.js
@@ -16,9 +16,9 @@ function render(input, out, __component, component, state) {
       __component = widget,
       component = __component._c;
 
-  marko_dynamicTag(input, {
+  marko_dynamicTag(out, input, {
       x: 1
-    }, null, out, __component, "hi");
+    }, null, null, __component, "hi");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/macros/expected.js
+++ b/test/compiler/fixtures-html/macros/expected.js
@@ -30,9 +30,9 @@ function render(input, out, __component, component, state) {
 
         out.w("<li>");
 
-        marko_dynamicTag(macro_renderTree, {
+        marko_dynamicTag(out, macro_renderTree, {
             node: child
-          }, null, out, __component, "4" + keyscope__2);
+          }, null, null, __component, "4" + keyscope__2);
 
         out.w("</li>");
       });
@@ -41,9 +41,9 @@ function render(input, out, __component, component, state) {
     }
   }
 
-  marko_dynamicTag(macro_renderTree, {
+  marko_dynamicTag(out, macro_renderTree, {
       node: input.node
-    }, null, out, __component, "5");
+    }, null, null, __component, "5");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/render-body-call/expected.js
+++ b/test/compiler/fixtures-html/render-body-call/expected.js
@@ -12,44 +12,44 @@ var marko_template = module.exports = require("marko/src/html").t(__filename),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(input, {}, null, out, __component, "0");
+  marko_dynamicTag(out, input, {}, null, null, __component, "0");
 
-  marko_dynamicTag(input.renderThing, {}, null, out, __component, "1");
+  marko_dynamicTag(out, input.renderThing, {}, null, null, __component, "1");
 
-  marko_dynamicTag(input, attrs, null, out, __component, "2");
+  marko_dynamicTag(out, input, attrs, null, null, __component, "2");
 
-  marko_dynamicTag(renderBody, {}, null, out, __component, "3");
+  marko_dynamicTag(out, renderBody, {}, null, null, __component, "3");
 
-  marko_dynamicTag(input.template, {
+  marko_dynamicTag(out, input.template, {
       x: 1
-    }, null, out, __component, "4");
+    }, null, null, __component, "4");
 
-  marko_dynamicTag(input.template, {
+  marko_dynamicTag(out, input.template, {
       y: function() {}
-    }, null, out, __component, "5");
+    }, null, null, __component, "5");
 
-  marko_dynamicTag({
+  marko_dynamicTag(out, {
       render: input.barRenderer
-    }, {}, null, out, __component, "6");
+    }, {}, null, null, __component, "6");
 
-  marko_dynamicTag(function(out) {
+  marko_dynamicTag(out, function(out) {
     input.barRenderer({}, true, out);
-  }, {}, null, out, __component, "7");
+  }, {}, null, null, __component, "7");
 
   if (x) {
-    marko_dynamicTag(renderA, {}, null, out, __component, "8");
+    marko_dynamicTag(out, renderA, {}, null, null, __component, "8");
   } else if (y) {
-    marko_dynamicTag(renderB, {}, null, out, __component, "9");
+    marko_dynamicTag(out, renderB, {}, null, null, __component, "9");
   } else {
-    marko_dynamicTag(renderC, {}, null, out, __component, "10");
+    marko_dynamicTag(out, renderC, {}, null, null, __component, "10");
   }
 
   if (x) {
-    marko_dynamicTag(render, {}, null, out, __component, "11");
+    marko_dynamicTag(out, render, {}, null, null, __component, "11");
   }
 
   if (!x) {
-    marko_dynamicTag(render, {}, null, out, __component, "12");
+    marko_dynamicTag(out, render, {}, null, null, __component, "12");
   }
 
   var for__13 = 0;
@@ -57,17 +57,17 @@ function render(input, out, __component, component, state) {
   marko_forRange(0, 9, null, function(i) {
     var keyscope__14 = "[" + ((for__13++) + "]");
 
-    marko_dynamicTag(input.items[i], {}, null, out, __component, "15" + keyscope__14);
+    marko_dynamicTag(out, input.items[i], {}, null, null, __component, "15" + keyscope__14);
   });
 
   let i = 10;
 
   while (i--) {
-    marko_dynamicTag(input, {}, null, out, __component, "16");
+    marko_dynamicTag(out, input, {}, null, null, __component, "16");
   }
 
   if (z) {
-    marko_dynamicTag(renderD, {}, null, out, __component, "17");
+    marko_dynamicTag(out, renderD, {}, null, null, __component, "17");
   }
 
   // if.test

--- a/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
+++ b/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
@@ -14,7 +14,7 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(foo ? "foo" : "bar", {}, null, out, __component, "0");
+  marko_dynamicTag(out, foo ? "foo" : "bar", {}, null, null, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-vdom/include/expected.js
+++ b/test/compiler/fixtures-vdom/include/expected.js
@@ -15,9 +15,9 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(IncludeTarget, {
+  marko_dynamicTag(out, IncludeTarget, {
       foo: "bar"
-    }, null, out, __component, "0");
+    }, null, null, __component, "0");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
+++ b/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
@@ -22,10 +22,10 @@ function render(input, out, __component, component, state) {
 
   out.be("svg", marko_attrs0, "0", component, null, 1);
 
-  marko_dynamicTag(isCircle ? "circle" : "square", {
+  marko_dynamicTag(out, isCircle ? "circle" : "square", {
       width: 200,
       height: 200
-    }, null, out, __component, "1");
+    }, null, null, __component, "1");
 
   out.ee();
 }

--- a/test/components-browser/fixtures/dynamic-tag-no-update-html-attributes/index.marko
+++ b/test/components-browser/fixtures/dynamic-tag-no-update-html-attributes/index.marko
@@ -1,0 +1,17 @@
+class {
+    onCreate() {
+        this.state = {
+            className: "initial"
+        }
+    }
+
+    changeClass() {
+        this.state.className = "SHOULD NOT CHANGE";
+    }
+}
+
+$ const tagName = "button";
+
+<div key="root">
+    <${tagName} class:no-update=state.className/>
+</div>

--- a/test/components-browser/fixtures/dynamic-tag-no-update-html-attributes/test.js
+++ b/test/components-browser/fixtures/dynamic-tag-no-update-html-attributes/test.js
@@ -1,0 +1,20 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var root = component.getEl("root");
+    var tag = root.querySelector(".initial");
+
+    expect(tag).to.have.property("className", "initial");
+
+    tag.className = "changed";
+    component.forceUpdate();
+    component.update();
+
+    // Should not update the class again.
+    expect(tag).to.have.property("className", "changed");
+
+    component.changeClass();
+    component.update();
+    expect(tag).to.have.property("className", "changed");
+};

--- a/test/components-browser/template.marko
+++ b/test/components-browser/template.marko
@@ -5,8 +5,8 @@
     </head>
     <body>
         <div#testsTarget>
-            <for(component in input.components)>
-                <include(require(component.template), component.input) key="components[]"/>
+            <for|component| of=input.components>
+                <${require(component.template)} ...component.input key="components[]"/>
             </for>
         </div>
     </body>

--- a/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, widget, component) {
     "><h1>Header</h1><div>");
 
   if (typeof input.renderBody === "function") {
-    marko_dynamicTag(input, {}, null, out, __component, "2");
+    marko_dynamicTag(out, input, {}, null, null, __component, "2");
   } else {
     out.w(marko_escapeXml(input.renderBody));
   }

--- a/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -46,7 +46,7 @@ function render(input, out, __component, component, state) {
 
   out.w("</p></div><span>B</span>");
 
-  marko_dynamicTag(Foo, {}, null, out, __component, "7");
+  marko_dynamicTag(out, Foo, {}, null, null, __component, "7");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/components-compilation/fixtures-html/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html/component-include-attr/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
   if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
-    marko_dynamicTag(data.renderBody, {}, null, out, __component, "3");
+    marko_dynamicTag(out, data.renderBody, {}, null, null, __component, "3");
   }
 
   out.w("</div></div>");

--- a/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
@@ -18,9 +18,9 @@ function render(input, out, __component, component, state) {
   if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
-    marko_dynamicTag(data.renderBody, {
+    marko_dynamicTag(out, data.renderBody, {
         test: 1
-      }, null, out, __component, "1");
+      }, null, null, __component, "1");
   }
 
   out.w("\n</div>");

--- a/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
   if (typeof data.renderBody === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
-    marko_dynamicTag(data.renderBody, {}, null, out, __component, "1");
+    marko_dynamicTag(out, data.renderBody, {}, null, null, __component, "1");
   }
 
   out.w("\n</div>");

--- a/test/components-compilation/fixtures-html/macro-widget/expected.js
+++ b/test/components-compilation/fixtures-html/macro-widget/expected.js
@@ -33,9 +33,9 @@ function render(input, out, __component, component, state) {
     ], function(color) {
     var keyscope__3 = "[" + ((for__2++) + "]");
 
-    marko_dynamicTag(macro_renderButton, {
+    marko_dynamicTag(out, macro_renderButton, {
         color: color
-      }, null, out, __component, "4" + keyscope__3);
+      }, null, null, __component, "4" + keyscope__3);
   });
 
   out.w("</div>");


### PR DESCRIPTION
## Description

Currently if you have a dynamic tag that renders an html element with a `no-update` attribute the attribute will still be updated on new renders. This is a regression from https://github.com/marko-js/marko/blob/master/CHANGELOG.md#4110 (also happens for the include tag since it migrates to the dynamic tag).

This PR passes the properties (containing info like which attributes to preserve) through to the dynamic tag and resolves the issue.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.