### PR TITLE
fix: improve node locations in sourcemaps

### DIFF
--- a/packages/marko/src/compiler/index.js
+++ b/packages/marko/src/compiler/index.js
@@ -32,11 +32,11 @@ function configure(newConfig) {
   compiler.configure(newConfig);
 }
 
-function resultCompat({ code, meta }, options = {}) {
+function resultCompat({ code, meta, map }, options = {}) {
   if (options.sourceOnly !== false) {
     return code;
   } else {
-    return { code, meta };
+    return { code, meta, map };
   }
 }
 

--- a/packages/translator-default/src/cdata/index[html].js
+++ b/packages/translator-default/src/cdata/index[html].js
@@ -1,8 +1,14 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write`<![CDATA[${t.stringLiteral(node.value)}]]>`);
+  path.replaceWith(
+    withPreviousLocation(
+      write`<![CDATA[${t.stringLiteral(node.value)}]]>`,
+      node
+    )
+  );
 }

--- a/packages/translator-default/src/cdata/index[vdom].js
+++ b/packages/translator-default/src/cdata/index[vdom].js
@@ -1,8 +1,11 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/vdom-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write("t", t.stringLiteral(node.value)));
+  path.replaceWith(
+    withPreviousLocation(write("t", t.stringLiteral(node.value)), node)
+  );
 }

--- a/packages/translator-default/src/comment/index[html].js
+++ b/packages/translator-default/src/comment/index[html].js
@@ -1,12 +1,15 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 const ieConditionalCommentRegExp = /^\[if |<!\[endif\]$/;
 
 export default function(path) {
   const { node } = path;
 
   if (ieConditionalCommentRegExp.test(node.value)) {
-    path.replaceWith(write`<!--${t.stringLiteral(node.value)}-->`);
+    path.replaceWith(
+      withPreviousLocation(write`<!--${t.stringLiteral(node.value)}-->`, node)
+    );
   } else {
     path.remove();
   }

--- a/packages/translator-default/src/declaration/index[html].js
+++ b/packages/translator-default/src/declaration/index[html].js
@@ -1,8 +1,11 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write`<?${t.stringLiteral(node.value)}?>`);
+  path.replaceWith(
+    withPreviousLocation(write`<?${t.stringLiteral(node.value)}?>`, node)
+  );
 }

--- a/packages/translator-default/src/document-type/index[html].js
+++ b/packages/translator-default/src/document-type/index[html].js
@@ -1,8 +1,11 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write`<!${t.stringLiteral(node.value)}>`);
+  path.replaceWith(
+    withPreviousLocation(write`<!${t.stringLiteral(node.value)}>`, node)
+  );
 }

--- a/packages/translator-default/src/placeholder/index[html].js
+++ b/packages/translator-default/src/placeholder/index[html].js
@@ -5,6 +5,7 @@ import { x as escapeXML } from "marko/src/runtime/html/helpers/escape-xml";
 import escapeScript from "marko/src/runtime/html/helpers/escape-script-placeholder";
 import escapeStyle from "marko/src/runtime/html/helpers/escape-style-placeholder";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 const ESCAPE_TYPES = {
   html: {
@@ -63,7 +64,7 @@ export default function(path) {
   const replacement = write`${value}`;
 
   if (replacement) {
-    path.replaceWith(replacement);
+    path.replaceWith(withPreviousLocation(replacement, node));
   } else {
     path.remove();
   }

--- a/packages/translator-default/src/placeholder/index[vdom].js
+++ b/packages/translator-default/src/placeholder/index[vdom].js
@@ -1,4 +1,5 @@
 import write from "../util/vdom-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
@@ -9,6 +10,6 @@ export default function(path) {
   if (confident && !computed) {
     path.remove();
   } else {
-    path.replaceWith(write(method, value));
+    path.replaceWith(withPreviousLocation(write(method, value), node));
   }
 }

--- a/packages/translator-default/src/tag/attribute-tag.js
+++ b/packages/translator-default/src/tag/attribute-tag.js
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/babel-types";
 import { findParentTag, assertNoArgs, getTagDef } from "@marko/babel-utils";
 import { getAttrs } from "./util";
+import withPreviousLocation from "../util/with-previous-location";
 
 const EMPTY_OBJECT = {};
 const parentIdentifierLookup = new WeakMap();
@@ -80,16 +81,23 @@ export default function(path) {
 
   if (isRepeated) {
     path.replaceWith(
-      t.expressionStatement(
-        t.callExpression(t.memberExpression(identifier, t.identifier("push")), [
-          getAttrs(path)
-        ])
+      withPreviousLocation(
+        t.expressionStatement(
+          t.callExpression(
+            t.memberExpression(identifier, t.identifier("push")),
+            [getAttrs(path)]
+          )
+        ),
+        node
       )
     );
   } else {
     path.replaceWith(
-      t.expressionStatement(
-        t.assignmentExpression("=", identifier, getAttrs(path))
+      withPreviousLocation(
+        t.expressionStatement(
+          t.assignmentExpression("=", identifier, getAttrs(path))
+        ),
+        node
       )
     );
   }

--- a/packages/translator-default/src/tag/attribute/directives/class.js
+++ b/packages/translator-default/src/tag/attribute/directives/class.js
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/babel-types";
 import { isNativeTag } from "@marko/babel-utils";
 import classToString from "marko/src/runtime/helpers/class-value";
+import withPreviousLocation from "../../../util/with-previous-location";
 
 export default {
   exit(tag, _, value) {
@@ -13,13 +14,16 @@ export default {
     value.replaceWith(
       confident
         ? t.stringLiteral(classToString(computed) || "")
-        : t.callExpression(
-            hub.importDefault(
-              tag,
-              "marko/src/runtime/helpers/class-value",
-              "marko_class_merge"
+        : withPreviousLocation(
+            t.callExpression(
+              hub.importDefault(
+                tag,
+                "marko/src/runtime/helpers/class-value",
+                "marko_class_merge"
+              ),
+              [value.node]
             ),
-            [value.node]
+            value.node
           )
     );
   }

--- a/packages/translator-default/src/tag/attribute/directives/style.js
+++ b/packages/translator-default/src/tag/attribute/directives/style.js
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/babel-types";
 import { isNativeTag } from "@marko/babel-utils";
 import styleToString from "marko/src/runtime/helpers/style-value";
+import withPreviousLocation from "../../../util/with-previous-location";
 
 export default {
   exit(tag, _, value) {
@@ -10,16 +11,19 @@ export default {
 
     const { confident, value: computed } = value.evaluate();
     value.replaceWith(
-      confident
-        ? t.stringLiteral(styleToString(computed) || "")
-        : t.callExpression(
-            hub.importDefault(
-              tag,
-              "marko/src/runtime/helpers/style-value",
-              "marko_style_merge"
+      withPreviousLocation(
+        confident
+          ? t.stringLiteral(styleToString(computed) || "")
+          : t.callExpression(
+              hub.importDefault(
+                tag,
+                "marko/src/runtime/helpers/style-value",
+                "marko_style_merge"
+              ),
+              [value.node]
             ),
-            [value.node]
-          )
+        value.node
+      )
     );
   }
 };

--- a/packages/translator-default/src/tag/attribute/modifiers/scoped.js
+++ b/packages/translator-default/src/tag/attribute/modifiers/scoped.js
@@ -1,12 +1,16 @@
 import { types as t } from "@marko/babel-types";
+import withPreviousLocation from "../../../util/with-previous-location";
 
 export default {
   exit(tag, _, value) {
     const { hub } = tag;
     value.replaceWith(
-      t.callExpression(
-        t.memberExpression(hub._componentDefIdentifier, t.identifier("elId")),
-        [value.node]
+      withPreviousLocation(
+        t.callExpression(
+          t.memberExpression(hub._componentDefIdentifier, t.identifier("elId")),
+          [value.node]
+        ),
+        value.node
       )
     );
   }

--- a/packages/translator-default/src/tag/custom-tag.js
+++ b/packages/translator-default/src/tag/custom-tag.js
@@ -2,6 +2,7 @@ import { types as t } from "@marko/babel-types";
 import { assertNoArgs, getTagDef } from "@marko/babel-utils";
 import { getAttrs, buildEventHandlerArray } from "./util";
 import nativeTag from "./native-tag";
+import withPreviousLocation from "../util/with-previous-location";
 
 // TODO: support transform and other entries.
 const TAG_FILE_ENTRIES = ["template", "renderer"];
@@ -74,7 +75,7 @@ export default function(path) {
     ])
   );
 
-  path.replaceWith(customTagRenderCall);
+  path.replaceWith(withPreviousLocation(customTagRenderCall, node));
 }
 
 function resolveRelativePath(hub, tagDef) {

--- a/packages/translator-default/src/tag/dynamic-tag.js
+++ b/packages/translator-default/src/tag/dynamic-tag.js
@@ -1,5 +1,6 @@
 import { types as t } from "@marko/babel-types";
 import { getAttrs, buildEventHandlerArray } from "./util";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node, hub } = path;
@@ -49,5 +50,5 @@ export default function(path) {
     ]
   );
 
-  path.replaceWith(dynamicTagRenderCall);
+  path.replaceWith(withPreviousLocation(dynamicTagRenderCall, node));
 }

--- a/packages/translator-default/src/tag/native-tag[html]/index.js
+++ b/packages/translator-default/src/tag/native-tag[html]/index.js
@@ -6,6 +6,7 @@ import write from "../../util/html-out-write";
 import { hasUserKey } from "../../util/key-manager";
 import translateAttributes from "./attributes";
 import getComponentFiles from "../../util/get-component-files";
+import withPreviousLocation from "../../util/with-previous-location";
 
 const EMPTY_OBJECT = {};
 
@@ -103,10 +104,13 @@ export default function(path) {
     }
   }
 
-  const writeStartNode = write`<${tagName}${dataMarko}${translateAttributes(
-    path,
-    path.get("attributes")
-  )}>`;
+  const writeStartNode = withPreviousLocation(
+    write`<${tagName}${dataMarko}${translateAttributes(
+      path,
+      path.get("attributes")
+    )}>`,
+    node.name
+  );
 
   if (SELF_CLOSING.indexOf(tagName) !== -1) {
     path.replaceWith(writeStartNode);

--- a/packages/translator-default/src/tag/native-tag[vdom]/index.js
+++ b/packages/translator-default/src/tag/native-tag[vdom]/index.js
@@ -5,6 +5,7 @@ import write from "../../util/vdom-out-write";
 import * as FLAGS from "../../util/runtime-flags";
 import { getAttrs, evaluateAttr } from "../util";
 import { getTagDef } from "@marko/babel-utils";
+import withPreviousLocation from "../../util/with-previous-location";
 
 const EMPTY_OBJECT = {};
 const SIMPLE_ATTRS = ["id", "class", "style"];
@@ -136,7 +137,7 @@ export default function(path) {
     writeArgs.push(t.objectExpression(tagProperties));
   }
 
-  const writeStartNode = write(...writeArgs);
+  const writeStartNode = withPreviousLocation(write(...writeArgs), node.name);
 
   if (isSelfClosing) {
     path.replaceWith(writeStartNode);

--- a/packages/translator-default/src/taglib/core/conditional/util.js
+++ b/packages/translator-default/src/taglib/core/conditional/util.js
@@ -1,4 +1,5 @@
 import { types as t } from "@marko/babel-types";
+import withPreviousLocation from "../../../util/with-previous-location";
 
 export function buildIfStatement(path, args) {
   if (!args || !args.length) {
@@ -26,5 +27,5 @@ export function buildIfStatement(path, args) {
     }
   }
 
-  return ifStatement;
+  return withPreviousLocation(ifStatement, path.node);
 }

--- a/packages/translator-default/src/taglib/core/macro/translate.js
+++ b/packages/translator-default/src/taglib/core/macro/translate.js
@@ -1,4 +1,5 @@
 import { types as t } from "@marko/babel-types";
+import withPreviousLocation from "../../../util/with-previous-location";
 
 const EMPTY_ARR = [];
 
@@ -10,5 +11,7 @@ export function exit(path) {
   } = node;
   const params = [t.identifier("out")].concat(node.params || EMPTY_ARR);
   const block = t.blockStatement(body);
-  path.replaceWith(t.functionDeclaration(id, params, block));
+  path.replaceWith(
+    withPreviousLocation(t.functionDeclaration(id, params, block), node)
+  );
 }

--- a/packages/translator-default/src/taglib/core/translate-while.js
+++ b/packages/translator-default/src/taglib/core/translate-while.js
@@ -4,6 +4,7 @@ import {
   assertNoAttributes,
   assertNoParams
 } from "@marko/babel-utils";
+import withPreviousLocation from "../../util/with-previous-location";
 
 export function exit(path) {
   assertNoParams(path);
@@ -19,9 +20,12 @@ export function exit(path) {
   }
 
   path.replaceWith(
-    t.whileStatement(
-      getArgOrSequence(path),
-      t.blockStatement(path.node.body.body)
+    withPreviousLocation(
+      t.whileStatement(
+        getArgOrSequence(path),
+        t.blockStatement(path.node.body.body)
+      ),
+      path.node
     )
   );
 }

--- a/packages/translator-default/src/taglib/migrate/all-templates.js
+++ b/packages/translator-default/src/taglib/migrate/all-templates.js
@@ -1,9 +1,10 @@
 import { types as t } from "@marko/babel-types";
+import withPreviousLocation from "../../util/with-previous-location";
 
 export default () => ({
   ReferencedIdentifier(path) {
     if (path.node.name === "data" && !path.scope.hasBinding("data")) {
-      path.replaceWith(t.identifier("input"));
+      path.replaceWith(withPreviousLocation(t.identifier("input"), path.node));
     }
   }
 });

--- a/packages/translator-default/src/text/index[html].js
+++ b/packages/translator-default/src/text/index[html].js
@@ -1,8 +1,11 @@
 import { types as t } from "@marko/babel-types";
 import write from "../util/html-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write`${t.stringLiteral(node.value)}`);
+  path.replaceWith(
+    withPreviousLocation(write`${t.stringLiteral(node.value)}`, node)
+  );
 }

--- a/packages/translator-default/src/text/index[vdom].js
+++ b/packages/translator-default/src/text/index[vdom].js
@@ -1,9 +1,12 @@
 import { decode } from "he";
 import { types as t } from "@marko/babel-types";
 import write from "../util/vdom-out-write";
+import withPreviousLocation from "../util/with-previous-location";
 
 export default function(path) {
   const { node } = path;
 
-  path.replaceWith(write("t", t.stringLiteral(decode(node.value))));
+  path.replaceWith(
+    withPreviousLocation(write("t", t.stringLiteral(decode(node.value))), node)
+  );
 }

--- a/packages/translator-default/src/util/with-previous-location.js
+++ b/packages/translator-default/src/util/with-previous-location.js
@@ -1,0 +1,4 @@
+export default function withPreviousLocation(newNode, originalNode) {
+  const { start, end, loc } = originalNode;
+  return Object.assign(newNode, { start, end, loc });
+}


### PR DESCRIPTION
## Description

During the translate stage the new Marko compiler inserts a bunch of new art nodes. These nodes lose track of the source position intended for that operation which causes the debugger to jump in and out of a source mapped file. This PR updates most nodes inserted during this stage to map to an appropriate location in the source.

It also includes a fix where the sourcemaps were not being exposes properly with the legacy compiler api.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
