### PR TITLE
fix: include default step for legacy for loop ranges

### DIFF
--- a/packages/marko/src/core-tags/migrate/for-tag.js
+++ b/packages/marko/src/core-tags/migrate/for-tag.js
@@ -325,12 +325,6 @@ function normalizeParts(parsed, builder) {
     return;
   }
 
-  if (step) {
-    if (step.type === "Literal" && step.value === 1) {
-      step = undefined;
-    }
-  }
-
   return {
     varName: varName,
     from: from,

--- a/packages/marko/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
+++ b/packages/marko/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
@@ -57,7 +57,7 @@ function render(input, out, __component, component, state) {
 
   var $for$0 = 0;
 
-  marko_forRange(0, 9, null, function(i) {
+  marko_forRange(0, 9, 1, function(i) {
     var $keyScope$0 = "[" + (($for$0++) + "]");
 
     marko_dynamicTag(out, input.items[i], null, null, null, null, __component, "13" + $keyScope$0);

--- a/packages/marko/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
@@ -92,7 +92,7 @@ $ input.iterator(colors, function(item) {
     <li>${i}</li>
 </for>
 <!-- Regular -->
-<for|i| from=0 to=(list.length - 1)>${i}</for>
+<for|i| from=0 to=(list.length - 1) step=1>${i}</for>
 <for|i| from=0 to=listSize step=2>${i}</for>
 <for|i| from=0 to=listSize step=2>${i}</for>
 <!-- Stange: backwards -->

--- a/packages/marko/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
@@ -38,7 +38,7 @@
 <if(!x)>
     <${render}/>
 </if>
-<for|i| from=0 to=9>
+<for|i| from=0 to=9 step=1>
     <${input.items[i]}/>
 </for>
 $ let i = 10;


### PR DESCRIPTION
## Description
This ensures that the legacy loop syntax when being transformed to a `<for|i| from=a to=b>` loop always includes the `step` to avoid an issue with values like `<for|i| from=0 to=-1>`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
