### PR TITLE
Legacy compat fixes

### DIFF
--- a/src/runtime/components/Component.js
+++ b/src/runtime/components/Component.js
@@ -293,9 +293,11 @@ Component.prototype = componentProto = {
     getComponents: function(key) {
         var lookup = this.___keyedElements[key + "[]"];
         return lookup
-            ? Object.keys(lookup).map(function(key) {
-                  return componentsByDOMNode.get(lookup[key]);
-              })
+            ? Object.keys(lookup)
+                  .map(function(key) {
+                      return componentsByDOMNode.get(lookup[key]);
+                  })
+                  .filter(Boolean)
             : [];
     },
     destroy: function() {

--- a/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -145,6 +145,8 @@ module.exports = function defineRenderer(renderingLogic) {
                 templateData = {};
             }
 
+            templateData.___widgetProps = newProps;
+
             // If we have widget state then pass it to the template
             // so that it is available to the widget tag
             if (widgetState) {

--- a/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -42,7 +42,12 @@ module.exports = function defineWidget(def, renderer) {
 
     if (!proto.___isComponent) {
         // Inherit from Component if they didn't already
-        inherit(ComponentClass, BaseComponent);
+        ComponentClass.prototype = Object.create(BaseComponent.prototype);
+        for (var propName in proto) {
+            if (proto.hasOwnProperty(propName)) {
+                ComponentClass.prototype[propName] = proto[propName];
+            }
+        }
     }
 
     // The same prototype will be used by our constructor after

--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -66,6 +66,9 @@ function createRendererFunc(templateRenderFunc, componentProps) {
                 customEvents,
                 ownerComponentId
             );
+            if (input.___widgetProps) {
+                component.input = input.___widgetProps;
+            }
         } else {
             if (!component) {
                 if (isRerender) {

--- a/src/runtime/vdom/morphdom/index.js
+++ b/src/runtime/vdom/morphdom/index.js
@@ -56,12 +56,12 @@ function onNodeAdded(node, componentsContext) {
 
 function morphdom(fromNode, toNode, doc, componentsContext) {
     var globalComponentsContext;
-    var isRerenderInBrowser = false;
+    var isHydrate = false;
     var keySequences = {};
 
     if (componentsContext) {
         globalComponentsContext = componentsContext.___globalContext;
-        isRerenderInBrowser = globalComponentsContext.___isHydrate;
+        isHydrate = globalComponentsContext.___isHydrate;
     }
 
     function insertVirtualNodeBefore(
@@ -173,7 +173,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                     (matchingFromComponent =
                         existingComponentLookup[component.id]) === undefined
                 ) {
-                    if (isRerenderInBrowser === true) {
+                    if (isHydrate === true) {
                         var rootNode = beginFragmentNode(
                             curFromNodeChild,
                             fromNode
@@ -328,7 +328,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                                 curToNodeKey
                             ]) === undefined
                     ) {
-                        if (isRerenderInBrowser === true && curFromNodeChild) {
+                        if (isHydrate === true && curFromNodeChild) {
                             if (
                                 curFromNodeChild.nodeType === ELEMENT_NODE &&
                                 caseInsensitiveCompare(
@@ -600,7 +600,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
                             curFromNodeChild
                         );
                         if (curVFromNodeChild === undefined) {
-                            if (isRerenderInBrowser === true) {
+                            if (isHydrate === true) {
                                 curVFromNodeChild = virtualizeElement(
                                     curFromNodeChild
                                 );
@@ -761,7 +761,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
     ) {
         var nodeName = toEl.___nodeName;
 
-        if (isRerenderInBrowser === true && toElKey) {
+        if (isHydrate === true && toElKey) {
             ownerComponent.___keyedElements[toElKey] = fromEl;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- temporary fix to ensure `getComponents` doesn't return `null` entries - these should really be removed from the `lookup` instead
- use a `for...in` loop to extend the `BaseComponent` (doesn't support getters properly) to maintain the same behavior as `marko-widgets`
- ensure that the original `input` for a widget is what gets serialized, not the result of `getTemplateData` (which is called again when hydrating)
- Bonus Change: rename `isRerenderInBrowser` to `isHydrate`

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
