### PR TITLE
fix: implement missing methods for void-writer

### DIFF
--- a/packages/marko/src/runtime/html/AsyncStream.js
+++ b/packages/marko/src/runtime/html/AsyncStream.js
@@ -11,7 +11,20 @@ var escapeXmlOrNullish = escapeXmlHelper.x;
 var escapeXmlString = escapeXmlHelper.___escapeXML;
 var selfClosingTags = require("self-closing-tags");
 
-var voidWriter = { write: function() {} };
+function noop() {}
+
+var voidWriter = {
+  write: noop,
+  script: noop,
+  merge: noop,
+  clear: noop,
+  get: function() {
+    return [];
+  },
+  toString: function() {
+    return "";
+  }
+};
 
 function State(root, stream, writer, events) {
   this.root = root;


### PR DESCRIPTION
## Description

The `voidWriter` is used on the server side to handle when there is an uncaught exception and we are now writing to dead stream. It allows us to gracefully handle that case (since the actual error should have surfaced somewhere else) and also does not buffer anything written after that point.

The `StringWriter` and `BufferedWriter` implementations recently got new methods to better handle concatenating component logic and handling batched flushes. These are missing from the `voidWriter`.

This PR adds those missing methods as `noop`'s to the `voidWriter`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
