### PR TITLE
fix: add 'get' API for marko-widgets compat

### DIFF
--- a/packages/marko/src/runtime/components/legacy/index-browser.js
+++ b/packages/marko/src/runtime/components/legacy/index-browser.js
@@ -19,7 +19,7 @@ exports.makeRenderable = exports.renderable = require("../../renderable");
 // browser only
 var Widget = (exports.Widget = Component);
 exports.onInitWidget = modernMarko.onInitComponent;
-exports.getWidgetForEl = modernMarko.getComponentForEl;
+exports.getWidgetForEl = exports.get = modernMarko.getComponentForEl;
 exports.initWidgets = modernMarko.init;
 
 // monkey patch Widget


### PR DESCRIPTION
## Description
In `marko-widgets@6` there was an alias for `getWidgetForEl` of `get`. This alias was not added in the compatibility layer (`marko-widgets@7`).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
