### PR TITLE
Allow macros with tag params to be implicit components

### DIFF
--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -149,6 +149,7 @@ class Normalizer {
             elNode.params.length &&
             elNode.tagName !== "for" &&
             elNode.tagName !== "macro" &&
+            !context.isMacro(elNode.tagName) &&
             !(
                 (elNode.tagName === "@then" || elNode.tagName === "@catch") &&
                 elNode.parentNode.tagName === "await"

--- a/test/components-browser/fixtures/tag-params-nested-tags/index.marko
+++ b/test/components-browser/fixtures/tag-params-nested-tags/index.marko
@@ -1,5 +1,3 @@
-class {}
-
 <name key="name">
     <@first|{ name }|>
         Hello, ${name}!

--- a/test/components-browser/fixtures/tag-params/index.marko
+++ b/test/components-browser/fixtures/tag-params/index.marko
@@ -1,5 +1,3 @@
-class {}
-
 <name|{ name }| key="name">
     Hello, ${name}!
 </name>

--- a/test/components-pages/fixtures/implicit-component-macro-params/components/hello-implicit-component/index.marko
+++ b/test/components-pages/fixtures/implicit-component-macro-params/components/hello-implicit-component/index.marko
@@ -1,0 +1,15 @@
+$ if (typeof window !== "undefined") {
+  window.helloImplicitComponentSent = true;
+}
+
+<macro|macroInput| name="add1">
+  <${macroInput}(macroInput.value + 1)/>
+</macro>
+
+<add1|result| value=1>
+  Result: ${result}
+</add1>
+
+<add1|result| value=2>
+  Result: ${result}
+</add1>

--- a/test/components-pages/fixtures/implicit-component-macro-params/template.marko
+++ b/test/components-pages/fixtures/implicit-component-macro-params/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        <hello-implicit-component/>
+
+        init-components

--- a/test/components-pages/fixtures/implicit-component-macro-params/tests.js
+++ b/test/components-pages/fixtures/implicit-component-macro-params/tests.js
@@ -1,0 +1,8 @@
+var path = require("path");
+var expect = require("chai").expect;
+
+describe(path.basename(__dirname), function() {
+    it("should not mount implicit components with macros that have tag parameters", function() {
+        expect(window.helloImplicitComponentSent).to.equal(undefined);
+    });
+});


### PR DESCRIPTION
## Description
Currently using tag parameters force templates to become components except for the built in modules (for, await, macro). Using a macro that accepts tag parameters is not in this whitelist and causes the whole template to be treated as a component.

In the future this heuristic should improve to actually check with the implementor of the tag params to see if it itself is a component, however for now this PR adds any `macro` usage to this whitelist.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.