### PR TITLE
Control flow and looping migration fixes

### DIFF
--- a/src/core-tags/migrate/all-tags/control-flow-directives.js
+++ b/src/core-tags/migrate/all-tags/control-flow-directives.js
@@ -15,7 +15,7 @@ module.exports = function migrate(el, context) {
         if (
             CONTROL_FLOW_ATTRIBUTES.includes(name) &&
             (name === "else" || attr.argument) &&
-            (el.tagName !== "else" || name !== "if") // <else if(x)> gets passed through
+            !(el.tagName === "else" && name === "if") // <else if(x)> gets passed through
         ) {
             context.deprecate(
                 `The "${name}" attribute is deprecated. Please use the <${name}> tag instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-control-flow-directive`

--- a/src/core-tags/migrate/all-tags/control-flow-directives.js
+++ b/src/core-tags/migrate/all-tags/control-flow-directives.js
@@ -10,15 +10,12 @@ const CONTROL_FLOW_ATTRIBUTES = [
 module.exports = function migrate(el, context) {
     const builder = context.builder;
 
-    if (CONTROL_FLOW_ATTRIBUTES.includes(el.tagName)) {
-        return;
-    }
-
     el.forEachAttribute(attr => {
         const name = attr.name;
         if (
             CONTROL_FLOW_ATTRIBUTES.includes(name) &&
-            (name === "else" || attr.argument)
+            (name === "else" || attr.argument) &&
+            (el.tagName !== "else" || name !== "if") // <else if(x)> gets passed through
         ) {
             context.deprecate(
                 `The "${name}" attribute is deprecated. Please use the <${name}> tag instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-control-flow-directive`

--- a/src/core-tags/migrate/for-tag.js
+++ b/src/core-tags/migrate/for-tag.js
@@ -258,20 +258,23 @@ function normalizeParts(parsed, builder) {
     const update = parsed.update;
     const test = parsed.test;
 
-    if (
-        !init ||
-        !update ||
-        !test ||
-        init.type !== "Vars" ||
-        init.declarations.length !== 1 ||
-        test.type !== "BinaryExpression"
-    ) {
+    if (!init || !update || !test || test.type !== "BinaryExpression") {
         return;
     }
 
-    const declarator = init.declarations[0];
-    const varName = declarator.id;
-    let from = declarator.init;
+    let varName;
+    let from;
+
+    if (init.type === "Vars" && init.declarations.length === 1) {
+        const declarator = init.declarations[0];
+        varName = declarator.id;
+        from = declarator.init;
+    } else if (init.type === "Assignment" && init.operator === "=") {
+        varName = init.left;
+        from = init.right;
+    } else {
+        return;
+    }
 
     if (!from) {
         return;

--- a/test/migrate/fixtures/control-flow-directives/snapshot-expected.marko
+++ b/test/migrate/fixtures/control-flow-directives/snapshot-expected.marko
@@ -18,3 +18,8 @@
 <if(!x)>
     <div/>
 </if>
+<if(y)>
+    <if(x)>A</if>
+</if>
+<!-- passed through -->
+<else if(x)>A</else>

--- a/test/migrate/fixtures/control-flow-directives/template.marko
+++ b/test/migrate/fixtures/control-flow-directives/template.marko
@@ -5,3 +5,7 @@
 <span else(z)/>
 
 <div unless(x)/>
+
+<if(x) if(y)>A</if>
+<!-- passed through -->
+<else if(x)>A</else>

--- a/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
+++ b/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
@@ -94,6 +94,7 @@ $ input.iterator(colors, function(item) {
 <!-- Regular -->
 <for|i| from=0 to=(list.length - 1)>${i}</for>
 <for|i| from=0 to=listSize step=2>${i}</for>
+<for|i| from=0 to=listSize step=2>${i}</for>
 <!-- Stange: backwards -->
 $ var i = 0;
 <while(list.length >= i)>

--- a/test/migrate/fixtures/legacy-for-syntax/template.marko
+++ b/test/migrate/fixtures/legacy-for-syntax/template.marko
@@ -92,6 +92,10 @@
     ${i}
 </for>
 
+<for(i = 0; i <= listSize; i += 2)>
+    ${i}
+</for>
+
 <!-- Stange: backwards -->
 <for(var i = 0; list.length >= i; i++)>
     ${i}


### PR DESCRIPTION
## Description

This PR fixes two migration issues.

1. Inline control flow directives on control flow tags was erroneously omitted from being migrated. Now only the `<else if(x)>` is not migrated while `<if(x) if(y)>` is migrated.

2. Legacy for loops without a `var` will not still properly migrate to a for tag instead of a `while` tag.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.