### PR TITLE
don't modify the widget prototype for init

### DIFF
--- a/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -18,12 +18,14 @@ module.exports = function defineWidget(def, renderer) {
 
     var ComponentClass = function() {};
     var proto;
+    var init;
 
     if (typeof def === "function") {
         proto = def.prototype;
-        proto.init = def;
+        init = def;
     } else if (typeof def === "object") {
         proto = def;
+        init = def.init;
     } else {
         throw TypeError();
     }
@@ -108,7 +110,6 @@ module.exports = function defineWidget(def, renderer) {
     });
 
     // get legacy methods
-    var init = proto.init;
     var onRender = proto.onRender;
     var onBeforeUpdate = proto.onBeforeUpdate;
     var onUpdate = proto.onUpdate;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prior to this change, a widget def like this will go into an infinite look because the `defineWidget` helper set the constructor to the init property.  This PR makes it so Marko doesn't modify the widget prototype in this case.

```js
class Widget {
  constructor() {
    this.init()
  }
  init() {
    // do stuff
  }
}
```



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
