### PR TITLE
Support overriding the 'ready' method in legacy widgets

### DIFF
--- a/src/runtime/components/ready.js
+++ b/src/runtime/components/ready.js
@@ -146,6 +146,11 @@ function ready(callback, thisObj, doc) {
 module.exports = ready;
 
 module.exports.patchComponent = function(proto) {
+    if (proto && proto.ready) {
+        // Don't patch if the component has overwritten the ready method.
+        return;
+    }
+
     (proto || require("./Component").prototype).ready = function(callback) {
         var document = this.el.ownerDocument;
         ready(callback, this, document);


### PR DESCRIPTION
## Description

Currently if a legacy widget overrides the `ready` method it will not work.
This PR improves consistency with Marko 3 components by allowing it to be overwritten.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
