### PR TITLE
Rename private legacy widget props property for better legacy compat

### DIFF
--- a/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -145,7 +145,7 @@ module.exports = function defineRenderer(renderingLogic) {
                 templateData = {};
             }
 
-            templateData.___widgetProps = newProps;
+            template.widgetProps = newProps;
 
             // If we have widget state then pass it to the template
             // so that it is available to the widget tag

--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -66,8 +66,8 @@ function createRendererFunc(templateRenderFunc, componentProps) {
                 customEvents,
                 ownerComponentId
             );
-            if (input.___widgetProps) {
-                component.input = input.___widgetProps;
+            if (input.widgetProps) {
+                component.input = input.widgetProps;
             }
         } else {
             if (!component) {
@@ -140,8 +140,8 @@ function createRendererFunc(templateRenderFunc, componentProps) {
                         customEvents,
                         ownerComponentId
                     );
-                    if (input.___widgetProps) {
-                        component.input = input.___widgetProps;
+                    if (input.widgetProps) {
+                        component.input = input.widgetProps;
                     }
                     Object.assign(component, oldComponent);
                     beginComponent(


### PR DESCRIPTION
## Description

`widgetProps` is added to `data` while rendering with `marko-widgets@6`. This PR updates the MarkoV3 compatibility layer to use the same name and exposes `widgetProps` on `input` for legacy components.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
