### PR TITLE
Fix and deprecate passing a non string key

### DIFF
--- a/src/runtime/components/ComponentDef.js
+++ b/src/runtime/components/ComponentDef.js
@@ -1,4 +1,5 @@
 "use strict";
+var complain = "MARKO_DEBUG" && require("complain");
 var componentUtil = require("./util");
 var attachBubblingEvent = componentUtil.___attachBubblingEvent;
 var addDelegatedEventHandler = require("./event-delegation")
@@ -50,17 +51,23 @@ ComponentDef.prototype = {
 
     /**
      * This helper method generates a unique and fully qualified DOM element ID
-     * that is unique within the scope of the current component. This method prefixes
-     * the the nestedId with the ID of the current component. If nestedId ends
-     * with `[]` then it is treated as a repeated ID and we will generate
-     * an ID with the current index for the current nestedId.
-     * (e.g. "myParentId-foo[0]", "myParentId-foo[1]", etc.)
+     * that is unique within the scope of the current component.
      */
     elId: function(nestedId) {
         var id = this.id;
+
         if (nestedId == null) {
             return id;
         } else {
+            if (typeof nestedId !== "string") {
+                // eslint-disable-next-line no-constant-condition
+                if ("MARKO_DEBUG") {
+                    complain("Using non strings as keys is deprecated.");
+                }
+
+                nestedId = String(nestedId);
+            }
+
             if (nestedId.indexOf("#") === 0) {
                 id = "#" + id;
                 nestedId = nestedId.substring(1);

--- a/src/runtime/components/ServerComponent.js
+++ b/src/runtime/components/ServerComponent.js
@@ -1,4 +1,5 @@
 "use strict";
+var complain = "MARKO_DEBUG" && require("complain");
 
 class ServerComponent {
     constructor(id, input, out, typeName, customEvents, scope) {
@@ -53,16 +54,28 @@ class ServerComponent {
         return this.___state;
     }
 
-    elId(scopedId, index) {
+    elId(nestedId) {
         var id = this.id;
 
-        var elId = scopedId != null ? id + "-" + scopedId : id;
+        if (nestedId == null) {
+            return id;
+        } else {
+            if (typeof nestedId !== "string") {
+                // eslint-disable-next-line no-constant-condition
+                if ("MARKO_DEBUG") {
+                    complain("Using non strings as keys is deprecated.");
+                }
 
-        if (index != null) {
-            elId += "[" + index + "]";
+                nestedId = String(nestedId);
+            }
+
+            if (nestedId.indexOf("#") === 0) {
+                id = "#" + id;
+                nestedId = nestedId.substring(1);
+            }
+
+            return id + "-" + nestedId;
         }
-
-        return elId;
     }
 }
 

--- a/test/components-browser/fixtures-deprecated/component-elId/index.marko
+++ b/test/components-browser/fixtures-deprecated/component-elId/index.marko
@@ -1,0 +1,2 @@
+class {}
+<div key="root" data-id:scoped=1/>

--- a/test/components-browser/fixtures-deprecated/component-elId/test.js
+++ b/test/components-browser/fixtures-deprecated/component-elId/test.js
@@ -1,0 +1,7 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var root = component.getEl("root");
+    expect(root.dataset.id).to.include("-1");
+};


### PR DESCRIPTION
## Description
Fixes a regression from https://github.com/marko-js/marko/pull/1172 which broke passing non strings as keys. This PR now casts these keys to a string and logs a deprecation warning.

`.elId`'s server implementation was also missed here and so the implementation was copied there. In doing that it looks like previously `.elId(key, index)` was once supported but is not consistent with the client side implementation. This should probably be addressed in a separate PR.

Fixes #1342

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
