### PR TITLE
Add migration for legacy widget with `getInitialState` and no `getTemplateData`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,160 +14,48 @@
             }
         },
         "@babel/core": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.2.2.tgz",
-            "integrity": "sha512-59vB0RWt09cAct5EIe58+NzGP4TFSD3Bz//2/ELy3ZeTeKF6VTD1AXlH8BGGbCX0PuobZBsIzO7IAI9PH67eKw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.5.4.tgz",
+            "integrity": "sha512-+DaeBEpYq6b2+ZmHx3tHspC+ZRflrvLqwfv8E3hNr5LVQoyBnL8RPKSBCg+rK2W2My9PWlujBiqd0ZPsR9Q6zQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.2.2",
-                "@babel/helpers": "^7.2.0",
-                "@babel/parser": "^7.2.2",
-                "@babel/template": "^7.2.2",
-                "@babel/traverse": "^7.2.2",
-                "@babel/types": "^7.2.2",
+                "@babel/generator": "^7.5.0",
+                "@babel/helpers": "^7.5.4",
+                "@babel/parser": "^7.5.0",
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.5.0",
+                "@babel/types": "^7.5.0",
                 "convert-source-map": "^1.1.0",
                 "debug": "^4.1.0",
                 "json5": "^2.1.0",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "resolve": "^1.3.2",
                 "semver": "^5.4.1",
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "@babel/generator": {
-                    "version": "7.2.2",
-                    "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.2.tgz",
-                    "integrity": "sha512-I4o675J/iS8k+P38dvJ3IBGqObLXyQLTxtrR4u9cSUJOURvafeEWb/pFMOTwtNrmq73mJzyF6ueTbO1BtN0Zeg==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/types": "^7.2.2",
-                        "jsesc": "^2.5.1",
-                        "lodash": "^4.17.10",
-                        "source-map": "^0.5.0",
-                        "trim-right": "^1.0.1"
-                    }
-                },
-                "@babel/parser": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.3.tgz",
-                    "integrity": "sha512-0LyEcVlfCoFmci8mXx8A5oIkpkOgyo8dRHtxBnK9RRBwxO2+JZPNsqtVEZQ7mJFPxnXF9lfmU24mHOPI0qnlkA==",
-                    "dev": true
-                },
-                "@babel/template": {
-                    "version": "7.2.2",
-                    "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-                    "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/parser": "^7.2.2",
-                        "@babel/types": "^7.2.2"
-                    }
-                },
-                "@babel/traverse": {
-                    "version": "7.2.3",
-                    "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.2.3.tgz",
-                    "integrity": "sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==",
-                    "dev": true,
-                    "requires": {
-                        "@babel/code-frame": "^7.0.0",
-                        "@babel/generator": "^7.2.2",
-                        "@babel/helper-function-name": "^7.1.0",
-                        "@babel/helper-split-export-declaration": "^7.0.0",
-                        "@babel/parser": "^7.2.3",
-                        "@babel/types": "^7.2.2",
-                        "debug": "^4.1.0",
-                        "globals": "^11.1.0",
-                        "lodash": "^4.17.10"
-                    }
-                },
-                "@babel/types": {
-                    "version": "7.2.2",
-                    "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.2.tgz",
-                    "integrity": "sha512-fKCuD6UFUMkR541eDWL+2ih/xFZBXPOg/7EQFeTluMDebfqR4jrpaCjLhkWlQS4hT6nRa2PMEgXKbRB5/H2fpg==",
-                    "dev": true,
-                    "requires": {
-                        "esutils": "^2.0.2",
-                        "lodash": "^4.17.10",
-                        "to-fast-properties": "^2.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.10.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.10.0.tgz",
-                    "integrity": "sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==",
-                    "dev": true
-                },
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
-                "json5": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
-                    "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
-                    "dev": true,
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
                     "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
-                },
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
                 }
             }
         },
         "@babel/generator": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.2.0.tgz",
-            "integrity": "sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.5.0.tgz",
+            "integrity": "sha512-1TTVrt7J9rcG5PMjvO7VEG3FrEoEJNHxumRq66GemPmzboLWtIjjcJgk8rokuAS7IiRSpgVSu5Vb9lc99iJkOA==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.2.0",
+                "@babel/types": "^7.5.0",
                 "jsesc": "^2.5.1",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "source-map": "^0.5.0",
                 "trim-right": "^1.0.1"
             },
             "dependencies": {
-                "jsesc": {
-                    "version": "2.5.2",
-                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-                    "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-                    "dev": true
-                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -197,176 +85,101 @@
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-            "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
+            "integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.0.0"
+                "@babel/types": "^7.4.4"
             }
         },
         "@babel/helpers": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.2.0.tgz",
-            "integrity": "sha512-Fr07N+ea0dMcMN8nFpuK6dUIT7/ivt9yKQdEEnjVS83tG2pHwPi03gYmk/tyuwONnZ+sY+GFFPlWGgCtW1hF9A==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.5.4.tgz",
+            "integrity": "sha512-6LJ6xwUEJP51w0sIgKyfvFMJvIb9mWAfohJp0+m6eHJigkFdcH8duZ1sfhn0ltJRzwUIT/yqqhdSfRpCpL7oow==",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.1.2",
-                "@babel/traverse": "^7.1.5",
-                "@babel/types": "^7.2.0"
+                "@babel/template": "^7.4.4",
+                "@babel/traverse": "^7.5.0",
+                "@babel/types": "^7.5.0"
             }
         },
         "@babel/highlight": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
-            "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+            "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.0",
                 "esutils": "^2.0.2",
                 "js-tokens": "^4.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "js-tokens": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "@babel/parser": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.2.0.tgz",
-            "integrity": "sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.0.tgz",
+            "integrity": "sha512-I5nW8AhGpOXGCCNYGc+p7ExQIBxRFnS2fd/d862bNOKvmoEPjYPcfIjsfdy0ujagYOIYPczKgD9l3FsgTkAzKA==",
             "dev": true
         },
         "@babel/runtime": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.2.0.tgz",
-            "integrity": "sha512-oouEibCbHMVdZSDlJBO6bZmID/zA/G/Qx3H1d3rSNPTD+L8UNKvCat7aKWSJ74zYbm5zWGh0GQN0hKj8zYFTCg==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+            "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
             "dev": true,
             "requires": {
-                "regenerator-runtime": "^0.12.0"
-            },
-            "dependencies": {
-                "regenerator-runtime": {
-                    "version": "0.12.1",
-                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
-                    "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==",
-                    "dev": true
-                }
+                "regenerator-runtime": "^0.13.2"
             }
         },
         "@babel/template": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.1.2.tgz",
-            "integrity": "sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==",
+            "version": "7.4.4",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.4.tgz",
+            "integrity": "sha512-CiGzLN9KgAvgZsnivND7rkA+AeJ9JB0ciPOD4U59GKbQP2iQl+olF1l76kJOupqidozfZ32ghwBEJDhnk9MEcw==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/parser": "^7.1.2",
-                "@babel/types": "^7.1.2"
+                "@babel/parser": "^7.4.4",
+                "@babel/types": "^7.4.4"
             }
         },
         "@babel/traverse": {
-            "version": "7.1.6",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
-            "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.5.0.tgz",
+            "integrity": "sha512-SnA9aLbyOCcnnbQEGwdfBggnc142h/rbqqsXcaATj2hZcegCl903pUD/lfpsNBlBSuWow/YDfRyJuWi2EPR5cg==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
-                "@babel/generator": "^7.1.6",
+                "@babel/generator": "^7.5.0",
                 "@babel/helper-function-name": "^7.1.0",
-                "@babel/helper-split-export-declaration": "^7.0.0",
-                "@babel/parser": "^7.1.6",
-                "@babel/types": "^7.1.6",
+                "@babel/helper-split-export-declaration": "^7.4.4",
+                "@babel/parser": "^7.5.0",
+                "@babel/types": "^7.5.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
-                "lodash": "^4.17.10"
-            },
-            "dependencies": {
-                "debug": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-                    "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
-                "globals": {
-                    "version": "11.9.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-                    "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                }
+                "lodash": "^4.17.11"
             }
         },
         "@babel/types": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.2.0.tgz",
-            "integrity": "sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.5.0.tgz",
+            "integrity": "sha512-UFpDVqRABKsW01bvw7/wSUe56uy6RXM5+VJibVVAybDGxEW25jdwiFJEf7ASvSaC7sN7rbE/l3cLp2izav+CtQ==",
             "dev": true,
             "requires": {
                 "esutils": "^2.0.2",
-                "lodash": "^4.17.10",
+                "lodash": "^4.17.11",
                 "to-fast-properties": "^2.0.0"
-            },
-            "dependencies": {
-                "to-fast-properties": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-                    "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-                    "dev": true
-                }
             }
         },
         "@marko/migrate": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@marko/migrate/-/migrate-4.1.1.tgz",
-            "integrity": "sha512-ddvdPbMF5hDNaY2aj3PDoqtEeF3RF8fG2LZ70jnR+yRBAda5dEWC3PkCHmrczVkZ7AMa4E37lkphysOaKNWPiA==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@marko/migrate/-/migrate-5.1.0.tgz",
+            "integrity": "sha512-kZGliqxtnFsq3aAXx0Oq6vAG+wqvZXsfz84PvekJ0lNrfsZyKfQeiFdy1a7ByZqjmQJadRW4JhZofPnntOdjqQ==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.2.0",
-                "@marko/migrate-v3-widget": "^1.0.7",
-                "@marko/prettyprint": "^1.4.1",
+                "@marko/migrate-v3-widget": "^1.1.0",
+                "@marko/prettyprint": "^2.1.2",
                 "argly": "^1.2.0",
+                "chalk": "^2.4.2",
                 "dependent-path-update": "^0.1.1",
                 "enquirer": "^2.1.1",
                 "glob": "^7.1.3",
@@ -384,9 +197,9 @@
             }
         },
         "@marko/migrate-v3-widget": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@marko/migrate-v3-widget/-/migrate-v3-widget-1.0.8.tgz",
-            "integrity": "sha512-aeCuJwFp0Om73DB6FHKB67Jf7pRIaHqDn+y2pxlBWrKN3801W2zWFj5MZEfjkRA2HG4yOeV1J6Nndsh6lVjdrA==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@marko/migrate-v3-widget/-/migrate-v3-widget-1.1.2.tgz",
+            "integrity": "sha512-s6PvJWP6FZCjN5PjQl4t0MZp+79nfn6b01ktHjTuxRW3OGDn5qOb1EwFiqix/UtAfcSIzKkBbLYyDBTLb/QySw==",
             "dev": true,
             "requires": {
                 "@babel/core": "^7.1.5",
@@ -397,31 +210,22 @@
             }
         },
         "@marko/prettyprint": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/@marko/prettyprint/-/prettyprint-1.4.1.tgz",
-            "integrity": "sha512-4bWMUyIlQ8dm8QH5Kj1vLCihvI1bTLy8x+chIS6AALRK5wKuKBXHH0kMwM2htuPbxxKom02zERCgzQT0/7oqwg==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/@marko/prettyprint/-/prettyprint-2.1.2.tgz",
+            "integrity": "sha512-QseJB5U77CUl08bB5oVzzhb23XYwSBYmFZeYMhJ1yIADNztYq0dEycUZ/Ac0XW2o8zbDEEQMmiuQVKmPi14Muw==",
             "dev": true,
             "requires": {
                 "argly": "^1.2.0",
+                "chalk": "^2.4.2",
                 "editorconfig": "^0.15.2",
                 "lasso-package-root": "^1.0.1",
-                "marko": "^4.14.20",
+                "marko": "4.14.21",
                 "minimatch": "^3.0.4",
                 "prettier": "^1.15.3",
                 "redent": "^2.0.0",
                 "resolve-from": "^4.0.0"
             },
             "dependencies": {
-                "redent": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
-                    "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
-                    "dev": true,
-                    "requires": {
-                        "indent-string": "^3.0.0",
-                        "strip-indent": "^2.0.0"
-                    }
-                },
                 "resolve-from": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -439,18 +243,6 @@
                 "any-observable": "^0.3.0"
             }
         },
-        "@types/node": {
-            "version": "10.12.18",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
-            "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ==",
-            "dev": true
-        },
-        "@types/semver": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-5.5.0.tgz",
-            "integrity": "sha512-41qEJgBH/TWgo5NFSvBCJ1qkoi3Q6ONSF2avrHq1LVEZfYpdHmj0y9SuTK+u9ZhG1sYQKBL1AWXKyLWP4RaUoQ==",
-            "dev": true
-        },
         "abab": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.0.tgz",
@@ -458,13 +250,13 @@
             "dev": true
         },
         "accepts": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-            "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+            "version": "1.3.7",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
+            "integrity": "sha512-Il80Qs2WjYlJIBNzNkK6KYqlVMTbZLXgHx2oT0pU/fjRHyEp+PEfEPY0R3WCwAGVOtauxh1hOxNgIf5bv7dQpA==",
             "dev": true,
             "requires": {
-                "mime-types": "~2.1.18",
-                "negotiator": "0.6.1"
+                "mime-types": "~2.1.24",
+                "negotiator": "0.6.2"
             }
         },
         "acorn": {
@@ -474,9 +266,9 @@
             "dev": true
         },
         "acorn-globals": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.0.tgz",
-            "integrity": "sha512-hMtHj3s5RnuhvHPowpBYvJVj3rAar82JiDQHvGs1zO0l10ocX/xEdBShNHTJaboucJUsScghp74pH3s7EnHHQw==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-4.3.2.tgz",
+            "integrity": "sha512-BbzvZhVtZP+Bs1J1HcwrQe8ycfO0wStkSGxuul3He3GkHOIZ6eTqOkPuw9IP1X3+IkOo4wiJmwkobzXYz4wewQ==",
             "dev": true,
             "requires": {
                 "acorn": "^6.0.1",
@@ -484,16 +276,16 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.0.4",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
-                    "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.2.0.tgz",
+                    "integrity": "sha512-8oe72N3WPMjA+2zVG71Ia0nXZ8DpQH+QyyHO+p06jT8eg8FGG3FbcUIi8KziHlAfheJQZeoqbvq1mQSQHXKYLw==",
                     "dev": true
                 }
             }
         },
         "acorn-jsx": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
             "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
             "dev": true,
             "requires": {
@@ -502,22 +294,31 @@
             "dependencies": {
                 "acorn": {
                     "version": "3.3.0",
-                    "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
                     "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
                     "dev": true
                 }
             }
         },
         "acorn-walk": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.1.1.tgz",
-            "integrity": "sha512-OtUw6JUTgxA2QoqqmrmQ7F2NYqiBPi/L2jqHyFtllhOUvXYQXf0Z1CYUinIfyT4bTCGmrA7gX9FvHA81uzCoVw==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
+            "integrity": "sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==",
             "dev": true
         },
+        "agent-base": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+            "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
+            "dev": true,
+            "requires": {
+                "es6-promisify": "^5.0.0"
+            }
+        },
         "ajv": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
-            "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
+            "version": "6.10.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+            "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^2.0.1",
@@ -533,15 +334,15 @@
             "dev": true
         },
         "ansi-colors": {
-            "version": "3.2.3",
-            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-            "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+            "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
             "dev": true
         },
         "ansi-escapes": {
-            "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-            "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+            "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
             "dev": true
         },
         "ansi-regex": {
@@ -551,10 +352,13 @@
             "dev": true
         },
         "ansi-styles": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-            "dev": true
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "^1.9.0"
+            }
         },
         "any-observable": {
             "version": "0.3.0",
@@ -649,7 +453,7 @@
         },
         "array-equal": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
             "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
             "dev": true
         },
@@ -661,7 +465,7 @@
         },
         "array-flatten": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
             "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
             "dev": true
         },
@@ -704,9 +508,9 @@
             "dev": true
         },
         "async-each": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
             "dev": true
         },
         "async-limiter": {
@@ -789,6 +593,39 @@
                 "chalk": "^1.1.3",
                 "esutils": "^2.0.2",
                 "js-tokens": "^3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
+                "js-tokens": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+                    "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
             }
         },
         "babel-core": {
@@ -818,6 +655,27 @@
                 "source-map": "^0.5.7"
             },
             "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "json5": {
+                    "version": "0.5.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+                    "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -842,6 +700,12 @@
                 "trim-right": "^1.0.1"
             },
             "dependencies": {
+                "jsesc": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
+                    "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+                    "dev": true
+                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -921,6 +785,14 @@
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
+            },
+            "dependencies": {
+                "regenerator-runtime": {
+                    "version": "0.11.1",
+                    "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+                    "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+                    "dev": true
+                }
             }
         },
         "babel-template": {
@@ -951,6 +823,29 @@
                 "globals": "^9.18.0",
                 "invariant": "^2.2.2",
                 "lodash": "^4.17.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "globals": {
+                    "version": "9.18.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+                    "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
             }
         },
         "babel-types": {
@@ -963,6 +858,14 @@
                 "esutils": "^2.0.2",
                 "lodash": "^4.17.4",
                 "to-fast-properties": "^1.0.3"
+            },
+            "dependencies": {
+                "to-fast-properties": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+                    "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+                    "dev": true
+                }
             }
         },
         "babylon": {
@@ -1063,43 +966,55 @@
             }
         },
         "binary-extensions": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
-            "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+            "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
             "dev": true
         },
         "bluebird": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-            "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+            "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
             "dev": true
         },
         "body-parser": {
-            "version": "1.18.3",
-            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-            "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
+            "version": "1.19.0",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
+            "integrity": "sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==",
             "dev": true,
             "requires": {
-                "bytes": "3.0.0",
+                "bytes": "3.1.0",
                 "content-type": "~1.0.4",
                 "debug": "2.6.9",
                 "depd": "~1.1.2",
-                "http-errors": "~1.6.3",
-                "iconv-lite": "0.4.23",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
                 "on-finished": "~2.3.0",
-                "qs": "6.5.2",
-                "raw-body": "2.3.3",
-                "type-is": "~1.6.16"
+                "qs": "6.7.0",
+                "raw-body": "2.4.0",
+                "type-is": "~1.6.17"
             },
             "dependencies": {
-                "iconv-lite": {
-                    "version": "0.4.23",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
                     "dev": true,
                     "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
+                        "ms": "2.0.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
                 }
             }
         },
@@ -1146,25 +1061,27 @@
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
         },
-        "builtin-modules": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
-            "dev": true
-        },
         "builtins": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/builtins/-/builtins-2.0.0.tgz",
-            "integrity": "sha512-8srrxpDx3a950BHYcbse+xMjupHHECvQYnShkoPz2ZLhTBrk/HQO6nWMh4o4ui8YYp2ourGVYXlGqFm+UYQwmA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/builtins/-/builtins-2.0.1.tgz",
+            "integrity": "sha512-XkkVe5QAb6guWPXTzpSrYpSlN3nqEmrrE2TkAr/tp7idSF6+MONh9WvKrAuR3HiKLvoSgmbs8l1U9IPmMrIoLw==",
             "dev": true,
             "requires": {
-                "semver": "^5.4.1"
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.2.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+                    "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+                    "dev": true
+                }
             }
         },
         "bytes": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-            "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.0.tgz",
+            "integrity": "sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==",
             "dev": true
         },
         "cache-base": {
@@ -1212,18 +1129,18 @@
         },
         "callsites": {
             "version": "2.0.0",
-            "resolved": "http://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
             "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=",
             "dev": true
         },
         "camelcase": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-            "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+            "version": "5.3.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         },
         "camelcase-keys": {
             "version": "2.1.0",
-            "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
             "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
             "dev": true,
             "requires": {
@@ -1247,7 +1164,7 @@
         },
         "chai": {
             "version": "3.5.0",
-            "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
             "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
             "requires": {
                 "assertion-error": "^1.0.1",
@@ -1256,16 +1173,14 @@
             }
         },
         "chalk": {
-            "version": "1.1.3",
-            "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "^2.2.1",
-                "escape-string-regexp": "^1.0.2",
-                "has-ansi": "^2.0.0",
-                "strip-ansi": "^3.0.0",
-                "supports-color": "^2.0.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "char-props": {
@@ -1367,7 +1282,7 @@
                 },
                 "slice-ansi": {
                     "version": "0.0.4",
-                    "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+                    "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
                     "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
                     "dev": true
                 },
@@ -1403,15 +1318,15 @@
             "dev": true
         },
         "codecov": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.1.0.tgz",
-            "integrity": "sha512-aWQc/rtHbcWEQLka6WmBAOpV58J2TwyXqlpAQGhQaSiEUoigTTUk6lLd2vB3kXkhnDyzyH74RXfmV4dq2txmdA==",
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.5.0.tgz",
+            "integrity": "sha512-/OsWOfIHaQIr7aeZ4pY0UC1PZT6kimoKFOFYFNb6wxo3iw12nRrh+mNGH72rnXxNsq6SGfesVPizm/6Q3XqcFQ==",
             "dev": true,
             "requires": {
                 "argv": "^0.0.2",
                 "ignore-walk": "^3.0.1",
-                "js-yaml": "^3.12.0",
-                "request": "^2.87.0",
+                "js-yaml": "^3.13.1",
+                "teeny-request": "^3.11.3",
                 "urlgrey": "^0.4.4"
             }
         },
@@ -1441,18 +1356,18 @@
             "dev": true
         },
         "combined-stream": {
-            "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-            "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
             "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
-            "version": "2.19.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-            "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==",
+            "version": "2.20.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+            "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
             "dev": true
         },
         "complain": {
@@ -1464,9 +1379,9 @@
             }
         },
         "component-emitter": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
-            "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+            "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
             "dev": true
         },
         "concat-map": {
@@ -1487,10 +1402,13 @@
             }
         },
         "content-disposition": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-            "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
-            "dev": true
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+            "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.2"
+            }
         },
         "content-type": {
             "version": "1.0.4",
@@ -1517,9 +1435,9 @@
             }
         },
         "cookie": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
+            "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==",
             "dev": true
         },
         "cookie-signature": {
@@ -1535,9 +1453,9 @@
             "dev": true
         },
         "core-js": {
-            "version": "2.6.0",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.0.tgz",
-            "integrity": "sha512-kLRC6ncVpuEW/1kwrOXYX6KQASCVtrh1gQr/UiaVgFlf9WE5Vp+lNe5+h3LuMr5PAucWnnEXwH0nQHRH/gpGtw==",
+            "version": "2.6.9",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+            "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
             "dev": true
         },
         "core-util-is": {
@@ -1547,37 +1465,29 @@
             "dev": true
         },
         "cosmiconfig": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.7.tgz",
-            "integrity": "sha512-PcLqxTKiDmNT6pSpy4N6KtuPwb53W+2tzNvwOZw0WH9N6O0vLIBq0x8aj8Oj75ere4YcGi48bDFCL+3fRJdlNA==",
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+            "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
             "dev": true,
             "requires": {
                 "import-fresh": "^2.0.0",
                 "is-directory": "^0.3.1",
-                "js-yaml": "^3.9.0",
+                "js-yaml": "^3.13.1",
                 "parse-json": "^4.0.0"
             }
         },
         "coveralls": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.2.tgz",
-            "integrity": "sha512-Tv0LKe/MkBOilH2v7WBiTBdudg2ChfGbdXafc/s330djpF3zKOmuehTeRwjXWc7pzfj9FrDUTA7tEx6Div8NFw==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.5.tgz",
+            "integrity": "sha512-/KD7PGfZv/tjKB6LoW97jzIgFqem0Tu9tZL9/iwBnBd8zkIZp7vT1ZSHNvnr0GSQMV/LTMxUstWg8WcDDUVQKg==",
             "dev": true,
             "requires": {
                 "growl": "~> 1.10.0",
-                "js-yaml": "^3.11.0",
+                "js-yaml": "^3.13.1",
                 "lcov-parse": "^0.0.10",
                 "log-driver": "^1.2.7",
                 "minimist": "^1.2.0",
-                "request": "^2.85.0"
-            },
-            "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-                    "dev": true
-                }
+                "request": "^2.86.0"
             }
         },
         "cross-spawn": {
@@ -1592,18 +1502,18 @@
             }
         },
         "cssom": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
-            "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
+            "version": "0.3.8",
+            "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+            "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
             "dev": true
         },
         "cssstyle": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.1.1.tgz",
-            "integrity": "sha512-364AI1l/M5TYcFH83JnOH/pSqgaNnKmYgKrm0didZMGKWjQB60dymwWy1rKUgL3J1ffdq9xVi2yGLHdSjjSNog==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-1.3.0.tgz",
+            "integrity": "sha512-wXsoRfsRfsLVNaVzoKdqvEmK/5PFaEXNspVT22Ots6K/cnJdpoDKuQFw+qlMiXnmaif1OgeC466X1zISgAOcGg==",
             "dev": true,
             "requires": {
-                "cssom": "0.3.x"
+                "cssom": "~0.3.6"
             }
         },
         "currently-unhandled": {
@@ -1655,12 +1565,12 @@
             "dev": true
         },
         "debug": {
-            "version": "2.6.9",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-            "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+            "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
             "dev": true,
             "requires": {
-                "ms": "2.0.0"
+                "ms": "^2.1.1"
             }
         },
         "decamelize": {
@@ -1683,7 +1593,7 @@
         },
         "deep-eql": {
             "version": "0.1.3",
-            "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
             "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
             "requires": {
                 "type-detect": "0.1.1"
@@ -1835,21 +1745,13 @@
             }
         },
         "dom-serializer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+            "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
             "dev": true,
             "requires": {
-                "domelementtype": "~1.1.1",
-                "entities": "~1.1.1"
-            },
-            "dependencies": {
-                "domelementtype": {
-                    "version": "1.1.3",
-                    "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-                    "dev": true
-                }
+                "domelementtype": "^1.3.0",
+                "entities": "^1.1.1"
             }
         },
         "domelementtype": {
@@ -1897,15 +1799,13 @@
             }
         },
         "editorconfig": {
-            "version": "0.15.2",
-            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.2.tgz",
-            "integrity": "sha512-GWjSI19PVJAM9IZRGOS+YKI8LN+/sjkSjNyvxL5ucqP9/IqtYNXBaQ/6c/hkPNYQHyOHra2KoXZI/JVpuqwmcQ==",
+            "version": "0.15.3",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.15.3.tgz",
+            "integrity": "sha512-M9wIMFx96vq0R4F+gRpY3o2exzb8hEj/n9S8unZtHSvYjibBp/iMufSzvmOcV/laG0ZtuTVGtiJggPOSW2r93g==",
             "dev": true,
             "requires": {
-                "@types/node": "^10.11.7",
-                "@types/semver": "^5.5.0",
                 "commander": "^2.19.0",
-                "lru-cache": "^4.1.3",
+                "lru-cache": "^4.1.5",
                 "semver": "^5.6.0",
                 "sigmund": "^1.0.1"
             }
@@ -1929,9 +1829,9 @@
             "dev": true
         },
         "enquirer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.0.tgz",
-            "integrity": "sha512-RNGUbRVlfnjmpxV+Ed+7CGu0rg3MK7MmlW+DW0v7V2zdAUBC1s4BxCRiIAozbYB2UJ+q4D+8tW9UFb11kF72/g==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.1.tgz",
+            "integrity": "sha512-7slmHsJY+mvnIrzD0Z0FfTFLmVJuIzRNCW72X9s35BshOoC+MI4jLJ8aPyAC/BelAirXBZB+Mu1wSqP0wpW4Kg==",
             "dev": true,
             "requires": {
                 "ansi-colors": "^3.2.1"
@@ -1960,6 +1860,21 @@
                 "stackframe": "^1.0.4"
             }
         },
+        "es6-promise": {
+            "version": "4.2.8",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+            "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+            "dev": true
+        },
+        "es6-promisify": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^4.0.3"
+            }
+        },
         "escape-html": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -1973,9 +1888,9 @@
             "dev": true
         },
         "escodegen": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.0.tgz",
-            "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.11.1.tgz",
+            "integrity": "sha512-JwiqFD9KdGVVpeuRa68yU3zZnBEOcPs0nKW7wZzXky8Z7tffdYUHbe11bPCV5jYlK6DVdKLWLm0f5I/QlL0Kmw==",
             "requires": {
                 "esprima": "^3.1.3",
                 "estraverse": "^4.2.0",
@@ -1993,7 +1908,7 @@
         },
         "eslint": {
             "version": "4.19.1",
-            "resolved": "http://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.19.1.tgz",
             "integrity": "sha512-bT3/1x1EbZB7phzYu7vCr1v3ONuzDtX8WjuM9c0iYxe+cq+pwcKEoQjl7zd3RpC6YOLgnSy3cTN58M2jcoPDIQ==",
             "dev": true,
             "requires": {
@@ -2055,26 +1970,6 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -2086,26 +1981,14 @@
                 },
                 "fast-deep-equal": {
                     "version": "1.1.0",
-                    "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
                     "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-                    "dev": true
-                },
-                "globals": {
-                    "version": "11.9.0",
-                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.9.0.tgz",
-                    "integrity": "sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==",
                     "dev": true
                 },
                 "json-schema-traverse": {
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
                     "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-                    "dev": true
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
                     "dev": true
                 },
                 "strip-ansi": {
@@ -2115,15 +1998,6 @@
                     "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -2155,7 +2029,7 @@
         },
         "espree": {
             "version": "3.5.4",
-            "resolved": "http://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
             "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
             "dev": true,
             "requires": {
@@ -2204,7 +2078,7 @@
         },
         "events": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
             "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
         },
         "events-light": {
@@ -2241,7 +2115,7 @@
         },
         "expand-range": {
             "version": "1.8.2",
-            "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
@@ -2249,41 +2123,64 @@
             }
         },
         "express": {
-            "version": "4.16.4",
-            "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-            "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
+            "version": "4.17.1",
+            "resolved": "https://registry.npmjs.org/express/-/express-4.17.1.tgz",
+            "integrity": "sha512-mHJ9O79RqluphRrcw2X/GTh3k9tVv8YcoyY4Kkh4WDMUYKRZUq0h1o0w2rrrxBqM7VoeUVqgb27xlEMXTnYt4g==",
             "dev": true,
             "requires": {
-                "accepts": "~1.3.5",
+                "accepts": "~1.3.7",
                 "array-flatten": "1.1.1",
-                "body-parser": "1.18.3",
-                "content-disposition": "0.5.2",
+                "body-parser": "1.19.0",
+                "content-disposition": "0.5.3",
                 "content-type": "~1.0.4",
-                "cookie": "0.3.1",
+                "cookie": "0.4.0",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
                 "depd": "~1.1.2",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
-                "finalhandler": "1.1.1",
+                "finalhandler": "~1.1.2",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
                 "methods": "~1.1.2",
                 "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
+                "parseurl": "~1.3.3",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "~2.0.4",
-                "qs": "6.5.2",
-                "range-parser": "~1.2.0",
+                "proxy-addr": "~2.0.5",
+                "qs": "6.7.0",
+                "range-parser": "~1.2.1",
                 "safe-buffer": "5.1.2",
-                "send": "0.16.2",
-                "serve-static": "1.13.2",
-                "setprototypeof": "1.1.0",
-                "statuses": "~1.4.0",
-                "type-is": "~1.6.16",
+                "send": "0.17.1",
+                "serve-static": "1.14.1",
+                "setprototypeof": "1.1.1",
+                "statuses": "~1.5.0",
+                "type-is": "~1.6.18",
                 "utils-merge": "1.0.1",
                 "vary": "~1.1.2"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
+                "qs": {
+                    "version": "6.7.0",
+                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
+                    "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==",
+                    "dev": true
+                }
             }
         },
         "extend": {
@@ -2315,7 +2212,7 @@
         },
         "external-editor": {
             "version": "2.2.0",
-            "resolved": "http://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.2.0.tgz",
             "integrity": "sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==",
             "dev": true,
             "requires": {
@@ -2377,7 +2274,7 @@
         },
         "file-type": {
             "version": "3.9.0",
-            "resolved": "http://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+            "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
             "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek=",
             "dev": true
         },
@@ -2401,18 +2298,35 @@
             }
         },
         "finalhandler": {
-            "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-            "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
+            "integrity": "sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
                 "on-finished": "~2.3.0",
-                "parseurl": "~1.3.2",
-                "statuses": "~1.4.0",
+                "parseurl": "~1.3.3",
+                "statuses": "~1.5.0",
                 "unpipe": "~1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
             }
         },
         "find-parent-dir": {
@@ -2519,14 +2433,14 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+            "version": "1.2.9",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+            "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "^2.9.2",
-                "node-pre-gyp": "^0.10.0"
+                "nan": "^2.12.1",
+                "node-pre-gyp": "^0.12.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -2548,7 +2462,7 @@
                     "optional": true
                 },
                 "are-we-there-yet": {
-                    "version": "1.1.4",
+                    "version": "1.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2574,7 +2488,7 @@
                     }
                 },
                 "chownr": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2604,16 +2518,16 @@
                     "optional": true
                 },
                 "debug": {
-                    "version": "2.6.9",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
                 },
                 "deep-extend": {
-                    "version": "0.5.1",
+                    "version": "0.6.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2662,7 +2576,7 @@
                     }
                 },
                 "glob": {
-                    "version": "7.1.2",
+                    "version": "7.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2682,12 +2596,12 @@
                     "optional": true
                 },
                 "iconv-lite": {
-                    "version": "0.4.21",
+                    "version": "0.4.24",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "^2.1.0"
+                        "safer-buffer": ">= 2.1.2 < 3"
                     }
                 },
                 "ignore-walk": {
@@ -2752,17 +2666,17 @@
                     "optional": true
                 },
                 "minipass": {
-                    "version": "2.2.4",
+                    "version": "2.3.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
-                    "version": "1.1.0",
+                    "version": "1.2.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2780,35 +2694,35 @@
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "needle": {
-                    "version": "2.2.0",
+                    "version": "2.3.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "^2.1.2",
+                        "debug": "^4.1.0",
                         "iconv-lite": "^0.4.4",
                         "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
-                    "version": "0.10.0",
+                    "version": "0.12.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
                         "detect-libc": "^1.0.2",
                         "mkdirp": "^0.5.1",
-                        "needle": "^2.2.0",
+                        "needle": "^2.2.1",
                         "nopt": "^4.0.1",
                         "npm-packlist": "^1.1.6",
                         "npmlog": "^4.0.2",
-                        "rc": "^1.1.7",
+                        "rc": "^1.2.7",
                         "rimraf": "^2.6.1",
                         "semver": "^5.3.0",
                         "tar": "^4"
@@ -2825,13 +2739,13 @@
                     }
                 },
                 "npm-bundled": {
-                    "version": "1.0.3",
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "npm-packlist": {
-                    "version": "1.1.10",
+                    "version": "1.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -2908,12 +2822,12 @@
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.7",
+                    "version": "1.2.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "^0.5.1",
+                        "deep-extend": "^0.6.0",
                         "ini": "~1.3.0",
                         "minimist": "^1.2.0",
                         "strip-json-comments": "~2.0.1"
@@ -2943,16 +2857,16 @@
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.1.1",
+                    "version": "5.1.2",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2970,7 +2884,7 @@
                     "optional": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.7.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -3023,17 +2937,17 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "4.4.1",
+                    "version": "4.4.8",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "^1.0.1",
+                        "chownr": "^1.1.1",
                         "fs-minipass": "^1.2.5",
-                        "minipass": "^2.2.4",
-                        "minizlib": "^1.1.0",
+                        "minipass": "^2.3.4",
+                        "minizlib": "^1.1.1",
                         "mkdirp": "^0.5.0",
-                        "safe-buffer": "^5.1.1",
+                        "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.2"
                     }
                 },
@@ -3044,12 +2958,12 @@
                     "optional": true
                 },
                 "wide-align": {
-                    "version": "1.1.2",
+                    "version": "1.1.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "^1.0.2"
+                        "string-width": "^1.0.2 || 2"
                     }
                 },
                 "wrappy": {
@@ -3059,7 +2973,7 @@
                     "optional": true
                 },
                 "yallist": {
-                    "version": "3.0.2",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -3086,7 +3000,7 @@
         },
         "get-stream": {
             "version": "3.0.0",
-            "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
             "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
             "dev": true
         },
@@ -3106,9 +3020,9 @@
             }
         },
         "glob": {
-            "version": "7.1.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-            "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+            "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
             "dev": true,
             "requires": {
                 "fs.realpath": "^1.0.0",
@@ -3139,15 +3053,15 @@
             }
         },
         "globals": {
-            "version": "9.18.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+            "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
         },
         "graceful-fs": {
-            "version": "4.1.15",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-            "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+            "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
             "dev": true
         },
         "growl": {
@@ -3278,32 +3192,32 @@
             }
         },
         "htmljs-parser": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.7.tgz",
-            "integrity": "sha512-+2amNVKiTPK6UKNbhzIDFP68vI2x0Ant/yvQX8Icr5Ry4LA2EFqiQEJIQSP0bun2w8gDFN5n9vc41BihVpbOnA==",
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-2.6.8.tgz",
+            "integrity": "sha512-il0NrLbNyt29nZuciLbrRKRMBi8VVVjVpv/x37z9qyubQscsoMzcsw3Fp35QvPR9p2eurQ/TBKrfdZ+joDX/rw==",
             "requires": {
                 "char-props": "^0.1.5",
                 "complain": "^1.0.0"
             }
         },
         "htmlparser2": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
-            "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
+            "version": "3.10.1",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+            "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
             "dev": true,
             "requires": {
-                "domelementtype": "^1.3.0",
+                "domelementtype": "^1.3.1",
                 "domhandler": "^2.3.0",
                 "domutils": "^1.5.1",
                 "entities": "^1.1.1",
                 "inherits": "^2.0.1",
-                "readable-stream": "^3.0.6"
+                "readable-stream": "^3.1.1"
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.0.6",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
-                    "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+                    "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
                     "dev": true,
                     "requires": {
                         "inherits": "^2.0.3",
@@ -3314,15 +3228,24 @@
             }
         },
         "http-errors": {
-            "version": "1.6.3",
-            "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-            "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+            "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
             "dev": true,
             "requires": {
                 "depd": "~1.1.2",
                 "inherits": "2.0.3",
-                "setprototypeof": "1.1.0",
-                "statuses": ">= 1.4.0 < 2"
+                "setprototypeof": "1.1.1",
+                "statuses": ">= 1.5.0 < 2",
+                "toidentifier": "1.0.0"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+                    "dev": true
+                }
             }
         },
         "http-signature": {
@@ -3334,6 +3257,27 @@
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
+            }
+        },
+        "https-proxy-agent": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+            "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
+            "dev": true,
+            "requires": {
+                "agent-base": "^4.3.0",
+                "debug": "^3.1.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.2.6",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
             }
         },
         "husky": {
@@ -3438,9 +3382,9 @@
             }
         },
         "inherits": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
             "dev": true
         },
         "inquirer": {
@@ -3471,26 +3415,6 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
                 "strip-ansi": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -3499,22 +3423,13 @@
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
                 }
             }
         },
         "interpret": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
-            "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+            "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
             "dev": true
         },
         "invariant": {
@@ -3527,9 +3442,9 @@
             }
         },
         "ipaddr.js": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-            "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+            "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA==",
             "dev": true
         },
         "is-absolute": {
@@ -3579,15 +3494,6 @@
             "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
             "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
             "dev": true
-        },
-        "is-builtin-module": {
-            "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-            "dev": true,
-            "requires": {
-                "builtin-modules": "^1.0.0"
-            }
         },
         "is-ci": {
             "version": "1.2.1",
@@ -3694,7 +3600,7 @@
         },
         "is-obj": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
@@ -3855,7 +3761,7 @@
         },
         "jest-get-type": {
             "version": "22.4.3",
-            "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+            "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
             "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
             "dev": true
         },
@@ -3869,55 +3775,24 @@
                 "jest-get-type": "^22.1.0",
                 "leven": "^2.1.0",
                 "pretty-format": "^23.6.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "jquery": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
-            "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
+            "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw==",
             "dev": true
         },
         "js-tokens": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+            "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "dev": true
         },
         "js-yaml": {
-            "version": "3.12.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-            "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+            "version": "3.13.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -3976,9 +3851,9 @@
             }
         },
         "jsesc": {
-            "version": "1.3.0",
-            "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-            "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+            "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
             "dev": true
         },
         "json-parse-better-errors": {
@@ -4012,14 +3887,17 @@
             "dev": true
         },
         "json5": {
-            "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-            "dev": true
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+            "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+            "dev": true,
+            "requires": {
+                "minimist": "^1.2.0"
+            }
         },
         "jsonfile": {
             "version": "2.4.0",
-            "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
             "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
             "dev": true,
             "requires": {
@@ -4149,26 +4027,6 @@
                 "stringify-object": "^3.2.2"
             },
             "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
                 "debug": {
                     "version": "3.2.6",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -4185,27 +4043,12 @@
                     "dev": true
                 },
                 "is-glob": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-                    "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
                     "dev": true,
                     "requires": {
                         "is-extglob": "^2.1.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
                     }
                 }
             }
@@ -4233,9 +4076,9 @@
             },
             "dependencies": {
                 "p-map": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.0.0.tgz",
-                    "integrity": "sha512-GO107XdrSUmtHxVoi60qc9tUl/KkNKm+X2CF4P9amalpGxv5YqVPJNfSb0wcA+syCopkZvYYIzW8OVTQW59x/w==",
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+                    "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
                     "dev": true
                 }
             }
@@ -4262,6 +4105,25 @@
                 "strip-ansi": "^3.0.1"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
+                    }
+                },
                 "figures": {
                     "version": "1.7.0",
                     "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
@@ -4280,6 +4142,12 @@
                     "requires": {
                         "chalk": "^1.0.0"
                     }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
                 }
             }
         },
@@ -4293,42 +4161,11 @@
                 "cli-cursor": "^2.1.0",
                 "date-fns": "^1.27.2",
                 "figures": "^2.0.0"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "load-json-file": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
             "dev": true,
             "requires": {
@@ -4350,16 +4187,16 @@
                 },
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+            "version": "4.17.14",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+            "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
             "dev": true
         },
         "lodash.sortby": {
@@ -4381,37 +4218,6 @@
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1"
-            },
-            "dependencies": {
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                }
             }
         },
         "log-update": {
@@ -4476,9 +4282,9 @@
             }
         },
         "marko": {
-            "version": "4.14.20",
-            "resolved": "https://registry.npmjs.org/marko/-/marko-4.14.20.tgz",
-            "integrity": "sha512-YZo+pLR2n9KJtgXTEgRFfPmGpWKzb0InL5OS9IWkPYVP2b/uw+qKuN3RURit56w8dfhR2jjk1XX7C4luXjwMRg==",
+            "version": "4.14.21",
+            "resolved": "https://registry.npmjs.org/marko/-/marko-4.14.21.tgz",
+            "integrity": "sha512-e4jfR/4P3NuoQIZsHuOh3VpIzagsYZKMiQM0gtRwRhmAqUgjVxJP5zEJUIl4KZv9xKjauWxy5ndListzuYsf6w==",
             "dev": true,
             "requires": {
                 "app-module-path": "^2.2.0",
@@ -4494,7 +4300,7 @@
                 "events": "^1.0.2",
                 "events-light": "^1.0.0",
                 "he": "^1.1.0",
-                "htmljs-parser": "^2.6.0",
+                "htmljs-parser": "^2.6.1",
                 "lasso-caching-fs": "^1.0.1",
                 "lasso-modules-client": "^2.0.4",
                 "lasso-package-root": "^1.0.1",
@@ -4526,20 +4332,20 @@
             }
         },
         "math-random": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
-            "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
+            "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
             "dev": true
         },
         "media-typer": {
             "version": "0.3.0",
-            "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
             "dev": true
         },
         "meow": {
             "version": "3.7.0",
-            "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
             "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
             "dev": true,
             "requires": {
@@ -4555,11 +4361,39 @@
                 "trim-newlines": "^1.0.0"
             },
             "dependencies": {
-                "minimist": {
-                    "version": "1.2.0",
-                    "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-                    "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+                "get-stdin": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+                    "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
                     "dev": true
+                },
+                "indent-string": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                    "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                    "dev": true,
+                    "requires": {
+                        "repeating": "^2.0.0"
+                    }
+                },
+                "redent": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                    "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                    "dev": true,
+                    "requires": {
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
+                    }
+                },
+                "strip-indent": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                    "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                    "dev": true,
+                    "requires": {
+                        "get-stdin": "^4.0.1"
+                    }
                 }
             }
         },
@@ -4635,6 +4469,15 @@
                                 "is-extendable": "^0.1.0"
                             }
                         }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -4848,28 +4691,34 @@
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
                     "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
                     "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 }
             }
         },
         "mime": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-            "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+            "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
             "dev": true
         },
         "mime-db": {
-            "version": "1.37.0",
-            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-            "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg==",
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+            "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
             "dev": true
         },
         "mime-types": {
-            "version": "2.1.21",
-            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-            "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+            "version": "2.1.24",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+            "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
             "dev": true,
             "requires": {
-                "mime-db": "~1.37.0"
+                "mime-db": "1.40.0"
             }
         },
         "mimic-fn": {
@@ -4887,15 +4736,15 @@
             }
         },
         "minimist": {
-            "version": "0.0.8",
-            "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
             "dev": true
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
@@ -4915,11 +4764,19 @@
         },
         "mkdirp": {
             "version": "0.5.1",
-            "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
             "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
             "dev": true,
             "requires": {
                 "minimist": "0.0.8"
+            },
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
             }
         },
         "mocha": {
@@ -4943,7 +4800,7 @@
             "dependencies": {
                 "commander": {
                     "version": "2.15.1",
-                    "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
                     "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
                     "dev": true
                 },
@@ -4976,6 +4833,12 @@
                     "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
                     "dev": true
                 },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                },
                 "supports-color": {
                     "version": "5.4.0",
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
@@ -4988,9 +4851,9 @@
             }
         },
         "ms": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
         },
         "mute-stream": {
@@ -5011,9 +4874,9 @@
             }
         },
         "nan": {
-            "version": "2.11.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-            "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+            "version": "2.14.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+            "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
             "dev": true,
             "optional": true
         },
@@ -5063,19 +4926,25 @@
             "dev": true
         },
         "negotiator": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
+            "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==",
+            "dev": true
+        },
+        "node-fetch": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+            "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
             "dev": true
         },
         "normalize-package-data": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+            "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
             "dev": true,
             "requires": {
                 "hosted-git-info": "^2.1.4",
-                "is-builtin-module": "^1.0.0",
+                "resolve": "^1.10.0",
                 "semver": "2 || 3 || 4 || 5",
                 "validate-npm-package-license": "^3.0.1"
             }
@@ -5125,60 +4994,43 @@
             "dev": true
         },
         "nwsapi": {
-            "version": "2.0.9",
-            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.0.9.tgz",
-            "integrity": "sha512-nlWFSCTYQcHk/6A9FFnfhKc14c3aFhfdNBXgo8Qgi9QTBu/qg3Ww+Uiz9wMzXd1T8GFxPc2QIHB6Qtf2XFryFQ==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.1.4.tgz",
+            "integrity": "sha512-iGfd9Y6SFdTNldEy2L0GUhcarIutFmk+MPWIn9dmj8NMIup03G08uUF2KGbbmv/Ux4RT0VZJoP/sVbWA6d/VIw==",
             "dev": true
         },
         "nyc": {
-            "version": "13.1.0",
-            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.1.0.tgz",
-            "integrity": "sha512-3GyY6TpQ58z9Frpv4GMExE1SV2tAgYqC7HSy2omEhNiCT3mhT9NyiOvIE8zkbuJVFzmvvNTnE4h/7/wQae7xLg==",
+            "version": "13.3.0",
+            "resolved": "https://registry.npmjs.org/nyc/-/nyc-13.3.0.tgz",
+            "integrity": "sha512-P+FwIuro2aFG6B0Esd9ZDWUd51uZrAEoGutqZxzrVmYl3qSfkLgcQpBPBjtDFsUQLFY1dvTQJPOyeqr8S9GF8w==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
                 "arrify": "^1.0.1",
-                "caching-transform": "^2.0.0",
+                "caching-transform": "^3.0.1",
                 "convert-source-map": "^1.6.0",
-                "debug-log": "^1.0.1",
                 "find-cache-dir": "^2.0.0",
                 "find-up": "^3.0.0",
                 "foreground-child": "^1.5.6",
                 "glob": "^7.1.3",
-                "istanbul-lib-coverage": "^2.0.1",
-                "istanbul-lib-hook": "^2.0.1",
-                "istanbul-lib-instrument": "^3.0.0",
-                "istanbul-lib-report": "^2.0.2",
-                "istanbul-lib-source-maps": "^2.0.1",
-                "istanbul-reports": "^2.0.1",
+                "istanbul-lib-coverage": "^2.0.3",
+                "istanbul-lib-hook": "^2.0.3",
+                "istanbul-lib-instrument": "^3.1.0",
+                "istanbul-lib-report": "^2.0.4",
+                "istanbul-lib-source-maps": "^3.0.2",
+                "istanbul-reports": "^2.1.1",
                 "make-dir": "^1.3.0",
                 "merge-source-map": "^1.1.0",
                 "resolve-from": "^4.0.0",
-                "rimraf": "^2.6.2",
+                "rimraf": "^2.6.3",
                 "signal-exit": "^3.0.2",
                 "spawn-wrap": "^1.4.2",
-                "test-exclude": "^5.0.0",
+                "test-exclude": "^5.1.0",
                 "uuid": "^3.3.2",
-                "yargs": "11.1.0",
-                "yargs-parser": "^9.0.2"
+                "yargs": "^12.0.5",
+                "yargs-parser": "^11.1.1"
             },
             "dependencies": {
-                "align-text": {
-                    "version": "0.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "kind-of": "^3.0.2",
-                        "longest": "^1.0.1",
-                        "repeat-string": "^1.5.2"
-                    }
-                },
-                "amdefine": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "ansi-regex": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -5203,9 +5055,12 @@
                     "dev": true
                 },
                 "async": {
-                    "version": "1.5.2",
+                    "version": "2.6.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "lodash": "^4.17.11"
+                    }
                 },
                 "balanced-match": {
                     "version": "1.0.0",
@@ -5221,61 +5076,42 @@
                         "concat-map": "0.0.1"
                     }
                 },
-                "builtin-modules": {
-                    "version": "1.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "caching-transform": {
-                    "version": "2.0.0",
+                    "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "make-dir": "^1.0.0",
-                        "md5-hex": "^2.0.0",
-                        "package-hash": "^2.0.0",
-                        "write-file-atomic": "^2.0.0"
+                        "hasha": "^3.0.0",
+                        "make-dir": "^1.3.0",
+                        "package-hash": "^3.0.0",
+                        "write-file-atomic": "^2.3.0"
                     }
                 },
                 "camelcase": {
-                    "version": "1.2.1",
+                    "version": "5.0.0",
                     "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "center-align": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "align-text": "^0.1.3",
-                        "lazy-cache": "^1.0.3"
-                    }
+                    "dev": true
                 },
                 "cliui": {
-                    "version": "2.1.0",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
-                    "optional": true,
                     "requires": {
-                        "center-align": "^0.1.1",
-                        "right-align": "^0.1.1",
-                        "wordwrap": "0.0.2"
-                    },
-                    "dependencies": {
-                        "wordwrap": {
-                            "version": "0.0.2",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
                     "dev": true
+                },
+                "commander": {
+                    "version": "2.17.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
                 },
                 "commondir": {
                     "version": "1.0.1",
@@ -5305,17 +5141,12 @@
                     }
                 },
                 "debug": {
-                    "version": "3.1.0",
+                    "version": "4.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ms": "2.0.0"
+                        "ms": "^2.1.1"
                     }
-                },
-                "debug-log": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true
                 },
                 "decamelize": {
                     "version": "1.2.0",
@@ -5328,6 +5159,14 @@
                     "dev": true,
                     "requires": {
                         "strip-bom": "^3.0.0"
+                    }
+                },
+                "end-of-stream": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "once": "^1.4.0"
                     }
                 },
                 "error-ex": {
@@ -5344,12 +5183,12 @@
                     "dev": true
                 },
                 "execa": {
-                    "version": "0.7.0",
+                    "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "^5.0.1",
-                        "get-stream": "^3.0.0",
+                        "cross-spawn": "^6.0.0",
+                        "get-stream": "^4.0.0",
                         "is-stream": "^1.1.0",
                         "npm-run-path": "^2.0.0",
                         "p-finally": "^1.0.0",
@@ -5358,11 +5197,13 @@
                     },
                     "dependencies": {
                         "cross-spawn": {
-                            "version": "5.1.0",
+                            "version": "6.0.5",
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "lru-cache": "^4.0.1",
+                                "nice-try": "^1.0.4",
+                                "path-key": "^2.0.1",
+                                "semver": "^5.5.0",
                                 "shebang-command": "^1.2.0",
                                 "which": "^1.2.9"
                             }
@@ -5407,9 +5248,12 @@
                     "dev": true
                 },
                 "get-stream": {
-                    "version": "3.0.0",
+                    "version": "4.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
                 },
                 "glob": {
                     "version": "7.1.3",
@@ -5425,28 +5269,25 @@
                     }
                 },
                 "graceful-fs": {
-                    "version": "4.1.11",
+                    "version": "4.1.15",
                     "bundled": true,
                     "dev": true
                 },
                 "handlebars": {
-                    "version": "4.0.11",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "async": "^1.4.0",
+                        "async": "^2.5.0",
                         "optimist": "^0.6.1",
-                        "source-map": "^0.4.4",
-                        "uglify-js": "^2.6"
+                        "source-map": "^0.6.1",
+                        "uglify-js": "^3.1.4"
                     },
                     "dependencies": {
                         "source-map": {
-                            "version": "0.4.4",
+                            "version": "0.6.1",
                             "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "amdefine": ">=0.0.4"
-                            }
+                            "dev": true
                         }
                     }
                 },
@@ -5454,6 +5295,14 @@
                     "version": "3.0.0",
                     "bundled": true,
                     "dev": true
+                },
+                "hasha": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "is-stream": "^1.0.1"
+                    }
                 },
                 "hosted-git-info": {
                     "version": "2.7.1",
@@ -5480,7 +5329,7 @@
                     "dev": true
                 },
                 "invert-kv": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -5488,20 +5337,6 @@
                     "version": "0.2.1",
                     "bundled": true,
                     "dev": true
-                },
-                "is-buffer": {
-                    "version": "1.1.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "is-builtin-module": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "builtin-modules": "^1.0.0"
-                    }
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
@@ -5519,12 +5354,12 @@
                     "dev": true
                 },
                 "istanbul-lib-coverage": {
-                    "version": "2.0.1",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true
                 },
                 "istanbul-lib-hook": {
-                    "version": "2.0.1",
+                    "version": "2.0.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -5532,37 +5367,61 @@
                     }
                 },
                 "istanbul-lib-instrument": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.0.0.tgz",
-                    "integrity": "sha512-eQY9vN9elYjdgN9Iv6NS/00bptm02EBBk70lRMaVjeA6QYocQgenVrSgC28TJurdnZa80AGO3ASdFN+w/njGiQ==",
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-3.3.0.tgz",
+                    "integrity": "sha512-5nnIN4vo5xQZHdXno/YDXJ0G+I3dAm4XgzfSVTPLQpj/zAV2dV6Juy0yaf10/zrJOJeHoN3fraFe+XRq2bFVZA==",
                     "dev": true,
                     "requires": {
-                        "@babel/generator": "^7.0.0",
-                        "@babel/parser": "^7.0.0",
-                        "@babel/template": "^7.0.0",
-                        "@babel/traverse": "^7.0.0",
-                        "@babel/types": "^7.0.0",
-                        "istanbul-lib-coverage": "^2.0.1",
-                        "semver": "^5.5.0"
+                        "@babel/generator": "^7.4.0",
+                        "@babel/parser": "^7.4.3",
+                        "@babel/template": "^7.4.0",
+                        "@babel/traverse": "^7.4.3",
+                        "@babel/types": "^7.4.0",
+                        "istanbul-lib-coverage": "^2.0.5",
+                        "semver": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "istanbul-lib-coverage": {
+                            "version": "2.0.5",
+                            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+                            "integrity": "sha512-8aXznuEPCJvGnMSRft4udDRDtb1V3pkQkMMI5LI+6HuQz5oQ4J2UFn1H82raA3qJtyOLkkwVqICBQkjnGtn5mA==",
+                            "dev": true
+                        },
+                        "semver": {
+                            "version": "6.2.0",
+                            "resolved": "https://registry.npmjs.org/semver/-/semver-6.2.0.tgz",
+                            "integrity": "sha512-jdFC1VdUGT/2Scgbimf7FSx9iJLXoqfglSF+gJeuNWVpiE37OIbc1jywR/GJyFdz3mnkz2/id0L0J/cr0izR5A==",
+                            "dev": true
+                        }
                     }
                 },
                 "istanbul-lib-report": {
-                    "version": "2.0.2",
+                    "version": "2.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "istanbul-lib-coverage": "^2.0.1",
+                        "istanbul-lib-coverage": "^2.0.3",
                         "make-dir": "^1.3.0",
-                        "supports-color": "^5.4.0"
+                        "supports-color": "^6.0.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "6.1.0",
+                            "bundled": true,
+                            "dev": true,
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
                     }
                 },
                 "istanbul-lib-source-maps": {
-                    "version": "2.0.1",
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "debug": "^3.1.0",
-                        "istanbul-lib-coverage": "^2.0.1",
+                        "debug": "^4.1.1",
+                        "istanbul-lib-coverage": "^2.0.3",
                         "make-dir": "^1.3.0",
                         "rimraf": "^2.6.2",
                         "source-map": "^0.6.1"
@@ -5576,11 +5435,11 @@
                     }
                 },
                 "istanbul-reports": {
-                    "version": "2.0.1",
+                    "version": "2.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "handlebars": "^4.0.11"
+                        "handlebars": "^4.1.0"
                     }
                 },
                 "json-parse-better-errors": {
@@ -5588,27 +5447,12 @@
                     "bundled": true,
                     "dev": true
                 },
-                "kind-of": {
-                    "version": "3.2.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                },
-                "lazy-cache": {
-                    "version": "1.0.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "lcid": {
-                    "version": "1.0.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "invert-kv": "^1.0.0"
+                        "invert-kv": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -5631,19 +5475,18 @@
                         "path-exists": "^3.0.0"
                     }
                 },
+                "lodash": {
+                    "version": "4.17.11",
+                    "bundled": true,
+                    "dev": true
+                },
                 "lodash.flattendeep": {
                     "version": "4.4.0",
                     "bundled": true,
                     "dev": true
                 },
-                "longest": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "lru-cache": {
-                    "version": "4.1.3",
+                    "version": "4.1.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -5659,25 +5502,22 @@
                         "pify": "^3.0.0"
                     }
                 },
-                "md5-hex": {
-                    "version": "2.0.0",
+                "map-age-cleaner": {
+                    "version": "0.1.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "md5-o-matic": "^0.1.1"
+                        "p-defer": "^1.0.0"
                     }
                 },
-                "md5-o-matic": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true
-                },
                 "mem": {
-                    "version": "1.1.0",
+                    "version": "4.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "^1.0.0"
+                        "map-age-cleaner": "^0.1.1",
+                        "mimic-fn": "^1.0.0",
+                        "p-is-promise": "^2.0.0"
                     }
                 },
                 "merge-source-map": {
@@ -5729,17 +5569,22 @@
                     }
                 },
                 "ms": {
-                    "version": "2.0.0",
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "nice-try": {
+                    "version": "1.0.5",
                     "bundled": true,
                     "dev": true
                 },
                 "normalize-package-data": {
-                    "version": "2.4.0",
+                    "version": "2.5.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "hosted-git-info": "^2.1.4",
-                        "is-builtin-module": "^1.0.0",
+                        "resolve": "^1.10.0",
                         "semver": "2 || 3 || 4 || 5",
                         "validate-npm-package-license": "^3.0.1"
                     }
@@ -5780,22 +5625,32 @@
                     "dev": true
                 },
                 "os-locale": {
-                    "version": "2.1.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "execa": "^0.7.0",
-                        "lcid": "^1.0.0",
-                        "mem": "^1.1.0"
+                        "execa": "^1.0.0",
+                        "lcid": "^2.0.0",
+                        "mem": "^4.0.0"
                     }
+                },
+                "p-defer": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
                 },
                 "p-finally": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "p-limit": {
+                "p-is-promise": {
                     "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "p-limit": {
+                    "version": "2.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -5816,13 +5671,13 @@
                     "dev": true
                 },
                 "package-hash": {
-                    "version": "2.0.0",
+                    "version": "3.0.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "^4.1.11",
+                        "graceful-fs": "^4.1.15",
+                        "hasha": "^3.0.0",
                         "lodash.flattendeep": "^4.4.0",
-                        "md5-hex": "^2.0.0",
                         "release-zalgo": "^1.0.0"
                     }
                 },
@@ -5847,6 +5702,11 @@
                 },
                 "path-key": {
                     "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "path-parse": {
+                    "version": "1.0.6",
                     "bundled": true,
                     "dev": true
                 },
@@ -5876,6 +5736,15 @@
                     "bundled": true,
                     "dev": true
                 },
+                "pump": {
+                    "version": "3.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                },
                 "read-pkg": {
                     "version": "3.0.0",
                     "bundled": true,
@@ -5903,12 +5772,6 @@
                         "es6-error": "^4.0.1"
                     }
                 },
-                "repeat-string": {
-                    "version": "1.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "require-directory": {
                     "version": "2.1.1",
                     "bundled": true,
@@ -5919,26 +5782,25 @@
                     "bundled": true,
                     "dev": true
                 },
+                "resolve": {
+                    "version": "1.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "path-parse": "^1.0.6"
+                    }
+                },
                 "resolve-from": {
                     "version": "4.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "right-align": {
-                    "version": "0.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "align-text": "^0.1.1"
-                    }
-                },
                 "rimraf": {
-                    "version": "2.6.2",
+                    "version": "2.6.3",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "glob": "^7.0.5"
+                        "glob": "^7.1.3"
                     }
                 },
                 "safe-buffer": {
@@ -5947,7 +5809,7 @@
                     "dev": true
                 },
                 "semver": {
-                    "version": "5.5.0",
+                    "version": "5.6.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -5974,12 +5836,6 @@
                     "bundled": true,
                     "dev": true
                 },
-                "source-map": {
-                    "version": "0.5.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
                 "spawn-wrap": {
                     "version": "1.4.2",
                     "bundled": true,
@@ -5994,7 +5850,7 @@
                     }
                 },
                 "spdx-correct": {
-                    "version": "3.0.0",
+                    "version": "3.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6003,7 +5859,7 @@
                     }
                 },
                 "spdx-exceptions": {
-                    "version": "2.1.0",
+                    "version": "2.2.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -6017,7 +5873,7 @@
                     }
                 },
                 "spdx-license-ids": {
-                    "version": "3.0.0",
+                    "version": "3.0.3",
                     "bundled": true,
                     "dev": true
                 },
@@ -6048,16 +5904,8 @@
                     "bundled": true,
                     "dev": true
                 },
-                "supports-color": {
-                    "version": "5.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
-                },
                 "test-exclude": {
-                    "version": "5.0.0",
+                    "version": "5.1.0",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6068,35 +5916,22 @@
                     }
                 },
                 "uglify-js": {
-                    "version": "2.8.29",
+                    "version": "3.4.9",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
+                        "commander": "~2.17.1",
+                        "source-map": "~0.6.1"
                     },
                     "dependencies": {
-                        "yargs": {
-                            "version": "3.10.0",
+                        "source-map": {
+                            "version": "0.6.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
-                            "requires": {
-                                "camelcase": "^1.0.2",
-                                "cliui": "^2.1.0",
-                                "decamelize": "^1.0.0",
-                                "window-size": "0.1.0"
-                            }
+                            "optional": true
                         }
                     }
-                },
-                "uglify-to-browserify": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "uuid": {
                     "version": "3.3.2",
@@ -6104,7 +5939,7 @@
                     "dev": true
                 },
                 "validate-npm-package-license": {
-                    "version": "3.0.3",
+                    "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6124,12 +5959,6 @@
                     "version": "2.0.0",
                     "bundled": true,
                     "dev": true
-                },
-                "window-size": {
-                    "version": "0.1.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "wordwrap": {
                     "version": "0.0.3",
@@ -6184,7 +6013,7 @@
                     "dev": true
                 },
                 "write-file-atomic": {
-                    "version": "2.3.0",
+                    "version": "2.4.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
@@ -6194,7 +6023,7 @@
                     }
                 },
                 "y18n": {
-                    "version": "3.2.1",
+                    "version": "4.0.0",
                     "bundled": true,
                     "dev": true
                 },
@@ -6204,87 +6033,31 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "11.1.0",
+                    "version": "12.0.5",
                     "bundled": true,
                     "dev": true,
                     "requires": {
                         "cliui": "^4.0.0",
-                        "decamelize": "^1.1.1",
-                        "find-up": "^2.1.0",
+                        "decamelize": "^1.2.0",
+                        "find-up": "^3.0.0",
                         "get-caller-file": "^1.0.1",
-                        "os-locale": "^2.0.0",
+                        "os-locale": "^3.0.0",
                         "require-directory": "^2.1.1",
                         "require-main-filename": "^1.0.1",
                         "set-blocking": "^2.0.0",
                         "string-width": "^2.0.0",
                         "which-module": "^2.0.0",
-                        "y18n": "^3.2.1",
-                        "yargs-parser": "^9.0.2"
-                    },
-                    "dependencies": {
-                        "cliui": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "string-width": "^2.1.1",
-                                "strip-ansi": "^4.0.0",
-                                "wrap-ansi": "^2.0.0"
-                            }
-                        },
-                        "find-up": {
-                            "version": "2.1.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "locate-path": "^2.0.0"
-                            }
-                        },
-                        "locate-path": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-locate": "^2.0.0",
-                                "path-exists": "^3.0.0"
-                            }
-                        },
-                        "p-limit": {
-                            "version": "1.3.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-try": "^1.0.0"
-                            }
-                        },
-                        "p-locate": {
-                            "version": "2.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "requires": {
-                                "p-limit": "^1.1.0"
-                            }
-                        },
-                        "p-try": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^11.1.1"
                     }
                 },
                 "yargs-parser": {
-                    "version": "9.0.2",
+                    "version": "11.1.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "camelcase": "^4.1.0"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "4.1.0",
-                            "bundled": true,
-                            "dev": true
-                        }
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
                     }
                 }
             }
@@ -6395,7 +6168,7 @@
         },
         "opn": {
             "version": "4.0.2",
-            "resolved": "http://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
             "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
             "dev": true,
             "requires": {
@@ -6405,7 +6178,7 @@
         },
         "opn-cli": {
             "version": "3.1.0",
-            "resolved": "http://registry.npmjs.org/opn-cli/-/opn-cli-3.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/opn-cli/-/opn-cli-3.1.0.tgz",
             "integrity": "sha1-+BmubK4LQRvQFJuFYP5siK2tIPg=",
             "dev": true,
             "requires": {
@@ -6431,13 +6204,13 @@
         },
         "os-homedir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
             "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
             "dev": true
         },
         "os-tmpdir": {
             "version": "1.0.2",
-            "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
             "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
             "dev": true
         },
@@ -6493,9 +6266,9 @@
             "dev": true
         },
         "parseurl": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-            "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+            "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
             "dev": true
         },
         "pascalcase": {
@@ -6515,7 +6288,7 @@
         },
         "path-is-absolute": {
             "version": "1.0.1",
-            "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
             "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
             "dev": true
         },
@@ -6556,7 +6329,7 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 }
@@ -6634,9 +6407,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.15.3.tgz",
-            "integrity": "sha512-gAU9AGAPMaKb3NNSUUuhhFAS7SCO4ALTN4nRIn6PJ075Qd28Yn2Ig2ahEJWdJwJmlEBTUfC7mMUSFy8MwsOCfg==",
+            "version": "1.18.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
             "dev": true
         },
         "pretty-format": {
@@ -6654,15 +6427,6 @@
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
-                },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
                 }
             }
         },
@@ -6673,9 +6437,9 @@
             "dev": true
         },
         "process-nextick-args": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
             "dev": true
         },
         "progress": {
@@ -6690,13 +6454,13 @@
             "integrity": "sha1-yyDTIqq32U//rCj0bJGGvVlHtLQ="
         },
         "proxy-addr": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-            "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+            "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
             "dev": true,
             "requires": {
                 "forwarded": "~0.1.2",
-                "ipaddr.js": "1.8.0"
+                "ipaddr.js": "1.9.0"
             }
         },
         "pseudomap": {
@@ -6706,9 +6470,9 @@
             "dev": true
         },
         "psl": {
-            "version": "1.1.29",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-            "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+            "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
             "dev": true
         },
         "punycode": {
@@ -6754,9 +6518,9 @@
             }
         },
         "range-parser": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+            "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
             "dev": true
         },
         "raptor-async": {
@@ -6859,26 +6623,15 @@
             "integrity": "sha1-I7DIA8jxrIocrmfZpjiLSRYcl1g="
         },
         "raw-body": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-            "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz",
+            "integrity": "sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==",
             "dev": true,
             "requires": {
-                "bytes": "3.0.0",
-                "http-errors": "1.6.3",
-                "iconv-lite": "0.4.23",
+                "bytes": "3.1.0",
+                "http-errors": "1.7.2",
+                "iconv-lite": "0.4.24",
                 "unpipe": "1.0.0"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.4.23",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-                    "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-                    "dev": true,
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                }
             }
         },
         "read-pkg": {
@@ -6904,7 +6657,7 @@
         },
         "readable-stream": {
             "version": "2.3.6",
-            "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
@@ -6950,45 +6703,19 @@
             }
         },
         "redent": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-            "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+            "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "dev": true,
             "requires": {
-                "indent-string": "^2.1.0",
-                "strip-indent": "^1.0.1"
-            },
-            "dependencies": {
-                "get-stdin": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
-                    "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=",
-                    "dev": true
-                },
-                "indent-string": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                    "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-                    "dev": true,
-                    "requires": {
-                        "repeating": "^2.0.0"
-                    }
-                },
-                "strip-indent": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
-                    "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-                    "dev": true,
-                    "requires": {
-                        "get-stdin": "^4.0.1"
-                    }
-                }
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "regenerator-runtime": {
-            "version": "0.11.1",
-            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+            "version": "0.13.2",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
+            "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
             "dev": true
         },
         "regex-cache": {
@@ -7012,7 +6739,7 @@
         },
         "regexpp": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-1.1.0.tgz",
             "integrity": "sha512-LOPw8FpgdQF9etWMaAfG/WRthIdXJGYp4mJ2Jgn/2lpkbod9jPn0t9UqN7AxBOKNfzRbYyVfgc7Vk4t/MpnXgw==",
             "dev": true
         },
@@ -7072,28 +6799,28 @@
             }
         },
         "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
+            "integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
             "dev": true,
             "requires": {
-                "lodash": "^4.13.1"
+                "lodash": "^4.17.11"
             }
         },
         "request-promise-native": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.5.tgz",
-            "integrity": "sha1-UoF3D2jgyXGeUWP9P6tIIhX0/aU=",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
+            "integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
             "dev": true,
             "requires": {
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
+                "request-promise-core": "1.1.2",
+                "stealthy-require": "^1.1.1",
+                "tough-cookie": "^2.3.3"
             }
         },
         "require-uncached": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
@@ -7112,7 +6839,7 @@
                 },
                 "callsites": {
                     "version": "0.2.0",
-                    "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+                    "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
                     "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
                     "dev": true
                 },
@@ -7125,12 +6852,12 @@
             }
         },
         "resolve": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
-            "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+            "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
             "dev": true,
             "requires": {
-                "path-parse": "^1.0.5"
+                "path-parse": "^1.0.6"
             }
         },
         "resolve-from": {
@@ -7161,12 +6888,12 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.6.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "version": "2.6.3",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+            "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "dev": true,
             "requires": {
-                "glob": "^7.0.5"
+                "glob": "^7.1.3"
             }
         },
         "run-async": {
@@ -7199,9 +6926,9 @@
             }
         },
         "rxjs": {
-            "version": "6.3.3",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.3.tgz",
-            "integrity": "sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+            "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -7215,7 +6942,7 @@
         },
         "safe-regex": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
@@ -7235,9 +6962,9 @@
             "dev": true
         },
         "semver": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-            "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+            "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
             "dev": true
         },
         "semver-compare": {
@@ -7247,9 +6974,9 @@
             "dev": true
         },
         "send": {
-            "version": "0.16.2",
-            "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-            "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+            "version": "0.17.1",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.17.1.tgz",
+            "integrity": "sha512-BsVKsiGcQMFwT8UxypobUKyv7irCNRHk1T0G680vk88yf6LBByGcZJOTJCrTP2xVN6yI+XjPJcNuE3V4fT9sAg==",
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
@@ -7259,30 +6986,55 @@
                 "escape-html": "~1.0.3",
                 "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "~1.6.2",
-                "mime": "1.4.1",
-                "ms": "2.0.0",
+                "http-errors": "~1.7.2",
+                "mime": "1.6.0",
+                "ms": "2.1.1",
                 "on-finished": "~2.3.0",
-                "range-parser": "~1.2.0",
-                "statuses": "~1.4.0"
+                "range-parser": "~1.2.1",
+                "statuses": "~1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    },
+                    "dependencies": {
+                        "ms": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                            "dev": true
+                        }
+                    }
+                },
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "serve-static": {
-            "version": "1.13.2",
-            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-            "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
+            "integrity": "sha512-JMrvUwE54emCYWlTI+hGrGv5I8dEwmco/00EvkzIIsR7MqrHonbD9pO2MOfFnpFntl7ecpZs+3mW+XbQZu9QCg==",
             "dev": true,
             "requires": {
                 "encodeurl": "~1.0.2",
                 "escape-html": "~1.0.3",
-                "parseurl": "~1.3.2",
-                "send": "0.16.2"
+                "parseurl": "~1.3.3",
+                "send": "0.17.1"
             }
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -7303,9 +7055,9 @@
             }
         },
         "setprototypeof": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-            "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+            "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==",
             "dev": true
         },
         "shebang-command": {
@@ -7352,9 +7104,9 @@
             "dev": true
         },
         "simple-sha1": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.1.tgz",
-            "integrity": "sha512-pFMPd+I/lQkpf4wFUeS/sED5IqdIG1lUlrQviBMV4u4mz8BRAcB5fvUx5Ckfg3kBigEglAjHg7E9k/yy2KlCqA==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/simple-sha1/-/simple-sha1-2.1.2.tgz",
+            "integrity": "sha512-TQl9rm4rdKAVmhO++sXAb8TNN0D6JAD5iyI1mqEPNpxUzTRrtm4aOG1pDf/5W/qCFihiaoK6uuL9rvQz1x1VKw==",
             "requires": {
                 "rusha": "^0.8.1"
             }
@@ -7390,6 +7142,15 @@
                 "use": "^3.1.0"
             },
             "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
                 "define-property": {
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
@@ -7407,6 +7168,12 @@
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.5.7",
@@ -7556,9 +7323,9 @@
             }
         },
         "spdx-license-ids": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz",
-            "integrity": "sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==",
+            "version": "3.0.5",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+            "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
             "dev": true
         },
         "split-string": {
@@ -7572,14 +7339,14 @@
         },
         "sprintf-js": {
             "version": "1.0.3",
-            "resolved": "http://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
             "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
             "dev": true
         },
         "sshpk": {
-            "version": "1.15.2",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.15.2.tgz",
-            "integrity": "sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==",
+            "version": "1.16.1",
+            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+            "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
             "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
@@ -7600,7 +7367,7 @@
         },
         "staged-git-files": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-1.1.1.tgz",
             "integrity": "sha512-H89UNKr1rQJvI1c/PIR3kiAMBV23yvR7LItZiV74HWZwzt7f3YHuujJ9nJZlt58WlFox7XQsOahexwk7nTe69A==",
             "dev": true
         },
@@ -7626,9 +7393,9 @@
             }
         },
         "statuses": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-            "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+            "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
             "dev": true
         },
         "stealthy-require": {
@@ -7672,7 +7439,7 @@
         },
         "string_decoder": {
             "version": "1.1.1",
-            "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
@@ -7692,7 +7459,7 @@
         },
         "strip-ansi": {
             "version": "3.0.1",
-            "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
@@ -7710,7 +7477,7 @@
         },
         "strip-eof": {
             "version": "1.0.0",
-            "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
             "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
             "dev": true
         },
@@ -7726,10 +7493,13 @@
             "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-            "dev": true
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "dev": true,
+            "requires": {
+                "has-flag": "^3.0.0"
+            }
         },
         "symbol-observable": {
             "version": "1.2.0",
@@ -7738,9 +7508,9 @@
             "dev": true
         },
         "symbol-tree": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-            "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
             "dev": true
         },
         "table": {
@@ -7769,29 +7539,9 @@
                         "json-schema-traverse": "^0.3.0"
                     }
                 },
-                "ansi-styles": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-                    "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-                    "dev": true,
-                    "requires": {
-                        "color-convert": "^1.9.0"
-                    }
-                },
-                "chalk": {
-                    "version": "2.4.1",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-                    "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-                    "dev": true,
-                    "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
-                    }
-                },
                 "fast-deep-equal": {
                     "version": "1.1.0",
-                    "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
                     "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
                     "dev": true
                 },
@@ -7800,16 +7550,18 @@
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
                     "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
                     "dev": true
-                },
-                "supports-color": {
-                    "version": "5.5.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                    "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                    "dev": true,
-                    "requires": {
-                        "has-flag": "^3.0.0"
-                    }
                 }
+            }
+        },
+        "teeny-request": {
+            "version": "3.11.3",
+            "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-3.11.3.tgz",
+            "integrity": "sha512-CKncqSF7sH6p4rzCgkb/z/Pcos5efl0DmolzvlqRQUNcpRIruOhY9+T1FsIlyEbfWd7MsFpodROOwHYh2BaXzw==",
+            "dev": true,
+            "requires": {
+                "https-proxy-agent": "^2.2.1",
+                "node-fetch": "^2.2.0",
+                "uuid": "^3.3.2"
             }
         },
         "temp-write": {
@@ -7828,13 +7580,13 @@
             "dependencies": {
                 "pify": {
                     "version": "2.3.0",
-                    "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
                 "uuid": {
                     "version": "2.0.3",
-                    "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
                     "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
                     "dev": true
                 }
@@ -7866,7 +7618,7 @@
         },
         "through": {
             "version": "2.3.8",
-            "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
             "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
             "dev": true
         },
@@ -7890,9 +7642,9 @@
             }
         },
         "to-fast-properties": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
             "dev": true
         },
         "to-object-path": {
@@ -7936,6 +7688,12 @@
                     }
                 }
             }
+        },
+        "toidentifier": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+            "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
+            "dev": true
         },
         "tough-cookie": {
             "version": "2.4.3",
@@ -7982,9 +7740,9 @@
             "integrity": "sha1-NEiaLKwMCcHMEO2RugEVlNQzO+I="
         },
         "tslib": {
-            "version": "1.9.3",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-            "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+            "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
             "dev": true
         },
         "tunnel-agent": {
@@ -8016,13 +7774,13 @@
             "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
         },
         "type-is": {
-            "version": "1.6.16",
-            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-            "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+            "version": "1.6.18",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+            "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "~2.1.18"
+                "mime-types": "~2.1.24"
             }
         },
         "typedarray": {
@@ -8038,38 +7796,15 @@
             "dev": true
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
                 "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
-                    }
-                }
+                "set-value": "^2.0.1"
             }
         },
         "unpipe": {
@@ -8329,9 +8064,9 @@
             "dev": true
         },
         "xtend": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+            "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
             "dev": true
         },
         "yallist": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
         "warp10": "^2.0.1"
     },
     "devDependencies": {
-        "@marko/migrate": "^4.1.1",
+        "@marko/migrate": "^5.1.0",
         "babel-cli": "^6.24.1",
         "babel-core": "^6.24.1",
         "babel-plugin-minprops": "^2.0.1",

--- a/scripts/babel-plugin-marko-debug.js
+++ b/scripts/babel-plugin-marko-debug.js
@@ -56,9 +56,7 @@ function replaceMarkoDebug(path, test, consequent, alternate) {
     // If we found a condition that is a string (and isn't "MARKO_DEBUG") it's most likely a mistake.
     if (test.value !== "MARKO_DEBUG") {
         throw new Error(
-            `Found if statement with StringLiteral "${
-                test.value
-            }", did you mean "MARKO_DEBUG".`
+            `Found if statement with StringLiteral "${test.value}", did you mean "MARKO_DEBUG".`
         );
     }
 

--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -75,9 +75,7 @@ class Normalizer {
                                 ROOT_TAGS.includes(node.tagName)
                             ) {
                                 context.addError(
-                                    `"${
-                                        node.tagName
-                                    }" can only be used at the root of the template.`,
+                                    `"${node.tagName}" can only be used at the root of the template.`,
                                     node
                                 );
                             }

--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -729,17 +729,11 @@ class CustomTag extends HtmlElement {
             if (!parentCustomTag) {
                 if (tagDef.parentTagName) {
                     codegen.addError(
-                        `Invalid usage of the <${
-                            this.tagName
-                        }> nested tag. Tag not nested within a <${
-                            tagDef.parentTagName
-                        }> tag.`
+                        `Invalid usage of the <${this.tagName}> nested tag. Tag not nested within a <${tagDef.parentTagName}> tag.`
                     );
                 } else {
                     codegen.addError(
-                        `Invalid usage of the <${
-                            this.tagName
-                        }> nested tag. Tag not nested within a custom tag.`
+                        `Invalid usage of the <${this.tagName}> nested tag. Tag not nested within a custom tag.`
                     );
                 }
 

--- a/src/core-tags/migrate/all-tags/params.js
+++ b/src/core-tags/migrate/all-tags/params.js
@@ -11,9 +11,7 @@ module.exports = function migrate(el, context) {
 function enableTagParams(el, context) {
     if (el.argument) {
         context.deprecate(
-            `The <${el.tagName}(param)> syntax is deprecated. Please use the <${
-                el.tagName
-            }|param|> syntax instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-paren-params`,
+            `The <${el.tagName}(param)> syntax is deprecated. Please use the <${el.tagName}|param|> syntax instead. See: https://github.com/marko-js/marko/wiki/Deprecation:-paren-params`,
             el
         );
         el.params = context.builder.parseJavaScriptParams(el.argument);

--- a/src/core-tags/migrate/all-templates/index.js
+++ b/src/core-tags/migrate/all-templates/index.js
@@ -1,6 +1,7 @@
 const commonMigrators = [
     require("./non-standard-template-literals"),
     require("./render-calls"),
+    require("./widget-data-is-state"),
     require("./widget-get-template-data")
 ];
 

--- a/src/core-tags/migrate/all-templates/widget-data-is-state.js
+++ b/src/core-tags/migrate/all-templates/widget-data-is-state.js
@@ -1,0 +1,16 @@
+"use strict";
+
+module.exports = function migrator(el, context) {
+    context.addMigration({
+        name: "dataIsState",
+        description:
+            "Migrate add `data = state` since only `getInitialState` was defined in widget",
+        apply() {
+            context.root.prependChild(
+                context.builder.scriptlet({
+                    value: "var data = state"
+                })
+            );
+        }
+    });
+};

--- a/src/runtime/components/legacy/dependencies/index.js
+++ b/src/runtime/components/legacy/dependencies/index.js
@@ -107,9 +107,7 @@ function getInitModule(path, components) {
             var virtualPath = path + ".init.js";
             var registrations = components.map(
                 component =>
-                    `components.register('${component.id}', require('${
-                        component.path
-                    }'));`
+                    `components.register('${component.id}', require('${component.path}'));`
             );
             var code = `
                 var components = require('marko/components');

--- a/test/migrate/fixtures/include-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/include-tag/snapshot-expected.marko
@@ -14,9 +14,11 @@ import ExampleH from "../../../hello/example-h/index.marko"
 <!-- Import: duplicated -->
 <${ExampleA} x=1/>
 <!-- Import: with attributes -->
-<${ExampleB} ...{
-    a: 1
-} b=2/>
+<${ExampleB}
+    ...{
+        a: 1
+    }
+    b=2/>
 <!-- Import: index -->
 <${ExampleC}/>
 <!-- Import: name conflict -->
@@ -40,11 +42,14 @@ $ const ExampleD = undefined;
 <!-- Dynamic: with attributes -->
 <if(typeof input.x === "string")>${input.x}</if>
 <else>
-    <${input.x} ...{
-        a: 1
-    } ...{
-        b: 2
-    } c=3/>
+    <${input.x}
+        ...{
+            a: 1
+        }
+        ...{
+            b: 2
+        }
+        c=3/>
 </else>
 <!-- Dynamic: with body -->
 <if(typeof input.x === "string")>${input.x}</if>

--- a/test/migrate/fixtures/layout-use/snapshot-expected.marko
+++ b/test/migrate/fixtures/layout-use/snapshot-expected.marko
@@ -10,9 +10,11 @@ import ExampleD_1 from "./example-d.marko"
     <div/>
 </>
 <!-- Import: with attributes -->
-<${ExampleB} ...{
-    a: 1
-} b=2>
+<${ExampleB}
+    ...{
+        a: 1
+    }
+    b=2>
     <div/>
 </>
 <!-- Import: index -->
@@ -29,8 +31,10 @@ $ const ExampleD = undefined;
     <div/>
 </>
 <!-- Dynamic: with attributes -->
-<${input.x} ...{
-    a: 1
-} b=2>
+<${input.x}
+    ...{
+        a: 1
+    }
+    b=2>
     <div/>
 </>

--- a/test/migrate/fixtures/widget-data-is-state/index.js
+++ b/test/migrate/fixtures/widget-data-is-state/index.js
@@ -1,0 +1,9 @@
+module.exports = require("marko-widgets").defineComponent({
+    template: require("./template"),
+    getInitialState(input) {
+        return {
+            x: input.x,
+            y: input.y
+        };
+    }
+});

--- a/test/migrate/fixtures/widget-data-is-state/prompts.js
+++ b/test/migrate/fixtures/widget-data-is-state/prompts.js
@@ -1,0 +1,12 @@
+module.exports = [
+    {
+        question:
+            "A widget file was discovered, would you like to migrate that as well?\nNote: widget migrations are not 100% safe and should be tested after migration.",
+        answer: true
+    },
+    {
+        question:
+            "Would you like to rename the component file?\nNote: Marko 4 automatically discovers these files based on the naming convention, you may be able to remove them from a browser.json file after this.",
+        answer: false
+    }
+];

--- a/test/migrate/fixtures/widget-data-is-state/snapshot-expected.js
+++ b/test/migrate/fixtures/widget-data-is-state/snapshot-expected.js
@@ -1,0 +1,10 @@
+// test/migrate/fixtures/widget-data-is-state/index.js
+
+module.exports = {
+    onCreate(input, out) {
+        this.state = {
+            x: input.x,
+            y: input.y
+        };
+    }
+};

--- a/test/migrate/fixtures/widget-data-is-state/snapshot-expected.marko
+++ b/test/migrate/fixtures/widget-data-is-state/snapshot-expected.marko
@@ -1,0 +1,4 @@
+<!-- test/migrate/fixtures/widget-data-is-state/template.marko -->
+
+$ var data = state;
+<div/>

--- a/test/migrate/fixtures/widget-data-is-state/template.marko
+++ b/test/migrate/fixtures/widget-data-is-state/template.marko
@@ -1,0 +1,1 @@
+<div w-bind/>


### PR DESCRIPTION
## Description

In Marko V3 when you have a widget with `getInitialState` and no `getTemplateData` the `data` variable in the template should equal the `state`. This PR adds an optional widget migration to similar to the one used for `getTemplateData`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
