### PR TITLE
Improve dynamic tag arguments parsing

### DIFF
--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -417,7 +417,14 @@ class CustomTag extends HtmlElement {
         }
 
         if (this.argument && !isDynamicTag) {
-            let argExpression = builder.parseExpression(this.argument);
+            let argExpression = builder.parseJavaScriptArgs(this.argument);
+
+            if (argExpression.length === 1) {
+                argExpression = argExpression[0];
+            } else {
+                argExpression = builder.arrayExpression(argExpression);
+            }
+
             inputProps = merge(argExpression, inputProps, context);
             context.deprecate(
                 "Using <tag(attrs)> to pass dynamic attributes is deprecated. use ...attrs instead."
@@ -616,7 +623,7 @@ class CustomTag extends HtmlElement {
             } else if (isDynamicTag) {
                 const argumentNode = this.argument
                     ? builder.arrayExpression(
-                          [].concat(builder.parseExpression(this.argument))
+                          builder.parseJavaScriptArgs(this.argument)
                       )
                     : builder.literalNull();
                 const properties = this.getProperties();

--- a/test/compiler/fixtures-html/spread-arguments/expected.js
+++ b/test/compiler/fixtures-html/spread-arguments/expected.js
@@ -1,0 +1,28 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/html").t(__filename),
+    marko_componentType = "/marko-test$1.0.0/compiler/fixtures-html/spread-arguments/template.marko",
+    components_helpers = require("marko/src/components/helpers"),
+    marko_renderer = components_helpers.r,
+    marko_defineComponent = components_helpers.c,
+    marko_helpers = require("marko/src/runtime/html/helpers"),
+    marko_dynamicTag = marko_helpers.d;
+
+function render(input, out, __component, component, state) {
+  var data = input;
+
+  marko_dynamicTag(out, input.renderBody, {}, [
+      ...input.items
+    ], null, __component, "0");
+}
+
+marko_template._ = marko_renderer(render, {
+    ___implicit: true,
+    ___type: marko_componentType
+  });
+
+marko_template.Component = marko_defineComponent({}, marko_template._);
+
+marko_template.meta = {
+    id: "/marko-test$1.0.0/compiler/fixtures-html/spread-arguments/template.marko"
+  };

--- a/test/compiler/fixtures-html/spread-arguments/template.marko
+++ b/test/compiler/fixtures-html/spread-arguments/template.marko
@@ -1,0 +1,1 @@
+<${input.renderBody}(...input.items)/>


### PR DESCRIPTION
## Description

Improves argument parsing for dynamic tag and custom tags.
Allows support for `...spread` arguments.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.