### PR TITLE
fix: spread attrs for native tag preserves case

### DIFF
--- a/packages/marko/src/runtime/html/helpers/attrs.js
+++ b/packages/marko/src/runtime/html/helpers/attrs.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var complain = "MARKO_DEBUG" && require("complain");
-var changeCase = require("../../helpers/_change-case");
 var attrHelper = require("./attr");
 var classAttrHelper = require("./class-attr");
 var styleAttrHelper = require("./style-attr");
@@ -20,10 +19,7 @@ module.exports = function attrs(arg) {
       } else if (attrName === "class") {
         out += classAttrHelper(arg[attrName]);
       } else if (attrName !== "renderBody" && isValidAttrName(attrName)) {
-        out += attrHelper(
-          changeCase.___camelToDashCase(attrName),
-          arg[attrName]
-        );
+        out += attrHelper(attrName, arg[attrName]);
       }
     }
     return out;

--- a/packages/marko/src/runtime/vdom/helpers/attrs.js
+++ b/packages/marko/src/runtime/vdom/helpers/attrs.js
@@ -1,7 +1,6 @@
 "use strict";
 
 var complain = "MARKO_DEBUG" && require("complain");
-var changeCase = require("../../helpers/_change-case");
 var classHelper = require("../../helpers/class-value");
 var styleHelper = require("../../helpers/style-value");
 
@@ -32,8 +31,6 @@ module.exports = function(attributes) {
         val = classHelper(val);
       } else if (attrName === "style") {
         val = styleHelper(val);
-      } else {
-        attrName = changeCase.___camelToDashCase(attrName);
       }
 
       newAttributes[attrName] = val;

--- a/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/expected.html
+++ b/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/expected.html
@@ -1,1 +1,1 @@
-<div data-dash="case" data-camel="case" class="a" style="color:green;"></div>
+<svg data-dash="case" viewBox="0 0 0 100" class="a" style="color:green;"></svg>

--- a/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/template.marko
+++ b/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/template.marko
@@ -1,9 +1,9 @@
 static var attrs = {
   "data-dash": "case",
-  dataCamel: "case",
+  viewBox: "0 0 0 100",
   class: ["a"],
   style: { color: "green" },
   skipped: false
 }
 
-<div ...attrs/>
+<svg ...attrs/>

--- a/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/vdom-expected.html
+++ b/packages/marko/test/render/fixtures/attrs-normalize-for-native-tag/vdom-expected.html
@@ -1,1 +1,1 @@
-<DIV class="a" data-camel="case" data-dash="case" style="color:green;">
+<svg:svg class="a" data-dash="case" style="color:green;" viewBox="0 0 0 100">


### PR DESCRIPTION
## Description

Fixes a regression from #1488 which incorrectly normalized native tag attributes when using `...spread`.

Resolves https://github.com/marko-js/marko/issues/1529

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
