### PR TITLE
Improve for loop auto keying

### DIFF
--- a/src/core-tags/components/TransformHelper/index.js
+++ b/src/core-tags/components/TransformHelper/index.js
@@ -54,13 +54,17 @@ class TransformHelper {
         );
     }
 
-    nextUniqueId() {
-        var componentNextElId = this.context.data.componentNextElId;
+    nextUniqueId(name) {
+        name = name || "";
+        var lookup = `_${name}UniqueIdCounter`;
+        var componentNextElId = this.context.data[lookup];
         if (componentNextElId == null) {
-            this.context.data.componentNextElId = 0;
+            this.context.data[lookup] = 0;
         }
 
-        return this.context.data.componentNextElId++;
+        var id = this.context.data[lookup]++;
+
+        return name ? `$${name}$${id}` : `${id}`;
     }
 
     serializeKey() {

--- a/test/compiler/fixtures-html-deprecated/at-tags-dynamic/expected.js
+++ b/test/compiler/fixtures-html-deprecated/at-tags-dynamic/expected.js
@@ -20,10 +20,10 @@ function render(input, out, __component, component, state) {
 
   hello_tag(marko_mergeNestedTagsHelper({
       renderBody: function renderBody(out, hello0) {
-        var for__1 = 0;
+        var $for$0 = 0;
 
         marko_forEach(input.colors, function(color) {
-          var keyscope__2 = "[" + ((for__1++) + "]");
+          var $keyScope$0 = "[" + (($for$0++) + "]");
 
           hello_foo_nested_tag({
               renderBody: function renderBody(out) {

--- a/test/compiler/fixtures-html-deprecated/macros/expected.js
+++ b/test/compiler/fixtures-html-deprecated/macros/expected.js
@@ -23,16 +23,16 @@ function render(input, out, __component, component, state) {
     if (node.children) {
       out.w("<ul>");
 
-      var for__1 = 0;
+      var $for$0 = 0;
 
       marko_forEach(node.children, function(child) {
-        var keyscope__2 = "[" + ((for__1++) + "]");
+        var $keyScope$0 = "[" + (($for$0++) + "]");
 
         out.w("<li>");
 
         marko_dynamicTag(out, macro_renderTree, {
             node: child
-          }, null, null, __component, "4" + keyscope__2);
+          }, null, null, __component, "2" + $keyScope$0);
 
         out.w("</li>");
       });
@@ -43,7 +43,7 @@ function render(input, out, __component, component, state) {
 
   marko_dynamicTag(out, macro_renderTree, {
       node: input.node
-    }, null, null, __component, "5");
+    }, null, null, __component, "3");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
+++ b/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
@@ -52,22 +52,22 @@ function render(input, out, __component, component, state) {
     marko_dynamicTag(out, render, {}, null, null, __component, "12");
   }
 
-  var for__13 = 0;
+  var $for$0 = 0;
 
   marko_forRange(0, 9, null, function(i) {
-    var keyscope__14 = "[" + ((for__13++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
-    marko_dynamicTag(out, input.items[i], {}, null, null, __component, "15" + keyscope__14);
+    marko_dynamicTag(out, input.items[i], {}, null, null, __component, "13" + $keyScope$0);
   });
 
   let i = 10;
 
   while (i--) {
-    marko_dynamicTag(out, input, {}, null, null, __component, "16");
+    marko_dynamicTag(out, input, {}, null, null, __component, "14");
   }
 
   if (z) {
-    marko_dynamicTag(out, renderD, {}, null, null, __component, "17");
+    marko_dynamicTag(out, renderD, {}, null, null, __component, "15");
   }
 
   // if.test

--- a/test/compiler/fixtures-html-deprecated/simple/expected.js
+++ b/test/compiler/fixtures-html-deprecated/simple/expected.js
@@ -19,10 +19,10 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.w("<ul>");
 
-    var for__1 = 0;
+    var $for$0 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var $keyScope$0 = "[" + (($for$0++) + "]");
 
       out.w("<li>" +
         marko_escapeXml(color) +
@@ -37,10 +37,10 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.w("<ul>");
 
-    var for__6 = 0;
+    var $for$1 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__7 = "[" + ((for__6++) + "]");
+      var $keyScope$1 = "[" + (($for$1++) + "]");
 
       out.w("<li>" +
         marko_escapeXml(color) +

--- a/test/compiler/fixtures-html/at-tags-dynamic/expected.js
+++ b/test/compiler/fixtures-html/at-tags-dynamic/expected.js
@@ -20,10 +20,10 @@ function render(input, out, __component, component, state) {
 
   hello_tag(marko_mergeNestedTagsHelper({
       renderBody: function renderBody(out, hello0) {
-        var for__1 = 0;
+        var $for$0 = 0;
 
         marko_forEach(input.colors, function(color) {
-          var keyscope__2 = "[" + ((for__1++) + "]");
+          var $keyScope$0 = "[" + (($for$0++) + "]");
 
           hello_foo_nested_tag({
               renderBody: function renderBody(out) {

--- a/test/compiler/fixtures-html/macros/expected.js
+++ b/test/compiler/fixtures-html/macros/expected.js
@@ -23,16 +23,16 @@ function render(input, out, __component, component, state) {
     if (node.children) {
       out.w("<ul>");
 
-      var for__1 = 0;
+      var $for$0 = 0;
 
       marko_forEach(node.children, function(child) {
-        var keyscope__2 = "[" + ((for__1++) + "]");
+        var $keyScope$0 = "[" + (($for$0++) + "]");
 
         out.w("<li>");
 
         marko_dynamicTag(out, macro_renderTree, {
             node: child
-          }, null, null, __component, "4" + keyscope__2);
+          }, null, null, __component, "2" + $keyScope$0);
 
         out.w("</li>");
       });
@@ -43,7 +43,7 @@ function render(input, out, __component, component, state) {
 
   marko_dynamicTag(out, macro_renderTree, {
       node: input.node
-    }, null, null, __component, "5");
+    }, null, null, __component, "3");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-html/simple/expected.js
+++ b/test/compiler/fixtures-html/simple/expected.js
@@ -19,10 +19,10 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.w("<ul>");
 
-    var for__1 = 0;
+    var $for$0 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var $keyScope$0 = "[" + (($for$0++) + "]");
 
       out.w("<li>" +
         marko_escapeXml(color) +
@@ -37,10 +37,10 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.w("<ul>");
 
-    var for__6 = 0;
+    var $for$1 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__7 = "[" + ((for__6++) + "]");
+      var $keyScope$1 = "[" + (($for$1++) + "]");
 
       out.w("<li>" +
         marko_escapeXml(color) +

--- a/test/compiler/fixtures-vdom-deprecated/control-flow/expected.js
+++ b/test/compiler/fixtures-vdom-deprecated/control-flow/expected.js
@@ -13,11 +13,11 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
     marko_createElement = marko_helpers.e,
     marko_const = marko_helpers.const,
     marko_const_nextId = marko_const("295cea"),
-    marko_node0 = marko_createElement("div", null, "4", null, 1, 0, {
+    marko_node0 = marko_createElement("div", null, "2", null, 1, 0, {
         i: marko_const_nextId()
       })
       .t("No colors!"),
-    marko_node1 = marko_createElement("div", null, "9", null, 1, 0, {
+    marko_node1 = marko_createElement("div", null, "5", null, 1, 0, {
         i: marko_const_nextId()
       })
       .t("No colors!");
@@ -34,12 +34,12 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.be("ul", null, "0", component);
 
-    var for__1 = 0;
+    var $for$0 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var $keyScope$0 = "[" + (($for$0++) + "]");
 
-      out.e("li", null, "3" + keyscope__2, component, 1)
+      out.e("li", null, "1" + $keyScope$0, component, 1)
         .t(color);
     });
 
@@ -49,14 +49,14 @@ function render(input, out, __component, component, state) {
   }
 
   if (input.colors.length) {
-    out.be("ul", null, "5", component);
+    out.be("ul", null, "3", component);
 
-    var for__6 = 0;
+    var $for$1 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__7 = "[" + ((for__6++) + "]");
+      var $keyScope$1 = "[" + (($for$1++) + "]");
 
-      out.e("li", null, "8" + keyscope__7, component, 1)
+      out.e("li", null, "4" + $keyScope$1, component, 1)
         .t(color);
     });
 

--- a/test/compiler/fixtures-vdom/macro-in-loop/expected.js
+++ b/test/compiler/fixtures-vdom/macro-in-loop/expected.js
@@ -16,12 +16,12 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
 function render(input, out, __component, component, state) {
   var data = input;
 
-  var for__0 = 0;
+  var $for$0 = 0;
 
   marko_forRange(0, 10, null, function(i) {
-    var keyscope__1 = "[" + ((for__0++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
-    out.e("div", null, "2" + keyscope__1, component, 1)
+    out.e("div", null, "0" + $keyScope$0, component, 1)
       .t(i);
 
     function macro_renderTree(out, node) {
@@ -32,16 +32,16 @@ function render(input, out, __component, component, state) {
       out.t(" Children: ");
 
       if (node.children) {
-        out.be("ul", null, "3", component);
+        out.be("ul", null, "1", component);
 
-        var for__4 = 0;
+        var $for$1 = 0;
 
         marko_forEach(node.children, function(child) {
-          var keyscope__5 = "[" + ((for__4++) + "]");
+          var $keyScope$1 = "[" + (($for$1++) + "]");
 
-          out.be("li", null, "6" + keyscope__5, component);
+          out.be("li", null, "2" + $keyScope$1, component);
 
-          marko_dynamicTag(out, macro_renderTree, child, null, null, __component, "7" + keyscope__5);
+          marko_dynamicTag(out, macro_renderTree, child, null, null, __component, "3" + $keyScope$1);
 
           out.ee();
         });
@@ -50,7 +50,7 @@ function render(input, out, __component, component, state) {
       }
     }
 
-    marko_dynamicTag(out, macro_renderTree, input.nodes[i], null, null, __component, "8" + keyscope__1);
+    marko_dynamicTag(out, macro_renderTree, input.nodes[i], null, null, __component, "4" + $keyScope$0);
   });
 }
 

--- a/test/compiler/fixtures-vdom/simple/expected.js
+++ b/test/compiler/fixtures-vdom/simple/expected.js
@@ -13,7 +13,7 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
     marko_createElement = marko_helpers.e,
     marko_const = marko_helpers.const,
     marko_const_nextId = marko_const("511e93"),
-    marko_node0 = marko_createElement("div", null, "4", null, 1, 0, {
+    marko_node0 = marko_createElement("div", null, "2", null, 1, 0, {
         i: marko_const_nextId()
       })
       .t("No colors!");
@@ -30,12 +30,12 @@ function render(input, out, __component, component, state) {
   if (input.colors.length) {
     out.be("ul", null, "0", component);
 
-    var for__1 = 0;
+    var $for$0 = 0;
 
     marko_forEach(input.colors, function(color) {
-      var keyscope__2 = "[" + ((for__1++) + "]");
+      var $keyScope$0 = "[" + (($for$0++) + "]");
 
-      out.e("li", null, "3" + keyscope__2, component, 1)
+      out.e("li", null, "1" + $keyScope$0, component, 1)
         .t(color);
     });
 

--- a/test/components-browser/fixtures/for-first-el-key-cache-value/index.marko
+++ b/test/components-browser/fixtures/for-first-el-key-cache-value/index.marko
@@ -1,0 +1,35 @@
+class  {
+    onCreate() {
+        this.callCount = 0;
+        this.state = {
+            list: [{
+                id: "foo",
+                text: "Foo Text"
+            }, {
+                id: "bar",
+                text: "Bar Text"
+            }]
+        }
+    }
+
+    calcKey(id) {
+        this.callCount++;
+        return `${id}`;
+    }
+
+    swap() {
+        const [a, b] = this.state.list;
+        this.state.list = [b, a];
+    }
+}
+
+<div.root>
+    <for|item| of=state.list>
+        <div key=component.calcKey(item.id)>
+            ${item.text}
+        </div>
+        <div>
+            Non Keyed ${item.text}
+        </div>
+    </for>
+</div>

--- a/test/components-browser/fixtures/for-first-el-key-cache-value/test.js
+++ b/test/components-browser/fixtures/for-first-el-key-cache-value/test.js
@@ -1,0 +1,27 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+
+    expect(component.callCount).to.equal(2);
+
+    var fooEl = component.getEl("foo");
+    var fooNextSibling = fooEl.nextElementSibling;
+    var barEl = component.getEl("bar");
+    var barNextSibling = barEl.nextElementSibling;
+
+    expect(fooNextSibling.nextElementSibling).to.equal(barEl);
+
+    component.swap();
+    component.update();
+
+    expect(component.callCount).to.equal(4);
+
+    expect(
+        component.getEl("bar").nextElementSibling.nextElementSibling
+    ).to.equal(component.getEl("foo"));
+    expect(component.getEl("foo")).to.equal(fooEl);
+    expect(component.getEl("foo").nextElementSibling).to.equal(fooNextSibling);
+    expect(component.getEl("bar")).to.equal(barEl);
+    expect(component.getEl("bar").nextElementSibling).to.equal(barNextSibling);
+};

--- a/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
@@ -20,10 +20,10 @@ function render(input, out, __component, component, state) {
 
   out.w("<div><span>A</span><ul>");
 
-  var for__2 = 0;
+  var $for$0 = 0;
 
   marko_forEach(colors, function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
     out.w("<li>" +
       marko_escapeXml(color) +
@@ -32,13 +32,13 @@ function render(input, out, __component, component, state) {
 
   out.w("</ul>");
 
-  var __key5 = __component.___nextKey("@preservedP");
+  var $key$0 = __component.___nextKey("@preservedP");
 
   out.w("<p>");
 
   _preserve_tag({
       bodyOnly: true,
-      key: __key5,
+      key: $key$0,
       renderBody: function renderBody(out) {
         out.w(marko_escapeXml(Date.now()));
       }
@@ -46,7 +46,7 @@ function render(input, out, __component, component, state) {
 
   out.w("</p></div><span>B</span>");
 
-  marko_dynamicTag(out, Foo, {}, null, null, __component, "7");
+  marko_dynamicTag(out, Foo, {}, null, null, __component, "4");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/components-compilation/fixtures-html-deprecated/macro-component/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/macro-component/expected.js
@@ -24,18 +24,18 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>");
 
-  var for__2 = 0;
+  var $for$0 = 0;
 
   marko_forEach([
       "red",
       "green",
       "blue"
     ], function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
     marko_dynamicTag(out, macro_renderButton, {
         color: color
-      }, null, null, __component, "4" + keyscope__3);
+      }, null, null, __component, "2" + $keyScope$0);
   });
 
   out.w("</div>");

--- a/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -20,10 +20,10 @@ function render(input, out, __component, component, state) {
 
   out.w("<div><span>A</span><ul>");
 
-  var for__2 = 0;
+  var $for$0 = 0;
 
   marko_forEach(colors, function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
     out.w("<li>" +
       marko_escapeXml(color) +
@@ -32,13 +32,13 @@ function render(input, out, __component, component, state) {
 
   out.w("</ul>");
 
-  var __key5 = __component.___nextKey("@preservedP");
+  var $key$0 = __component.___nextKey("@preservedP");
 
   out.w("<p>");
 
   _preserve_tag({
       bodyOnly: true,
-      key: __key5,
+      key: $key$0,
       renderBody: function renderBody(out) {
         out.w(marko_escapeXml(Date.now()));
       }
@@ -46,7 +46,7 @@ function render(input, out, __component, component, state) {
 
   out.w("</p></div><span>B</span>");
 
-  marko_dynamicTag(out, Foo, {}, null, null, __component, "7");
+  marko_dynamicTag(out, Foo, {}, null, null, __component, "4");
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/components-compilation/fixtures-html/macro-widget/expected.js
+++ b/test/components-compilation/fixtures-html/macro-widget/expected.js
@@ -24,18 +24,18 @@ function render(input, out, __component, component, state) {
 
   out.w("<div>");
 
-  var for__2 = 0;
+  var $for$0 = 0;
 
   marko_forEach([
       "red",
       "green",
       "blue"
     ], function(color) {
-    var keyscope__3 = "[" + ((for__2++) + "]");
+    var $keyScope$0 = "[" + (($for$0++) + "]");
 
     marko_dynamicTag(out, macro_renderButton, {
         color: color
-      }, null, null, __component, "4" + keyscope__3);
+      }, null, null, __component, "2" + $keyScope$0);
   });
 
   out.w("</div>");

--- a/test/render/fixtures/for-tag-block-scoped-key/expected.html
+++ b/test/render/fixtures/for-tag-block-scoped-key/expected.html
@@ -1,0 +1,1 @@
+<div><div>red</div><div>green</div><div>blue</div></div>

--- a/test/render/fixtures/for-tag-block-scoped-key/template.marko
+++ b/test/render/fixtures/for-tag-block-scoped-key/template.marko
@@ -1,0 +1,8 @@
+<div>
+    <for|item| of=["red", "green", "blue"]>
+        $ const id = item.length;
+        <div key=id>
+            ${item}
+        </div>
+    </for>
+</div>

--- a/test/render/fixtures/for-tag-block-scoped-key/test.js
+++ b/test/render/fixtures/for-tag-block-scoped-key/test.js
@@ -1,0 +1,2 @@
+exports.templateData = {};
+exports.skip_vdom = "keyed elements are not supported in server-rendered vdom";


### PR DESCRIPTION
## Description

Fixes a couple of issues regarding for loop auto keying/scoping.

1. Use a unique index for each variable declared (previously was shared with node key indexes).
2. Move key scope var to be just before elements, allowing for key to be defined within the loop (fixes #1345).
3. Ensure that only keys on the first found element are used instead of the first element with keys (prevents issues similar to 2).
4. Cache key into a variable to ensure it is only evaluated once.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.