### PR TITLE
fix: issue with optional arguments for legacy macro migration

### DIFF
--- a/packages/marko/src/core-tags/migrate/macro-tag.js
+++ b/packages/marko/src/core-tags/migrate/macro-tag.js
@@ -81,9 +81,10 @@ module.exports = function migrator(elNode, context) {
         child.argument
       ) {
         const childArgs = builder.parseJavaScriptArgs(child.argument);
+        const childArgsLength = Math.min(params.length, childArgs.length);
         child.argument = undefined;
 
-        for (let i = 0; i < params.length; i++) {
+        for (let i = 0; i < childArgsLength; i++) {
           const name = params[i].name;
           const value = childArgs[i];
           child.addAttribute({ name: name, value: value });

--- a/packages/marko/test/migrate/fixtures/legacy-macro-syntax/snapshot-expected.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-macro-syntax/snapshot-expected.marko
@@ -5,6 +5,7 @@
     $ var lastName = macroInput.lastName;
     <div>${firstName} ${lastName}</div>
 </macro>
+<test firstName="John"/>
 <test firstName="John" lastName="Smith"/>
 <test firstName="John" lastName="Smith"/>
 <macro|macroInput| name="test2">

--- a/packages/marko/test/migrate/fixtures/legacy-macro-syntax/template.marko
+++ b/packages/marko/test/migrate/fixtures/legacy-macro-syntax/template.marko
@@ -5,6 +5,7 @@
 </macro>
 
 
+<test("John")/>
 <test("John", "Smith")/>
 <test firstName="John" lastName="Smith"/>
 


### PR DESCRIPTION
## Description

Currently, the legacy macro syntax migrator has a bug where if the argument syntax is used and an argument is skipped, that argument will be set to `true` instead of `undefined`.

eg:

```marko
<macro some-tag(a, b)>
    <div/>
</macro>
<some-tag("hi")/>
```

In the above `b` would be `true`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
