### PR TITLE
fix: don't modify proto.init when creating a widget

### DIFF
--- a/packages/marko/src/runtime/components/legacy/defineWidget-legacy-browser.js
+++ b/packages/marko/src/runtime/components/legacy/defineWidget-legacy-browser.js
@@ -127,15 +127,6 @@ module.exports = function defineWidget(def, renderer) {
 
   // get legacy methods
 
-  Object.defineProperty(proto, "init", {
-    get: function() {
-      return legacyInit;
-    },
-    set: function(v) {
-      legacyInit = v;
-    }
-  });
-
   var legacyOnRender = proto.onRender;
   Object.defineProperty(proto, "onRender", {
     get: noop,

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/template.marko
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/template.marko
@@ -1,0 +1,2 @@
+<div.root w-bind>
+</div>

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/test.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/test.js
@@ -1,0 +1,7 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+  var component = helpers.mount(require.resolve("./template.marko"), {});
+
+  expect(component.foo).to.equal(123);
+};

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/widget.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-class-init-loop/widget.js
@@ -1,0 +1,8 @@
+function Widget() {
+  this.init();
+}
+Widget.prototype.init = function() {
+  this.foo = 123;
+};
+
+module.exports = Widget;

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/index.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/index.js
@@ -19,11 +19,6 @@ module.exports = require("marko/legacy-components").defineComponent({
 
 if (typeof window === "object") {
   Object.assign(module.exports.prototype, {
-    init: function() {
-      this.lifecycleEvents = [];
-      lifecycle.record(this.id, "init");
-    },
-
     onRender: function(eventArg) {
       lifecycle.record(
         this.id,

--- a/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/test.js
+++ b/packages/marko/test/components-browser/fixtures-deprecated/widget-lifecycle-events-stateful-conditional-bind-monkey-patched/test.js
@@ -10,24 +10,17 @@ module.exports = function(helpers) {
   var targetEl = helpers.targetEl;
 
   expect(targetEl.innerHTML).to.contain("Hello Frank!");
-  expect(lifecycle.events[widget.id]).to.deep.equal([
-    "init",
-    "onRender:firstRender"
-  ]);
+  expect(lifecycle.events[widget.id]).to.deep.equal(["onRender:firstRender"]);
 
   widget.setState("name", "Jane");
 
   expect(targetEl.innerHTML).to.contain("Hello Frank!");
-  expect(lifecycle.events[widget.id]).to.deep.equal([
-    "init",
-    "onRender:firstRender"
-  ]);
+  expect(lifecycle.events[widget.id]).to.deep.equal(["onRender:firstRender"]);
 
   widget.update();
 
   expect(targetEl.innerHTML).to.contain("Hello Jane!");
   expect(lifecycle.events[widget.id]).to.deep.equal([
-    "init",
     "onRender:firstRender",
     "onBeforeUpdate",
     "onUpdate",
@@ -38,7 +31,6 @@ module.exports = function(helpers) {
   widget.update();
 
   expect(lifecycle.events[widget.id]).to.deep.equal([
-    "init",
     "onRender:firstRender",
     "onBeforeUpdate",
     "onUpdate",
@@ -52,7 +44,6 @@ module.exports = function(helpers) {
   widget.update();
 
   expect(lifecycle.events[widget.id]).to.deep.equal([
-    "init",
     "onRender:firstRender",
     "onBeforeUpdate",
     "onUpdate",
@@ -60,7 +51,6 @@ module.exports = function(helpers) {
     "onBeforeUpdate",
     "onBeforeDestroy",
     "onDestroy",
-    "init",
     "onRender:firstRender"
   ]);
 

--- a/packages/marko/test/components-browser/index.test.js
+++ b/packages/marko/test/components-browser/index.test.js
@@ -84,7 +84,12 @@ function runHydrateTest(fixture) {
             marko.register(ssrTemplate.meta.id, rootComponent);
             components.forEach(function(def) {
               Object.keys(def.components).forEach(type => {
-                marko.register(type, browser.require(def.components[type]));
+                const componentPath = def.components[type];
+                let component = browser.require(componentPath);
+                if (/widget$/.test(type)) {
+                  component = legacy.defineWidget(component);
+                }
+                marko.register(type, component);
               });
             });
           }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Re-fixes the issue fixed in https://github.com/marko-js/marko/pull/1490 that was regressed in https://github.com/marko-js/marko/pull/1521.

Fixes the test runner to handle widgets that don't call `defineWidget`.

Adds a test so this doesn't happen again.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
