### PR TITLE
Preserve legacy widget input when rerendered

### DIFF
--- a/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -58,7 +58,7 @@ module.exports = function defineRenderer(renderingLogic) {
 
             // Render the template associated with the component using the final template
             // data that we constructed
-            var newProps = input || {};
+            var newProps = input;
             var widgetConfig;
             var widgetState;
             var widgetBody;
@@ -111,6 +111,7 @@ module.exports = function defineRenderer(renderingLogic) {
                     widgetBody = newProps.renderBody;
                 }
             } else if (component) {
+                newProps = newProps || component.___widgetProps;
                 widgetBody = component.___legacyBody;
                 widgetState = component.___rawState;
                 widgetConfig = component.widgetConfig;

--- a/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -160,6 +160,7 @@ module.exports = function defineWidget(def, renderer) {
 
             self.___didUpdate = true;
         });
+        this.___widgetProps = this.___input;
         this.___input = null;
     };
 
@@ -167,6 +168,7 @@ module.exports = function defineWidget(def, renderer) {
         if (onUpdate) onUpdate.call(this);
         if (onRender && this.___didUpdate) onRender.call(this, {});
         this.___didUpdate = false;
+        this.___widgetProps = this.___input;
         this.___input = null;
     };
 


### PR DESCRIPTION
## Description

Improves v3 compatibility by supporting input with `getTemplateData(state, input, out)` on state based rerenders.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
