### PR TITLE
Sync button disabled attribute

### DIFF
--- a/src/morphdom/specialElHandlers.js
+++ b/src/morphdom/specialElHandlers.js
@@ -19,6 +19,9 @@ SpecialElHandlers.prototype = {
     OPTION: function(fromEl, toEl) {
         syncBooleanAttrProp(fromEl, toEl, "selected");
     },
+    BUTTON: function(fromEl, toEl) {
+        syncBooleanAttrProp(fromEl, toEl, "disabled");
+    },
     /**
      * The "value" attribute is special for the <input> element since it sets
      * the initial value. Changing the "value" attribute without changing the

--- a/test/morphdom/fixtures/button-element-disabled/expected.html
+++ b/test/morphdom/fixtures/button-element-disabled/expected.html
@@ -1,0 +1,3 @@
+<BODY>
+  <BUTTON disabled="">
+    "Hello World"

--- a/test/morphdom/fixtures/button-element-disabled/from.html
+++ b/test/morphdom/fixtures/button-element-disabled/from.html
@@ -1,0 +1,1 @@
+<button>Hello World</button>

--- a/test/morphdom/fixtures/button-element-disabled/index.js
+++ b/test/morphdom/fixtures/button-element-disabled/index.js
@@ -1,0 +1,5 @@
+exports.verify = function(context, expect) {
+    var rootNode = context.rootNode;
+    var button = rootNode.querySelector("button");
+    expect(button.disabled).to.equal(true);
+};

--- a/test/morphdom/fixtures/button-element-disabled/to.html
+++ b/test/morphdom/fixtures/button-element-disabled/to.html
@@ -1,0 +1,1 @@
+<button disabled>Hello World</button>

--- a/test/morphdom/fixtures/button-element-enabled/expected.html
+++ b/test/morphdom/fixtures/button-element-enabled/expected.html
@@ -1,0 +1,3 @@
+<BODY>
+  <BUTTON>
+    "Hello World"

--- a/test/morphdom/fixtures/button-element-enabled/from.html
+++ b/test/morphdom/fixtures/button-element-enabled/from.html
@@ -1,0 +1,1 @@
+<button disabled>Hello World</button>

--- a/test/morphdom/fixtures/button-element-enabled/index.js
+++ b/test/morphdom/fixtures/button-element-enabled/index.js
@@ -1,0 +1,5 @@
+exports.verify = function(context, expect) {
+    var rootNode = context.rootNode;
+    var button = rootNode.querySelector("button");
+    expect(button.disabled).to.equal(false);
+};

--- a/test/morphdom/fixtures/button-element-enabled/to.html
+++ b/test/morphdom/fixtures/button-element-enabled/to.html
@@ -1,0 +1,1 @@
+<button>Hello World</button>

--- a/test/morphdom/fixtures/input-element-disabled/index.js
+++ b/test/morphdom/fixtures/input-element-disabled/index.js
@@ -1,4 +1,5 @@
 exports.verify = function(context, expect) {
     var rootNode = context.rootNode;
-    expect(rootNode.disabled).to.equal(true);
+    var input = rootNode.querySelector("input");
+    expect(input.disabled).to.equal(true);
 };

--- a/test/morphdom/fixtures/input-element-enabled/index.js
+++ b/test/morphdom/fixtures/input-element-enabled/index.js
@@ -1,4 +1,5 @@
 exports.verify = function(context, expect) {
     var rootNode = context.rootNode;
-    expect(rootNode.disabled).to.equal(false);
+    var input = rootNode.querySelector("input");
+    expect(input.disabled).to.equal(false);
 };

--- a/test/morphdom/index.test.js
+++ b/test/morphdom/index.test.js
@@ -7,10 +7,12 @@ chai.config.includeStack = true;
 
 var autotest = require("../autotest");
 const fs = require("fs");
+const path = require("path");
 const morphdom = require("marko/morphdom");
 const createBrowser = require("jsdom-context-require");
 
 autotest("fixtures", fixture => {
+    let dir = fixture.dir;
     let test = fixture.test;
     let resolve = fixture.resolve;
     let snapshot = fixture.snapshot;
@@ -56,6 +58,10 @@ autotest("fixtures", fixture => {
 
         var actualHTML = serializeNode(fromNode);
         snapshot(actualHTML, ".html");
+
+        if (fs.existsSync(path.join(dir, "index.js"))) {
+            require(dir).verify({ rootNode: fromNode }, chai.expect);
+        }
     });
 });
 


### PR DESCRIPTION
## Description

The morphdom implementation in Marko currently supports syncing a predefined set of elements properties (which can be found [here](https://github.com/marko-js/marko/blob/master/src/morphdom/specialElHandlers.js)). This PR adds the `disabled` property from `button` elements to this list.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.