### PR TITLE
Improve webpack compatibility for legacy components.

### DIFF
--- a/src/loader/browser.json
+++ b/src/loader/browser.json
@@ -1,8 +1,0 @@
-{
-    "requireRemap": [
-        {
-            "from": "./index.js",
-            "to": "./index-browser-dynamic.js"
-        }
-    ]
-}

--- a/src/loader/index-browser-dynamic.js
+++ b/src/loader/index-browser-dynamic.js
@@ -1,7 +1,0 @@
-"use strict";
-module.exports = function load(templatePath) {
-    // We make the assumption that the template path is a
-    // fully resolved module path and that the module exists
-    // as a CommonJS module
-    return require(templatePath);
-};

--- a/src/loader/index-browser.js
+++ b/src/loader/index-browser.js
@@ -1,4 +1,14 @@
 "use strict";
 module.exports = function load(templatePath) {
-    throw Error("Not found: " + templatePath);
+    // We make the assumption that the template path is a
+    // fully resolved module path and that the module exists
+    // as a CommonJS module
+    // eslint-disable-next-line no-undef
+    if (typeof __webpack_require__ !== "undefined") {
+        // In webpack we can accept paths from `require.resolve`.
+        // eslint-disable-next-line no-undef
+        return __webpack_require__(templatePath);
+    } else {
+        return require(templatePath);
+    }
 };

--- a/src/runtime/components/legacy/index-browser.js
+++ b/src/runtime/components/legacy/index-browser.js
@@ -1,12 +1,13 @@
 var modernMarko = require("../");
 var Component = require("../Component");
+var loader = require("../../../loader");
 
 var complain = "MARKO_DEBUG" && require("complain");
 
 // expose legacy
 window.$markoLegacy = exports;
 exports.load = function(typeName) {
-    return exports.defineWidget(require(typeName));
+    return exports.defineWidget(loader(typeName));
 };
 
 // legacy api


### PR DESCRIPTION
## Description
Removes Webpack warnings about dynamic requires for legacy components by checking for `__webpack_require__`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.