### PR TITLE
Fix resolving renderer path for legacy widgets

### DIFF
--- a/src/core-tags/migrate/all-tags/w-bind.js
+++ b/src/core-tags/migrate/all-tags/w-bind.js
@@ -27,10 +27,6 @@ module.exports = function migrate(el, context) {
             );
             return;
         }
-
-        if (componentModule.requirePath === "./") {
-            rendererModule = componentModule;
-        }
     } else if (attr.isLiteralValue()) {
         const literalValue = attr.literalValue;
 
@@ -58,10 +54,13 @@ module.exports = function migrate(el, context) {
         componentModule = {
             legacy: true,
             filename,
-            requirePath: literalValue
+            requirePath: literalValue.replace(/\/index(\.[^.]+)?$/, "/")
         };
     }
 
+    if (componentModule && componentModule.requirePath === "./") {
+        rendererModule = componentModule;
+    }
     context.legacyComponentModule = componentModule;
     context.legacyRendererModule = rendererModule;
 


### PR DESCRIPTION
## Description

Currently the `w-bind` migration for legacy widgets looks for `index.js` and `widget.js` to determine if a component is split. However we were only looking for the`defineComponent` (`index.js`) when `w-bind` without a value was used.

This PR accounts for cases like `w-bind="index"` which we assume is a `defineComponent` and should not be split.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
