### PR TITLE
Remove empty layout-put tags

### DIFF
--- a/src/core-tags/migrate/layout-put-tag.js
+++ b/src/core-tags/migrate/layout-put-tag.js
@@ -29,5 +29,11 @@ module.exports = function migrator(oldNode, context) {
     }
 
     oldNode.moveChildrenTo(newNode);
-    oldNode.replaceWith(newNode);
+    newNode._normalizeChildTextNodes(context, true, true);
+
+    if (newNode.childCount) {
+        oldNode.replaceWith(newNode);
+    } else {
+        oldNode.detach();
+    }
 };

--- a/test/migrate/fixtures/layout-put/template.marko
+++ b/test/migrate/fixtures/layout-put/template.marko
@@ -1,2 +1,9 @@
 <layout-put into="body">BODY CONTENT</layout-put>
 <layout-put into="footer" value="FOOTER CONTENT"></layout-put>
+
+<layout-put into="example-empty1" value=""/>
+<layout-put into="example-empty2"></layout-put>
+<layout-put into="example-empty3">
+
+</layout-put>
+<layout-put into="example-empty4"/>


### PR DESCRIPTION
## Description
Currently empty layout-put tags get migrated to an empty `@tag` which intern becomes an empty object.

In Marko 3 empty `layout-put`'s are effectively ignored at runtime and so a more compatible migration is to simply remove them.

Currently this can cause issues when it is migrated to a dynamic tag where an empty object (without a renderBody) is passed in because of the empty `layout-put` (causing a runtime error).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.