### PR TITLE
Revert #921 to avoid issues with hot reloading and js/marko file name conflicts

### DIFF
--- a/src/loader/index-default.js
+++ b/src/loader/index-default.js
@@ -9,28 +9,12 @@ var cwd = process.cwd();
 var fsOptions = { encoding: "utf8" };
 
 module.exports = function load(templatePath, templateSrc, options) {
-    if (typeof templatePath === "string") {
-        const parsed = nodePath.parse(templatePath);
-
-        if (parsed.ext === ".js") {
-            // assume compiled template
-            return require(templatePath);
-        } else if (parsed.ext === ".marko") {
-            // Check if precompiled js file already exists.
-            const jsFilePath = nodePath.join(parsed.dir, parsed.name + ".js");
-            let foundPrecompiled = false;
-
-            try {
-                fs.accessSync(jsFilePath);
-                foundPrecompiled = true;
-            } catch (e) {
-                /* ignore error */
-            }
-
-            if (foundPrecompiled) {
-                return require(jsFilePath);
-            }
-        }
+    if (
+        typeof templatePath === "string" &&
+        nodePath.extname(templatePath) === ".js"
+    ) {
+        // assume compiled template
+        return require(templatePath);
     }
 
     if (arguments.length === 1) {

--- a/test/api/fixtures/load-prefer-precompiled/dummy.js
+++ b/test/api/fixtures/load-prefer-precompiled/dummy.js
@@ -1,1 +1,0 @@
-module.exports = "SHOULD LOAD";

--- a/test/api/fixtures/load-prefer-precompiled/dummy.marko
+++ b/test/api/fixtures/load-prefer-precompiled/dummy.marko
@@ -1,1 +1,0 @@
-module.exports = "SHOULD NOT LOAD";

--- a/test/api/fixtures/load-prefer-precompiled/test.js
+++ b/test/api/fixtures/load-prefer-precompiled/test.js
@@ -1,8 +1,0 @@
-var nodePath = require("path");
-
-exports.check = function(marko, markoCompiler, expect, helpers, done) {
-    var templatePath = nodePath.join(__dirname, "dummy.marko");
-    var template = marko.load(templatePath);
-    expect(template).to.equal("SHOULD LOAD");
-    done();
-};


### PR DESCRIPTION
## Description
Reverts #921 which causes issues with the `hot-reload` functionality. This optimization is not really being used and alternative solutions are planned for Marko 5. 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.