### PR TITLE
docs: add lasso configuration description to installing.md

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -178,6 +178,25 @@ First install `lasso` and `lasso-marko`:
 npm install --save lasso lasso-marko @lasso/marko-taglib
 ```
 
+Next, register and config the lasso:
+
+_server.js_
+
+```
+var isProduction = process.env.NODE_ENV === 'production';
+
+// Configure lasso to control how JS/CSS/etc. is delivered to the browser
+require('lasso').configure({
+    plugins: [
+        'lasso-marko' // Allow Marko templates to be compiled and transported to the browser
+    ],
+    outputDir: __dirname + '/static', // Place all generated JS/CSS/etc. files into the "static" dir
+    bundlingEnabled: isProduction, // Only enable bundling in production
+    minify: isProduction, // Only minify JS and CSS code in production
+    fingerprintsEnabled: isProduction, // Only add fingerprints to URLs in production
+});
+```
+
 Next, in your page or layout view, add the `lasso-head` and `lasso-body` tags:
 
 _layout.marko_
@@ -198,8 +217,23 @@ _layout.marko_
 
 Finally, configure your server to serve the static files that `lasso` generates:
 
+If you're using `express`, just do:
+
 _server.js_
 
 ```js
 app.use(require("lasso/middleware").serveStatic());
 ```
+
+And if `koa`, do:
+
+_server.js_
+
+```
+const mount = require('koa-mount');
+const serve = require('koa-static');
+
+app.use(mount('/static', serve(__dirname + '/static')));
+```
+
+For the full application code for the Koa and assets bundling, please see the sample: [Marko + Koa](https://github.com/marko-js-samples/marko-koa).


### PR DESCRIPTION
Add lasso configuration description for "Initializing server-rendered components", let it clearly to read and more easy in practice.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
- add lasso configuration description for "Initializing server-rendered components", let it clearly to read and more easy in practice.
- add koa static binding to docs.

<!--- Why is this change required? What problem does it solve? -->
When I get started, I found:

- the page I created is rendering in browser without a correct style sheet.
- I have never hear about `lasso`, I didn't known it must config lasso first.
- I get a lot of error when using `app.use(require("lasso/middleware").serveStatic());`,
`app.use(require("lasso/middleware/koa/serveStatic"));` when I run on a Koa server.

This issues waste my half a day.

I finally find a solution, so I update the docs, to let others' time to be save.

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

This is just a document, so nothing about tests.
