### PR TITLE
fix: improve a few small things legacy compatibility

### DIFF
--- a/packages/marko/src/core-tags/migrate/all-tags/w-bind.js
+++ b/packages/marko/src/core-tags/migrate/all-tags/w-bind.js
@@ -41,7 +41,7 @@ module.exports = function migrate(el, context) {
     const filename = resolveFrom(context.dirname, literalValue);
 
     if (!filename) {
-      this.addError(
+      context.addError(
         "Target file not found: " +
           literalValue +
           " (from: " +
@@ -54,11 +54,14 @@ module.exports = function migrate(el, context) {
     componentModule = {
       legacy: true,
       filename,
-      requirePath: literalValue.replace(/\/index(\.[^.]+)?$/, "/")
+      requirePath: literalValue
     };
   }
 
-  if (componentModule && componentModule.requirePath === "./") {
+  if (
+    componentModule &&
+    componentModule.requirePath.replace(/\/index(\.[^.]+)?$/, "/") === "./"
+  ) {
     rendererModule = componentModule;
   }
   context.legacyComponentModule = componentModule;

--- a/packages/marko/src/runtime/components/ComponentDef.js
+++ b/packages/marko/src/runtime/components/ComponentDef.js
@@ -139,7 +139,7 @@ ComponentDef.___deserialize = function(o, types, global, registry) {
       component.state = state;
     }
 
-    if (componentProps) {
+    if (!isLegacy && componentProps) {
       extend(component, componentProps);
     }
   }

--- a/packages/marko/src/runtime/renderable.js
+++ b/packages/marko/src/runtime/renderable.js
@@ -126,7 +126,7 @@ module.exports = function(target, renderer) {
       if (callback) {
         finalOut
           .on("finish", function() {
-            callback(null, finalOut.___getResult());
+            callback(null, finalOut.___getResult(), finalOut);
           })
           .once("error", callback);
       }


### PR DESCRIPTION
## Description

Fixes three small issues:

1. The `w-bind` migrator would normalize `w-bind="./index"` to `w-bind="./"` which was not safe if you had a `package.json` in the same folder with a `main` field.
2. `widgetConfig` was being incorrectly merged into the component instance (as well as being available on `this.widgetConfig`. This is a regression from https://github.com/marko-js/marko/pull/1539
3. Previously in Marko 3 `template.render` with a callback would provide `out` as the third  argument. This has been added back for compatibility.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
