### PR TITLE
Remove require.resolve from dom-data for improved rollup support

### DIFF
--- a/src/runtime/components/dom-data.js
+++ b/src/runtime/components/dom-data.js
@@ -1,5 +1,6 @@
+var runtimeId = require("./util").___runtimeId;
 var counter = 0;
-var seed = require.resolve("./dom-data");
+var seed = "M" + runtimeId;
 var WeakMap =
     global.WeakMap ||
     function WeakMap() {


### PR DESCRIPTION
## Description

Rollup does not play well with `require.resolve` which we are using in the `dom-data` weak polyfill.
This PR updates the seed for these fake weak maps to use the client side runtime id instead which is guaranteed unique across multiple instances of Marko on the page.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
