### PR TITLE
Fix issue with ssr'd components under 'no-update' not initializing

### DIFF
--- a/src/runtime/components/beginComponent.js
+++ b/src/runtime/components/beginComponent.js
@@ -32,6 +32,7 @@ module.exports = function beginComponent(
 
     // On the server
     if (
+        !globalContext.___isPreserved &&
         ownerComponentDef &&
         ownerComponentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER
     ) {

--- a/test/components-pages/fixtures/no-update-component/components/counter/index.marko
+++ b/test/components-pages/fixtures/no-update-component/components/counter/index.marko
@@ -1,0 +1,19 @@
+class {
+    onCreate() {
+        this.state = {
+            count: 0
+        };
+    }
+
+    onMount() {
+        window.counterComponent = this;
+    }
+
+    handleClick() {
+        this.state.count++;
+    }
+}
+
+<button key="button" onClick("handleClick")>
+    Count: ${state.count}
+</button>

--- a/test/components-pages/fixtures/no-update-component/template.marko
+++ b/test/components-pages/fixtures/no-update-component/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        counter no-update
+
+        init-components immediate

--- a/test/components-pages/fixtures/no-update-component/tests.js
+++ b/test/components-pages/fixtures/no-update-component/tests.js
@@ -1,0 +1,13 @@
+var expect = require("chai").expect;
+
+it("should should have mounted the component", function() {
+    expect(window.counterComponent).to.not.equal(undefined);
+});
+
+it("should be interactive", function() {
+    var btn = window.counterComponent.getEl("button");
+    expect(btn.textContent).to.equal("Count: 0");
+    btn.click();
+    window.counterComponent.update();
+    expect(btn.textContent).to.equal("Count: 1");
+});


### PR DESCRIPTION
## Description

After #1480 top level components under a `no-update` root were not mounting properly.
This ensures that those components are initialized independently of their parent.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
