### PR TITLE
Fix getComponentForEl with nested fragments (returns owner component)

### DIFF
--- a/src/runtime/components/util-browser.js
+++ b/src/runtime/components/util-browser.js
@@ -11,14 +11,6 @@ var componentLookup = {};
 var defaultDocument = document;
 var EMPTY_OBJECT = {};
 
-function getParentComponentForEl(node) {
-    while (node && !componentsByDOMNode.get(node)) {
-        node = node.previousSibling || node.parentNode;
-        node = (node && node.fragment) || node;
-    }
-    return node && componentsByDOMNode.get(node);
-}
-
 function getComponentForEl(el, doc) {
     if (el) {
         var node =
@@ -26,7 +18,8 @@ function getComponentForEl(el, doc) {
                 ? (doc || defaultDocument).getElementById(el)
                 : el;
         if (node) {
-            return getParentComponentForEl(node);
+            var vElement = vElementsByDOMNode.get(node);
+            return vElement && vElement.___ownerComponent;
         }
     }
 }

--- a/test/components-browser/fixtures/get-component-for-el-nested-fragments/components/child/index.marko
+++ b/test/components-browser/fixtures/get-component-for-el-nested-fragments/components/child/index.marko
@@ -1,0 +1,15 @@
+class {
+    onCreate(input) {
+        this.name = input.name;
+    }
+}
+
+<macro|input| name="fragment">
+    <${input}/>
+</macro>
+
+<fragment>
+    <fragment>
+        <div class=input.name/>
+    </fragment>
+</fragment>

--- a/test/components-browser/fixtures/get-component-for-el-nested-fragments/index.marko
+++ b/test/components-browser/fixtures/get-component-for-el-nested-fragments/index.marko
@@ -1,0 +1,19 @@
+class {
+    onCreate() {
+        this.name = "parent";
+    }
+}
+
+<macro|input| name="fragment">
+    <${input}/>
+</macro>
+
+<div key="root">
+    <fragment>
+        <fragment>
+            <child name="child-a"/>
+        </fragment>
+    </fragment>
+    <div.child-b/>
+    <child name="child-c"/>
+</div>

--- a/test/components-browser/fixtures/get-component-for-el-nested-fragments/test.js
+++ b/test/components-browser/fixtures/get-component-for-el-nested-fragments/test.js
@@ -1,0 +1,14 @@
+var expect = require("chai").expect;
+var getComponentForEl = require("marko/components").getComponentForEl;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index.marko"), {});
+    var root = component.getEl("root");
+    var childA = root.querySelector(".child-a");
+    var childB = root.querySelector(".child-b");
+    var childC = root.querySelector(".child-c");
+
+    expect(getComponentForEl(childA)).has.property("name", "child-a");
+    expect(getComponentForEl(childB)).has.property("name", "parent");
+    expect(getComponentForEl(childC)).has.property("name", "child-c");
+};


### PR DESCRIPTION
## Description

Currently `require('marko/components').getComponentForEl` will fail to return a component if there are nested fragments at play. This PR updates the logic to always return the owner component for an element which is simpler and typically what the user wants.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.