### PR TITLE
perf: attempt to determine dynamic native tag, string concat if so

### DIFF
--- a/packages/marko/src/compiler/CodeWriter.js
+++ b/packages/marko/src/compiler/CodeWriter.js
@@ -119,8 +119,7 @@ class CodeWriter {
       }
       node.writeCode(this);
     } else if (isArray(code) || code instanceof Container) {
-      code.forEach(this.write, this);
-      return;
+      this.writeStatements(code);
     } else if (typeof code === "string") {
       this._code += code;
     } else if (typeof code === "boolean" || typeof code === "number") {

--- a/packages/marko/src/compiler/CompileContext.js
+++ b/packages/marko/src/compiler/CompileContext.js
@@ -18,6 +18,7 @@ var utilFingerprint = require("./util/finger-print");
 var safeVarName = require("./util/safeVarName");
 var htmlElements = require("./util/html-elements");
 var markoModules = require("./modules");
+var discoverBranchTypes = require("./util/discover-branch-types");
 
 const markoPkgVersion = require("../../package.json").version;
 const rootDir = path.join(__dirname, "../");
@@ -540,8 +541,12 @@ class CompileContext extends EventEmitter {
     var tagDef;
 
     var taglibLookup = this.taglibLookup;
+    var isDynamic = tagName instanceof Node;
+    var branchTypes = isDynamic && discoverBranchTypes(tagName);
+    var isNativeDynamic = branchTypes && !branchTypes.expression;
+    var isNullable = branchTypes && branchTypes.empty;
 
-    if (isAtTag || tagName instanceof Node) {
+    if (isAtTag || (isDynamic && !isNativeDynamic)) {
       // NOTE: The tag definition can't be determined now
       //       For @tags it will be determined by the parent
       //       For dynamic tags we cannot know at compile time
@@ -614,6 +619,7 @@ class CompileContext extends EventEmitter {
     }
 
     node.pos = elDef.pos;
+    node.isNullable = isNullable;
 
     var foundAttrs = {};
 

--- a/packages/marko/src/compiler/ast/HtmlElement/index.js
+++ b/packages/marko/src/compiler/ast/HtmlElement/index.js
@@ -5,7 +5,6 @@ var Literal = require("../Literal");
 var HtmlAttributeCollection = require("../HtmlAttributeCollection");
 var generateHTMLCode = require("./html/generateCode");
 var generateVDOMCode = require("./vdom/generateCode");
-var vdomUtil = require("../../util/vdom");
 
 function beforeGenerateCode(event) {
   var tagName = event.node.tagName;
@@ -70,7 +69,7 @@ class HtmlElement extends Node {
   }
 
   generateVDOMCode(codegen) {
-    return generateVDOMCode(this, codegen, vdomUtil);
+    return generateVDOMCode(this, codegen);
   }
 
   getAttribute(name) {

--- a/packages/marko/src/compiler/ast/TemplateLiteral.js
+++ b/packages/marko/src/compiler/ast/TemplateLiteral.js
@@ -47,7 +47,6 @@ class TemplateLiteral extends Node {
       if (expr) code += "${" + expr.toString() + "}";
     }
     writer.write(quote + code + quote);
-    writer.write("\n");
   }
 
   walk(walker) {

--- a/packages/marko/src/compiler/util/discover-branch-types.js
+++ b/packages/marko/src/compiler/util/discover-branch-types.js
@@ -1,0 +1,24 @@
+module.exports = function discoverBranchTypes(node, result) {
+  result = result || {};
+  if (node.type === "ConditionalExpression") {
+    discoverBranchTypes(node.consequent, result);
+    discoverBranchTypes(node.alternate, result);
+  } else if (node.type === "LogicalExpression") {
+    if (node.operator === "&&") {
+      if (node.left.type !== "Literal" || !node.left.value) {
+        result.empty = true;
+      }
+      discoverBranchTypes(node.right, result);
+    } else {
+      discoverBranchTypes(node.left, result);
+      discoverBranchTypes(node.right, result);
+    }
+  } else if (node.type === "Literal") {
+    if (!node.value) {
+      result.empty = true;
+    }
+  } else {
+    result.expression = true;
+  }
+  return result;
+};

--- a/packages/marko/test/codegen/fixtures/htmlElement-dynamic/expected.js
+++ b/packages/marko/test/codegen/fixtures/htmlElement-dynamic/expected.js
@@ -1,5 +1,5 @@
-out.w("<" +
-  data.tagName +
+var tagName = data.tagNameout.w("<" +
+  tagName +
   " class=\"greeting\">Hello World</" +
-  data.tagName +
+  tagName +
   ">")

--- a/packages/marko/test/codegen/fixtures/htmlElement-dynamic/expected.js
+++ b/packages/marko/test/codegen/fixtures/htmlElement-dynamic/expected.js
@@ -1,5 +1,7 @@
-var tagName = data.tagNameout.w("<" +
+var tagName = data.tagName;
+
+out.w("<" +
   tagName +
   " class=\"greeting\">Hello World</" +
   tagName +
-  ">")
+  ">");

--- a/packages/marko/test/codegen/fixtures/templateLiteral/expected.js
+++ b/packages/marko/test/codegen/fixtures/templateLiteral/expected.js
@@ -1,8 +1,15 @@
-`hello ${name}`
-`hello \${name}`
-`hello \\${name}`
-`hello "\`"`
-"hello ${name}"
-"hello \${name}"
-"hello \\${name}"
-"hello \"`\""
+`hello ${name}`;
+
+`hello \${name}`;
+
+`hello \\${name}`;
+
+`hello "\`"`;
+
+"hello ${name}";
+
+"hello \${name}";
+
+"hello \\${name}";
+
+"hello \"`\"";

--- a/packages/marko/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
+++ b/packages/marko/test/compiler/fixtures-vdom/dynamic-tag-name/expected.js
@@ -7,13 +7,12 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
       return module.exports;
     }),
     marko_renderer = require("marko/src/runtime/components/renderer"),
-    marko_defineComponent = require("marko/src/runtime/components/defineComponent"),
-    marko_dynamicTag = require("marko/src/runtime/helpers/dynamic-tag");
+    marko_defineComponent = require("marko/src/runtime/components/defineComponent");
 
 function render(input, out, __component, component, state) {
   var data = input;
 
-  marko_dynamicTag(out, foo ? "foo" : "bar", null, null, null, null, __component, "0");
+  out.e(foo ? "foo" : "bar", null, "0", component, 0);
 }
 
 marko_template._ = marko_renderer(render, {

--- a/packages/marko/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
+++ b/packages/marko/test/compiler/fixtures-vdom/svg-dynamic-tag-name/expected.js
@@ -8,10 +8,13 @@ var marko_template = module.exports = require("marko/src/vdom").t(),
     }),
     marko_renderer = require("marko/src/runtime/components/renderer"),
     marko_defineComponent = require("marko/src/runtime/components/defineComponent"),
-    marko_dynamicTag = require("marko/src/runtime/helpers/dynamic-tag"),
     marko_attrs0 = {
         width: "140",
         height: "30"
+      },
+    marko_attrs1 = {
+        width: "200",
+        height: "200"
       };
 
 function render(input, out, __component, component, state) {
@@ -19,16 +22,8 @@ function render(input, out, __component, component, state) {
 
   var isCircle = true;
 
-  out.be("svg", marko_attrs0, "0", component);
-
-  marko_dynamicTag(out, isCircle ? "circle" : "square", function() {
-    return {
-        width: 200,
-        height: 200
-      };
-  }, null, null, null, __component, "1");
-
-  out.ee();
+  out.e("svg", marko_attrs0, "0", component, 1)
+    .e(isCircle ? "circle" : "square", marko_attrs1, "1", component, 0);
 }
 
 marko_template._ = marko_renderer(render, {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Perf improvement: Attempt to determine if a dynamic tag is can only be a native tag, and if so output using string concat on the server (and `out.e`/`be` in the browser) instead of using the dynamic tag helper.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
