### PR TITLE
fix regex attribute that's not static

### DIFF
--- a/src/runtime/html/helper-attr.js
+++ b/src/runtime/html/helper-attr.js
@@ -22,7 +22,7 @@ function attr(name, value, shouldEscape) {
     } else if (value == null || value === false) {
         return "";
     } else if (type === "object") {
-        value = JSON.stringify(value);
+        value = value instanceof RegExp ? value.source : JSON.stringify(value);
         if (shouldEscape) {
             value = escapeString(
                 value,

--- a/src/runtime/vdom/VElement.js
+++ b/src/runtime/vdom/VElement.js
@@ -29,7 +29,7 @@ function convertAttrValue(type, value) {
     if (value === true) {
         return "";
     } else if (type == "object") {
-        return JSON.stringify(value);
+        return value instanceof RegExp ? value.source : JSON.stringify(value);
     } else {
         return toString(value);
     }

--- a/test/render/fixtures/pattern-attr-runtime/expected.html
+++ b/test/render/fixtures/pattern-attr-runtime/expected.html
@@ -1,0 +1,1 @@
+<input type="text" pattern="\w{2,20}">

--- a/test/render/fixtures/pattern-attr-runtime/template.marko
+++ b/test/render/fixtures/pattern-attr-runtime/template.marko
@@ -1,0 +1,1 @@
+<input type="text" pattern=(true && /\w{2,20}/) />

--- a/test/render/fixtures/pattern-attr-runtime/test.js
+++ b/test/render/fixtures/pattern-attr-runtime/test.js
@@ -1,0 +1,1 @@
+exports.templateData = {};

--- a/test/render/fixtures/pattern-attr-runtime/vdom-expected.html
+++ b/test/render/fixtures/pattern-attr-runtime/vdom-expected.html
@@ -1,0 +1,1 @@
+<INPUT pattern="\w{2,20}" type="text">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

If the attribute was a literal, it would work:
```marko
<input type="text" pattern=/\w{2,20}/ />
```

Prior to this PR, a non-literal regex did not work:
```marko
<input type="text" pattern=(true && /\w{2,20}/) />
<input type="text" pattern=regex />
```

Now it does.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
