### PR TITLE
Preserve SSR content with no-update

### DIFF
--- a/src/core-tags/components/TransformHelper/assignComponentId.js
+++ b/src/core-tags/components/TransformHelper/assignComponentId.js
@@ -102,47 +102,9 @@ module.exports = function assignComponentId(isRepeated) {
         }
     }
 
-    var transformHelper = this;
-
     this.componentIdInfo = {
         idExpression: idExpression,
-        nestedIdExpression: nestedIdExpression,
-        idVarNode: null,
-        createIdVarNode: function() {
-            if (this.idVarNode) {
-                return this.idVarNode;
-            }
-
-            const idVar = builder.identifier(context.nextUniqueId("key"));
-
-            this.idVarNode = builder.vars([
-                {
-                    id: idVar,
-                    init: builder.functionCall(
-                        builder.memberExpression(
-                            builder.identifier("__component"),
-                            builder.identifier("___nextKey")
-                        ),
-                        [idExpression]
-                    )
-                }
-            ]);
-
-            this.idExpression = idExpression = idVar;
-
-            this.nestedIdExpression = nestedIdExpression = builder.concat(
-                builder.literal("#"),
-                idVar
-            );
-
-            if (isCustomTag) {
-                transformHelper.getComponentArgs().setKey(nestedIdExpression);
-            } else {
-                el.setKey(idExpression);
-            }
-
-            return this.idVarNode;
-        }
+        nestedIdExpression: nestedIdExpression
     };
 
     return this.componentIdInfo;

--- a/src/core-tags/components/TransformHelper/handleComponentPreserve.js
+++ b/src/core-tags/components/TransformHelper/handleComponentPreserve.js
@@ -9,40 +9,28 @@ function addPreserve(transformHelper, bodyOnly, condition) {
 
     if (bodyOnly) {
         preserveAttrs["body-only"] = builder.literal(bodyOnly);
+        el.forEachChild(child => {
+            child._canBePreserved = true;
+        });
+    } else {
+        el._canBePreserved = true;
     }
 
     if (condition) {
         preserveAttrs["if"] = condition;
     }
 
-    let componentIdInfo = transformHelper.assignComponentId();
-    let idVarNode = componentIdInfo.idVarNode
-        ? null
-        : componentIdInfo.createIdVarNode();
-
-    if (el.type === "HtmlElement") {
-        preserveAttrs.key = transformHelper.getIdExpression();
-        preserveAttrs.preserveKey = preserveAttrs.key;
-    } else {
-        preserveAttrs.cid = transformHelper.getIdExpression();
-    }
-
+    preserveAttrs.key = builder.concat(
+        builder.literal("p_"),
+        transformHelper.assignComponentId().nestedIdExpression
+    );
     let preserveNode = context.createNodeForEl("_preserve", preserveAttrs);
-    let idVarNodeTarget;
 
     if (bodyOnly) {
         el.moveChildrenTo(preserveNode);
         el.appendChild(preserveNode);
-        idVarNodeTarget = el;
     } else {
         el.wrapWith(preserveNode);
-        idVarNodeTarget = preserveNode;
-    }
-
-    if (idVarNode) {
-        idVarNodeTarget.onBeforeGenerateCode(event => {
-            event.insertCode(idVarNode);
-        });
     }
 
     return preserveNode;

--- a/src/core-tags/components/TransformHelper/index.js
+++ b/src/core-tags/components/TransformHelper/index.js
@@ -63,7 +63,7 @@ class TransformHelper {
         if (
             !this.__keySerialized &&
             context.isServerTarget() &&
-            context.isSplitComponent
+            (context.isSplitComponent || isPreserved(el))
         ) {
             var markoKeyAttrVar = context.importModule(
                 "marko_keyAttr",
@@ -160,6 +160,20 @@ class TransformHelper {
     getTransformHelper(el) {
         return new TransformHelper(el, this.context);
     }
+}
+
+function isPreserved(el) {
+    let curNode = el;
+
+    do {
+        if (curNode._canBePreserved) {
+            return true;
+        }
+
+        curNode = curNode.parentNode;
+    } while (curNode);
+
+    return false;
 }
 
 TransformHelper.prototype.assignComponentId = require("./assignComponentId");

--- a/src/core-tags/components/helpers/markoKeyAttr.js
+++ b/src/core-tags/components/helpers/markoKeyAttr.js
@@ -3,7 +3,10 @@ var FLAG_WILL_RERENDER_IN_BROWSER = 1;
 // var FLAG_HAS_HEAD_EL = 4;
 
 module.exports = function markoKeyAttr(key, componentDef) {
-    if ((componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER) === 0) {
+    if (
+        (componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER) === 0 ||
+        componentDef.___globalComponentsContext.___isPreserved
+    ) {
         return componentDef.___nextKey(key) + " " + componentDef.id;
     }
 };

--- a/src/core-tags/components/preserve-tag-browser.js
+++ b/src/core-tags/components/preserve-tag-browser.js
@@ -1,13 +1,19 @@
 module.exports = function render(input, out) {
+    var componentsContext = out.___components;
+    var isHydrate =
+        componentsContext && componentsContext.___globalContext.___isHydrate;
     var ownerComponentDef = out.___assignedComponentDef;
     var ownerComponent = ownerComponentDef.___component;
-    var key = ownerComponentDef.___nextKey(out.___assignedKey);
-    var isPreserved = !("if" in input) || input["if"];
+    var key = out.___assignedKey;
+    var shouldPreserve = !("if" in input) || input["if"];
+    var isPreserved = Boolean(
+        shouldPreserve && (isHydrate || ownerComponent.___keyedElements[key])
+    );
 
-    out.___beginFragment(key, ownerComponent, isPreserved);
+    out.___beginFragment(key, ownerComponent, shouldPreserve);
 
-    if (!isPreserved || !ownerComponent.___keyedElements[key]) {
-        input.renderBody && input.renderBody(out);
+    if (!isPreserved && input.renderBody) {
+        input.renderBody(out);
     }
 
     out.___endFragment();

--- a/src/core-tags/components/preserve-tag.js
+++ b/src/core-tags/components/preserve-tag.js
@@ -1,6 +1,24 @@
 module.exports = function render(input, out) {
-    // TODO Remove the preserve tag out of the AST if compiled for the server
-    if (input.renderBody) {
-        input.renderBody(out);
+    var globalContext = out.___components.___globalContext;
+    var parentPreserved = globalContext.___isPreserved;
+    var shouldPreserve = Boolean(!("if" in input) || input["if"]);
+
+    if (parentPreserved || !shouldPreserve) {
+        input.renderBody && input.renderBody(out);
+        return;
     }
+
+    var ownerComponentDef = out.___assignedComponentDef;
+    var ownerComponent = ownerComponentDef.___component;
+    var key = out.___assignedKey;
+
+    out.___beginFragment(key, ownerComponent, true);
+
+    if (input.renderBody) {
+        globalContext.___isPreserved = true;
+        input.renderBody(out);
+        globalContext.___isPreserved = false;
+    }
+
+    out.___endFragment();
 };

--- a/src/runtime/components/ComponentDef.js
+++ b/src/runtime/components/ComponentDef.js
@@ -32,8 +32,6 @@ function ComponentDef(component, componentId, globalComponentsContext) {
     this.___nextIdIndex = 0; // The unique integer to use for the next scoped ID
 
     this.___keySequence = null;
-
-    this.___preservedDOMNodes = null;
 }
 
 ComponentDef.prototype = {
@@ -41,12 +39,6 @@ ComponentDef.prototype = {
         var keySequence =
             this.___keySequence || (this.___keySequence = new KeySequence());
         return keySequence.___nextKey(key);
-    },
-
-    ___preserveDOMNode: function(key, bodyOnly) {
-        var lookup =
-            this.___preservedDOMNodes || (this.___preservedDOMNodes = {});
-        lookup[key] = bodyOnly ? 2 : 1;
     },
 
     /**

--- a/src/runtime/components/GlobalComponentsContext.js
+++ b/src/runtime/components/GlobalComponentsContext.js
@@ -2,8 +2,6 @@ var nextComponentIdProvider = require("./util").___nextComponentIdProvider;
 var KeySequence = require("./KeySequence");
 
 function GlobalComponentsContext(out) {
-    this.___preservedEls = {};
-    this.___preservedElBodies = {};
     this.___renderedComponentsById = {};
     this.___rerenderComponent = undefined;
     this.___nextComponentId = nextComponentIdProvider(out);

--- a/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
@@ -28,19 +28,14 @@ function render(input, out, __component, component, state) {
       "</li>");
   });
 
-  out.w("</ul>");
-
-  var $key$0 = __component.___nextKey("@preservedP");
-
-  out.w("<p>");
+  out.w("</ul><p>");
 
   _preserve_tag({
       bodyOnly: true,
-      preserveKey: $key$0,
       renderBody: function(out) {
         out.w(marko_escapeXml(Date.now()));
       }
-    }, out, __component, $key$0);
+    }, out, __component, "p_preservedP");
 
   out.w("</p></div><span>B</span>");
 

--- a/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -28,19 +28,14 @@ function render(input, out, __component, component, state) {
       "</li>");
   });
 
-  out.w("</ul>");
-
-  var $key$0 = __component.___nextKey("@preservedP");
-
-  out.w("<p>");
+  out.w("</ul><p>");
 
   _preserve_tag({
       bodyOnly: true,
-      preserveKey: $key$0,
       renderBody: function(out) {
         out.w(marko_escapeXml(Date.now()));
       }
-    }, out, __component, $key$0);
+    }, out, __component, "p_preservedP");
 
   out.w("</p></div><span>B</span>");
 

--- a/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/components/root/index.marko
+++ b/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/components/root/index.marko
@@ -1,0 +1,5 @@
+class {}
+
+<div id="root" no-update>
+    Is Server: ${typeof window === "undefined"}
+</div>

--- a/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/template.marko
+++ b/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/template.marko
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8"/>
+        <title>Marko Test</title>
+    </head>
+    <body>
+
+        <div id="test"/>
+        <div id="mocha"/>
+        <div id="testsTarget"/>
+
+        <root/>
+
+        <init-components immediate/>
+    </body>
+</html>

--- a/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/tests.js
+++ b/test/components-pages/fixtures/preserve-server-rendered-content-on-mount/tests.js
@@ -1,0 +1,6 @@
+var expect = require("chai").expect;
+
+it("should update correctly", function() {
+    var $el = document.getElementById("root");
+    expect($el).has.property("textContent", "Is Server: true");
+});


### PR DESCRIPTION
## Description
Currently when using `no-update` on the server side, whatever you have will be thrown away when rerendering in the browser.

This PR updates `no-update` to preserve that content when hydrating.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
