### PR TITLE
Register components before mounting

### DIFF
--- a/src/runtime/components/init-components-browser.js
+++ b/src/runtime/components/init-components-browser.js
@@ -179,9 +179,6 @@ function initComponent(componentDef, doc) {
     component.___document = doc;
 
     var isExisting = componentDef.___isExisting;
-    var id = component.id;
-
-    componentLookup[id] = component;
 
     if (isExisting) {
         component.___removeDOMEventListeners();
@@ -238,8 +235,17 @@ function initClientRendered(componentDefs, doc) {
     eventDelegation.___init(doc);
 
     doc = doc || defaultDocument;
-    for (var i = componentDefs.length - 1; i >= 0; i--) {
-        var componentDef = componentDefs[i];
+    var len = componentDefs.length;
+    var componentDef;
+    var i;
+
+    for (i = len; i--; ) {
+        componentDef = componentDefs[i];
+        trackComponent(componentDef);
+    }
+
+    for (i = len; i--; ) {
+        componentDef = componentDefs[i];
         initComponent(componentDef, doc);
     }
 }
@@ -322,6 +328,8 @@ function initServerRendered(renderedComponents, doc) {
 }
 
 function hydrateComponentAndGetMount(componentDef, doc) {
+    trackComponent(componentDef);
+
     var componentId = componentDef.id;
     var component = componentDef.___component;
     var rootNode = serverComponentRootNodes[componentId];
@@ -348,6 +356,13 @@ function hydrateComponentAndGetMount(componentDef, doc) {
         return function mount() {
             initComponent(componentDef, doc);
         };
+    }
+}
+
+function trackComponent(componentDef) {
+    var component = componentDef.___component;
+    if (component) {
+        componentLookup[component.id] = component;
     }
 }
 

--- a/src/runtime/components/init-components-browser.js
+++ b/src/runtime/components/init-components-browser.js
@@ -328,8 +328,6 @@ function initServerRendered(renderedComponents, doc) {
 }
 
 function hydrateComponentAndGetMount(componentDef, doc) {
-    trackComponent(componentDef);
-
     var componentId = componentDef.id;
     var component = componentDef.___component;
     var rootNode = serverComponentRootNodes[componentId];
@@ -348,9 +346,12 @@ function hydrateComponentAndGetMount(componentDef, doc) {
         if (componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER) {
             component.___document = doc;
             renderResult = component.___rerender(component.___input, true);
+            trackComponent(componentDef);
             return function mount() {
                 renderResult.afterInsert(doc);
             };
+        } else {
+            trackComponent(componentDef);
         }
 
         return function mount() {

--- a/test/components-browser/fixtures/emit-event-during-mount/components/custom-tag/index.marko
+++ b/test/components-browser/fixtures/emit-event-during-mount/components/custom-tag/index.marko
@@ -1,0 +1,7 @@
+class {
+  onMount() {
+    this.emit("custom-event", { hello: "world" });
+  }
+}
+
+<div/>

--- a/test/components-browser/fixtures/emit-event-during-mount/index.marko
+++ b/test/components-browser/fixtures/emit-event-during-mount/index.marko
@@ -1,0 +1,7 @@
+class {
+    handleCustomEvent(data) {
+        this.receivedData = data;
+    }
+}
+
+<custom-tag on-custom-event("handleCustomEvent")/>

--- a/test/components-browser/fixtures/emit-event-during-mount/test.js
+++ b/test/components-browser/fixtures/emit-event-during-mount/test.js
@@ -1,0 +1,6 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"));
+    expect(component.receivedData).to.eql({ hello: "world" });
+};


### PR DESCRIPTION
## Description

Currently components are registered into the global component lookup leaf nodes first during mount.
This PR changes it so that all components are registered before mounting. This allows for children to emit events to their parents during the mount phase.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
