### PR TITLE
Always output no-update fragment on the server

### DIFF
--- a/src/core-tags/components/preserve-tag.js
+++ b/src/core-tags/components/preserve-tag.js
@@ -1,11 +1,5 @@
 module.exports = function render(input, out) {
     var shouldPreserve = Boolean(!("if" in input) || input["if"]);
-
-    if (!shouldPreserve) {
-        input.renderBody && input.renderBody(out);
-        return;
-    }
-
     var ownerComponentDef = out.___assignedComponentDef;
     var ownerComponent = ownerComponentDef.___component;
     var key = out.___assignedKey;
@@ -15,7 +9,7 @@ module.exports = function render(input, out) {
     if (input.renderBody) {
         var globalContext = out.___components.___globalContext;
         var parentPreserved = globalContext.___isPreserved;
-        globalContext.___isPreserved = true;
+        globalContext.___isPreserved = parentPreserved || shouldPreserve;
         input.renderBody(out);
         globalContext.___isPreserved = parentPreserved;
     }


### PR DESCRIPTION
## Description

This fixes an issue where `no-update` can cause the structure to change in a browser vs a server render causing some SSR'd dom to be incorrectly removed. Now we always output fragment markers for SSR'd no-update content to maintain a consistent structure.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
