### PR TITLE
Remove redundant part of key path for nested macros

### DIFF
--- a/src/components/taglib/TransformHelper/assignComponentId.js
+++ b/src/components/taglib/TransformHelper/assignComponentId.js
@@ -208,7 +208,7 @@ const forASTNodes = ["ForEach", "ForEachProp", "ForRange", "ForStatement"];
 
 const getParentFor = el => {
     let current = el;
-    while ((current = current.parentNode)) {
+    while ((current = current.parentNode) && current.type !== "Macro") {
         if (current.tagName === "for" || forASTNodes.includes(current.type)) {
             return current;
         }

--- a/test/compiler/fixtures-vdom/macro-in-loop/expected.js
+++ b/test/compiler/fixtures-vdom/macro-in-loop/expected.js
@@ -1,0 +1,62 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/vdom").t(),
+    components_helpers = require("marko/src/components/helpers"),
+    marko_registerComponent = components_helpers.rc,
+    marko_componentType = marko_registerComponent("/marko-test$1.0.0/compiler/fixtures-vdom/macro-in-loop/template.marko", function() {
+      return module.exports;
+    }),
+    marko_renderer = components_helpers.r,
+    marko_defineComponent = components_helpers.c,
+    marko_forRange = require("marko/src/runtime/helper-forRange"),
+    marko_helpers = require("marko/src/runtime/vdom/helpers"),
+    marko_forEach = marko_helpers.f,
+    marko_dynamicTag = marko_helpers.d;
+
+function render(input, out, __component, component, state) {
+  var data = input;
+
+  var for__0 = 0;
+
+  marko_forRange(0, 10, null, function(i) {
+    var keyscope__1 = "[" + ((for__0++) + "]");
+
+    out.e("DIV", null, "2" + keyscope__1, component, 1)
+      .t(i);
+
+    function macro_renderTree(out, node) {
+      out.t("Name: ");
+
+      out.t(node.name);
+
+      out.t(" Children: ");
+
+      if (node.children) {
+        out.be("UL", null, "3", component);
+
+        var for__4 = 0;
+
+        marko_forEach(node.children, function(child) {
+          var keyscope__5 = "[" + ((for__4++) + "]");
+
+          out.be("LI", null, "6" + keyscope__5, component);
+
+          marko_dynamicTag(out, macro_renderTree, child, null, null, __component, "7" + keyscope__5);
+
+          out.ee();
+        });
+
+        out.ee();
+      }
+    }
+
+    marko_dynamicTag(out, macro_renderTree, input.nodes[i], null, null, __component, "8" + keyscope__1);
+  });
+}
+
+marko_template._ = marko_renderer(render, {
+    ___implicit: true,
+    ___type: marko_componentType
+  });
+
+marko_template.Component = marko_defineComponent({}, marko_template._);

--- a/test/compiler/fixtures-vdom/macro-in-loop/template.marko
+++ b/test/compiler/fixtures-vdom/macro-in-loop/template.marko
@@ -1,0 +1,19 @@
+<for|i| from=0 to=10>
+    <div>${i}</div>
+    <macro|node| name="renderTree">
+        Name: ${node.name}
+
+        Children:
+        <if(node.children)>
+            <ul>
+                <for|child| of=node.children>
+                    <li>
+                        <renderTree ...child/>
+                    </li>
+                </for>
+            </ul>
+        </if>
+    </macro>
+
+    <renderTree ...input.nodes[i]/>
+</for>


### PR DESCRIPTION
## Description

Currently to keep track of automated keys within loops we automatically prepend a `for scope` key to all keys within the loop. This is unneccesary when a `<macro>` is inside a loop since it will be rendered within a new key namespace anyways.

This PR makes it so that `macro` acts as a boundary when checking to see if the current autokey should be combined with the `for scope`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
