### PR TITLE
Fix preserve context

### DIFF
--- a/packages/marko/src/core-tags/components/preserve-tag.js
+++ b/packages/marko/src/core-tags/components/preserve-tag.js
@@ -1,3 +1,6 @@
+var ComponentsContext = require("../../runtime/components/ComponentsContext");
+var getComponentsContext = ComponentsContext.___getComponentsContext;
+
 module.exports = function render(input, out) {
   var shouldPreserve = Boolean(!("if" in input) || input["if"]);
   var ownerComponentDef = out.___assignedComponentDef;
@@ -7,11 +10,11 @@ module.exports = function render(input, out) {
   out.___beginFragment(key, ownerComponent, true);
 
   if (input.renderBody) {
-    var globalContext = out.___components.___globalContext;
-    var parentPreserved = globalContext.___isPreserved;
-    globalContext.___isPreserved = parentPreserved || shouldPreserve;
+    var componentsContext = getComponentsContext(out);
+    var parentPreserved = componentsContext.___isPreserved;
+    componentsContext.___isPreserved = parentPreserved || shouldPreserve;
     input.renderBody(out);
-    globalContext.___isPreserved = parentPreserved;
+    componentsContext.___isPreserved = parentPreserved;
   }
 
   out.___endFragment();

--- a/packages/marko/src/runtime/components/ComponentDef.js
+++ b/packages/marko/src/runtime/components/ComponentDef.js
@@ -17,8 +17,8 @@ var FLAG_OLD_HYDRATE_NO_CREATE = 8;
  * a single component and this information is used to instantiate the component
  * later (after the rendered HTML has been added to the DOM)
  */
-function ComponentDef(component, componentId, globalComponentsContext) {
-  this.___globalComponentsContext = globalComponentsContext; // The AsyncWriter that this component is associated with
+function ComponentDef(component, componentId, componentsContext) {
+  this.___componentsContext = componentsContext; // The AsyncWriter that this component is associated with
   this.___component = component;
   this.id = componentId;
 

--- a/packages/marko/src/runtime/components/ComponentsContext.js
+++ b/packages/marko/src/runtime/components/ComponentsContext.js
@@ -31,6 +31,8 @@ function ComponentsContext(out, parentComponentsContext) {
   this.___out = out;
   this.___componentDef = componentDef;
   this.___nestedContexts = undefined;
+  this.___isPreserved =
+    parentComponentsContext && parentComponentsContext.___isPreserved;
 }
 
 ComponentsContext.prototype = {

--- a/packages/marko/src/runtime/components/beginComponent-browser.js
+++ b/packages/marko/src/runtime/components/beginComponent-browser.js
@@ -7,14 +7,14 @@ module.exports = function beginComponent(
   ownerComponentDef
 ) {
   var componentId = component.id;
-
-  var globalContext = componentsContext.___globalContext;
   var componentDef = (componentsContext.___componentDef = new ComponentDef(
     component,
     componentId,
-    globalContext
+    componentsContext
   ));
-  globalContext.___renderedComponentsById[componentId] = true;
+  componentsContext.___globalContext.___renderedComponentsById[
+    componentId
+  ] = true;
   componentsContext.___components.push(componentDef);
 
   var out = componentsContext.___out;

--- a/packages/marko/src/runtime/components/beginComponent.js
+++ b/packages/marko/src/runtime/components/beginComponent.js
@@ -54,7 +54,7 @@ module.exports = function beginComponent(
 
   if (isSplitComponent === false && out.global.noBrowserRerender !== true) {
     componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER;
-    componentDef.__parentPreserved = componentsContext.___isPreserved;
+    componentDef.___parentPreserved = componentsContext.___isPreserved;
     componentsContext.___isPreserved = false;
   }
 

--- a/packages/marko/src/runtime/components/beginComponent.js
+++ b/packages/marko/src/runtime/components/beginComponent.js
@@ -16,8 +16,6 @@ module.exports = function beginComponent(
   isImplicitComponent,
   existingComponentDef
 ) {
-  var globalContext = componentsContext.___globalContext;
-
   var componentId = component.id;
 
   // existingComponentDef is only here to allow binding a conditional
@@ -27,12 +25,12 @@ module.exports = function beginComponent(
     (componentsContext.___componentDef = new ComponentDef(
       component,
       componentId,
-      globalContext
+      componentsContext
     ));
 
   // On the server
   if (
-    !globalContext.___isPreserved &&
+    !componentsContext.___isPreserved &&
     ownerComponentDef &&
     ownerComponentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER
   ) {
@@ -56,6 +54,8 @@ module.exports = function beginComponent(
 
   if (isSplitComponent === false && out.global.noBrowserRerender !== true) {
     componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER;
+    componentDef.__parentPreserved = componentsContext.___isPreserved;
+    componentsContext.___isPreserved = false;
   }
 
   if (out.global.oldHydrateNoCreate === true) {

--- a/packages/marko/src/runtime/components/endComponent.js
+++ b/packages/marko/src/runtime/components/endComponent.js
@@ -6,6 +6,6 @@ var getComponentsContext = ComponentsContext.___getComponentsContext;
 module.exports = function endComponent(out, componentDef) {
   if (componentDef.___renderBoundary) {
     out.w("<!--" + out.global.runtimeId + "/-->");
-    getComponentsContext(out).___isPreserved = componentDef.__parentPreserved;
+    getComponentsContext(out).___isPreserved = componentDef.___parentPreserved;
   }
 };

--- a/packages/marko/src/runtime/components/endComponent.js
+++ b/packages/marko/src/runtime/components/endComponent.js
@@ -1,7 +1,11 @@
 "use strict";
 
+var ComponentsContext = require("./ComponentsContext");
+var getComponentsContext = ComponentsContext.___getComponentsContext;
+
 module.exports = function endComponent(out, componentDef) {
   if (componentDef.___renderBoundary) {
     out.w("<!--" + out.global.runtimeId + "/-->");
+    getComponentsContext(out).___isPreserved = componentDef.__parentPreserved;
   }
 };

--- a/packages/marko/src/runtime/html/helpers/data-marko.js
+++ b/packages/marko/src/runtime/html/helpers/data-marko.js
@@ -13,7 +13,7 @@ module.exports = function dataMarko(props, key, componentDef) {
     !componentDef ||
     (componentDef.___renderBoundary &&
       (componentDef.___flags & FLAG_WILL_RERENDER_IN_BROWSER) === 0) ||
-    componentDef.___globalComponentsContext.___isPreserved;
+    componentDef.___componentsContext.___isPreserved;
 
   if (willNotRerender) {
     if (props) {

--- a/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/components/counter/index.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/components/counter/index.js
@@ -1,0 +1,9 @@
+module.exports = require("marko-widgets").defineComponent({
+  template: require("./template.marko"),
+  getInitialState(input) {
+    return { count: input.count || 0 };
+  },
+  increment() {
+    this.setState("count", this.state.count + 1);
+  }
+});

--- a/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/components/counter/template.marko
+++ b/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/components/counter/template.marko
@@ -1,0 +1,4 @@
+
+<div w-bind>
+  <button w-id="button" on-click("increment")>${data.count}</button>
+</div>

--- a/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/index.marko
+++ b/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/index.marko
@@ -1,0 +1,12 @@
+class {}
+
+$ const isServer = typeof window === "undefined";
+$ const message = isServer ? "Server" : "Browser";
+
+<div>
+    <div no-update>
+        <span key="preserved">${message}</span>
+        <counter key="counter" count=(isServer ? 0 : 10)/>
+    </div>
+    <span key="unpreserved">${message}</span>
+</div>

--- a/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/test.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/preserve-with-nested-rerender-root/test.js
@@ -1,0 +1,19 @@
+var expect = require("chai").expect;
+
+module.exports = async function(helpers) {
+  var isHydrate = helpers.isHydrate;
+  var component = helpers.mount(require.resolve("./index"));
+
+  var preservedText = component.getEl("preserved");
+  var unpreservedText = component.getEl("unpreserved");
+  var button = component.getComponent("counter").getEl("button");
+
+  expect(preservedText.textContent).to.equal(isHydrate ? "Server" : "Browser");
+  expect(unpreservedText.textContent).to.equal("Browser");
+  expect(button.textContent).to.equal(isHydrate ? "0" : "10");
+
+  button.click();
+  await new Promise(resolve => setTimeout(resolve));
+
+  expect(button.textContent).to.equal(isHydrate ? "1" : "11");
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Uses the `componentsContext` rather than `globalComponentsContext` to track whether a section is preserved.  The `componentContext` is a more true context and maintains values for async parts of the render.
2. When entering a stateful component, it becomes a new render root and children of this component should not be preserved.  This fixes the following issues in preserved subtrees:
   - Legacy widgets output `data-marko` attributes and root widgets claim the keyed elements, which causes errors during hydration.
   - Split components under a stateful component output `data-marko` attributes, but since they do not claim the keyed elements due to not being roots, there is no observable impact other than increased HTML size.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
