### PR TITLE
Ensure space when dynamic attributes as string is provided

### DIFF
--- a/src/runtime/html/helper-merge-attrs.js
+++ b/src/runtime/html/helper-merge-attrs.js
@@ -19,6 +19,11 @@ function mergeAttrs() {
                     "Passing a string as dynamic attributes ('<div ${string}>' or '<div ...string>') is deprecated, use an object instead."
                 );
             }
+
+            if (source[0] !== " ") {
+                source = " " + source;
+            }
+
             result += attrsHelper(currentAttrs) + source;
             currentAttrs = {};
         } else if (source != null) {

--- a/test/render/fixtures-deprecated/dynamic-attrs-string/expected.html
+++ b/test/render/fixtures-deprecated/dynamic-attrs-string/expected.html
@@ -1,1 +1,1 @@
-<div x=1 class="a" id="b"></div>
+<div  x=1 class="a" id="b"></div><div x=1 class="a" id="b"></div><div x=1 class="a" id="b"></div>

--- a/test/render/fixtures-deprecated/dynamic-attrs-string/template.marko
+++ b/test/render/fixtures-deprecated/dynamic-attrs-string/template.marko
@@ -1,1 +1,3 @@
+<div class="a" ${"  x=1"} id="b"/>
 <div class="a" ${" x=1"} id="b"/>
+<div class="a" ${"x=1"} id="b"/>


### PR DESCRIPTION
## Description
This PR solves a regression when using the legacy dynamic attribute syntax and passing a string value.

```marko
<div ${"x=1"}/>
```

would output

```marko
<divx=1/>
```

This PR fixes this to ensure that there is always a leading space.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.