### PR TITLE
Fix regression with body-only-if and control flow attribute

### DIFF
--- a/src/core-tags/migrate/all-tags/index.js
+++ b/src/core-tags/migrate/all-tags/index.js
@@ -1,6 +1,6 @@
 const commonMigrators = [
-    require("./body-only-if"),
     require("./control-flow-directives"),
+    require("./body-only-if"),
     require("./dynamic-attributes"),
     require("./include-directive"),
     require("./legacy-nested-tag"),

--- a/test/migrate/fixtures/body-only-if/snapshot-expected.marko
+++ b/test/migrate/fixtures/body-only-if/snapshot-expected.marko
@@ -2,4 +2,7 @@
 
 <div>
     <${input.test ? null : "span"}>Blah</>
+    <if(input.shouldShow)>
+        <${input.test ? null : "span"}>Blah</>
+    </if>
 </div>

--- a/test/migrate/fixtures/body-only-if/template.marko
+++ b/test/migrate/fixtures/body-only-if/template.marko
@@ -2,4 +2,8 @@
     <span body-only-if(input.test)>
         Blah
     </span>
+
+    <span if(input.shouldShow) body-only-if(input.test)>
+        Blah
+    </span>
 </div>


### PR DESCRIPTION
## Description
Fixes a regression where a tag with `body-only-if` and a legacy control flow attribute, eg: `<div body-only-if(...) if(...)>` would not migrate properly.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.