### PR TITLE
fix: switch safe renderer to use nextTick for errors

### DIFF
--- a/packages/marko/src/runtime/renderable.js
+++ b/packages/marko/src/runtime/renderable.js
@@ -1,4 +1,5 @@
 var defaultCreateOut = require("./createOut");
+var nextTick = require("./nextTick");
 var extend = require("raptor-util/extend");
 
 function safeRender(renderFunc, finalData, finalOut, shouldEnd) {
@@ -12,10 +13,10 @@ function safeRender(renderFunc, finalData, finalOut, shouldEnd) {
     var actualEnd = finalOut.end;
     finalOut.end = function() {};
 
-    setTimeout(function() {
+    nextTick(function() {
       finalOut.end = actualEnd;
       finalOut.error(err);
-    }, 0);
+    });
   }
   return finalOut;
 }


### PR DESCRIPTION
## Description

Updates the `safeRender` helper to use our `nextTick` helper instead of `setTimeout` since that is more inline with what we want and is more predictable.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
