### PR TITLE
fix: test case failures for 'custom-tag-open-tag-only' with x compiler

### DIFF
--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/expected.html
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/expected.html
@@ -1,0 +1,2 @@
+Hello Frank!
+Hello John!

--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/marko.json
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/marko.json
@@ -1,8 +1,6 @@
 {
     "<open-tag-only>": {
         "renderer": "./open-tag-only-tag.js",
-        "parse-options": {
-            "openTagOnly": true
-        }
+        "open-tag-only": true
     }
 }

--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/open-tag-only-tag.js
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/open-tag-only-tag.js
@@ -1,0 +1,3 @@
+module.exports = function(input, out) {
+    out.write("Hello " + input.name + "!\n");
+};

--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/template.marko
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/template.marko
@@ -1,0 +1,2 @@
+<open-tag-only name="Frank">
+<open-tag-only name="John" />

--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/test.js
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/test.js
@@ -1,0 +1,1 @@
+exports.templateData = {};

--- a/test/render/fixtures-deprecated/custom-tag-open-tag-only/vdom-expected.html
+++ b/test/render/fixtures-deprecated/custom-tag-open-tag-only/vdom-expected.html
@@ -1,0 +1,1 @@
+"Hello Frank!\nHello John!\n"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Resolved test case failures for "custom-tag-open-tag-only" with x compiler.
<!--- Why is this change required? What problem does it solve? -->
Progress towards: Tag def open tag only (parse options) (**API CHANGE**)
<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
