### PR TITLE
Fix regression with unary expression printing

### DIFF
--- a/src/compiler/ast/UnaryExpression.js
+++ b/src/compiler/ast/UnaryExpression.js
@@ -47,7 +47,7 @@ class UnaryExpression extends Node {
     }
 
     isCompoundExpression() {
-        return false;
+        return true;
     }
 
     toJSON() {

--- a/test/codegen/fixtures/body-only-if/expected.js
+++ b/test/codegen/fixtures/body-only-if/expected.js
@@ -1,5 +1,5 @@
 if (true) {
-  if (!!data.url) {
+  if (!(!data.url)) {
     out.w("<a" +
       marko_attr("href", data.url) +
       ">");
@@ -7,7 +7,7 @@ if (true) {
 
   out.w("Hello World");
 
-  if (!!data.url) {
+  if (!(!data.url)) {
     out.w("</a>");
   }
 }

--- a/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/component-include-attr/expected.js
@@ -17,7 +17,7 @@ function render(input, out, __component, widget, component) {
     marko_attr("id", __component.elId()) +
     "><h1>Header</h1><div>");
 
-  if (typeof input.renderBody === "function") {
+  if ((typeof input.renderBody) === "function") {
     marko_dynamicTag(out, input, {}, null, null, __component, "2");
   } else {
     out.w(marko_escapeXml(input.renderBody));

--- a/test/components-compilation/fixtures-html/component-include-attr/expected.js
+++ b/test/components-compilation/fixtures-html/component-include-attr/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div><h1>Header</h1><div>");
 
-  if (typeof data.renderBody === "string") {
+  if ((typeof data.renderBody) === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(out, data.renderBody, {}, null, null, __component, "3");

--- a/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-input-whitespace-preserved/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>\n    ");
 
-  if (typeof data.renderBody === "string") {
+  if ((typeof data.renderBody) === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(out, data.renderBody, {

--- a/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
+++ b/test/components-compilation/fixtures-html/include-whitespace-preserved/expected.js
@@ -15,7 +15,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>\n    ");
 
-  if (typeof data.renderBody === "string") {
+  if ((typeof data.renderBody) === "string") {
     out.w(marko_escapeXml(data.renderBody));
   } else {
     marko_dynamicTag(out, data.renderBody, {}, null, null, __component, "1");

--- a/test/expression-toString/fixtures/UnaryExpression/expected.js
+++ b/test/expression-toString/fixtures/UnaryExpression/expected.js
@@ -1,1 +1,1 @@
-((typeof foo && !i) && delete foo.bar) && typeof (x || y)
+(((typeof foo) && (!i)) && (delete foo.bar)) && (typeof (x || y))

--- a/test/render/fixtures/unary-expression/expected.html
+++ b/test/render/fixtures/unary-expression/expected.html
@@ -1,0 +1,1 @@
+<div aria-hidden="true"></div>

--- a/test/render/fixtures/unary-expression/template.marko
+++ b/test/render/fixtures/unary-expression/template.marko
@@ -1,0 +1,1 @@
+<div aria-hidden=(!!input.hidden).toString()/>

--- a/test/render/fixtures/unary-expression/test.js
+++ b/test/render/fixtures/unary-expression/test.js
@@ -1,0 +1,3 @@
+exports.templateData = {
+    hidden: true
+};


### PR DESCRIPTION
## Description
[Previously](https://github.com/marko-js/marko/commit/ff31597a56c6941b8e4da7cebdf61d36829db782#diff-f9b0c7cf6672c52d0c33f85ad8e78be2L50) an optimization was added for printing unary expressions however in some cases this can cause invalid javascript to be printed. This PR reverts that change.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.