### PR TITLE
Make legacy widget property configurable

### DIFF
--- a/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -114,6 +114,7 @@ module.exports = function defineWidget(def, renderer) {
         var config = this.widgetConfig;
         if (this.el) {
             Object.defineProperty(this.el, "__widget", {
+                configurable: true,
                 get: function() {
                     // eslint-disable-next-line no-constant-condition
                     if ("MARKO_DEBUG") {


### PR DESCRIPTION
## Description
Previously before the deprecation warning this was configurable, and it was in Marko 3.
This PR improves the compatibility layer with Marko 3.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
