### PR TITLE
Fix invalid deprecation message for core-tags on windows

### DIFF
--- a/src/taglib/taglib-loader/Tag.js
+++ b/src/taglib/taglib-loader/Tag.js
@@ -5,6 +5,7 @@ var CustomTag;
 var path = require("path");
 var markoModules = require("../../compiler/modules");
 var complain = require("complain");
+var coreTagsPath = path.join(__dirname, "../../core-tags");
 
 function createCustomTag(el, tagDef) {
     CustomTag = CustomTag || require("../../compiler/ast/CustomTag");
@@ -314,7 +315,7 @@ class Tag {
     }
 
     isCoreTag() {
-        return this.filePath && this.filePath.indexOf("core-tags/") > -1;
+        return this.filePath && this.filePath.startsWith(coreTagsPath);
     }
 }
 


### PR DESCRIPTION
## Description
Currently in Windows `core-tags` will log deprecation warnings which is unexpected due to a path issue. This PR updates the `isCoreTag` to check paths in a way that works on Windows.

Fixes: #1438 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
