### PR TITLE
Fix issue with lost component def in legacy renderer

### DIFF
--- a/src/components/legacy/renderer-legacy.js
+++ b/src/components/legacy/renderer-legacy.js
@@ -37,7 +37,7 @@ function createRendererFunc(templateRenderFunc, componentProps) {
         var isRerender = component !== undefined;
         var id = assignedId;
         var isExisting;
-        var parentComponentDef;
+        var parentComponentDef = componentsContext.___componentDef;
         var ownerComponentDef = out.___assignedComponentDef;
         var ownerComponentId = ownerComponentDef && ownerComponentDef.id;
         var key = out.___assignedKey;
@@ -50,7 +50,7 @@ function createRendererFunc(templateRenderFunc, componentProps) {
             isExisting = true;
             globalComponentsContext.___rerenderComponent = null;
         } else {
-            if ((parentComponentDef = componentsContext.___componentDef)) {
+            if (parentComponentDef) {
                 if (key != null) {
                     key = key.toString();
                 }


### PR DESCRIPTION
## Description
Currently with the legacy renderer it is possible to loose the current `componentDef` from the `ComponentsContext` which can cause issues with the dynamic tag (and potentially other issues).

This PR updates the legacy renderer to be more inline with the modern one.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.