### PR TITLE
Fix issue with Marko@3 widget hydration

### DIFF
--- a/src/components/index.js
+++ b/src/components/index.js
@@ -90,7 +90,7 @@ function addComponentsFromContext(
             }
         }
 
-        var undefinedPropNames;
+        var undefinedPropNames = undefined;
 
         if (state) {
             // Update state properties with an `undefined` value to have a `null`

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/browser.json
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/browser.json
@@ -1,0 +1,3 @@
+{
+    "dependencies": ["require: ./components/app-foo"]
+}

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/components/app-foo/index.js
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/components/app-foo/index.js
@@ -1,0 +1,14 @@
+module.exports = require("marko-widgets").defineComponent({
+    template: require("./template.marko"),
+
+    getInitialState: function(input) {
+        return {
+            data: input.data
+        };
+    },
+
+    init: function() {
+        window.fooWidgets = window.fooWidgets || [];
+        window.fooWidgets.push(this);
+    }
+});

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/components/app-foo/template.marko
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/components/app-foo/template.marko
@@ -1,0 +1,1 @@
+div w-bind

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/marko.json
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/marko.json
@@ -1,0 +1,3 @@
+{
+    "tags-dir": "./components"
+}

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/template.marko
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/template.marko
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Widgets Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        app-foo data=1
+        app-foo data=undefined
+
+        init-widgets immediate

--- a/test/components-pages/fixtures-deprecated/widget-state-undefined/tests.js
+++ b/test/components-pages/fixtures-deprecated/widget-state-undefined/tests.js
@@ -1,0 +1,9 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it("should serialize widget config down to the browser", function() {
+        expect(window.fooWidgets[0].state.data).to.equal(undefined);
+        expect(window.fooWidgets[1].state.data).to.equal(1);
+    });
+});


### PR DESCRIPTION
## Description

For legacy widget state serialization we have some code which ensures that `undefined` properties are persisted. The loop here had a hoisted variable that could cause a previous element to have incorrectly applied the undefined properties.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.