### PR TITLE
fix: prevent lasso 2 from inlining full system paths

### DIFF
--- a/packages/marko/src/runtime/components/legacy/dependencies/index.js
+++ b/packages/marko/src/runtime/components/legacy/dependencies/index.js
@@ -1,4 +1,4 @@
-var path = require("path");
+var nodePath = require("path");
 var defaultResolveFrom = require("resolve-from");
 var env = process.env.NODE_ENV;
 var production = !env || env !== "development";
@@ -56,7 +56,7 @@ function attachDepsAndComponentsToTemplate(target, context) {
   }
 
   var meta = template.meta;
-  var root = path.dirname(template.path);
+  var root = nodePath.dirname(template.path);
 
   if (meta.deps) {
     meta.deps.forEach(dep => {
@@ -77,7 +77,7 @@ function attachDepsAndComponentsToTemplate(target, context) {
     meta.tags.forEach(tagPath => {
       var resolveFrom = context.resolveFrom || defaultResolveFrom;
       var tag = resolveFrom(root, tagPath);
-      var ext = path.extname(tag);
+      var ext = nodePath.extname(tag);
       var req = context.require || require;
 
       try {
@@ -103,10 +103,14 @@ function getInitModule(path, components) {
     components = Object.keys(components).map(key => components[key]);
 
     if (components.length) {
+      var root = nodePath.dirname(path);
       var virtualPath = path + ".init.js";
       var registrations = components.map(
         component =>
-          `components.register('${component.id}', require('${component.path}'));`
+          `components.register('${component.id}', require('${nodePath.relative(
+            root,
+            component.path
+          )}'));`
       );
       var code = `
                 var components = require('marko/components');
@@ -149,7 +153,7 @@ function resolveDep(dep, root, context) {
   }
 
   if (dep.virtualPath) {
-    dep.virtualPath = path.resolve(root, dep.virtualPath);
+    dep.virtualPath = nodePath.resolve(root, dep.virtualPath);
   }
 
   if (dep.type === "js") {


### PR DESCRIPTION
## Description

Currently if you are using `lasso@2` it can cause Marko to inline a full file system path as a comment. This is bad if you are relying on the file content as a hash.... which is happening.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
