### PR TITLE
Update webpack property loaders to rules

### DIFF
--- a/docs/webpack.md
+++ b/docs/webpack.md
@@ -47,7 +47,7 @@ module.exports = {
     extensions: [".js", ".marko"]
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.marko$/,
         loader: "marko-loader"
@@ -92,7 +92,7 @@ _webpack.config.js_
 
 ```js
 //...
-loaders: [
+rules: [
   //...
   {
     test: /\.less$/, // matches style.less { ... } from our template
@@ -127,7 +127,7 @@ module.exports = {
     extensions: [".js", ".marko"]
   },
   module: {
-    loaders: [
+    rules: [
       {
         test: /\.marko$/,
         loader: "marko-loader"


### PR DESCRIPTION
loaders is incorrect syntax using latest webpack (4.29.6)

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
