### PR TITLE
Fix regression with browser remap for legacy widgets

### DIFF
--- a/src/runtime/components/legacy/package.json
+++ b/src/runtime/components/legacy/package.json
@@ -1,5 +1,6 @@
 {
     "browser": {
-        "./index.js": "./index-browser.js"
+        "./index.js": "./index-browser.js",
+        "./defineWidget-legacy.js": "./defineWidget-legacy-browser.js"
     }
 }


### PR DESCRIPTION
## Description

Fixes a regression from #1468 which removed a browser remap that is used via `marko-widgets` (compatibility layer).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
