### PR TITLE
fix: improve support for legacy widget for range

### DIFF
--- a/packages/marko/src/compiler/CompileContext.js
+++ b/packages/marko/src/compiler/CompileContext.js
@@ -244,6 +244,14 @@ class CompileContext extends EventEmitter {
     }
   }
 
+  hasMigrationFlag(name) {
+    if (this._mfe) {
+      return this._mfe.hasAttribute(name);
+    }
+
+    return false;
+  }
+
   get migrationFlagEl() {
     if (!this._mfe) {
       this._mfe = this.builder.htmlElement("marko-migration-flags");

--- a/packages/marko/src/core-tags/migrate/for-tag.js
+++ b/packages/marko/src/core-tags/migrate/for-tag.js
@@ -11,6 +11,10 @@ module.exports = function migrator(elNode, context) {
 
 function migrateForLoop(elNode, context) {
   const builder = context.builder;
+  const isLegacyTemplate =
+    context.meta.legacy ||
+    context.hasMigrationFlag("legacyWidgetAttrsWithoutBind");
+
   let parsed;
 
   if (!elNode.argument) {
@@ -192,6 +196,8 @@ function migrateForLoop(elNode, context) {
 
       if (parsed.step) {
         elNode.setAttributeValue("step", parsed.step);
+      } else if (isLegacyTemplate) {
+        elNode.setAttributeValue("step", builder.literal(1));
       }
 
       break;

--- a/packages/marko/test/migrate/fixtures/legacy-for-range-widget/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-for-range-widget/snapshot-expected.marko
@@ -1,0 +1,11 @@
+<!-- packages/marko/test/migrate/fixtures/legacy-for-range-widget/template.marko -->
+
+<marko-migration-flags legacyWidgetAttrsWithoutBind/>
+<div key="hi" id:scoped="hi"/>
+<for|i| from=0 to=-1 step=1>
+    <li>${i}</li>
+</for>
+$ var last = -1;
+<for|i| from=0 to=last step=1>
+    <li>${i}</li>
+</for>

--- a/packages/marko/test/migrate/fixtures/legacy-for-range-widget/template.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-for-range-widget/template.marko
@@ -1,0 +1,10 @@
+<div w-id="hi"/>
+
+<for(i from 0 to -1)>
+    <li>${i}</li>
+</for>
+
+<var last=-1/>
+<for(i from 0 to last)>
+    <li>${i}</li>
+</for>


### PR DESCRIPTION
## Description

In Marko 3 the `for from to` loop would iterate differently depending on if the `to` was able to be statically evaluated than if it was dynamic. This was obviously bad, but this PR brings back that behavior when we detect a template is using legacy widget features to improve compatibility.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
