### PR TITLE
Fix regression with body-only-if migration for legacy renderers

### DIFF
--- a/src/runtime/helpers/dynamic-tag.js
+++ b/src/runtime/helpers/dynamic-tag.js
@@ -74,8 +74,22 @@ module.exports = function dynamicTag(
                 attrs.renderBody = renderBody;
             }
 
-            if (tag._ || tag.renderer || tag.render) {
-                var renderer = tag._ || tag.renderer || tag.render;
+            var renderer =
+                tag._ ||
+                tag.render ||
+                (tag.renderer && tag.renderer.renderer) ||
+                tag.renderer;
+
+            // eslint-disable-next-line no-constant-condition
+            if ("MARKO_DEBUG") {
+                if (tag.renderer && tag.renderer.renderer === renderer) {
+                    complain(
+                        "An object with a 'renderer' was passed to the dynamic tag, but renderer was another template."
+                    );
+                }
+            }
+
+            if (renderer) {
                 out.c(componentDef, key, customEvents);
                 renderer(attrs, out);
                 out.___assignedComponentDef = null;


### PR DESCRIPTION
## Description

Currently the `body-only-if` migration outputs `{ renderer: dynamicTagValue }` when the tag being converted has a renderer to avoid the dynamic tag thinking it is a renderBody since https://github.com/marko-js/marko/pull/1384. This causes a regression if you specify a component/legacy widget as the renderer.

This PR adds a check in the dynamic tag runtime to see if the `renderer` was a another tag and renders it as a tag instead. It also logs a deprecation in this case.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
