### PR TITLE
Fix issue with setting textarea value to false

### DIFF
--- a/src/runtime/vdom/VElement.js
+++ b/src/runtime/vdom/VElement.js
@@ -216,7 +216,7 @@ defineProperty(proto, "___value", {
         if (value == null) {
             value = this.___attributes.value;
         }
-        return value != null
+        return value != null && value !== false
             ? toString(value)
             : this.___attributes.type === "checkbox" ||
               this.___attributes.type === "radio"

--- a/test/components-browser/fixtures/textarea-value-attribute/index.marko
+++ b/test/components-browser/fixtures/textarea-value-attribute/index.marko
@@ -1,0 +1,9 @@
+class {
+    onCreate() {
+        this.state = {
+            value: "Hello"
+        }
+    }
+}
+
+<textarea key="textarea" value=state.value/>

--- a/test/components-browser/fixtures/textarea-value-attribute/test.js
+++ b/test/components-browser/fixtures/textarea-value-attribute/test.js
@@ -1,0 +1,33 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index.marko"));
+    var textarea = component.getEl("textarea");
+
+    expect(textarea.value).to.equal("Hello");
+
+    component.state.value = "World";
+    component.update();
+
+    expect(textarea.value).to.equal("World");
+
+    component.state.value = false;
+    component.update();
+
+    expect(textarea.value).to.equal("");
+
+    component.state.value = undefined;
+    component.update();
+
+    expect(textarea.value).to.equal("");
+
+    component.state.value = null;
+    component.update();
+
+    expect(textarea.value).to.equal("");
+
+    component.state.value = 0;
+    component.update();
+
+    expect(textarea.value).to.equal("0");
+};


### PR DESCRIPTION
## Description

Currently, unlike other attributes, setting `<textarea value=false` will cause a the string `false` to be set as the textarea value (only in the client side).

This PR fixes that to ensure that `false` value is ignored just like other attributes.

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.