### PR TITLE
Fix issue with registering events under a 'no-update' when server rendered

### DIFF
--- a/src/compiler/ast/HtmlElement/html/generateCode.js
+++ b/src/compiler/ast/HtmlElement/html/generateCode.js
@@ -16,7 +16,10 @@ module.exports = function generateCode(node, codegen) {
 
     var properties = node.getProperties();
 
-    if (properties && !codegen.context.isStatefulComponent) {
+    if (
+        properties &&
+        (!codegen.context.isStatefulComponent || isPreserved(node))
+    ) {
         var objectProps = Object.keys(properties).map(propName => {
             return builder.property(
                 builder.literal(propName),
@@ -91,3 +94,17 @@ module.exports = function generateCode(node, codegen) {
         return [startTag, body, endTag, propertiesScript];
     }
 };
+
+function isPreserved(el) {
+    let curNode = el;
+
+    do {
+        if (curNode._canBePreserved) {
+            return true;
+        }
+
+        curNode = curNode.parentNode;
+    } while (curNode);
+
+    return false;
+}

--- a/test/components-pages/fixtures/no-update-with-an-event/components/counter/index.marko
+++ b/test/components-pages/fixtures/no-update-with-an-event/components/counter/index.marko
@@ -1,0 +1,19 @@
+class {
+    onCreate() {
+        this.state = {
+            count: 0
+        };
+    }
+
+    onMount() {
+        window.counterComponent = this;
+    }
+
+    handleClick() {
+        this.state.count++;
+    }
+}
+<div key="count">Count: ${state.count}</div>
+<button key="button" onClick("handleClick") no-update>
+    Increment
+</button>

--- a/test/components-pages/fixtures/no-update-with-an-event/template.marko
+++ b/test/components-pages/fixtures/no-update-with-an-event/template.marko
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        counter no-update
+
+        init-components immediate

--- a/test/components-pages/fixtures/no-update-with-an-event/tests.js
+++ b/test/components-pages/fixtures/no-update-with-an-event/tests.js
@@ -1,0 +1,14 @@
+var expect = require("chai").expect;
+
+it("should should have mounted the component", function() {
+    expect(window.counterComponent).to.not.equal(undefined);
+});
+
+it("should be interactive", function() {
+    var countDisplay = window.counterComponent.getEl("count");
+    var btn = window.counterComponent.getEl("button");
+    expect(countDisplay.textContent).to.equal("Count: 0");
+    btn.click();
+    window.counterComponent.update();
+    expect(countDisplay.textContent).to.equal("Count: 1");
+});


### PR DESCRIPTION
## Description

Currently if you have a some content under a `no-update` section with an event handler which is initially rendered on the server it can fail to register the event.

This is related to the changes in https://github.com/marko-js/marko/pull/1480

Fixes #1492 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
