### PR TITLE
scripts now always generate a single text child - even if they have placeholders

### DIFF
--- a/src/core-tags/html/marko.json
+++ b/src/core-tags/html/marko.json
@@ -706,7 +706,8 @@
         "@src": "#html-src",
         "@type": "#html-type",
         "html": true,
-        "attribute-groups": ["html-attributes"]
+        "attribute-groups": ["html-attributes"],
+        "code-generator": "./normalize-script-text.js"
     },
     "<section>": {
         "html": true,

--- a/src/core-tags/html/normalize-script-text.js
+++ b/src/core-tags/html/normalize-script-text.js
@@ -1,0 +1,30 @@
+module.exports = function codeGenerator(elNode, codegen) {
+    const builder = codegen.builder;
+    const body = elNode.body.array.map(text => text.argument);
+    if (body.length > 1) {
+        const quasis = [];
+        const expressions = [];
+        for (const content of body) {
+            if (content.type === "Literal") {
+                if (quasis.length === expressions.length) {
+                    quasis.push(content.value);
+                } else {
+                    quasis[quasis.length - 1] += content.value;
+                }
+            } else {
+                if (quasis.length === expressions.length) {
+                    quasis.push("");
+                }
+                expressions.push(content);
+            }
+        }
+        if (quasis.length === expressions.length) {
+            quasis.push("");
+        }
+        elNode.body.removeChildren();
+        elNode.appendChild(
+            builder.text(builder.templateLiteral(quasis, expressions))
+        );
+    }
+    return elNode;
+};

--- a/test/compiler/fixtures-vdom/script-placeholders/expected.js
+++ b/test/compiler/fixtures-vdom/script-placeholders/expected.js
@@ -7,13 +7,28 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
       return module.exports;
     }),
     marko_renderer = components_helpers.r,
-    marko_defineComponent = components_helpers.c;
+    marko_defineComponent = components_helpers.c,
+    marko_helpers = require("marko/src/runtime/vdom/helpers"),
+    marko_createElement = marko_helpers.e,
+    marko_const = marko_helpers.const,
+    marko_const_nextId = marko_const("da453e"),
+    marko_node0 = marko_createElement("script", null, null, null, 0, 0, {
+        i: marko_const_nextId()
+      });
 
 function render(input, out, __component, component, state) {
   var data = input;
 
   out.e("script", null, null, null, 1)
     .t(("\n    var x = \"" + input.value) + "\";\n");
+
+  out.e("script", null, null, null, 1)
+    .t(("\n    var x = " + JSON.stringify(input.value)) + "\n");
+
+  out.e("script", null, null, null, 1)
+    .t(("" + input.a) + input.b);
+
+  out.n(marko_node0, component);
 }
 
 marko_template._ = marko_renderer(render, {

--- a/test/compiler/fixtures-vdom/script-placeholders/expected.js
+++ b/test/compiler/fixtures-vdom/script-placeholders/expected.js
@@ -1,0 +1,24 @@
+"use strict";
+
+var marko_template = module.exports = require("marko/src/vdom").t(),
+    components_helpers = require("marko/src/runtime/components/helpers"),
+    marko_registerComponent = components_helpers.rc,
+    marko_componentType = marko_registerComponent("/marko-test$1.0.0/compiler/fixtures-vdom/script-placeholders/template.marko", function() {
+      return module.exports;
+    }),
+    marko_renderer = components_helpers.r,
+    marko_defineComponent = components_helpers.c;
+
+function render(input, out, __component, component, state) {
+  var data = input;
+
+  out.e("script", null, null, null, 1)
+    .t(("\n    var x = \"" + input.value) + "\";\n");
+}
+
+marko_template._ = marko_renderer(render, {
+    ___implicit: true,
+    ___type: marko_componentType
+  });
+
+marko_template.Component = marko_defineComponent({}, marko_template._);

--- a/test/compiler/fixtures-vdom/script-placeholders/template.marko
+++ b/test/compiler/fixtures-vdom/script-placeholders/template.marko
@@ -1,3 +1,8 @@
 <script>
     var x = "${input.value}";
 </script>
+<script>
+    var ${"x"} = ${JSON.stringify(input.value)}
+</script>
+<script>${input.a}${input.b}</script>
+<script></script>

--- a/test/compiler/fixtures-vdom/script-placeholders/template.marko
+++ b/test/compiler/fixtures-vdom/script-placeholders/template.marko
@@ -1,0 +1,3 @@
+<script>
+    var x = "${input.value}";
+</script>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prior to this change, the following would have 3 text nodes, now it has 1.

```marko
<script>
  var x = ${JSON.stringify(value)}
</script>
```

If the text nodes are inserted into the script sequentially while it's in the document, this would cause the execution of incomplete code, throwing a SyntaxError.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
