### PR TITLE
fix: issue with hydrating body-only-if content

### DIFF
--- a/packages/marko/src/compiler/ast/HtmlElement/html/generateCode.js
+++ b/packages/marko/src/compiler/ast/HtmlElement/html/generateCode.js
@@ -69,8 +69,38 @@ module.exports = function generateCode(node, codegen) {
   }
 
   if (isNullable) {
-    startTag = builder.ifStatement(tagName, startTag);
-    endTag = endTag && builder.ifStatement(tagName, endTag);
+    startTag = builder.ifStatement(
+      tagName,
+      startTag,
+      builder.elseStatement(
+        builder.functionCall(
+          builder.memberExpression(
+            builder.identifier("out"),
+            builder.identifier("bf")
+          ),
+          [
+            builder.concat(builder.literal("f_"), node.key),
+            builder.identifier("component"),
+            builder.literal(1)
+          ]
+        )
+      )
+    );
+    endTag =
+      endTag &&
+      builder.ifStatement(
+        tagName,
+        endTag,
+        builder.elseStatement(
+          builder.functionCall(
+            builder.memberExpression(
+              builder.identifier("out"),
+              builder.identifier("ef")
+            ),
+            []
+          )
+        )
+      );
   }
 
   if (isCustomElement && attributes && attributes.length) {

--- a/packages/marko/src/compiler/ast/HtmlElement/vdom/generateCode.js
+++ b/packages/marko/src/compiler/ast/HtmlElement/vdom/generateCode.js
@@ -109,8 +109,35 @@ module.exports = function(node, codegen) {
     var endElVDOM = new EndElementVDOM();
     htmlElVDOM.body = null;
     if (isNullable) {
-      htmlElVDOM = builder.ifStatement(tagName, htmlElVDOM);
-      endElVDOM = builder.ifStatement(tagName, endElVDOM);
+      htmlElVDOM = builder.ifStatement(
+        tagName,
+        htmlElVDOM,
+        builder.elseStatement(
+          builder.functionCall(
+            builder.memberExpression(
+              builder.identifier("out"),
+              builder.identifier("bf")
+            ),
+            [
+              builder.concat(builder.literal("f_"), node.key),
+              builder.identifier("component")
+            ]
+          )
+        )
+      );
+      endElVDOM = builder.ifStatement(
+        tagName,
+        endElVDOM,
+        builder.elseStatement(
+          builder.functionCall(
+            builder.memberExpression(
+              builder.identifier("out"),
+              builder.identifier("ef")
+            ),
+            []
+          )
+        )
+      );
     }
     return [tagNameVar, htmlElVDOM, body, endElVDOM];
   }

--- a/packages/marko/src/core-tags/components/preserve-tag-browser.js
+++ b/packages/marko/src/core-tags/components/preserve-tag-browser.js
@@ -10,11 +10,11 @@ module.exports = function render(input, out) {
     shouldPreserve && (isHydrate || ownerComponent.___keyedElements[key])
   );
 
-  out.___beginFragment(key, ownerComponent, shouldPreserve);
+  out.bf(key, ownerComponent, shouldPreserve);
 
   if (!isPreserved && input.renderBody) {
     input.renderBody(out);
   }
 
-  out.___endFragment();
+  out.ef();
 };

--- a/packages/marko/src/core-tags/components/preserve-tag.js
+++ b/packages/marko/src/core-tags/components/preserve-tag.js
@@ -7,7 +7,7 @@ module.exports = function render(input, out) {
   var ownerComponent = ownerComponentDef.___component;
   var key = out.___assignedKey;
 
-  out.___beginFragment(key, ownerComponent, true);
+  out.bf(key, ownerComponent, true);
 
   if (input.renderBody) {
     var componentsContext = getComponentsContext(out);
@@ -17,5 +17,5 @@ module.exports = function render(input, out) {
     componentsContext.___isPreserved = parentPreserved;
   }
 
-  out.___endFragment();
+  out.ef();
 };

--- a/packages/marko/src/runtime/helpers/dynamic-tag.js
+++ b/packages/marko/src/runtime/helpers/dynamic-tag.js
@@ -108,7 +108,7 @@ module.exports = function dynamicTag(
           var willRerender = flags & FLAG_WILL_RERENDER_IN_BROWSER;
           var isW10NOOP = render === w10NOOP;
           var preserve = IS_SERVER ? willRerender : isW10NOOP;
-          out.___beginFragment(key, component, preserve);
+          out.bf(key, component, preserve);
           if (!isW10NOOP && isFn) {
             var componentsContext = getComponentsContext(out);
             var parentComponentDef = componentsContext.___componentDef;
@@ -128,16 +128,16 @@ module.exports = function dynamicTag(
 
             componentsContext.___componentDef = parentComponentDef;
           }
-          out.___endFragment();
+          out.ef();
         } else {
           out.error("Invalid dynamic tag value");
         }
       }
     }
   } else if (renderBody) {
-    out.___beginFragment(key, component);
+    out.bf(key, component);
     renderBody(out);
-    out.___endFragment();
+    out.ef();
   }
 };
 

--- a/packages/marko/src/runtime/html/AsyncStream.js
+++ b/packages/marko/src/runtime/html/AsyncStream.js
@@ -571,7 +571,7 @@ var proto = (AsyncStream.prototype = {
     this.write(escapeXmlOrNullish(str));
   },
 
-  ___beginFragment: function(key, component, preserve) {
+  bf: function(key, component, preserve) {
     if (preserve) {
       this.write("<!--F#" + escapeXmlString(key) + "-->");
     }
@@ -582,7 +582,7 @@ var proto = (AsyncStream.prototype = {
     }
   },
 
-  ___endFragment: function() {
+  ef: function() {
     var preserve = this._elStack.pop();
     if (preserve) {
       this.write("<!--F/-->");

--- a/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
+++ b/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
@@ -186,13 +186,13 @@ var proto = (AsyncVDOMBuilder.prototype = {
     );
   },
 
-  ___beginFragment: function(key, component, preserve) {
+  bf: function(key, component, preserve) {
     var fragment = new VFragment(key, component, preserve);
     this.___beginNode(fragment, null, true);
     return this;
   },
 
-  ___endFragment: function() {
+  ef: function() {
     this.endElement();
   },
 

--- a/packages/marko/test/render/fixtures-deprecated/body-only-if/expected.html
+++ b/packages/marko/test/render/fixtures-deprecated/body-only-if/expected.html
@@ -1,1 +1,1 @@
-<a href="/foo">Some Link</a>Another Link
+<a href=/foo>Some Link</a><!--F#f_1-->Another Link<!--F/-->


### PR DESCRIPTION
## Description
Currently, there is a regression that causes `body-only-if` and `<${null}>` content to not match correctly if set to `false` and hydrated in the client.

In this PR it is fixed so that the fragments created on the server are the same as on the browser.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
