### PR TITLE
Fix regression with namespace inside of a fragment

### DIFF
--- a/src/runtime/vdom/morphdom/fragment.js
+++ b/src/runtime/vdom/morphdom/fragment.js
@@ -15,6 +15,9 @@ var fragmentPrototype = {
         var parentNode = this.startNode.parentNode;
         return parentNode === this.detachedContainer ? undefined : parentNode;
     },
+    get namespaceURI() {
+        return this.startNode.parentNode.namespaceURI;
+    },
     get nextSibling() {
         return this.endNode.nextSibling;
     },

--- a/test/components-browser/fixtures/nested-fragment-namespace/index.marko
+++ b/test/components-browser/fixtures/nested-fragment-namespace/index.marko
@@ -1,0 +1,11 @@
+class {}
+
+<macro name="nested">
+    <title>Test</title>
+</macro>
+
+<div key="root">
+    <svg>
+        <nested/>
+    </svg>
+</div>

--- a/test/components-browser/fixtures/nested-fragment-namespace/test.js
+++ b/test/components-browser/fixtures/nested-fragment-namespace/test.js
@@ -1,0 +1,11 @@
+var expect = require("chai").expect;
+var svgNS = "http://www.w3.org/2000/svg";
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"));
+    var root = component.getEl("root");
+    var svgEl = root.firstChild;
+    expect(svgEl.namespaceURI).to.equal(svgNS);
+    expect(svgEl.firstElementChild.tagName).to.equal("title");
+    expect(svgEl.firstElementChild.namespaceURI).to.equal(svgNS);
+};


### PR DESCRIPTION
## Description
A regression was introduced in 4.17 that caused the parent namespaceURI to be missing when the node is inside of a fragment.

This PR adds a namespaceURI property to these fragments which forwards the namespace from the actual parent node.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.