### PR TITLE
Fix issue with tracking components for client-reorder await tags

### DIFF
--- a/src/compiler/ast/Node.js
+++ b/src/compiler/ast/Node.js
@@ -109,10 +109,10 @@ class Node {
      */
     makeContainer(array) {
         if (array instanceof Container) {
-            return array;
-        }
-
-        if (!Array.isArray(array) && array instanceof Node) {
+            const container = array;
+            array = container.items;
+            container.items = [];
+        } else if (!Array.isArray(array) && array instanceof Node) {
             array = [array];
         }
 

--- a/src/core-tags/components/init-components-tag.js
+++ b/src/core-tags/components/init-components-tag.js
@@ -5,17 +5,6 @@ const INIT_COMPONENTS_KEY = Symbol();
 const writeInitComponentsCode = require("../../runtime/components")
     .writeInitComponentsCode;
 
-const ComponentsContext = require("../../runtime/components/ComponentsContext");
-
-function handleAwaitBeforeRender(eventArgs) {
-    if (eventArgs.clientReorder) {
-        const asyncFragmentOut = eventArgs.out;
-        asyncFragmentOut.___components = new ComponentsContext(
-            asyncFragmentOut
-        );
-    }
-}
-
 function handleAwaitFinish(eventArgs) {
     const asyncFragmentOut = eventArgs.out;
     writeInitComponentsCode(asyncFragmentOut, asyncFragmentOut, false);
@@ -26,7 +15,6 @@ module.exports = function render(input, out) {
     if (outGlobal[INIT_COMPONENTS_KEY] === undefined) {
         outGlobal[INIT_COMPONENTS_KEY] = true;
 
-        out.on("await:beforeRender", handleAwaitBeforeRender);
         out.on("await:finish", handleAwaitFinish);
 
         if (out.isSync() === true) {

--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -5,12 +5,10 @@ var componentLookup = componentsUtil.___componentLookup;
 var registry = require("../registry");
 var modernRenderer = require("../renderer");
 var resolveComponentKey = modernRenderer.___resolveComponentKey;
-var handleBeginAsync = modernRenderer.___handleBeginAsync;
+var trackAsyncComponents = modernRenderer.___trackAsyncComponents;
 var beginComponent = require("../beginComponent");
 var endComponent = require("../endComponent");
 var w10NOOP = require("warp10/constants").NOOP;
-
-var WIDGETS_BEGIN_ASYNC_ADDED_KEY = "$wa";
 
 function createRendererFunc(templateRenderFunc, componentProps) {
     var typeName = componentProps.___type;
@@ -18,12 +16,7 @@ function createRendererFunc(templateRenderFunc, componentProps) {
     var isSplit = componentProps.___split === true;
 
     return function renderer(input, out, assignedId, renderingLogic) {
-        var outGlobal = out.global;
-
-        if (!outGlobal[WIDGETS_BEGIN_ASYNC_ADDED_KEY]) {
-            outGlobal[WIDGETS_BEGIN_ASYNC_ADDED_KEY] = true;
-            out.on("beginAsync", handleBeginAsync);
-        }
+        trackAsyncComponents(out);
 
         var widgetBody = input.renderBody;
         var widgetState = input.widgetState;

--- a/src/runtime/html/AsyncStream.js
+++ b/src/runtime/html/AsyncStream.js
@@ -469,6 +469,10 @@ var proto = (AsyncStream.prototype = {
         var newOut = new AsyncStream(this.global);
         // Forward error events to the parent out.
         newOut.on("error", this.emit.bind(this, "error"));
+        this._state.events.emit("beginDetachedAsync", {
+            out: newOut,
+            parentOut: this
+        });
         return newOut;
     },
 


### PR DESCRIPTION
## Description
Currently the `ComponentsContext` is not forwarded when using an `<await client-reorder>` tag.
This PR ensures that `await` tags with `client-reorder` are tracked accordingly which ensures more reliable keys, fixes some issues with hooking up events for split components and fixes some runtime errors that could occur if nesting `await` tags without components in between them.

This PR also contains a `bonus change`™️  which ensures that when creating new AST nodes while copying over body content from another node that the children properly track their new parent node. This fixes some issues with migrations which rely on this and also walk up the ast in some cases.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.