### PR TITLE
fix: prevent issue with range loop iterating in reverse

### DIFF
--- a/packages/marko/src/core-tags/migrate/for-tag.js
+++ b/packages/marko/src/core-tags/migrate/for-tag.js
@@ -325,12 +325,6 @@ function normalizeParts(parsed, builder) {
     return;
   }
 
-  if (step) {
-    if (step.type === "Literal" && step.value === 1) {
-      step = undefined;
-    }
-  }
-
   return {
     varName: varName,
     from: from,

--- a/packages/marko/src/runtime/helpers/for-range.js
+++ b/packages/marko/src/runtime/helpers/for-range.js
@@ -3,45 +3,23 @@
 var complain = "MARKO_DEBUG" && require("complain");
 
 module.exports = function forRangeHelper(from, to, step, callback) {
-  var i;
+  if (step == null) {
+    step = from <= to ? 1 : -1;
 
-  // eslint-disable-next-line no-constant-condition
-  if ("MARKO_DEBUG") {
-    var isNegative = step < 0;
-    var isNull = step == null;
-  }
-
-  step = step == null ? 1 : Math.abs(step);
-
-  if (from <= to) {
     // eslint-disable-next-line no-constant-condition
     if ("MARKO_DEBUG") {
-      if (isNegative && from < to) {
-        complain(
-          '<for> "from" is less than "to" but you supplied a negative step value. This will no longer be supported in future versions of Marko.'
-        );
-      }
-    }
-
-    for (i = from; i <= to; i += step) {
-      callback(i);
-    }
-  } else {
-    // eslint-disable-next-line no-constant-condition
-    if ("MARKO_DEBUG") {
-      if (isNull) {
+      if (step === -1) {
         complain(
           '<for> "step" is now required when moving backwards. This will no longer be supported in future versions of Marko.'
         );
-      } else if (!isNegative) {
-        complain(
-          '<for> "from" is greater than "to" but you supplied a positive step value. This will no longer be supported in future versions of Marko.'
-        );
       }
     }
+  }
 
-    for (i = from; i >= to; i -= step) {
-      callback(i);
-    }
+  var currentStep = 0;
+  var totalSteps = (to - from) / step;
+
+  while (currentStep <= totalSteps) {
+    callback(from + currentStep++ * step);
   }
 };

--- a/packages/marko/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
+++ b/packages/marko/test/compiler/fixtures-html-deprecated/render-body-call/expected.js
@@ -57,7 +57,7 @@ function render(input, out, __component, component, state) {
 
   var $for$0 = 0;
 
-  marko_forRange(0, 9, null, function(i) {
+  marko_forRange(0, 9, 1, function(i) {
     var $keyScope$0 = "[" + (($for$0++) + "]");
 
     marko_dynamicTag(out, input.items[i], null, null, null, null, __component, "13" + $keyScope$0);

--- a/packages/marko/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-for-syntax/snapshot-expected.marko
@@ -92,7 +92,7 @@ $ input.iterator(colors, function(item) {
     <li>${i}</li>
 </for>
 <!-- Regular -->
-<for|i| from=0 to=(list.length - 1)>${i}</for>
+<for|i| from=0 to=(list.length - 1) step=1>${i}</for>
 <for|i| from=0 to=listSize step=2>${i}</for>
 <for|i| from=0 to=listSize step=2>${i}</for>
 <!-- Stange: backwards -->

--- a/packages/marko/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/render-call-in-scriptlet/snapshot-expected.marko
@@ -38,7 +38,7 @@
 <if(!x)>
     <${render}/>
 </if>
-<for|i| from=0 to=9>
+<for|i| from=0 to=9 step=1>
     <${input.items[i]}/>
 </for>
 $ let i = 10;


### PR DESCRIPTION
## Description

Currently some of the old for loop syntax is migrated to use a `<for|i| from=a to=b>` loop. This however has caused some issues around how the range loop works by automatically iterating in reverse if `from` is less than `to`. This PR updates the for range logic to prevent this reversing of direction when an explicit step is supplied, and updates the migrator to provide the step in the case that it is needed.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
