### PR TITLE
Fix issue with hydrating nested fragments that are adjacent in the dom

### DIFF
--- a/src/components/Component.js
+++ b/src/components/Component.js
@@ -302,7 +302,6 @@ Component.prototype = componentProto = {
         root.detached = true;
 
         delete componentLookup[this.id];
-        delete this.___rootNode;
         this.___keyedElements = {};
     },
 

--- a/src/morphdom/index.js
+++ b/src/morphdom/index.js
@@ -356,12 +356,28 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                             ) {
                                 var content = curFromNodeChild.nodeValue;
                                 if (content == "F#" + curToNodeKeyOriginal) {
-                                    var endNode = curFromNodeChild;
-                                    while (
-                                        endNode.nodeType !== COMMENT_NODE ||
-                                        endNode.nodeValue !== "F/"
-                                    )
+                                    var endNode = curFromNodeChild.nextSibling;
+                                    var depth = 0;
+                                    var nodeValue;
+
+                                    // eslint-disable-next-line no-constant-condition
+                                    while (true) {
+                                        if (endNode.nodeType === COMMENT_NODE) {
+                                            nodeValue = endNode.nodeValue;
+                                            if (nodeValue === "F/") {
+                                                if (depth === 0) {
+                                                    break;
+                                                } else {
+                                                    depth--;
+                                                }
+                                            } else if (
+                                                nodeValue.indexOf("F#") === 0
+                                            ) {
+                                                depth++;
+                                            }
+                                        }
                                         endNode = endNode.nextSibling;
+                                    }
 
                                     var fragment = createFragmentNode(
                                         curFromNodeChild,

--- a/test/components-browser/fixtures/adjacent-nested-fragments/components/text-display/index.marko
+++ b/test/components-browser/fixtures/adjacent-nested-fragments/components/text-display/index.marko
@@ -1,0 +1,11 @@
+<macro|{ type, value }| name="value">
+    ${type}: ${value}
+</macro>
+
+<macro|{ value }| name="display">
+    $ const type = typeof value;
+    <value type=type value=value/>
+    <span>: ${type}</span>
+</macro>
+
+<display value=input.value/>

--- a/test/components-browser/fixtures/adjacent-nested-fragments/index.marko
+++ b/test/components-browser/fixtures/adjacent-nested-fragments/index.marko
@@ -1,0 +1,17 @@
+class {
+    onCreate() {
+        this.state = {
+            show: true
+        }
+    }
+
+    hide() {
+        this.state.show = false;
+    }
+}
+
+<div key="root">
+    <if(state.show)>
+        <text-display value=123/>
+    </if>
+</div>

--- a/test/components-browser/fixtures/adjacent-nested-fragments/test.js
+++ b/test/components-browser/fixtures/adjacent-nested-fragments/test.js
@@ -1,0 +1,10 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index.marko"), {});
+    var root = component.getEl("root");
+    expect(root.textContent).to.equal("number: 123: number");
+    component.hide();
+    component.update();
+    expect(root.textContent).to.equal("");
+};


### PR DESCRIPTION
## Description

Currently in situations where there are nested fragments that are siblings it is possible that a fragment will find the incorrect ending marker which can cause strange behavior after hydrating.

This PR resolves the issue by keeping track of the number of open fragments discovered while looking for the end marker.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.