### PR TITLE
Fix hot reload

### DIFF
--- a/src/hot-reload.js
+++ b/src/hot-reload.js
@@ -34,6 +34,10 @@ function tryReloadTemplate(path) {
     path = path.replace(/\.js$/, "");
 
     try {
+        if (require.extensions[".marko"]) {
+            return require(path);
+        }
+
         return marko.load(path);
     } catch (e) {
         return undefined;

--- a/src/node-require/index.js
+++ b/src/node-require/index.js
@@ -92,13 +92,11 @@ function install(options) {
         ? options.require.extensions
         : require.extensions;
 
-    var compilerOptions = options.compilerOptions;
-
-    if (compilerOptions) {
-        require("../compiler").configure(compilerOptions);
-    } else {
-        compilerOptions = {};
-    }
+    var compilerOptions = Object.assign(
+        { requireTemplates: true },
+        options.compilerOptions
+    );
+    require("../compiler").configure(compilerOptions);
 
     var extensions = [];
 


### PR DESCRIPTION
## Description
Currently `marko.load` can cause issues with hot reloading, especially when `precompiled` files from `Marko CLI` are discovered (or if there is a naming conflict between a marko file and a js file).

This PR ensures that if you are using the require hook that any subsequently loaded template also uses the require hook and makes the `hot-reload` functionality also use the require hook if available.

Fixes #1282.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.