### PR TITLE
Clean up test noise

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry=https://registry.npmjs.org/
+scripts-prepend-node-path=true

--- a/test/__util__/create-marko-jsdom-module.js
+++ b/test/__util__/create-marko-jsdom-module.js
@@ -29,6 +29,7 @@ module.exports = function(dir, html, options) {
         // runScripts: 'dangerously', // JSDOM 10+
         beforeParse(window, browser) {
             window.global = window;
+            window.alert = () => {};
             jQuery(window);
             browser.require("complain").log = (...args) =>
                 require("complain").log(...args);

--- a/test/express/versions/express-4/package.json
+++ b/test/express/versions/express-4/package.json
@@ -1,6 +1,7 @@
 {
     "name": "marko-test-express-4",
     "version": "1.0.0",
+    "private": true,
     "dependencies": {
         "express": "^4"
     }

--- a/test/express/versions/express-5/package.json
+++ b/test/express/versions/express-5/package.json
@@ -1,6 +1,7 @@
 {
     "name": "marko-test-express-4",
     "version": "1.0.0",
+    "private": true,
     "dependencies": {
         "express": ">5.0.0-alpha"
     }

--- a/test/migrate/package.json
+++ b/test/migrate/package.json
@@ -1,4 +1,5 @@
 {
+  "private": true,
   "dependencies": {
     "marko": "file:../../"
   }

--- a/test/node-require/index.test.js
+++ b/test/node-require/index.test.js
@@ -3,7 +3,7 @@
 require("../__util__/test-init");
 
 const chai = require("chai");
-chai.Assertion.includeStack = true;
+chai.config.includeStack = true;
 require("chai").should();
 const expect = require("chai").expect;
 

--- a/test/render/fixtures-deprecated/inline-script/expected.html
+++ b/test/render/fixtures-deprecated/inline-script/expected.html
@@ -1,4 +1,4 @@
-<html><head><title>Inline Script</title></head><body>Hello name! <script type="text/javascript">
+<html><head><title>Inline Script</title></head><body>Hello name! <script type="n/a">
         <div if(foo)></div>
         $(function() {
             alert('World');

--- a/test/render/fixtures-deprecated/inline-script/template.marko
+++ b/test/render/fixtures-deprecated/inline-script/template.marko
@@ -7,7 +7,7 @@
     <body>
         Hello ${name}!
 
-        <script type="text/javascript">
+        <script type="n/a">
         <div if(foo)></div>
         $(function() {
             alert('${input.name}');

--- a/test/render/fixtures-deprecated/inline-script/vdom-expected.html
+++ b/test/render/fixtures-deprecated/inline-script/vdom-expected.html
@@ -4,5 +4,5 @@
       "Inline Script"
   <BODY>
     "Hello name! "
-    <SCRIPT type="text/javascript">
+    <SCRIPT type="n/a">
       "\n        <div if(foo)></div>\n        $(function() {\n            alert('World');\n        })\n        "

--- a/test/render/fixtures/bodyText/expected.html
+++ b/test/render/fixtures/bodyText/expected.html
@@ -1,3 +1,3 @@
-<script>
+<script type="text/html">
     <DIV>FOO</DIV>
 </script>

--- a/test/render/fixtures/bodyText/tags/test-bodyText/code-generator.js
+++ b/test/render/fixtures/bodyText/tags/test-bodyText/code-generator.js
@@ -4,7 +4,7 @@ function compile(bodyText) {
 
 module.exports = function generateCode(elNode, codegen) {
     var builder = codegen.builder;
-    return builder.htmlElement("script", {}, [
+    return builder.htmlElement("script", { type: '"text/html"' }, [
         builder.text(builder.literal(compile(elNode.bodyText)))
     ]);
 };

--- a/test/render/fixtures/bodyText/vdom-expected.html
+++ b/test/render/fixtures/bodyText/vdom-expected.html
@@ -1,2 +1,2 @@
-<SCRIPT>
+<SCRIPT type="text/html">
   "\n    <DIV>FOO</DIV>\n"

--- a/test/render/fixtures/inline-script/expected.html
+++ b/test/render/fixtures/inline-script/expected.html
@@ -1,4 +1,4 @@
-<html><head><title>Inline Script</title></head><body>Hello name! <script type="text/javascript">
+<html><head><title>Inline Script</title></head><body>Hello name! <script type="n/a">
         <div if(foo)></div>
         $(function() {
             alert('World');

--- a/test/render/fixtures/inline-script/template.marko
+++ b/test/render/fixtures/inline-script/template.marko
@@ -6,7 +6,7 @@ $ var value = "input.name";
     </head>
     <body>
         Hello ${name}!
-        <script type="text/javascript">
+        <script type="n/a">
         <div if(foo)></div>
         $(function() {
             alert('${input.name}');

--- a/test/render/fixtures/inline-script/vdom-expected.html
+++ b/test/render/fixtures/inline-script/vdom-expected.html
@@ -4,5 +4,5 @@
       "Inline Script"
   <BODY>
     "Hello name! "
-    <SCRIPT type="text/javascript">
+    <SCRIPT type="n/a">
       "\n        <div if(foo)></div>\n        $(function() {\n            alert('World');\n        })\n        "

--- a/test/render/fixtures/script-string-literal-placeholder/expected.html
+++ b/test/render/fixtures/script-string-literal-placeholder/expected.html
@@ -1,4 +1,4 @@
 <script>
 var content = 'abc';
-var foo `Text 1: ${content}`;
+var foo = `Text 1: ${content}`;
 </script>

--- a/test/render/fixtures/script-string-literal-placeholder/template.marko
+++ b/test/render/fixtures/script-string-literal-placeholder/template.marko
@@ -1,4 +1,4 @@
 <script>
 var content = 'abc';
-var foo `Text 1: ${content}`;
+var foo = `Text 1: ${content}`;
 </script>

--- a/test/render/fixtures/script-string-literal-placeholder/vdom-expected.html
+++ b/test/render/fixtures/script-string-literal-placeholder/vdom-expected.html
@@ -1,2 +1,2 @@
 <SCRIPT>
-  "\nvar content = 'abc';\nvar foo `Text 1: ${content}`;\n"
+  "\nvar content = 'abc';\nvar foo = `Text 1: ${content}`;\n"

--- a/test/render/fixtures/script-tag-entities-static/expected.html
+++ b/test/render/fixtures/script-tag-entities-static/expected.html
@@ -1,1 +1,1 @@
-<script><test></script>
+<script type="n/a"><test></script>

--- a/test/render/fixtures/script-tag-entities-static/tags/test-script/code-generator.js
+++ b/test/render/fixtures/script-tag-entities-static/tags/test-script/code-generator.js
@@ -1,6 +1,6 @@
 module.exports = function generateCode(elNode, codegen) {
     var builder = codegen.builder;
-    return builder.htmlElement("script", {}, [
+    return builder.htmlElement("script", { type: '"n/a"' }, [
         builder.text(builder.literal("<test>"))
     ]);
 };

--- a/test/render/fixtures/script-tag-entities-static/vdom-expected.html
+++ b/test/render/fixtures/script-tag-entities-static/vdom-expected.html
@@ -1,2 +1,2 @@
-<SCRIPT>
+<SCRIPT type="n/a">
   "<test>"


### PR DESCRIPTION
## Description

Removes unnecessary console output when `npm run test`.

Unfortunately, there are some I was not able to fix:

* Any of the tests expected to fail
* Uncaught jsdom `TypeError`s in `components-browser/fixtures/{split-browser,split-browser-export-class,state-freeze}`
* The output from `[marko/hot-reload]` (didn’t see a way to mock functions in autotest)
* This thing:
```
AsyncStream
[…snip…]
    ✓ should catch error in promise catch if `error` listener only set inside mixin
(node:41213) UnhandledPromiseRejectionWarning: Error: Should not get here!
    at out.catch.then (/Users/tigt/git/marko/test/async-stream/index.test.js:297:19)
    at processTicksAndRejections (internal/process/next_tick.js:81:5)
(node:41213) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:41213) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~~I have updated/added documentation affected by my changes.~~
- [ ] ~~I have added tests to cover my changes.~~
