### PR TITLE
fix: support monkey patching lifecycle methods for legacy widgets

### DIFF
--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/index.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/index.js
@@ -1,0 +1,54 @@
+var lifecycle = require("./lifecycle-recorder");
+
+module.exports = require("marko/legacy-components").defineComponent({
+  template: require.resolve("./template.marko"),
+  getInitialState: function(input) {
+    return {
+      shouldBind: input.shouldBind,
+      name: input.name
+    };
+  },
+
+  getTemplateData: function(state) {
+    return {
+      shouldBind: state.shouldBind,
+      name: state.name
+    };
+  }
+});
+
+if (typeof window === "object") {
+  Object.assign(module.exports.prototype, {
+    init: function() {
+      this.lifecycleEvents = [];
+      lifecycle.record(this.id, "init");
+    },
+
+    onRender: function(eventArg) {
+      lifecycle.record(
+        this.id,
+        eventArg.firstRender ? "onRender:firstRender" : "onRender"
+      );
+    },
+
+    setName: function(newName) {
+      this.setState("name", newName);
+    },
+
+    onBeforeDestroy: function() {
+      lifecycle.record(this.id, "onBeforeDestroy");
+    },
+
+    onDestroy: function() {
+      lifecycle.record(this.id, "onDestroy");
+    },
+
+    onBeforeUpdate: function() {
+      lifecycle.record(this.id, "onBeforeUpdate");
+    },
+
+    onUpdate: function() {
+      lifecycle.record(this.id, "onUpdate");
+    }
+  });
+}

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/lifecycle-recorder.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/lifecycle-recorder.js
@@ -1,0 +1,16 @@
+var widgetLifecycleEvents = {};
+
+function recordWidgetLifecycleEvent(key, eventType) {
+  var events = widgetLifecycleEvents[key] || (widgetLifecycleEvents[key] = []);
+  events.push(eventType);
+}
+
+function resetWidgetLifecycleEvents() {
+  widgetLifecycleEvents = {};
+}
+
+module.exports = {
+  events: widgetLifecycleEvents,
+  reset: resetWidgetLifecycleEvents,
+  record: recordWidgetLifecycleEvent
+};

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/template.marko
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/template.marko
@@ -1,0 +1,5 @@
+<if(data.shouldBind)>
+	<div w-bind>
+		Hello ${data.name}!
+	</div>
+</if>

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/test.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/test.js
@@ -1,0 +1,68 @@
+var expect = require("chai").expect;
+var lifecycle = require("./lifecycle-recorder");
+
+module.exports = function(helpers) {
+  var widget = helpers.mount(require.resolve("./index"), {
+    shouldBind: true,
+    name: "Frank"
+  });
+
+  var targetEl = helpers.targetEl;
+
+  expect(targetEl.innerHTML).to.contain("Hello Frank!");
+  expect(lifecycle.events[widget.id]).to.deep.equal([
+    "init",
+    "onRender:firstRender"
+  ]);
+
+  widget.setState("name", "Jane");
+
+  expect(targetEl.innerHTML).to.contain("Hello Frank!");
+  expect(lifecycle.events[widget.id]).to.deep.equal([
+    "init",
+    "onRender:firstRender"
+  ]);
+
+  widget.update();
+
+  expect(targetEl.innerHTML).to.contain("Hello Jane!");
+  expect(lifecycle.events[widget.id]).to.deep.equal([
+    "init",
+    "onRender:firstRender",
+    "onBeforeUpdate",
+    "onUpdate",
+    "onRender"
+  ]);
+
+  widget.setState("shouldBind", false);
+  widget.update();
+
+  expect(lifecycle.events[widget.id]).to.deep.equal([
+    "init",
+    "onRender:firstRender",
+    "onBeforeUpdate",
+    "onUpdate",
+    "onRender",
+    "onBeforeUpdate",
+    "onBeforeDestroy",
+    "onDestroy"
+  ]);
+
+  widget.setState("shouldBind", true);
+  widget.update();
+
+  expect(lifecycle.events[widget.id]).to.deep.equal([
+    "init",
+    "onRender:firstRender",
+    "onBeforeUpdate",
+    "onUpdate",
+    "onRender",
+    "onBeforeUpdate",
+    "onBeforeDestroy",
+    "onDestroy",
+    "init",
+    "onRender:firstRender"
+  ]);
+
+  lifecycle.reset();
+};


### PR DESCRIPTION
## Description

In v3 components it is possible to dynamically set lifecycle methods during runtime eg:

```
module.exports = require("marko-widgets").defineComponent({
  template: require("./template.marko"),
  init() {
    this.onBeforeDestroy = function () { ... }
  }
})
```

This PR updates these remapped lifecycle methods in the compatibility layer to have a setter in order to support this anti pattern.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
