### PR TITLE
fix destorying a component that has already removed some top-level nodes

### DIFF
--- a/src/runtime/components/Component.js
+++ b/src/runtime/components/Component.js
@@ -287,9 +287,10 @@ Component.prototype = componentProto = {
         }
 
         var root = this.___rootNode;
-        var nodes = this.___rootNode.nodes;
 
         this.___destroyShallow();
+
+        var nodes = root.nodes;
 
         nodes.forEach(function(node) {
             destroyNodeRecursive(node);

--- a/test/components-browser/fixtures/destroy-cleanup/component.js
+++ b/test/components-browser/fixtures/destroy-cleanup/component.js
@@ -1,0 +1,11 @@
+module.exports = {
+    onMount() {
+        const root = this.getEl("root");
+        this.before = document.createElement("span");
+        this.before.id = "before";
+        root.parentNode.insertBefore(this.before, root);
+    },
+    onDestroy() {
+        this.before.remove();
+    }
+};

--- a/test/components-browser/fixtures/destroy-cleanup/index.marko
+++ b/test/components-browser/fixtures/destroy-cleanup/index.marko
@@ -1,0 +1,1 @@
+<div key="root"/>

--- a/test/components-browser/fixtures/destroy-cleanup/test.js
+++ b/test/components-browser/fixtures/destroy-cleanup/test.js
@@ -1,0 +1,13 @@
+const expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    const component = helpers.mount(require.resolve("./index"), {});
+    const root = component.getEl("root");
+    const before = component.before;
+
+    expect(root.parentNode).to.equal(helpers.targetEl);
+    expect(before.parentNode).to.equal(helpers.targetEl);
+    component.destroy();
+    expect(root.parentNode).to.equal(null);
+    expect(before.parentNode).to.equal(null);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When using a library that touches the dom, you might need to cleanup references on destroy, but if the library's cleanup function removes dom nodes, this would cause an issue as Marko gets the list of nodes it needs before the destroy handler is called.  This PR changes the order so that Marko determines which nodes to remove after the destroy handler is called.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
