### PR TITLE
Deprecate the partial dynamic tag

### DIFF
--- a/src/core-tags/migrate/all-tags/index.js
+++ b/src/core-tags/migrate/all-tags/index.js
@@ -1,6 +1,7 @@
 const commonMigrators = [
     require("./control-flow-directives"),
     require("./body-only-if"),
+    require("./partial-dynamic-tag"),
     require("./dynamic-attributes"),
     require("./include-directive"),
     require("./legacy-nested-tag"),

--- a/src/core-tags/migrate/all-tags/partial-dynamic-tag.js
+++ b/src/core-tags/migrate/all-tags/partial-dynamic-tag.js
@@ -1,0 +1,11 @@
+module.exports = function migrator(elNode, context) {
+    if (!elNode.rawTagNameExpression || elNode.tagName[0] === "$") {
+        return;
+    }
+
+    context.deprecate(
+        'The "<partial-${dynamic}>" tag is syntax deprecated. Please use the regular dynamic tag syntax instead with a template literal "<${`partial-${dynamic}`}/>". See: https://github.com/marko-js/marko/wiki/Deprecation:-partial-dynamic-tag'
+    );
+
+    elNode.rawTagNameExpression = `\`${elNode.tagName}\``;
+};

--- a/test/migrate/fixtures/partial-dynamic-tag/snapshot-expected.marko
+++ b/test/migrate/fixtures/partial-dynamic-tag/snapshot-expected.marko
@@ -1,0 +1,4 @@
+<!-- test/migrate/fixtures/partial-dynamic-tag/template.marko -->
+
+<${`h${input.size}`} id="heading">Hello</>
+<${`tag-${input.name}-${input.size}`}>Test</>

--- a/test/migrate/fixtures/partial-dynamic-tag/template.marko
+++ b/test/migrate/fixtures/partial-dynamic-tag/template.marko
@@ -1,0 +1,7 @@
+<h${input.size} id="heading">
+  Hello
+</>
+
+<tag-${input.name}-${input.size}>
+  Test
+</>

--- a/test/render/fixtures-deprecated/dynamic-tag-name-concise/expected.html
+++ b/test/render/fixtures-deprecated/dynamic-tag-name-concise/expected.html
@@ -1,0 +1,1 @@
+<hello-world class="my-class" foo="bar">My nested content</hello-world>

--- a/test/render/fixtures-deprecated/dynamic-tag-name-concise/template.marko
+++ b/test/render/fixtures-deprecated/dynamic-tag-name-concise/template.marko
@@ -1,0 +1,2 @@
+hello-${input.myTagName} class="my-class" foo="bar"
+    -- My nested content

--- a/test/render/fixtures-deprecated/dynamic-tag-name-concise/test.js
+++ b/test/render/fixtures-deprecated/dynamic-tag-name-concise/test.js
@@ -1,0 +1,4 @@
+exports.templateData = {
+    myTagName: "world",
+    foo: true
+};

--- a/test/render/fixtures-deprecated/dynamic-tag-name-concise/vdom-expected.html
+++ b/test/render/fixtures-deprecated/dynamic-tag-name-concise/vdom-expected.html
@@ -1,0 +1,2 @@
+<HELLO-WORLD class="my-class" foo="bar">
+  "My nested content"

--- a/test/render/fixtures-deprecated/dynamic-tag-name/expected.html
+++ b/test/render/fixtures-deprecated/dynamic-tag-name/expected.html
@@ -1,0 +1,1 @@
+<hello-world class="my-class" foo="bar">My nested content</hello-world>

--- a/test/render/fixtures-deprecated/dynamic-tag-name/template.marko
+++ b/test/render/fixtures-deprecated/dynamic-tag-name/template.marko
@@ -1,0 +1,3 @@
+<hello-${input.myTagName} class="my-class" foo="bar">
+    My nested content
+</>

--- a/test/render/fixtures-deprecated/dynamic-tag-name/test.js
+++ b/test/render/fixtures-deprecated/dynamic-tag-name/test.js
@@ -1,0 +1,4 @@
+exports.templateData = {
+    myTagName: "world",
+    foo: true
+};

--- a/test/render/fixtures-deprecated/dynamic-tag-name/vdom-expected.html
+++ b/test/render/fixtures-deprecated/dynamic-tag-name/vdom-expected.html
@@ -1,0 +1,2 @@
+<HELLO-WORLD class="my-class" foo="bar">
+  "My nested content"

--- a/test/render/fixtures/dynamic-tag-name-concise/expected.html
+++ b/test/render/fixtures/dynamic-tag-name-concise/expected.html
@@ -1,1 +1,1 @@
-<hello-world class="my-class" foo="bar">My nested content</hello-world><foo class="my-class" foo="bar">My nested content</foo>
+<foo class="my-class" foo="bar">My nested content</foo>

--- a/test/render/fixtures/dynamic-tag-name-concise/template.marko
+++ b/test/render/fixtures/dynamic-tag-name-concise/template.marko
@@ -1,5 +1,2 @@
-hello-${input.myTagName} class="my-class" foo="bar"
-    -- My nested content
-
 ${input.foo ? 'foo' : 'bar'} class="my-class" foo="bar"
     -- My nested content

--- a/test/render/fixtures/dynamic-tag-name-concise/vdom-expected.html
+++ b/test/render/fixtures/dynamic-tag-name-concise/vdom-expected.html
@@ -1,4 +1,2 @@
-<HELLO-WORLD class="my-class" foo="bar">
-  "My nested content"
 <FOO class="my-class" foo="bar">
   "My nested content"

--- a/test/render/fixtures/dynamic-tag-name/expected.html
+++ b/test/render/fixtures/dynamic-tag-name/expected.html
@@ -1,1 +1,1 @@
-<hello-world class="my-class" foo="bar">My nested content</hello-world><foo class="my-class" foo="bar">My nested content</foo>
+<foo class="my-class" foo="bar">My nested content</foo>

--- a/test/render/fixtures/dynamic-tag-name/template.marko
+++ b/test/render/fixtures/dynamic-tag-name/template.marko
@@ -1,7 +1,3 @@
-<hello-${input.myTagName} class="my-class" foo="bar">
-    My nested content
-</>
-
 <${input.foo ? 'foo' : 'bar'} class="my-class" foo="bar">
     My nested content
 </>

--- a/test/render/fixtures/dynamic-tag-name/vdom-expected.html
+++ b/test/render/fixtures/dynamic-tag-name/vdom-expected.html
@@ -1,4 +1,2 @@
-<HELLO-WORLD class="my-class" foo="bar">
-  "My nested content"
 <FOO class="my-class" foo="bar">
   "My nested content"


### PR DESCRIPTION
## Description
This PR deprecates and adds an auto migration for the `<partial-${dynamic}>` tag.

It is not currently documented that this is possible, and an alternative syntax already exists `<${"partial-" + dynamic}>`

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.