### PR TITLE
Add optgroup support for controlled select elements

### DIFF
--- a/src/runtime/vdom/morphdom/specialElHandlers.js
+++ b/src/runtime/vdom/morphdom/specialElHandlers.js
@@ -9,6 +9,22 @@ function syncBooleanAttrProp(fromEl, toEl, name) {
     }
 }
 
+function forEachOption(el, fn, i) {
+    var curChild = el.___firstChild;
+
+    while (curChild) {
+        if (curChild.___nodeName === "option") {
+            fn(curChild, ++i);
+        } else {
+            i = forEachOption(curChild, fn, i);
+        }
+
+        curChild = curChild.___nextSibling;
+    }
+
+    return i;
+}
+
 // We use a JavaScript class to benefit from fast property lookup
 function SpecialElHandlers() {}
 SpecialElHandlers.prototype = {
@@ -65,18 +81,16 @@ SpecialElHandlers.prototype = {
     },
     select: function(fromEl, toEl) {
         if (!toEl.___hasAttribute("multiple")) {
-            var i = -1;
             var selected = 0;
-            var curChild = toEl.___firstChild;
-            while (curChild) {
-                if (curChild.___nodeName === "option") {
-                    i++;
-                    if (curChild.___hasAttribute("selected")) {
+            forEachOption(
+                toEl,
+                function(option, i) {
+                    if (option.___hasAttribute("selected")) {
                         selected = i;
                     }
-                }
-                curChild = curChild.___nextSibling;
-            }
+                },
+                -1
+            );
 
             if (fromEl.selectedIndex !== selected) {
                 fromEl.selectedIndex = selected;

--- a/test/morphdom/fixtures/select-element-optgroup/expected.html
+++ b/test/morphdom/fixtures/select-element-optgroup/expected.html
@@ -1,0 +1,30 @@
+<BODY>
+  <DIV>
+    "\n    "
+    <SELECT id="dino-select">
+      "\n        "
+      <OPTGROUP label="Theropods">
+        "\n            "
+        <OPTION>
+          "Tyrannosaurus"
+        "\n            "
+        <OPTION selected="">
+          "Velociraptor"
+        "\n            "
+        <OPTION>
+          "Deinonychus"
+        "\n        "
+      "\n        "
+      <OPTGROUP label="Sauropods">
+        "\n            "
+        <OPTION>
+          "Diplodocus"
+        "\n            "
+        <OPTION>
+          "Saltasaurus"
+        "\n            "
+        <OPTION>
+          "Apatosaurus"
+        "\n        "
+      "\n    "
+    "\n"

--- a/test/morphdom/fixtures/select-element-optgroup/from.html
+++ b/test/morphdom/fixtures/select-element-optgroup/from.html
@@ -1,0 +1,14 @@
+<div>
+    <select id="dino-select">
+        <optgroup label="Theropods">
+            <option>Tyrannosaurus</option>
+            <option>Velociraptor</option>
+            <option>Deinonychus</option>
+        </optgroup>
+        <optgroup label="Sauropods">
+            <option>Diplodocus</option>
+            <option selected>Saltasaurus</option>
+            <option>Apatosaurus</option>
+        </optgroup>
+    </select>
+</div>

--- a/test/morphdom/fixtures/select-element-optgroup/index.js
+++ b/test/morphdom/fixtures/select-element-optgroup/index.js
@@ -1,0 +1,5 @@
+exports.verify = function(context, expect) {
+    var rootNode = context.rootNode;
+    var selectNode = rootNode.querySelector("select");
+    expect(selectNode.selectedIndex).to.equal(1);
+};

--- a/test/morphdom/fixtures/select-element-optgroup/to.html
+++ b/test/morphdom/fixtures/select-element-optgroup/to.html
@@ -1,0 +1,14 @@
+<div>
+    <select id="dino-select">
+        <optgroup label="Theropods">
+            <option>Tyrannosaurus</option>
+            <option selected>Velociraptor</option>
+            <option>Deinonychus</option>
+        </optgroup>
+        <optgroup label="Sauropods">
+            <option>Diplodocus</option>
+            <option>Saltasaurus</option>
+            <option>Apatosaurus</option>
+        </optgroup>
+    </select>
+</div>


### PR DESCRIPTION
## Description

This PR adds support for controlling `select` elements with nested [`optgroup`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/optgroup) tags.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.