### PR TITLE
Fix issue when using getEls with repeated id in a split component

### DIFF
--- a/src/core-tags/components/helpers/markoKeyAttr.js
+++ b/src/core-tags/components/helpers/markoKeyAttr.js
@@ -4,6 +4,6 @@ var FLAG_WILL_RERENDER_IN_BROWSER = 1;
 
 module.exports = function markoKeyAttr(key, componentDef) {
     if ((componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER) === 0) {
-        return key + " " + componentDef.id;
+        return componentDef.___nextKey(key) + " " + componentDef.id;
     }
 };

--- a/test/components-pages/fixtures/getEl-split/components/split-component/index.marko
+++ b/test/components-pages/fixtures/getEl-split/components/split-component/index.marko
@@ -1,3 +1,9 @@
 <div.split-component>
     <button key="button">Click me</button>
+
+    <ul>
+        <for|i| from=1 to=3>
+            <li key="li[]">${i}</li>
+        </for>
+    </ul>
 </div>

--- a/test/components-pages/fixtures/getEl-split/tests.js
+++ b/test/components-pages/fixtures/getEl-split/tests.js
@@ -6,5 +6,12 @@ describe(path.basename(__dirname), function() {
         var splitComponent = window.splitComponent;
         expect(splitComponent.getEl("button") != null).to.equal(true);
         expect(splitComponent.getEl("button").nodeName).to.equal("BUTTON");
+
+        expect(splitComponent.getEls("li").length).to.equal(3);
+        expect(splitComponent.getEls("li").map(el => el.textContent)).to.eql([
+            "1",
+            "2",
+            "3"
+        ]);
     });
 });


### PR DESCRIPTION
## Description
Currently split components with keys that are `repeated[]` do not get properly put into the keyed elements lookup. This PR ensures that the keys are handled the same way as repeated keys on the client.

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
