### PR TITLE
disable strict mode if a macro is not at the root

### DIFF
--- a/src/compiler/ast/Macro.js
+++ b/src/compiler/ast/Macro.js
@@ -23,6 +23,10 @@ class Macro extends Node {
         var macroDef = codegen.context.registerMacro(name);
         var functionName = macroDef.functionName;
 
+        if (this.parentNode && this.parentNode.type !== "TemplateRoot") {
+            codegen.context.disableStrictMode = true;
+        }
+
         // Walk the body after registering the macro
         var body = codegen.generateCode(this.body);
 

--- a/src/compiler/ast/TemplateRoot.js
+++ b/src/compiler/ast/TemplateRoot.js
@@ -93,7 +93,9 @@ class TemplateRoot extends Node {
             body.push(_buildVersionComment(builder, context));
         }
 
-        body.push(builder.literal("use strict"));
+        if (!context.disableStrictMode) {
+            body.push(builder.literal("use strict"));
+        }
 
         let staticNodes = context.getStaticNodes([templateDeclaration]);
         if (staticNodes.length) {

--- a/test/compiler/fixtures-vdom/macro-in-loop/expected.js
+++ b/test/compiler/fixtures-vdom/macro-in-loop/expected.js
@@ -1,5 +1,3 @@
-"use strict";
-
 var marko_template = module.exports = require("marko/src/vdom").t(),
     components_helpers = require("marko/src/runtime/components/helpers"),
     marko_registerComponent = components_helpers.rc,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Allows `<macro>` tags to be nested in the template by disabling the addition of `"use strict";` to the compiled output.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
