### PR TITLE
fix: add devmode warning for removing fragment markers

### DIFF
--- a/packages/marko/src/runtime/components/util-browser.js
+++ b/packages/marko/src/runtime/components/util-browser.js
@@ -170,6 +170,33 @@ function addComponentRootToKeyedElements(
   }
 }
 
+// eslint-disable-next-line no-constant-condition
+if ("MARKO_DEBUG") {
+  var warnNodeRemoved = function(event) {
+    var fragment = event.target.fragment;
+    if (fragment) {
+      var baseError = new Error(
+        "Fragment boundary marker removed.  This will cause an error when the fragment is updated."
+      );
+      fragment.___markersRemovedError = function(message) {
+        var error = new Error(message + " Boundary markers missing.");
+
+        baseError.stack = baseError.stack.replace(/.*warnNodeRemoved.*\n/, "");
+
+        // eslint-disable-next-line no-console
+        console.warn(baseError);
+        return error;
+      };
+    }
+  };
+  exports.___startDOMManipulationWarning = function() {
+    document.addEventListener("DOMNodeRemoved", warnNodeRemoved);
+  };
+  exports.___stopDOMManipulationWarning = function() {
+    document.removeEventListener("DOMNodeRemoved", warnNodeRemoved);
+  };
+}
+
 exports.___runtimeId = runtimeId;
 exports.___componentLookup = componentLookup;
 exports.___getComponentForEl = getComponentForEl;

--- a/packages/marko/src/runtime/components/util.js
+++ b/packages/marko/src/runtime/components/util.js
@@ -69,3 +69,9 @@ exports.___isServer = true;
 exports.___attachBubblingEvent = attachBubblingEvent;
 exports.___destroyComponentForNode = function noop() {};
 exports.___destroyNodeRecursive = function noop() {};
+
+// eslint-disable-next-line no-constant-condition
+if ("MARKO_DEBUG") {
+  exports.___startDOMManipulationWarning = function noop() {};
+  exports.___stopDOMManipulationWarning = function noop() {};
+}

--- a/packages/marko/src/runtime/vdom/morphdom/fragment.js
+++ b/packages/marko/src/runtime/vdom/morphdom/fragment.js
@@ -22,6 +22,12 @@ var fragmentPrototype = {
     return this.endNode.nextSibling;
   },
   get nodes() {
+    // eslint-disable-next-line no-constant-condition
+    if ("MARKO_DEBUG") {
+      if (this.___markersRemovedError) {
+        throw this.___markersRemovedError("Cannot get fragment nodes.");
+      }
+    }
     var nodes = [];
     var current = this.startNode;
     while (current !== this.endNode) {

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -670,6 +670,11 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
     }
   } // END: morphEl(...)
 
+  // eslint-disable-next-line no-constant-condition
+  if ("MARKO_DEBUG") {
+    componentsUtil.___stopDOMManipulationWarning();
+  }
+
   morphChildren(fromNode, toNode, toNode.___component);
 
   detachedNodes.forEach(function(node) {
@@ -693,6 +698,11 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
       }
     }
   });
+
+  // eslint-disable-next-line no-constant-condition
+  if ("MARKO_DEBUG") {
+    componentsUtil.___startDOMManipulationWarning();
+  }
 }
 
 module.exports = morphdom;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This adds additional checks in dev mode to give more context to the user as to why diffing failed when the DOM has been updated manually and fragment markers (empty text nodes) were removed.

Instead of throwing `TypeError: Cannot read property 'nextSibling' of null`, it now throws `Error: Cannot get fragment nodes. Boundary markers missing.`.  In addition to the new error text, a second error is passed to `console.warn` showing the location where the fragment marker was removed.

![image](https://user-images.githubusercontent.com/1958812/78836436-edd65480-79a6-11ea-98e6-b327b840878d.png)



## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
