### PR TITLE
fix(legacy dependencies): relative path should begin with ./

### DIFF
--- a/packages/marko/src/runtime/components/legacy/dependencies/index.js
+++ b/packages/marko/src/runtime/components/legacy/dependencies/index.js
@@ -107,10 +107,9 @@ function getInitModule(path, components) {
       var virtualPath = path + ".init.js";
       var registrations = components.map(
         component =>
-          `components.register('${component.id}', require('${nodePath.relative(
-            root,
-            component.path
-          )}'));`
+          `components.register('${component.id}', require('.${
+            nodePath.sep
+          }${nodePath.relative(root, component.path)}'));`
       );
       var code = `
                 var components = require('marko/components');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an issue introduced in #1555: relative paths that are in the current directory or a child directory did not have the `./` prefix.

Lasso resolves relative paths that don't start with a `./` or `../` as node modules, which is not what we want and results in component files being undiscoverable.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
