### PR TITLE
Support dynamic tags with attribute tags and the ignoreUnrecognizedTa…

### DIFF
--- a/src/compiler/Normalizer.js
+++ b/src/compiler/Normalizer.js
@@ -124,7 +124,8 @@ class Normalizer {
                 tagName = builder.parseExpression(elNode.rawTagNameExpression);
             } else if (
                 context.ignoreUnrecognizedTags &&
-                !elNode.parentNode.tagDef
+                !elNode.parentNode.tagDef &&
+                !elNode.parentNode.rawTagNameExpression
             ) {
                 tagName = tagName.replace(/^@/, "at_"); // escapes @tags inside unrecognized tags
             }


### PR DESCRIPTION
## Description

Currently the `ignoreUnrecognizedTags` compiler option does not honor a nested attribute tag within a dynamic tag.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
