### PR TITLE
Fix issue with invoke tag that has control flow

### DIFF
--- a/src/core-tags/migrate/invoke-tag.js
+++ b/src/core-tags/migrate/invoke-tag.js
@@ -3,10 +3,10 @@ const commonTagMigrator = require("./all-tags");
 
 module.exports = function migrator(elNode, context) {
     const builder = context.builder;
-    const functionAttr = elNode.attributes[0];
-    const functionArgs = functionAttr.argument;
     commonTagMigrator(elNode, context);
     elNode.setTransformerApplied(commonTagMigrator);
+    const functionAttr = elNode.attributes[0];
+    const functionArgs = functionAttr.argument;
 
     context.deprecate(
         'The "<invoke>" tag is deprecated. Please use "$ <js_code>" for JavaScript in the template. See: https://github.com/marko-js/marko/wiki/Deprecation:-var-assign-invoke-tags'

--- a/test/migrate/fixtures/invoke-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/invoke-tag/snapshot-expected.marko
@@ -8,3 +8,6 @@ $ console.log("y");
 <${function(out) {
     input.barRenderer({}, true, out);
 }}/>
+<if(renderBody)>
+    <${renderBody}/>
+</if>

--- a/test/migrate/fixtures/invoke-tag/template.marko
+++ b/test/migrate/fixtures/invoke-tag/template.marko
@@ -4,3 +4,4 @@
 <invoke input.item.renderBody(out)/>
 <invoke template.render({ x: 1 }, out)/>
 <invoke input.barRenderer({}, true, out)/>
+<invoke if(renderBody) renderBody(out)/>


### PR DESCRIPTION
## Description
Currently there is a bug with the `invoke` tag migration where it will incorrectly read the attributes before they are normalized by the common transformers.

This causes an issue where an invoke tag contains control flow:

```
<invoke if(x) y()/>
```

Which will error at compile time before this fix.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.