### PR TITLE
Added support for state tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2349,9 +2349,9 @@
             }
         },
         "estraverse": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
-            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
         },
         "esutils": {
             "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "deresolve": "^1.1.2",
         "escodegen": "^1.8.1",
         "esprima": "^4.0.0",
-        "estraverse": "^4.2.0",
+        "estraverse": "^4.3.0",
         "events": "^1.0.2",
         "events-light": "^1.0.0",
         "he": "^1.1.0",

--- a/src/compiler/Builder.js
+++ b/src/compiler/Builder.js
@@ -198,8 +198,8 @@ class Builder {
         return new ElseIf({ test, body, else: elseStatement });
     }
 
-    expression(value) {
-        return new Expression({ value });
+    expression(value, ast) {
+        return new Expression({ value, ast });
     }
 
     forEach(params, ofExpression, body) {

--- a/src/compiler/ast/Expression.js
+++ b/src/compiler/ast/Expression.js
@@ -7,6 +7,7 @@ class Expression extends Node {
     constructor(def) {
         super("Expression");
         this.value = def.value;
+        this.ast = def.ast;
         ok(this.value != null, "Invalid expression");
     }
 

--- a/src/compiler/util/parseJavaScript.js
+++ b/src/compiler/util/parseJavaScript.js
@@ -9,7 +9,7 @@ function parseExpression(src, builder, isExpression) {
     const ast = isExpression
         ? parseRawJavaScriptAst`(${src})`
         : parseRawJavaScriptAst`${src}`;
-    return covertRawJavaScriptAst(ast, builder) || builder.expression(src);
+    return covertRawJavaScriptAst(ast, builder) || builder.expression(src, ast);
 }
 
 module.exports = parseExpression;

--- a/src/compiler/util/parseJavaScriptArgs.js
+++ b/src/compiler/util/parseJavaScriptArgs.js
@@ -13,7 +13,10 @@ function parseJavaScriptArgs(args, builder) {
     return ast.body[0].expression.arguments.map(
         node =>
             convertRawJavaScriptAst(node, builder) ||
-            builder.expression(ast.source.slice(node.range[0], node.range[1]))
+            builder.expression(
+                ast.source.slice(node.range[0], node.range[1]),
+                ast
+            )
     );
 }
 

--- a/src/compiler/util/parseJavaScriptParams.js
+++ b/src/compiler/util/parseJavaScriptParams.js
@@ -13,7 +13,7 @@ function parseJavaScriptParams(params, builder) {
         const paramSrc = ast.source.slice(node.range[0], node.range[1]);
         return node.type === "Identifier"
             ? builder.identifier(paramSrc)
-            : builder.expression(paramSrc);
+            : builder.expression(paramSrc, ast);
     });
 }
 

--- a/src/runtime/components/Component.js
+++ b/src/runtime/components/Component.js
@@ -376,6 +376,9 @@ Component.prototype = componentProto = {
     setState: function(name, value) {
         var state = this.___state;
 
+        if (!state) {
+            state = this.___state = new this.___State(this);
+        }
         if (typeof name == "object") {
             // Merge in the new state with the old state
             var newState = name;

--- a/test/components-browser/fixtures/set-null-state/index.marko
+++ b/test/components-browser/fixtures/set-null-state/index.marko
@@ -1,0 +1,9 @@
+class {}
+$ function handleClick() {
+    component.setState('initNull', true);
+}
+
+<div>
+    <span.null>${state && state.initNull}</span>
+    <button key="button" onClick(handleClick)>Update</button>
+</div>

--- a/test/components-browser/fixtures/set-null-state/test.js
+++ b/test/components-browser/fixtures/set-null-state/test.js
@@ -1,0 +1,11 @@
+"use strict";
+
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+
+    expect(component.state).to.equal(null);
+    helpers.triggerEvent(component.getEl("button"), "click");
+    expect(component.state.initNull).to.equal(true);
+};


### PR DESCRIPTION
## Description
In order to support the new state tag, I had to fix a couple of things in the old marko v4 version.

* Added expression statements to have ast
* Added a change on `setState` to initialize the state if it's null
* Upgraded estraverse to the latest version (for traversing esprima ast)

## Checklist:

- [X] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [X] I have updated/added documentation affected by my changes.
- [X] (NA) I have added tests to cover my changes.
