### PR TITLE
Prevent serializing input for legacy split widgets

### DIFF
--- a/src/runtime/components/legacy/renderer-legacy.js
+++ b/src/runtime/components/legacy/renderer-legacy.js
@@ -65,7 +65,9 @@ function createRendererFunc(templateRenderFunc, componentProps) {
                 customEvents,
                 ownerComponentId
             );
-            if (input.widgetProps) {
+            if (isSplit) {
+                component.input = null;
+            } else if (input.widgetProps) {
                 component.input = input.widgetProps;
             }
         } else {
@@ -139,7 +141,10 @@ function createRendererFunc(templateRenderFunc, componentProps) {
                         customEvents,
                         ownerComponentId
                     );
-                    if (input.widgetProps) {
+
+                    if (isSplit) {
+                        component.input = null;
+                    } else if (input.widgetProps) {
                         component.input = input.widgetProps;
                     }
                     Object.assign(component, oldComponent);


### PR DESCRIPTION
## Description

In Marko 3 split components do not have access to their `input`, however modern split components do. This PR prevents serializing input for legacy split components to increase performance in that case.

This is a subset of https://github.com/marko-js/marko/commit/f4f89c93046b4958052832ec44d1afb9980d558f

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
