### PR TITLE
Improve consistency with spread attributes

### DIFF
--- a/src/compiler/ast/CustomTag.js
+++ b/src/compiler/ast/CustomTag.js
@@ -320,7 +320,9 @@ class CustomTag extends HtmlElement {
             if (attr.spread) {
                 let isFirstOfMany =
                     i === 0 &&
-                    (this._hasDynamicNestedTags || this.attributes.length > 1);
+                    (this._hasDynamicNestedTags ||
+                        this.attributes.length > 1 ||
+                        additionalAttrs);
                 if (explicitAttrs || isFirstOfMany) {
                     attrs.push(builder.objectExpression(explicitAttrs || {}));
                 }

--- a/src/runtime/helpers/_change-case.js
+++ b/src/runtime/helpers/_change-case.js
@@ -1,0 +1,45 @@
+"use strict";
+
+var camelToDashLookup = Object.create(null);
+var dashToCamelLookup = Object.create(null);
+
+/**
+ * Helper for converting camelCase to dash-case.
+ */
+exports.___camelToDashCase = function camelToDashCase(name) {
+    var nameDashed = camelToDashLookup[name];
+    if (!nameDashed) {
+        nameDashed = camelToDashLookup[name] = name
+            .replace(/([A-Z])/g, "-$1")
+            .toLowerCase();
+
+        if (nameDashed !== name) {
+            dashToCamelLookup[nameDashed] = name;
+        }
+    }
+
+    return nameDashed;
+};
+
+/**
+ * Helper for converting dash-case to camelCase.
+ */
+exports.___dashToCamelCase = function dashToCamelCase(name) {
+    var nameCamel = dashToCamelLookup[name];
+    if (!nameCamel) {
+        nameCamel = dashToCamelLookup[name] = name.replace(
+            /-([a-z])/g,
+            matchToUpperCase
+        );
+
+        if (nameCamel !== name) {
+            camelToDashLookup[nameCamel] = name;
+        }
+    }
+
+    return nameCamel;
+};
+
+function matchToUpperCase(_, char) {
+    return char.toUpperCase();
+}

--- a/src/runtime/helpers/dynamic-tag.js
+++ b/src/runtime/helpers/dynamic-tag.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var complain = "MARKO_DEBUG" && require("complain");
-var removeDashes = require("../../compiler/util/removeDashes");
+var changeCase = require("./_change-case");
 var ComponentsContext = require("../components/ComponentsContext");
 var getComponentsContext = ComponentsContext.___getComponentsContext;
 var ComponentDef = require("../components/ComponentDef");
@@ -61,14 +61,17 @@ module.exports = function dynamicTag(
                 out.___elementDynamic(tag, attrs, key, component, 0, 0, props);
             }
         } else {
-            var defaultAttrs = renderBody ? { renderBody: renderBody } : {};
             if (attrs == null) {
-                attrs = defaultAttrs;
+                attrs = {};
             } else if (typeof attrs === "object") {
                 attrs = Object.keys(attrs).reduce(function(r, key) {
-                    r[removeDashes(key)] = attrs[key];
+                    r[changeCase.___dashToCamelCase(key)] = attrs[key];
                     return r;
-                }, defaultAttrs);
+                }, {});
+            }
+
+            if (renderBody) {
+                attrs.renderBody = renderBody;
             }
 
             if (tag._ || tag.renderer || tag.render) {

--- a/src/runtime/helpers/style-value.js
+++ b/src/runtime/helpers/style-value.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var dashedNames = Object.create(null);
+var changeCase = require("./_change-case");
 
 /**
  * Helper for generating the string for a style attribute
@@ -29,13 +29,8 @@ module.exports = function styleHelper(style) {
                         value += "px";
                     }
 
-                    var nameDashed = dashedNames[name];
-                    if (!nameDashed) {
-                        nameDashed = dashedNames[name] = name
-                            .replace(/([A-Z])/g, "-$1")
-                            .toLowerCase();
-                    }
-                    styles += nameDashed + ":" + value + ";";
+                    styles +=
+                        changeCase.___camelToDashCase(name) + ":" + value + ";";
                 }
             }
         }

--- a/src/runtime/html/helpers/attrs.js
+++ b/src/runtime/html/helpers/attrs.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var complain = "MARKO_DEBUG" && require("complain");
+var changeCase = require("../../helpers/_change-case");
 var attrHelper = require("./attr");
 var classAttrHelper = require("./class-attr");
 var styleAttrHelper = require("./style-attr");
@@ -18,8 +19,11 @@ module.exports = function attrs(arg) {
                 out += styleAttrHelper(arg[attrName]);
             } else if (attrName === "class") {
                 out += classAttrHelper(arg[attrName]);
-            } else if (isValidAttrName(attrName)) {
-                out += attrHelper(attrName, arg[attrName]);
+            } else if (attrName !== "renderBody" && isValidAttrName(attrName)) {
+                out += attrHelper(
+                    changeCase.___camelToDashCase(attrName),
+                    arg[attrName]
+                );
             }
         }
         return out;

--- a/src/runtime/vdom/helpers/attrs.js
+++ b/src/runtime/vdom/helpers/attrs.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var complain = "MARKO_DEBUG" && require("complain");
+var changeCase = require("../../helpers/_change-case");
 var classHelper = require("../../helpers/class-value");
 var styleHelper = require("../../helpers/style-value");
 
@@ -18,19 +19,29 @@ module.exports = function(attributes) {
         return parseAttrs(attributes);
     }
 
-    if (attributes && (attributes.style || attributes.class)) {
+    if (attributes) {
         var newAttributes = {};
-        Object.keys(attributes).forEach(function(name) {
-            if (name === "class") {
-                newAttributes[name] = classHelper(attributes[name]);
-            } else if (name === "style") {
-                newAttributes[name] = styleHelper(attributes[name]);
-            } else {
-                newAttributes[name] = attributes[name];
+
+        for (var attrName in attributes) {
+            var val = attributes[attrName];
+            if (attrName === "renderBody" || val == null || val === false) {
+                continue;
             }
-        });
+
+            if (attrName === "class") {
+                val = classHelper(val);
+            } else if (attrName === "style") {
+                val = styleHelper(val);
+            } else {
+                attrName = changeCase.___camelToDashCase(attrName);
+            }
+
+            newAttributes[attrName] = val;
+        }
+
         return newAttributes;
     }
+
     return attributes;
 };
 

--- a/test/render/fixtures/attrs-normalize-for-native-tag/components/custom-tag/index.marko
+++ b/test/render/fixtures/attrs-normalize-for-native-tag/components/custom-tag/index.marko
@@ -1,0 +1,3 @@
+<div.custom ...input>
+  <${input.renderBody}/>
+</div>

--- a/test/render/fixtures/attrs-normalize-for-native-tag/expected.html
+++ b/test/render/fixtures/attrs-normalize-for-native-tag/expected.html
@@ -1,0 +1,1 @@
+<div data-dash="case" data-camel="case" class="a" style="color:green;"></div>

--- a/test/render/fixtures/attrs-normalize-for-native-tag/template.marko
+++ b/test/render/fixtures/attrs-normalize-for-native-tag/template.marko
@@ -1,0 +1,9 @@
+static var attrs = {
+  "data-dash": "case",
+  dataCamel: "case",
+  class: ["a"],
+  style: { color: "green" },
+  skipped: false
+}
+
+<div ...attrs/>

--- a/test/render/fixtures/attrs-normalize-for-native-tag/test.js
+++ b/test/render/fixtures/attrs-normalize-for-native-tag/test.js
@@ -1,0 +1,7 @@
+exports.templateData = {
+    myAttrs: {
+        style: "background-color: #FF0000; <test>",
+        class: "my-div",
+        checked: true
+    }
+};

--- a/test/render/fixtures/attrs-normalize-for-native-tag/vdom-expected.html
+++ b/test/render/fixtures/attrs-normalize-for-native-tag/vdom-expected.html
@@ -1,0 +1,1 @@
+<DIV class="a" data-camel="case" data-dash="case" style="color:green;">

--- a/test/render/fixtures/attrs-with-render-body/components/custom-tag/index.marko
+++ b/test/render/fixtures/attrs-with-render-body/components/custom-tag/index.marko
@@ -1,0 +1,3 @@
+<div.custom ...input>
+  <${input.renderBody}/>
+</div>

--- a/test/render/fixtures/attrs-with-render-body/expected.html
+++ b/test/render/fixtures/attrs-with-render-body/expected.html
@@ -1,0 +1,1 @@
+<div class="native">Inline native element renderBody</div><div class="custom">Inline custom tag renderBody</div><div class="native"></div><div class="custom">RenderBody from input.</div>

--- a/test/render/fixtures/attrs-with-render-body/template.marko
+++ b/test/render/fixtures/attrs-with-render-body/template.marko
@@ -1,0 +1,11 @@
+<macro|input| name="test">
+  <div.native ...input>Inline native element renderBody</div>
+  <custom-tag ...input>Inline custom tag renderBody</custom-tag>
+
+  <div.native ...input/>
+  <custom-tag ...input/>
+</macro>
+
+<test>
+  RenderBody from input.
+</test>

--- a/test/render/fixtures/attrs-with-render-body/test.js
+++ b/test/render/fixtures/attrs-with-render-body/test.js
@@ -1,0 +1,7 @@
+exports.templateData = {
+    myAttrs: {
+        style: "background-color: #FF0000; <test>",
+        class: "my-div",
+        checked: true
+    }
+};

--- a/test/render/fixtures/attrs-with-render-body/vdom-expected.html
+++ b/test/render/fixtures/attrs-with-render-body/vdom-expected.html
@@ -1,0 +1,7 @@
+<DIV class="native">
+  "Inline native element renderBody"
+<DIV class="custom">
+  "Inline custom tag renderBody"
+<DIV class="native">
+<DIV class="custom">
+  "RenderBody from input."


### PR DESCRIPTION
## Description

Currently the behavior when spreading attributes meant for a custom tag into a native tag can be surprising.

This PR improves the support by:

1. `renderBody` attributes passed to native tags is now ignored.
2. `camelCase` properties are now consistently converted to dash case.


This PR also fixes the following:

1. Prevent spread attributes from being mutated if a `renderBody` exists.
2. A direct renderBody to the dynamic tag now correctly takes precedence over one passed via regular input (spread).

resolves #1485 
resolves #824 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
