### PR TITLE
Support having nullish keys in the legacy compatibility layer

### DIFF
--- a/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -65,13 +65,16 @@ module.exports = function defineRenderer(renderingLogic) {
             var id;
 
             if (!component && componentLookup) {
-                if ((parentComponentDef = componentsContext.___componentDef)) {
-                    var key = out.___assignedKey;
+                var key = out.___assignedKey;
 
-                    if (key != null) {
-                        key = key.toString();
-                    }
-                    id = resolveComponentKey(key, parentComponentDef);
+                if (
+                    (parentComponentDef = componentsContext.___componentDef) &&
+                    key != null
+                ) {
+                    id = resolveComponentKey(
+                        key.toString(),
+                        parentComponentDef
+                    );
                 } else if (parentComponentDef) {
                     id = parentComponentDef.___nextComponentId();
                 } else {

--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -43,11 +43,10 @@ function createRendererFunc(templateRenderFunc, componentProps) {
             isExisting = true;
             globalComponentsContext.___rerenderComponent = null;
         } else {
-            if (parentComponentDef) {
-                if (key != null) {
-                    key = key.toString();
-                }
-                id = id || resolveComponentKey(key, parentComponentDef);
+            if (key != null) {
+                id =
+                    id ||
+                    resolveComponentKey(key.toString(), parentComponentDef);
             } else if (parentComponentDef) {
                 id = parentComponentDef.___nextComponentId();
             } else {


### PR DESCRIPTION
## Description

Currently passing in a null key will throw an error in the compatibility layer. This is transparently handled In the modern runtime and in the current v3 implementation.

Ideally this should log a warning in the future.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
