### PR TITLE
Fix issue with removing children inside of fragments

### DIFF
--- a/src/runtime/vdom/morphdom/index.js
+++ b/src/runtime/vdom/morphdom/index.js
@@ -712,7 +712,10 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
         } else {
             // If curFromNodeChild is non-null then we still have some from nodes
             // left over that need to be removed
-            while (curFromNodeChild) {
+            var fragmentBoundary =
+                fromNode.nodeType === FRAGMENT_NODE ? fromNode.endNode : null;
+
+            while (curFromNodeChild && curFromNodeChild !== fragmentBoundary) {
                 fromNextSibling = nextSibling(curFromNodeChild);
 
                 if (

--- a/test/components-browser/fixtures/diffpatch-mismatch-remove-fragment/index.marko
+++ b/test/components-browser/fixtures/diffpatch-mismatch-remove-fragment/index.marko
@@ -1,0 +1,21 @@
+class  {
+    onCreate() {
+        this.state = { count: 0 };
+    }
+}
+
+<macro|input| name="fragment">
+    <${input}/>
+</macro>
+
+<div.root key="root">
+    <fragment>
+        <if(state.count === 0)>
+            <span>a</span>
+            <span>b</span>
+        </if>
+        <fragment>
+            <span>c</span>
+        </fragment>
+    </fragment>
+</div>

--- a/test/components-browser/fixtures/diffpatch-mismatch-remove-fragment/test.js
+++ b/test/components-browser/fixtures/diffpatch-mismatch-remove-fragment/test.js
@@ -1,0 +1,16 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var root = component.getEl("root");
+    expect(root.innerHTML).to.equal(
+        "<span>a</span><span>b</span><span>c</span>"
+    );
+
+    var cEl = root.firstElementChild.nextElementSibling.nextElementSibling;
+    component.state.count++;
+    component.update();
+
+    expect(root.innerHTML).to.equal("<span>c</span>");
+    expect(cEl).to.equal(root.firstElementChild);
+};


### PR DESCRIPTION
## Description

Currently when nodes are removed inside of a fragment (used by components, macros, and dynamic tag) it is possible for it to remove node's outside of the fragment if there is a next sibling fragment.

This PR checks that a fragment does not remove nodes outside of itself.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
