### PR TITLE
Fix regression with no-update-body on script tags

### DIFF
--- a/src/runtime/vdom/VNode.js
+++ b/src/runtime/vdom/VNode.js
@@ -54,6 +54,8 @@ VNode.prototype = {
                 var childValue = child.___nodeValue;
                 this.___valueInternal =
                     (this.___valueInternal || "") + childValue;
+            } else if (child.___preserve) {
+                this.___preserveTextAreaValue = true;
             } else {
                 throw TypeError();
             }

--- a/src/runtime/vdom/morphdom/specialElHandlers.js
+++ b/src/runtime/vdom/morphdom/specialElHandlers.js
@@ -58,6 +58,10 @@ SpecialElHandlers.prototype = {
     },
 
     textarea: function(fromEl, toEl) {
+        if (toEl.___preserveTextAreaValue) {
+            return;
+        }
+
         var newValue = toEl.___value;
         if (fromEl.value != newValue) {
             fromEl.value = newValue;


### PR DESCRIPTION
## Description

Fixes a regression caused by #1480 which broke `<textarea no-update-body>`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
