### PR TITLE
Improve conditional comment support

### DIFF
--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -1,7 +1,7 @@
 "use strict";
 var ok = require("assert").ok;
 
-var ieConditionalCommentRegExp = /^\[if [^]*?<!\[endif\]$/;
+var ieConditionalCommentRegExp = /^\[if |<!\[endif\]$/;
 var ROOT_TAGS = ["import", "static", "class"];
 
 function isIEConditionalComment(comment) {

--- a/test/render/fixtures/comments-preserve-ie-conditional/expected.html
+++ b/test/render/fixtures/comments-preserve-ie-conditional/expected.html
@@ -1,1 +1,1 @@
-<!--[if lt IE 9]><div><![endif]-->
+<!--[if lt IE 9]><div></div><![endif]--><!--[if !mso]><!-- --><span></span><!--<![endif]-->

--- a/test/render/fixtures/comments-preserve-ie-conditional/template.marko
+++ b/test/render/fixtures/comments-preserve-ie-conditional/template.marko
@@ -1,1 +1,4 @@
-<!--[if lt IE 9]><div><![endif]-->
+<!--[if lt IE 9]><div></div><![endif]-->
+<!--[if !mso]><!-- -->
+<span></span>
+<!--<![endif]-->

--- a/test/render/fixtures/comments-preserve-ie-conditional/vdom-expected.html
+++ b/test/render/fixtures/comments-preserve-ie-conditional/vdom-expected.html
@@ -1,1 +1,4 @@
-<!--"[if lt IE 9]><div><![endif]"-->
+<!--"[if lt IE 9]><div></div><![endif]"-->
+<!--"[if !mso]><!-- "-->
+<SPAN>
+<!--"<![endif]"-->


### PR DESCRIPTION
## Description

Fixes #1425 - comment conditionals that span multiple comments were not being preserved.


## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
