### PR TITLE
Improve w-body migration

### DIFF
--- a/src/taglibs/migrate/all-tags/w-body.js
+++ b/src/taglibs/migrate/all-tags/w-body.js
@@ -47,6 +47,14 @@ module.exports = function migrate(el, context) {
             builder.text(isDefault ? renderBodyValue : bodyValue)
         ])
     ]);
+
+    if (
+        el.hasAttribute("body-only-if") &&
+        el.getAttribute("body-only-if").argument === "true"
+    ) {
+        el.forEachChild(node => el.insertSiblingBefore(node));
+        el.detach();
+    }
 };
 
 function buildTypeOfFunction(node, context) {

--- a/test/migrate/fixtures/w-body/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-body/snapshot-expected.marko
@@ -6,3 +6,7 @@
     </if>
     <else>${input.renderBody}</else>
 </div>
+<if(typeof input.renderBody === "function")>
+    <${input}/>
+</if>
+<else>${input.renderBody}</else>

--- a/test/migrate/fixtures/w-body/template.marko
+++ b/test/migrate/fixtures/w-body/template.marko
@@ -1,1 +1,2 @@
 <div w-body/>
+<span w-body body-only-if(true)/>


### PR DESCRIPTION
## Description

Improves the output of the `w-body` migration when the `body-only-if(true)` directive is found (this is a common pattern in Marko 3 to avoid having to have a container for the renderBody).

If `body-only-if(true)` is discovered, the parent tag is now omitted from the migrated output.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.