### PR TITLE
Ignore unrecognized tags compiler option now includes @tags

### DIFF
--- a/src/compiler/CompileContext.js
+++ b/src/compiler/CompileContext.js
@@ -144,7 +144,6 @@ class CompileContext extends EventEmitter {
             writeVersionComment !== "undefined" ? writeVersionComment : true;
         this.ignoreUnrecognizedTags =
             this.options.ignoreUnrecognizedTags === true;
-        this.escapeAtTags = this.options.escapeAtTags === true;
 
         this._vars = {};
         this._uniqueVars = new UniqueVars();
@@ -493,18 +492,12 @@ class CompileContext extends EventEmitter {
         }
 
         var isAtTag = typeof tagName === "string" && tagName.startsWith("@");
-
-        if (isAtTag && this.escapeAtTags) {
-            tagName = tagName.replace(/^@/, "at_");
-            elDef.tagName = tagName;
-        }
-
         var node;
         var tagDef;
 
         var taglibLookup = this.taglibLookup;
 
-        if ((isAtTag && !this.escapeAtTags) || tagName instanceof Node) {
+        if (isAtTag || tagName instanceof Node) {
             // NOTE: The tag definition can't be determined now
             //       For @tags it will be determined by the parent
             //       For dynamic tags we cannot know at compile time

--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -106,9 +106,12 @@ class Normalizer {
             return;
         }
 
-        var newNode = this.context.createNodeForEl({
+        var newNode = context.createNodeForEl({
             tagName: elNode.rawTagNameExpression
                 ? builder.parseExpression(elNode.rawTagNameExpression)
+                : context.ignoreUnrecognizedTags &&
+                  elNode.parentNode.type === "HtmlElement"
+                ? elNode.tagName.replace(/^@/, "at_")
                 : elNode.tagName,
             argument: elNode.argument,
             params: elNode.params,

--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -109,9 +109,8 @@ class Normalizer {
         var newNode = context.createNodeForEl({
             tagName: elNode.rawTagNameExpression
                 ? builder.parseExpression(elNode.rawTagNameExpression)
-                : context.ignoreUnrecognizedTags &&
-                  elNode.parentNode.type === "HtmlElement"
-                ? elNode.tagName.replace(/^@/, "at_")
+                : context.ignoreUnrecognizedTags && !elNode.parentNode.tagDef
+                ? elNode.tagName.replace(/^@/, "at_") // escapes @tags inside unrecognized tags
                 : elNode.tagName,
             argument: elNode.argument,
             params: elNode.params,

--- a/src/compiler/config.js
+++ b/src/compiler/config.js
@@ -63,11 +63,6 @@ if (g.__MARKO_CONFIG) {
         ignoreUnrecognizedTags: false,
 
         /**
-         * Whether <@tags> should error when are used outside a custom component.
-         */
-        escapeAtTags: false,
-
-        /**
          * Controls whether or not a key should be assigned to all HTML
          * and custom tags at compile-time. The default is `true`
          */

--- a/test/__util__/runRenderTest.js
+++ b/test/__util__/runRenderTest.js
@@ -127,7 +127,6 @@ module.exports = function runRenderTest(dir, snapshot, done, options) {
         writeToDisk: main.writeToDisk !== false,
         preserveWhitespace: main.preserveWhitespaceGlobal === true,
         ignoreUnrecognizedTags: main.ignoreUnrecognizedTags === true,
-        escapeAtTags: main.escapeAtTags === true,
         autoKeyEnabled: !isVDOM
     };
 

--- a/test/render/fixtures/escape-at-tag/components/child/index.marko
+++ b/test/render/fixtures/escape-at-tag/components/child/index.marko
@@ -1,0 +1,3 @@
+<div class="child">
+  <${input.content}/>
+</div>

--- a/test/render/fixtures/escape-at-tag/expected.html
+++ b/test/render/fixtures/escape-at-tag/expected.html
@@ -1,1 +1,1 @@
-<div><at_hello></at_hello></div>
+<div class="child">Child Content</div><missing><at_content>Child Content</at_content></missing>

--- a/test/render/fixtures/escape-at-tag/template.marko
+++ b/test/render/fixtures/escape-at-tag/template.marko
@@ -1,1 +1,7 @@
-<div><@hello></@hello></div>
+<child>
+  <@content>Child Content</@content>
+</child>
+
+<missing>
+  <@content>Child Content</@content>
+</missing>

--- a/test/render/fixtures/escape-at-tag/test.js
+++ b/test/render/fixtures/escape-at-tag/test.js
@@ -1,3 +1,2 @@
 exports.templateData = {};
 exports.ignoreUnrecognizedTags = true;
-exports.escapeAtTags = true;


### PR DESCRIPTION
## Description

This PR removes the `escapeAtTags` compiler option and partially merges it in with the existing `ignoreUnrecognizedTags` option. It only ever made sense to use these in conjunction and previously it would just hard error if you used `@tags` within a custom tag which you were allowing to pass through (likely for shallow rendering purposes).

With this change, if a tag is allowed through the compiler without finding a match and it has `@tags`, these `@tags` are now automatically allowed to pass through as html tags.

This fixes an issue seen in [marko-tester](https://github.com/oxala/marko-tester) where all `@tags` were ignored blindly which broke the new syntax for the core `await` tag.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
