### PR TITLE
fix: support empty w-config

### DIFF
--- a/packages/marko/src/core-tags/migrate/all-tags/w-config.js
+++ b/packages/marko/src/core-tags/migrate/all-tags/w-config.js
@@ -11,20 +11,23 @@ module.exports = function migrate(el, context) {
     'The "w-config" attribute is deprecated. See: https://github.com/marko-js/marko/wiki/Deprecation:-w‐config'
   );
 
-  el.insertSiblingBefore(
-    builder.scriptlet({
-      value: printJS(
-        builder.assignment(
-          builder.memberExpression(
-            builder.identifier("component"),
-            builder.identifier("widgetConfig")
+  if (attr.value) {
+    el.insertSiblingBefore(
+      builder.scriptlet({
+        value: printJS(
+          builder.assignment(
+            builder.memberExpression(
+              builder.identifier("component"),
+              builder.identifier("widgetConfig")
+            ),
+            attr.value,
+            "="
           ),
-          attr.value,
-          "="
-        ),
-        context
-      )
-    })
-  );
+          context
+        )
+      })
+    );
+  }
+
   el.removeAttribute("w-config");
 };

--- a/packages/marko/test/migrate/fixtures/w-config/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/w-config/snapshot-expected.marko
@@ -6,3 +6,6 @@ $ component.widgetConfig = input.y;
     $ component.widgetConfig = input.x;
     <div/>
 </if>
+<else-if(y)>
+    <div/>
+</else-if>

--- a/packages/marko/test/migrate/fixtures/w-config/template.marko
+++ b/packages/marko/test/migrate/fixtures/w-config/template.marko
@@ -3,3 +3,6 @@
 <if(x)>
   <div w-config=input.x/>
 </if>
+<else-if(y)>
+  <div w-config/>
+</else-if>


### PR DESCRIPTION
## Description

In Marko 3 having an empty `w-config` (eg `<div w-bind w-config>`) would act as a noop.
In the Marko 4 compatibility layer this now outputs invalid javascript.

This PR updates the `w-config` migration to not output any code if the `w-config` has no value.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
