### PR TITLE
Merge new state on assignment for legacy widgets

### DIFF
--- a/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -57,6 +57,31 @@ module.exports = function defineWidget(def, renderer) {
 
     proto.constructor = def.constructor = Component;
 
+    Object.defineProperty(proto, "state", {
+        get: function() {
+            return this.___state;
+        },
+        set: function(newState) {
+            newState = newState || {};
+            // eslint-disable-next-line no-constant-condition
+            if ("MARKO_DEBUG") {
+                if (
+                    Object.keys(newState)
+                        .sort()
+                        .join("") !==
+                    Object.keys((this.___state && this.___state.___raw) || {})
+                        .sort()
+                        .join("")
+                )
+                    complain(
+                        "'widget.state = newState' has changed from merging the newState to replacing the old state."
+                    );
+            }
+
+            this.setState(newState);
+        }
+    });
+
     Object.defineProperty(proto, "__document", {
         get: function() {
             // eslint-disable-next-line no-constant-condition

--- a/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/index.js
+++ b/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/index.js
@@ -1,0 +1,9 @@
+module.exports = require("marko-widgets").defineComponent({
+    template: require("./template.marko"),
+    getInitialState: function() {
+        return {
+            size: "normal",
+            variant: "primary"
+        };
+    }
+});

--- a/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/template.marko
+++ b/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/template.marko
@@ -1,0 +1,8 @@
+<var classes = [
+    data.size !== 'normal' && 'app-button-'+data.size,
+    data.variant !== 'primary' && 'app-button-'+data.variant,
+]/>
+
+<button class=classes w-bind>
+    Hello
+</button>

--- a/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/test.js
+++ b/test/components-browser/fixtures-deprecated/widget-state-assignment-merge/test.js
@@ -1,0 +1,20 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var widget = helpers.mount(require.resolve("./"));
+    expect(Object.keys(widget.state.toJSON())).has.length(2);
+    expect(widget.state).has.property("size", "normal");
+    expect(widget.state).has.property("variant", "primary");
+
+    widget.state = {};
+    expect(Object.keys(widget.state.toJSON())).has.length(2);
+    expect(widget.state).has.property("size", "normal");
+    expect(widget.state).has.property("variant", "primary");
+
+    widget.state = { newProp: 1 };
+
+    expect(Object.keys(widget.state.toJSON())).has.length(3);
+    expect(widget.state).has.property("size", "normal");
+    expect(widget.state).has.property("variant", "primary");
+    expect(widget.state).has.property("newProp", 1);
+};


### PR DESCRIPTION
## Description

In Marko 3 using `widget.state = newState` caused `newState` to be merged into the existing state. This behavior changed in Marko 4 to replace the existing state. This PR improves the v3 compatibility layer to merge assigned state in the legacy compatibility mode.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
