### PR TITLE
fix widget.elId as <var> attribute

### DIFF
--- a/src/taglibs/migrate/all-tags/widget-in-attrs.js
+++ b/src/taglibs/migrate/all-tags/widget-in-attrs.js
@@ -2,7 +2,7 @@ module.exports = function migrate(el, context) {
     el.forEachAttribute(attr => {
         const value = attr.value;
 
-        if (isWidgetElIdFunctionCall(value)) {
+        if (isWidgetElIdFunctionCall(value) && el.tagName !== "var") {
             context.deprecate(
                 `The "*=widget.elId("someId")" is deprecated. Please use "*:scoped="someId"" modifier instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
             );

--- a/src/taglibs/migrate/all-tags/widget-in-attrs.js
+++ b/src/taglibs/migrate/all-tags/widget-in-attrs.js
@@ -2,7 +2,11 @@ module.exports = function migrate(el, context) {
     el.forEachAttribute(attr => {
         const value = attr.value;
 
-        if (isWidgetElIdFunctionCall(value) && el.tagName !== "var") {
+        if (
+            isWidgetElIdFunctionCall(value) &&
+            el.tagName !== "var" &&
+            el.tagName !== "assign"
+        ) {
             context.deprecate(
                 `The "*=widget.elId("someId")" is deprecated. Please use "*:scoped="someId"" modifier instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-w-*-Atrributes`
             );

--- a/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
@@ -4,4 +4,5 @@
 <div aria-describedby=(a && component.elId("x"))/>
 <div aria-describedby=(a && component.anything())/>
 <div aria-describedby=`${a} ${component.id}`/>
+$ var widgetId = component.elId();
 $ var widgetId = a ? component.id : component.elId("b");

--- a/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-in-attrs/snapshot-expected.marko
@@ -6,3 +6,4 @@
 <div aria-describedby=`${a} ${component.id}`/>
 $ var widgetId = component.elId();
 $ var widgetId = a ? component.id : component.elId("b");
+$ widgetId = component.elId();

--- a/test/migrate/fixtures/widget-in-attrs/template.marko
+++ b/test/migrate/fixtures/widget-in-attrs/template.marko
@@ -2,4 +2,5 @@
 <div aria-describedby=(a && widget.elId('x'))/>
 <div aria-describedby=(a && widget.anything())/>
 <div aria-describedby=`${a} ${widget.id}`/>
+<var widgetId=widget.elId()/>
 <var widgetId=(a ? widget.id : widget.elId("b"))/>

--- a/test/migrate/fixtures/widget-in-attrs/template.marko
+++ b/test/migrate/fixtures/widget-in-attrs/template.marko
@@ -4,3 +4,4 @@
 <div aria-describedby=`${a} ${widget.id}`/>
 <var widgetId=widget.elId()/>
 <var widgetId=(a ? widget.id : widget.elId("b"))/>
+<assign widgetId=widget.elId()/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Not migrated properly, throws an error:

```marko
<var wid=widget.elId()/>
```

This PR fixes it.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
