### PR TITLE
fix server-rendered conditional widgets in the compatibility layer

### DIFF
--- a/src/runtime/components/beginComponent.js
+++ b/src/runtime/components/beginComponent.js
@@ -13,17 +13,20 @@ module.exports = function beginComponent(
     key,
     ownerComponentDef,
     isSplitComponent,
-    isImplicitComponent
+    isImplicitComponent,
+    existingComponentDef
 ) {
     var globalContext = componentsContext.___globalContext;
 
     var componentId = component.id;
 
-    var componentDef = (componentsContext.___componentDef = new ComponentDef(
-        component,
-        componentId,
-        globalContext
-    ));
+    var componentDef =
+        existingComponentDef ||
+        (componentsContext.___componentDef = new ComponentDef(
+            component,
+            componentId,
+            globalContext
+        ));
 
     // On the server
     if (

--- a/src/runtime/components/beginComponent.js
+++ b/src/runtime/components/beginComponent.js
@@ -20,6 +20,8 @@ module.exports = function beginComponent(
 
     var componentId = component.id;
 
+    // existingComponentDef is only here to allow binding a conditional
+    // widget.  It should be removed when the legacy compat layer is removed.
     var componentDef =
         existingComponentDef ||
         (componentsContext.___componentDef = new ComponentDef(

--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -113,7 +113,8 @@ function createRendererFunc(templateRenderFunc, componentProps) {
             component,
             key,
             ownerComponentDef,
-            isSplit
+            isSplit,
+            isFakeComponent
         );
         var parentLegacyComponentDef = componentsContext.___legacyComponentDef;
         componentsContext.___legacyComponentDef = componentDef;
@@ -127,10 +128,38 @@ function createRendererFunc(templateRenderFunc, componentProps) {
 
         componentDef.t = function(typeName) {
             if (typeName) {
-                vComponentNode.___component = this.___component = component = registry.___createComponent(
-                    typeName,
-                    component.id
-                );
+                if (registry.___isServer) {
+                    var oldComponent = component;
+                    if (renderingLogic) delete renderingLogic.onRender;
+                    component = registry.___createComponent(
+                        renderingLogic || {},
+                        id,
+                        input,
+                        out,
+                        typeName,
+                        customEvents,
+                        ownerComponentId
+                    );
+                    if (input.___widgetProps) {
+                        component.input = input.___widgetProps;
+                    }
+                    Object.assign(component, oldComponent);
+                    beginComponent(
+                        componentsContext,
+                        component,
+                        key,
+                        ownerComponentDef,
+                        isSplit,
+                        false,
+                        this
+                    );
+                } else {
+                    vComponentNode.___component = component = registry.___createComponent(
+                        typeName,
+                        component.id
+                    );
+                }
+                this.___component = component;
             }
         };
 

--- a/test/components-browser/fixtures-deprecated/widget-conditional/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-conditional/test.js
@@ -15,5 +15,3 @@ module.exports = function(helpers) {
 
     expect(widget != null).to.equal(true);
 };
-
-module.exports.fails_hydrate = true;

--- a/test/components-browser/index.test.js
+++ b/test/components-browser/index.test.js
@@ -108,7 +108,7 @@ function runHydrateTest(fixture) {
                 helpers.isHydrate = true;
 
                 helpers.mount = function() {
-                    return browser.window.components[curInstance++];
+                    return browser.window.getComponent(curInstance++);
                 };
 
                 if (hasCallback) {

--- a/test/components-browser/template.component-browser.js
+++ b/test/components-browser/template.component-browser.js
@@ -1,5 +1,5 @@
 module.exports = {
     onMount() {
-        window.components = this.getComponents("components");
+        window.getComponent = index => this.getComponent(`component--${index}`);
     }
 };

--- a/test/components-browser/template.marko
+++ b/test/components-browser/template.marko
@@ -5,8 +5,8 @@
     </head>
     <body>
         <div#testsTarget>
-            <for|component| of=input.components>
-                <${require(component.template)} ...component.input key="components[]"/>
+            <for|component, index| of=input.components>
+                <${require(component.template)} ...component.input key=`component--${index}`/>
             </for>
         </div>
     </body>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Adds support to the compatibility layer for conditional widgets rendered on the server.

```marko
<widget-types default="./"/>
<div w-bind=(data.includeWidget ? 'default' : null)>
    ...
</div>
```

Fixes the existing failing test.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~ (see #1396)
- [x] I have added tests to cover my changes.
