### PR TITLE
fix: improve legacy compatibility with getWidgetForEl api

### DIFF
--- a/packages/marko/src/runtime/components/legacy/index-browser.js
+++ b/packages/marko/src/runtime/components/legacy/index-browser.js
@@ -19,7 +19,19 @@ exports.makeRenderable = exports.renderable = require("../../renderable");
 // browser only
 var Widget = (exports.Widget = Component);
 exports.onInitWidget = modernMarko.onInitComponent;
-exports.getWidgetForEl = exports.get = modernMarko.getComponentForEl;
+exports.getWidgetForEl = exports.get = function(elOrId) {
+  var el = elOrId;
+
+  if (typeof elOrId === "string") {
+    el = document.getElementById(elOrId);
+  }
+
+  if (el && el.__widget) {
+    return el.__widget;
+  }
+
+  return modernMarko.getComponentForEl(el);
+};
 exports.initWidgets = modernMarko.init;
 
 // monkey patch Widget


### PR DESCRIPTION
## Description

Fixes an issue for the legacy `require("marko-widgets").getWidgetForEl` which was not correctly returning the `w-bind` widget for an element in some cases.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
