### PR TITLE
Fallback to parent component helpers when unable to find the legacy parent

### DIFF
--- a/src/runtime/components/legacy/helper-getWidgetFromOut.js
+++ b/src/runtime/components/legacy/helper-getWidgetFromOut.js
@@ -4,7 +4,10 @@ var getComponentsContext = require("../ComponentsContext")
 module.exports = function(out) {
     var componentsContext = getComponentsContext(out);
     var componentDef =
-        (componentsContext && componentsContext.___legacyComponentDef) || {};
+        (componentsContext &&
+            (componentsContext.___legacyComponentDef ||
+                componentsContext.___componentDef)) ||
+        {};
     componentDef._c = componentDef.___component;
     return componentDef;
 };

--- a/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/components/custom-button/index.marko
+++ b/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/components/custom-button/index.marko
@@ -1,0 +1,3 @@
+<div>
+  <input w-id="test-input"/>
+</div>

--- a/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/index.marko
+++ b/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/index.marko
@@ -1,0 +1,5 @@
+class {}
+
+<div>
+    <custom-button/>
+</div>

--- a/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/test.js
+++ b/test/components-browser/fixtures-deprecated/no-parent-legacy-widget/test.js
@@ -1,0 +1,10 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var root = component.el;
+
+    expect(root.querySelector("input"))
+        .to.have.property("id")
+        .includes("test-input");
+};


### PR DESCRIPTION
## Description

In Marko 3 it is possible to have a template which relies on the parent widget arbitrarily higher in the tree.
We account for this by also tracking the legacy component def tree, however is some cases the parent widget might have been converted into a Marko 4 component and that causes `w-x` attributes to break.

This PR updates the legacy widget parent lookup to fallback to a regular v4 component.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
