### PR TITLE
fix legacy render lifecycle order to match marko-widgets@6

### DIFF
--- a/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -91,14 +91,6 @@ module.exports = function defineRenderer(renderingLogic) {
                     newProps = getInitialProps(newProps, out) || {};
                 }
 
-                if (getWidgetConfig) {
-                    // If getWidgetConfig() was implemented then use that to
-                    // get the widget config. The widget config will be passed
-                    // to the widget constructor. If rendered on the server the
-                    // widget config will be serialized.
-                    widgetConfig = getWidgetConfig(newProps, out);
-                }
-
                 if (getInitialState) {
                     // This optional method is used to derive the widget state
                     // from the input properties
@@ -161,6 +153,15 @@ module.exports = function defineRenderer(renderingLogic) {
             if (widgetBody) {
                 templateData.renderBody = widgetBody;
             }
+
+            if (isReceivingNewInput && getWidgetConfig) {
+                // If getWidgetConfig() was implemented then use that to
+                // get the widget config. The widget config will be passed
+                // to the widget constructor. If rendered on the server the
+                // widget config will be serialized.
+                widgetConfig = getWidgetConfig(newProps, out);
+            }
+
             if (widgetConfig) {
                 // eslint-disable-next-line no-constant-condition
                 if ("MARKO_DEBUG") {

--- a/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/index.js
+++ b/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/index.js
@@ -1,0 +1,27 @@
+module.exports = require("marko/legacy-components").defineComponent({
+    template: require("./template.marko"),
+
+    getInitialProps(input) {
+        input.calls = ["getInitialProps"];
+        return input;
+    },
+
+    getInitialState(input) {
+        input.calls.push("getInitialState");
+        return input;
+    },
+
+    getTemplateData(input) {
+        input.calls.push("getTemplateData");
+        return input;
+    },
+
+    getWidgetConfig: function(input) {
+        input.calls.push("getWidgetConfig");
+        return input.calls;
+    },
+
+    init: function(config) {
+        this.config = config;
+    }
+});

--- a/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/template.marko
+++ b/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/template.marko
@@ -1,0 +1,2 @@
+<div w-bind>
+</div>

--- a/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-config-render-lifecycle/test.js
@@ -1,0 +1,20 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var widget = helpers.mount(require.resolve("./index"), {
+        name: "Frank"
+    });
+
+    const expectedConfig = [
+        "getInitialProps",
+        "getInitialState",
+        "getTemplateData",
+        "getWidgetConfig"
+    ];
+
+    if (helpers.isHydrate) {
+        expectedConfig.push("getTemplateData");
+    }
+
+    expect(widget.config).to.deep.equal(expectedConfig);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Makes the legacy render lifecycle match that of Marko Widgets 6:

**Marko Widgets 6**:
getInitialProps
getInitialState
getTemplateData
getWidgetConfig

**Marko 4 (before this PR):**
getInitialProps
getWidgetConfig
getInitialState
getTemplateData

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
