### PR TITLE
no id:scoped for repeated w-id

### DIFF
--- a/src/core-tags/migrate/all-tags/w-id.js
+++ b/src/core-tags/migrate/all-tags/w-id.js
@@ -20,7 +20,9 @@ module.exports = function migrate(el, context) {
     el.setAttributeValue("key", attr.value);
     const isHTML = el.tagDef && el.tagDef.html;
     const isDynamic = Boolean(el.rawTagNameExpression);
-    if (!el.hasAttribute("id") && (isHTML || isDynamic))
+    const isRepeated =
+        attr.value.type === "Literal" && /\[\]$/.test(attr.value.value);
+    if (!el.hasAttribute("id") && !isRepeated && (isHTML || isDynamic))
         el.setAttributeValue("id:scoped", attr.value);
     el.removeAttribute(attr.name);
 };

--- a/test/migrate/fixtures/w-id/snapshot-expected.marko
+++ b/test/migrate/fixtures/w-id/snapshot-expected.marko
@@ -5,3 +5,5 @@
 <div key="b" id:scoped="b"/>
 <test key="c"/>
 <${tag} key="d" id:scoped="d"/>
+<div key="e[]"/>
+<div key="e[]"/>

--- a/test/migrate/fixtures/w-id/template.marko
+++ b/test/migrate/fixtures/w-id/template.marko
@@ -2,3 +2,5 @@
 <div w-id="b"/>
 <test w-id="c"/>
 <${tag} w-id="d"/>
+<div w-id="e[]"/>
+<div w-id="e[]"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In Marko 3, `w-id` was used as both a `key` and set a scoped `id`. The `id` was primarily an implementation detail, but it could also be used with `w-for` to associate DOM elements.

Marko 3:

```marko
<label w-for="foo"/>
<input w-id="foo"/>
```

Marko 4 equivalent:

```marko
<label for:scoped="foo"/>
<input key="foo" id:scoped="foo"/>
```

However Marko 4's `:scoped` modifier does not support repeated values.  This is because it's difficult to reason about association of repeated values (the primary use-case fore `:scoped`).  However, this causes the same ids to appear on the page because `:scoped` doesn't have special behavior for `repeated[]` values.

In Marko 3, this association doesn't actually work between repeated `w-id` and `w-for` attributes:

Input template:

```marko
<label w-for="foo[]">1</label>
<input w-id="foo[]" value="1">
<label w-for="foo[]">2</label>
<input w-id="foo[]" value="2">
```

Output HTML:

```html
<label for="foo[0]">1</label>
<input id="foo[1]" value="1">
<label for="foo[2]">2</label>
<input id="foo[3]" value="2">
```

Because of this, it should be safe to assume that a repeated `w-id` is only being used to reference the elements, not associate them with other elements.  This PR modifies the migration of `w-id` so that repeated ids do not add an `id:scoped` attribute.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
