### PR TITLE
Fix widget args not preserved when nested tags used

### DIFF
--- a/runtime/helpers.js
+++ b/runtime/helpers.js
@@ -334,10 +334,19 @@ module.exports = exports = {
         }
 
         if (targetProperty || hasNestedTags) {
+            // Handle nested tags
             return function(input, out, parent, renderBody) {
-                // Handle nested tags
+                // Preserve the widget args for the main tag.
+                var widgetArgs = out.data.widgetArgs;
+                delete out.data.widgetArgs;
+
                 if (renderBody) {
                     renderBody(out, input);
+                }
+
+                // restore the main tag widget args.
+                if (widgetArgs) {
+                    out.data.widgetArgs = widgetArgs;
                 }
 
                 if (targetProperty) {


### PR DESCRIPTION
## Description

This is a patch for Marko v3 which fixes an issue where nested tags would cause the event handlers (and any thing else related to the internal widget args) to be skipped if the nested tag itself also had widget args.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.