### PR TITLE
Fix preserve

### DIFF
--- a/src/core-tags/components/preserve-tag-browser.js
+++ b/src/core-tags/components/preserve-tag-browser.js
@@ -22,9 +22,9 @@ module.exports = function render(input, out) {
                     // but keep track that the node is being preserved so that we can ignore
                     // it while transforming the old DOM
                     if (bodyOnly) {
-                        globalComponentsContext.___preservedElBodies[
-                            key
-                        ] = true;
+                        var preservedBodies = (component.___preservedElBodies =
+                            component.___preservedElBodies || {});
+                        preservedBodies[key] = true;
                     } else {
                         // If we are preserving the entire DOM node (not just the body)
                         // then that means that we have need to render a placeholder to
@@ -38,7 +38,9 @@ module.exports = function render(input, out) {
                             0,
                             8 /* FLAG_PRESERVE */
                         );
-                        globalComponentsContext.___preservedEls[key] = true;
+                        var preservedEls = (component.___preservedEls =
+                            component.___preservedEls || {});
+                        preservedEls[key] = true;
                     }
 
                     return;

--- a/src/core-tags/components/preserve-tag-browser.js
+++ b/src/core-tags/components/preserve-tag-browser.js
@@ -22,9 +22,9 @@ module.exports = function render(input, out) {
                     // but keep track that the node is being preserved so that we can ignore
                     // it while transforming the old DOM
                     if (bodyOnly) {
-                        var preservedBodies = (component.___preservedElBodies =
-                            component.___preservedElBodies || {});
-                        preservedBodies[key] = true;
+                        globalComponentsContext.___preservedElBodies[
+                            key
+                        ] = true;
                     } else {
                         // If we are preserving the entire DOM node (not just the body)
                         // then that means that we have need to render a placeholder to
@@ -38,9 +38,7 @@ module.exports = function render(input, out) {
                             0,
                             8 /* FLAG_PRESERVE */
                         );
-                        var preservedEls = (component.___preservedEls =
-                            component.___preservedEls || {});
-                        preservedEls[key] = true;
+                        globalComponentsContext.___preservedEls[key] = true;
                     }
 
                     return;

--- a/src/core-tags/components/preserve-tag-browser.js
+++ b/src/core-tags/components/preserve-tag-browser.js
@@ -23,7 +23,7 @@ module.exports = function render(input, out) {
                     // it while transforming the old DOM
                     if (bodyOnly) {
                         globalComponentsContext.___preservedElBodies[
-                            key
+                            component.id + "-" + key
                         ] = true;
                     } else {
                         // If we are preserving the entire DOM node (not just the body)
@@ -38,7 +38,9 @@ module.exports = function render(input, out) {
                             0,
                             8 /* FLAG_PRESERVE */
                         );
-                        globalComponentsContext.___preservedEls[key] = true;
+                        globalComponentsContext.___preservedEls[
+                            component.id + "-" + key
+                        ] = true;
                     }
 
                     return;

--- a/src/runtime/vdom/morphdom/index.js
+++ b/src/runtime/vdom/morphdom/index.js
@@ -658,9 +658,9 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
                 if (curFromNodeKey) {
                     if (
-                        !parentComponent.___preservedEls ||
-                        parentComponent.___preservedEls[curFromNodeKey] ===
-                            undefined
+                        globalComponentsContext.___preservedEls[
+                            curFromNodeKey
+                        ] === undefined
                     ) {
                         detachNode(curFromNodeChild, fromNode, ownerComponent);
                     }
@@ -755,8 +755,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
         if (
             toElKey &&
-            parentComponent.___preservedElBodies &&
-            parentComponent.___preservedElBodies[toElKey] === true
+            globalComponentsContext.___preservedElBodies[toElKey] === true
         ) {
             // Don't morph the children since they are preserved
             return;

--- a/src/runtime/vdom/morphdom/index.js
+++ b/src/runtime/vdom/morphdom/index.js
@@ -658,9 +658,9 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
                 if (curFromNodeKey) {
                     if (
-                        globalComponentsContext.___preservedEls[
-                            curFromNodeKey
-                        ] === undefined
+                        !parentComponent.___preservedEls ||
+                        parentComponent.___preservedEls[curFromNodeKey] ===
+                            undefined
                     ) {
                         detachNode(curFromNodeChild, fromNode, ownerComponent);
                     }
@@ -755,7 +755,8 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
         if (
             toElKey &&
-            globalComponentsContext.___preservedElBodies[toElKey] === true
+            parentComponent.___preservedElBodies &&
+            parentComponent.___preservedElBodies[toElKey] === true
         ) {
             // Don't morph the children since they are preserved
             return;

--- a/src/runtime/vdom/morphdom/index.js
+++ b/src/runtime/vdom/morphdom/index.js
@@ -659,7 +659,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                 if (curFromNodeKey) {
                     if (
                         globalComponentsContext.___preservedEls[
-                            curFromNodeKey
+                            parentComponent.id + "-" + curFromNodeKey
                         ] === undefined
                     ) {
                         detachNode(curFromNodeChild, fromNode, ownerComponent);
@@ -755,7 +755,9 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
         if (
             toElKey &&
-            globalComponentsContext.___preservedElBodies[toElKey] === true
+            globalComponentsContext.___preservedElBodies[
+                parentComponent.id + "-" + toElKey
+            ] === true
         ) {
             // Don't morph the children since they are preserved
             return;

--- a/test/components-browser/fixtures/preserve-dom-body-shared-key/components/child-preserved.marko
+++ b/test/components-browser/fixtures/preserve-dom-body-shared-key/components/child-preserved.marko
@@ -1,0 +1,1 @@
+<span no-update-body key="shared">Hello</span>

--- a/test/components-browser/fixtures/preserve-dom-body-shared-key/index.marko
+++ b/test/components-browser/fixtures/preserve-dom-body-shared-key/index.marko
@@ -1,0 +1,4 @@
+class {}
+
+<div.unpreserved-counter key="shared">${input.counter}</div>
+<child-preserved count=input.counter/>

--- a/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
+++ b/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
@@ -1,0 +1,25 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var counter = 0;
+
+    var component = helpers.mount(require.resolve("./index"), {
+        counter: counter
+    });
+
+    expect(
+        helpers.targetEl.querySelector(".unpreserved-counter").innerHTML
+    ).to.equal("0");
+
+    component.input = {
+        counter: ++counter
+    };
+
+    component.update();
+
+    expect(
+        helpers.targetEl.querySelector(".unpreserved-counter").innerHTML
+    ).to.equal("1");
+};
+
+module.exports.fails = true;

--- a/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
+++ b/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
@@ -21,3 +21,5 @@ module.exports = function(helpers) {
         helpers.targetEl.querySelector(".unpreserved-counter").innerHTML
     ).to.equal("1");
 };
+
+module.exports.fails = true;

--- a/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
+++ b/test/components-browser/fixtures/preserve-dom-body-shared-key/test.js
@@ -21,5 +21,3 @@ module.exports = function(helpers) {
         helpers.targetEl.querySelector(".unpreserved-counter").innerHTML
     ).to.equal("1");
 };
-
-module.exports.fails = true;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Uses scoped keys for preserved elements.  Using a non-scoped key on the global components context meant there could be collisions where a node might be preserved when it shouldn't have been.  

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
