### PR TITLE
Fix excludePackage because of window path confusion

### DIFF
--- a/compiler/taglib-finder/index.js
+++ b/compiler/taglib-finder/index.js
@@ -16,7 +16,7 @@
 'use strict';
 
 var taglibLoader = require('../taglib-loader');
-var nodePath = require('path');
+var nodePath = require('upath');
 var fs = require('fs');
 var lassoPackageRoot = require('lasso-package-root');
 var resolveFrom = require('resolve-from');

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "raptor-util": "^2.0.1",
     "resolve-from": "^1.0.0",
     "strip-json-comments": "^2.0.1",
-    "try-require": "^1.2.1"
+    "try-require": "^1.2.1",
+    "upath": "^1.2.0"
   },
   "devDependencies": {
     "bluebird": "^2.9.30",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
On window platform `marko` has problems with paths. This PR fix the `excludePackage` function

## Description

Adding [upath](https://www.npmjs.com/package/upath) to normalize the path names.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [X] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
