### PR TITLE
fix getComponentForEl for split components

### DIFF
--- a/src/runtime/components/util-browser.js
+++ b/src/runtime/components/util-browser.js
@@ -11,6 +11,20 @@ var componentLookup = {};
 var defaultDocument = document;
 var EMPTY_OBJECT = {};
 
+function getParentComponentForEl(node) {
+    while (node && !componentsByDOMNode.get(node)) {
+        node = node.previousSibling || node.parentNode;
+        if (node.fragment) {
+            if (node === node.fragment.endNode) {
+                node = node.fragment.previousSibling || node.parentNode;
+            } else {
+                node = node.fragment;
+            }
+        }
+    }
+    return node && componentsByDOMNode.get(node);
+}
+
 function getComponentForEl(el, doc) {
     if (el) {
         var node =
@@ -19,7 +33,9 @@ function getComponentForEl(el, doc) {
                 : el;
         if (node) {
             var vElement = vElementsByDOMNode.get(node);
-            return vElement && vElement.___ownerComponent;
+            return vElement
+                ? vElement.___ownerComponent
+                : getParentComponentForEl(node);
         }
     }
 }

--- a/test/components-browser/fixtures/get-component-for-el-split-component/component-browser.js
+++ b/test/components-browser/fixtures/get-component-for-el-split-component/component-browser.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/components-browser/fixtures/get-component-for-el-split-component/components/child/component-browser.js
+++ b/test/components-browser/fixtures/get-component-for-el-split-component/components/child/component-browser.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/test/components-browser/fixtures/get-component-for-el-split-component/components/child/index.marko
+++ b/test/components-browser/fixtures/get-component-for-el-split-component/components/child/index.marko
@@ -1,0 +1,15 @@
+class {
+    onCreate(input) {
+        this.name = input.name;
+    }
+}
+
+<macro|input| name="fragment">
+    <${input}/>
+</macro>
+
+<fragment>
+    <fragment>
+        <div class=input.name/>
+    </fragment>
+</fragment>

--- a/test/components-browser/fixtures/get-component-for-el-split-component/index.marko
+++ b/test/components-browser/fixtures/get-component-for-el-split-component/index.marko
@@ -1,0 +1,19 @@
+class {
+    onCreate() {
+        this.name = "parent";
+    }
+}
+
+<macro|input| name="fragment">
+    <${input}/>
+</macro>
+
+<div key="root">
+    <fragment>
+        <fragment>
+            <child name="child-a"/>
+        </fragment>
+    </fragment>
+    <div.child-b/>
+    <child name="child-c"/>
+</div>

--- a/test/components-browser/fixtures/get-component-for-el-split-component/test.js
+++ b/test/components-browser/fixtures/get-component-for-el-split-component/test.js
@@ -1,0 +1,14 @@
+var expect = require("chai").expect;
+var getComponentForEl = require("marko/components").getComponentForEl;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index.marko"), {});
+    var root = component.getEl("root");
+    var childA = root.querySelector(".child-a");
+    var childB = root.querySelector(".child-b");
+    var childC = root.querySelector(".child-c");
+
+    expect(getComponentForEl(childA)).has.property("name", "child-a");
+    expect(getComponentForEl(childB)).has.property("name", "parent");
+    expect(getComponentForEl(childC)).has.property("name", "child-c");
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Fixes a regression of `getComponentForEl` with split components.  

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
