### PR TITLE
Fix issue with render call binding for dynamic tag migration

### DIFF
--- a/src/core-tags/migrate/util/renderCallToDynamicTag.js
+++ b/src/core-tags/migrate/util/renderCallToDynamicTag.js
@@ -46,7 +46,21 @@ module.exports = function renderCallToDynamicTag(ast, context) {
                 tagName = callee.object;
             } else {
                 tagName = builder.objectExpression({
-                    render: callee
+                    render:
+                        callee.object &&
+                        callee.object.type === "Identifier" &&
+                        (callee.object.name === "input" ||
+                            callee.object.name === "state" ||
+                            callee.object.name === "data")
+                            ? callee
+                            : builder.functionDeclaration(
+                                  null,
+                                  [
+                                      builder.identifier("_"),
+                                      builder.identifier("out")
+                                  ],
+                                  [ast]
+                              )
                 });
             }
         }

--- a/test/migrate/fixtures/invoke-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/invoke-tag/snapshot-expected.marko
@@ -5,3 +5,6 @@ $ console.log("y");
 <${renderBody}/>
 <${input.item}/>
 <${template} x=1/>
+<${function(out) {
+    input.barRenderer({}, true, out);
+}}/>

--- a/test/migrate/fixtures/invoke-tag/template.marko
+++ b/test/migrate/fixtures/invoke-tag/template.marko
@@ -3,3 +3,4 @@
 <invoke renderBody(out)/>
 <invoke input.item.renderBody(out)/>
 <invoke template.render({ x: 1 }, out)/>
+<invoke input.barRenderer({}, true, out)/>

--- a/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
+++ b/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
@@ -9,6 +9,17 @@
 <${{
     render: input.barRenderer
 }}/>
+<${{
+    render: state.barRenderer
+}}/>
+<${{
+    render: data.barRenderer
+}}/>
+<${{
+    render: function(_, out) {
+        x.barRenderer(null, out);
+    }
+}}/>
 <${function(out) {
     input.barRenderer({}, true, out);
 }}/>

--- a/test/migrate/fixtures/render-call-in-scriptlet/template.marko
+++ b/test/migrate/fixtures/render-call-in-scriptlet/template.marko
@@ -8,6 +8,9 @@ $ {
 $ input.template.render({ x: 1 }, out);
 $ input.template.renderer({ y() {} }, out);
 $ input.barRenderer(null, out);
+$ state.barRenderer(null, out);
+$ data.barRenderer(null, out);
+$ x.barRenderer(null, out);
 
 $ input.barRenderer({}, true, out);
 


### PR DESCRIPTION
## Description

Currently in some cases the dynamic tag migrations call the renderer with the incorrect `this`.
This PR updates those edge cases to a safe transformation by passing a wrapping function.

Fixes https://github.com/marko-js/marko/issues/1361

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
