### PR TITLE
fix: always include nested contexts when serializing

### DIFF
--- a/packages/marko/src/runtime/components/index.js
+++ b/packages/marko/src/runtime/components/index.js
@@ -18,10 +18,7 @@ function safeJSON(json) {
 function addComponentsFromContext(componentsContext, componentsToHydrate) {
   var components = componentsContext.___components;
 
-  var len;
-  if ((len = components.length) === 0) {
-    return;
-  }
+  var len = components.length;
 
   for (var i = 0; i < len; i++) {
     var componentDef = components[i];


### PR DESCRIPTION
## Description
Currently it is possible for a nested components context to be created without a parent component. The legacy `getInitWidgetsCode` and modern `writeInitComponentsCode` api's can fail to write out the initialization code for these nested contexts if the top level out is passed in.

This PR makes sure to visit nested contexts when serializing regardless of whether or not there are top level components.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
