### PR TITLE
allow empty <@catch> to swallow errors

### DIFF
--- a/src/core-tags/core/await/renderer.js
+++ b/src/core-tags/core/await/renderer.js
@@ -186,8 +186,10 @@ module.exports = function awaitTag(input, out) {
         }
 
         if (err) {
-            if (errorRenderer) {
-                errorRenderer(asyncOut, err);
+            if (input.catch) {
+                if (errorRenderer) {
+                    errorRenderer(asyncOut, err);
+                }
             } else {
                 asyncOut.error(err);
             }

--- a/test/render/fixtures/await-error-empty-catch/expected.html
+++ b/test/render/fixtures/await-error-empty-catch/expected.html
@@ -1,0 +1,1 @@
+BEFORE <!--FLUSH--> AFTER

--- a/test/render/fixtures/await-error-empty-catch/template.marko
+++ b/test/render/fixtures/await-error-empty-catch/template.marko
@@ -1,0 +1,8 @@
+---
+BEFORE
+<await(Promise.reject(new Error("Something went wrong!")))>
+    <@then|testData|>Success!</@then>
+    <@catch/>
+</await>
+AFTER
+---

--- a/test/render/fixtures/await-error-empty-catch/vdom-expected.html
+++ b/test/render/fixtures/await-error-empty-catch/vdom-expected.html
@@ -1,0 +1,1 @@
+"BEFORE  AFTER"

--- a/test/render/fixtures/await-error-no-catch/template.marko
+++ b/test/render/fixtures/await-error-no-catch/template.marko
@@ -1,0 +1,7 @@
+---
+BEFORE
+<await(Promise.reject(new Error("Something went wrong!")))>
+    <@then|testData|>Success!</@then>
+</await>
+AFTER
+---

--- a/test/render/fixtures/await-error-no-catch/test.js
+++ b/test/render/fixtures/await-error-no-catch/test.js
@@ -1,0 +1,8 @@
+var expect = require("chai").expect;
+
+exports.templateData = {};
+
+exports.checkError = function(e) {
+    var message = e.toString();
+    expect(message).to.contain("Something went wrong");
+};

--- a/test/render/index.test.js
+++ b/test/render/index.test.js
@@ -78,9 +78,11 @@ async function runRenderTest(fixture) {
             let e;
 
             try {
-                isVDOM
+                let template = isVDOM
                     ? browser.require(templatePath)
                     : marko.load(templatePath, loadOptions);
+                let templateData = Object.assign({}, main.templateData || {});
+                await template.render(templateData);
             } catch (_e) {
                 e = _e;
                 let errorFile = path.join(dir, "error.txt");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Allows an empty `<@catch/>` to swallow errors.

```marko
<await(Promise.reject(new Error("Something went wrong!")))>
    <@then|testData|>Success!</@then>
    <@catch/>
</await>
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
