### PR TITLE
fix macro with injected renderBody migration

### DIFF
--- a/test/migrate/fixtures/legacy-macro-syntax/snapshot-expected.marko
+++ b/test/migrate/fixtures/legacy-macro-syntax/snapshot-expected.marko
@@ -13,3 +13,34 @@
     </div>
 </macro>
 <test2>Hello</test2>
+<macro|macroInput| name="test3">
+    $ var renderBody = macroInput.renderBody;
+    <div>
+        <${renderBody}/>
+    </div>
+</macro>
+<macro|macroInput| name="test4">
+    $ var renderBody = macroInput.renderBody;
+    <div>
+        <${renderBody}/>
+    </div>
+</macro>
+<macro|macroInput| name="test5">
+    $ var renderBody = macroInput.renderBody;
+    <div>
+        <${renderBody}/>
+    </div>
+</macro>
+<macro|macroInput| name="test6">
+    $ var renderBody = macroInput.renderBody;
+    <div>
+        <span body=renderBody/>
+    </div>
+</macro>
+<test3>
+    <test4>
+        <test5>
+            <test6>Hello</test6>
+        </test5>
+    </test4>
+</test3>

--- a/test/migrate/fixtures/legacy-macro-syntax/template.marko
+++ b/test/migrate/fixtures/legacy-macro-syntax/template.marko
@@ -14,8 +14,41 @@
   </div>
 </macro>
 
-
 <test2>
   Hello
 </test2>
+
+<macro test3()>
+  <div>
+    <${renderBody}/>
+  </div>
+</macro>
+
+<macro test4()>
+  <div>
+    <invoke renderBody(out)/>
+  </div>
+</macro>
+
+<macro test5()>
+  <div>
+    <% renderBody(out) %>
+  </div>
+</macro>
+
+<macro test6()>
+  <div>
+    <span body=renderBody/>
+  </div>
+</macro>
+
+<test3>
+  <test4>
+    <test5>
+      <test6>
+        Hello
+      </test6>
+    </test5>
+  </test4>
+</test3>
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In addition to `<macro-body>` a special `renderBody` property used to be injected into the `<macro>` tag.  The migration did not account for this.

```marko
<macro test()>
  $ renderBody(out);
</macro>
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
