### PR TITLE
return the component id if no key is passed to getElId/elId

### DIFF
--- a/src/runtime/components/Component.js
+++ b/src/runtime/components/Component.js
@@ -238,6 +238,9 @@ Component.prototype = componentProto = {
         }
     },
     getElId: function(key, index) {
+        if (!key) {
+            return this.id;
+        }
         return resolveComponentIdHelper(this, key, index);
     },
     getEl: function(key, index) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prior to this PR, `component.elId()`/`component.getElId()` (no args) returned something like `c0-undefined`, where it should have simply returned `c0`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
