### PR TITLE
Fix issue with init-components inside nested awaits

### DIFF
--- a/src/core-tags/components/init-components-tag.js
+++ b/src/core-tags/components/init-components-tag.js
@@ -30,7 +30,7 @@ module.exports = function render(input, out) {
                 // Ensure we're getting init code starting from the root
                 let rootOut = out;
                 while (rootOut._parentOut) {
-                    rootOut = out._parentOut;
+                    rootOut = rootOut._parentOut;
                 }
                 // Write out all of the component init code from the main out
                 writeInitComponentsCode(rootOut, asyncOut, true);


### PR DESCRIPTION
## Description

The `<init-components>` tag previously on being rendered under the top level `out` however this was fixed in https://github.com/marko-js/marko/pull/1441. The fix however has a typo which caused it to only walk up one nested out. This PR fixes the typo and resolves the original issue.

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
