### PR TITLE
Walk nested fragments for getEl

### DIFF
--- a/src/runtime/components/Component.js
+++ b/src/runtime/components/Component.js
@@ -36,6 +36,22 @@ function removeListener(removeEventListenerHandle) {
     removeEventListenerHandle();
 }
 
+function walkFragments(fragment) {
+    var node;
+
+    while (fragment) {
+        node = fragment.firstChild;
+
+        if (!node) {
+            break;
+        }
+
+        fragment = node.fragment;
+    }
+
+    return node;
+}
+
 function handleCustomEventWithMethodListener(
     component,
     targetMethodName,
@@ -239,7 +255,8 @@ Component.prototype = componentProto = {
                             "Accessing the elements of a child component using 'component.getEl' is deprecated."
                         );
                     }
-                    return keyedComponent.___rootNode.firstChild;
+
+                    return walkFragments(keyedComponent.___rootNode);
                 }
             }
 
@@ -594,7 +611,8 @@ Component.prototype = componentProto = {
                 'The "this.el" attribute is deprecated. Please use "this.getEl(key)" instead.'
             );
         }
-        return this.___rootNode && this.___rootNode.firstChild;
+
+        return walkFragments(this.___rootNode);
     },
 
     get els() {

--- a/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/components/child/index.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/components/child/index.marko
@@ -1,0 +1,1 @@
+<nested-child/>

--- a/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/components/nested-child/index.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/components/nested-child/index.marko
@@ -1,0 +1,1 @@
+<div data-id="nested-child"/>

--- a/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/template.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/template.marko
@@ -1,0 +1,3 @@
+class {}
+
+<child key="child"/>

--- a/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/test.js
+++ b/test/components-browser/fixtures-deprecated/get-el-component-key-nested-fragments/test.js
@@ -1,0 +1,8 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./template.marko"));
+    var el = component.getEl("child");
+    expect(el).to.have.property("tagName", "DIV");
+    expect(el.getAttribute("data-id")).to.equal("nested-child");
+};

--- a/test/components-browser/fixtures-deprecated/get-el-nested-fragments/components/child/index.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-fragments/components/child/index.marko
@@ -1,0 +1,1 @@
+<nested-child/>

--- a/test/components-browser/fixtures-deprecated/get-el-nested-fragments/components/nested-child/index.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-fragments/components/nested-child/index.marko
@@ -1,0 +1,1 @@
+<div data-id="nested-child"/>

--- a/test/components-browser/fixtures-deprecated/get-el-nested-fragments/template.marko
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-fragments/template.marko
@@ -1,0 +1,3 @@
+class {}
+
+<child/>

--- a/test/components-browser/fixtures-deprecated/get-el-nested-fragments/test.js
+++ b/test/components-browser/fixtures-deprecated/get-el-nested-fragments/test.js
@@ -1,0 +1,8 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./template.marko"));
+    var el = component.el;
+    expect(el).to.have.property("tagName", "DIV");
+    expect(el.getAttribute("data-id")).to.equal("nested-child");
+};


### PR DESCRIPTION
## Description

This fixes a regression where `getEl` (or `el`) can possible return a fragment marker when nested fragments are present. With this PR these methods now walk the fragments until finding a normal dom node or undefined.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
