### PR TITLE
chore: fix lint staged escapes

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,0 @@
-{
-  "*.{json,css,md}": ["prettier --write", "git add"],
-  "*.js": ["eslint", "prettier --write", "git add"]
-}

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,0 +1,19 @@
+const escape = require("shell-quote").quote;
+
+module.exports = {
+  "*.{json,css,md}": escapeFileNames(["prettier --write", "git add"]),
+  "*.js": escapeFileNames(["eslint", "prettier --write", "git add"])
+};
+
+function escapeFileNames(commands) {
+  return filenames => {
+    const allFiles = filenames.join(" ");
+    const allFilesEscaped = filenames
+      .map(filename => `"${escape([filename])}"`)
+      .join(" ");
+    return commands.map(
+      command =>
+        `${command} ${command === "eslint" ? allFiles : allFilesEscaped}`
+    );
+  };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10734,6 +10734,12 @@
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true
 		},
+		"shell-quote": {
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.2.tgz",
+			"integrity": "sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==",
+			"dev": true
+		},
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "mocha": "^5.2.0",
     "mocha-autotest": "^1.0.3",
     "nyc": "^15.0.0",
-    "prettier": "^1.19.1"
+    "prettier": "^1.19.1",
+    "shell-quote": "^1.7.2"
   }
 }


### PR DESCRIPTION
## Description

`lint-staged` is breaking down with special characters in the paths, eg `index[html].js`. This PR escapes those via the lintstaged config.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
