### PR TITLE
Fix regression for unkeyed elements with toggled spread attributes

### DIFF
--- a/src/runtime/vdom/helpers/attrs.js
+++ b/src/runtime/vdom/helpers/attrs.js
@@ -24,7 +24,7 @@ module.exports = function(attributes) {
 
         for (var attrName in attributes) {
             var val = attributes[attrName];
-            if (attrName === "renderBody" || val == null || val === false) {
+            if (attrName === "renderBody") {
                 continue;
             }
 

--- a/test/components-browser/fixtures/component-toggle-spread-attributes/component.js
+++ b/test/components-browser/fixtures/component-toggle-spread-attributes/component.js
@@ -1,0 +1,5 @@
+module.exports = {
+    onCreate: function() {
+        this.state = { attrs: {} };
+    }
+};

--- a/test/components-browser/fixtures/component-toggle-spread-attributes/index.marko
+++ b/test/components-browser/fixtures/component-toggle-spread-attributes/index.marko
@@ -1,0 +1,1 @@
+<button ...state.attrs/>

--- a/test/components-browser/fixtures/component-toggle-spread-attributes/test.js
+++ b/test/components-browser/fixtures/component-toggle-spread-attributes/test.js
@@ -1,0 +1,27 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+    var component = helpers.mount(require.resolve("./index"), {});
+    var root = component.el;
+    expect(root.outerHTML).to.equal("<button></button>");
+
+    component.setState("attrs", { "aria-pressed": true });
+    component.update();
+    expect(root.outerHTML).to.equal('<button aria-pressed=""></button>');
+
+    component.setState("attrs", { "aria-pressed": null });
+    component.update();
+    expect(root.outerHTML).to.equal("<button></button>");
+
+    component.setState("attrs", { "aria-pressed": true });
+    component.update();
+    expect(root.outerHTML).to.equal('<button aria-pressed=""></button>');
+
+    component.setState("attrs", { "aria-pressed": false });
+    component.update();
+    expect(root.outerHTML).to.equal("<button></button>");
+
+    component.setState("attrs", { "aria-pressed": undefined });
+    component.update();
+    expect(root.outerHTML).to.equal("<button></button>");
+};


### PR DESCRIPTION
## Description

The changes in #1488 caused an issue where spread attributes passed to an element without a key would no longer be omitted if set to `null` or `false`. This is because the [assumption here](https://github.com/marko-js/marko/blob/master/src/runtime/vdom/VElement.js#L381) was broken.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ x I have added tests to cover my changes.
