### PR TITLE
fix: components under client-reorder not initializing

### DIFF
--- a/packages/marko/src/core-tags/core/await/reorderer-renderer.js
+++ b/packages/marko/src/core-tags/core/await/reorderer-renderer.js
@@ -46,6 +46,7 @@ module.exports = function(input, out) {
 
     function handleAwait(awaitInfo) {
       awaitInfo.out
+        .on("___toString", out.emit.bind(out, "___toString"))
         .on("finish", function(result) {
           if (!global._afRuntime) {
             asyncOut.script(clientReorder.getCode());

--- a/packages/marko/test/components-pages/fixtures/split-async-keys/components/app-hello/index.marko
+++ b/packages/marko/test/components-pages/fixtures/split-async-keys/components/app-hello/index.marko
@@ -1,7 +1,22 @@
-$ var promise = new Promise(resolve => setTimeout(resolve, 100));
-<await(promise) client-reorder>
+<div key="div0"/>
+<app-child key="child0"/>
+
+<await(new Promise(resolve => setTimeout(resolve, 100))) client-reorder>
     <@then>
-        <div key="div"/>
-        <app-child key="child"/>
+        <div key="div1"/>
+        <app-child key="child1"/>
+
+        <await(new Promise(resolve => setTimeout(resolve, 200)))>
+            <@then>
+                <div key="div2"/>
+                <app-child key="child2"/>
+            </@then>
+        </await>
+
+        <div key="div3"/>
+        <app-child key="child3"/>
     </@then>
 </await>
+
+<div key="div4"/>
+<app-child key="child4"/>

--- a/packages/marko/test/components-pages/fixtures/split-async-keys/tests.js
+++ b/packages/marko/test/components-pages/fixtures/split-async-keys/tests.js
@@ -1,7 +1,9 @@
 var expect = require("chai").expect;
 
 it("should initialize components correctly across async boundaries", function(done) {
-  expect(window.component.getEl("div")).to.not.equal(undefined);
-  expect(window.component.getComponent("child")).to.not.equal(undefined);
+  for (let i = 0; i <= 4; i++) {
+    expect(window.component.getEl(`div${i}`)).to.not.equal(undefined);
+    expect(window.component.getComponent(`child${i}`)).to.not.equal(undefined);
+  }
   done();
 });


### PR DESCRIPTION
## Description

Fixes a regression from #1502 which causes components under a `client-reorder` not to initialize.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
