### PR TITLE
improve precompiled heuristic to check for banner comment

### DIFF
--- a/src/loader/index-default.js
+++ b/src/loader/index-default.js
@@ -7,6 +7,7 @@ var compilerPath = nodePath.join(__dirname, "../compiler");
 var markoCompiler = require(compilerPath);
 var cwd = process.cwd();
 var fsOptions = { encoding: "utf8" };
+const banner = "// Compiled using marko";
 
 module.exports = function load(templatePath, templateSrc, options) {
     if (typeof templatePath === "string") {
@@ -21,8 +22,11 @@ module.exports = function load(templatePath, templateSrc, options) {
             let foundPrecompiled = false;
 
             try {
-                fs.accessSync(jsFilePath);
-                foundPrecompiled = true;
+                const buffer = Buffer.alloc(banner.length);
+                const fd = fs.openSync(jsFilePath);
+                fs.readSync(fd, buffer, 0, banner.length, 0);
+                fs.closeSync(fd);
+                foundPrecompiled = buffer.toString("utf-8") === banner;
             } catch (e) {
                 /* ignore error */
             }

--- a/src/loader/index-default.js
+++ b/src/loader/index-default.js
@@ -23,7 +23,7 @@ module.exports = function load(templatePath, templateSrc, options) {
 
             try {
                 const buffer = Buffer.alloc(banner.length);
-                const fd = fs.openSync(jsFilePath);
+                const fd = fs.openSync(jsFilePath, "r");
                 fs.readSync(fd, buffer, 0, banner.length, 0);
                 fs.closeSync(fd);
                 foundPrecompiled = buffer.toString("utf-8") === banner;

--- a/test/api/fixtures/load-prefer-precompiled/dummy.js
+++ b/test/api/fixtures/load-prefer-precompiled/dummy.js
@@ -1,1 +1,2 @@
+// Compiled using marko@0.0.0 - DO NOT EDIT
 module.exports = "SHOULD LOAD";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

The `marko.load` api currently checks for a JS file with the same name as the marko file being loaded (`index.marko` -> `index.js`) and loads the JS file if found, assuming it is a precompiled version of the template.  

This PR adds an additional check for Marko's comment banner: 
```js
// Compiled using marko@x.x.x - DO NOT EDIT
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
