### PR TITLE
Fix regression with container nodes

### DIFF
--- a/src/compiler/ast/Node.js
+++ b/src/compiler/ast/Node.js
@@ -109,9 +109,8 @@ class Node {
      */
     makeContainer(array) {
         if (array instanceof Container) {
-            const container = array;
-            array = container.items;
-            container.items = [];
+            array.node = this;
+            return array;
         } else if (!Array.isArray(array) && array instanceof Node) {
             array = [array];
         }


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/marko-js/marko/pull/1375/files#diff-73897f1fa5eecec95203fcfbe9e5832eR112. It turns out that the existing behavior of using the same container node instance is relied on and that change causes some nodes to act as if they were removed.

This PR fixes the regression by reusing the array container instance and just changing the owner node.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
