### PR TITLE
feat(compiler): expose register taglib api

### DIFF
--- a/packages/compiler/src/taglib/index.js
+++ b/packages/compiler/src/taglib/index.js
@@ -7,20 +7,9 @@ export { excludeDir, excludePackage } from "marko/src/taglib/taglib-finder";
 
 let lookupCache = Object.create(null);
 
-registeredTaglibs.push(
-  loader.loadTaglibFromProps(
-    loader.createTaglib(require.resolve("./html/marko.json")),
-    require("./html/marko.json")
-  ),
-  loader.loadTaglibFromProps(
-    loader.createTaglib(require.resolve("./svg/marko.json")),
-    require("./svg/marko.json")
-  ),
-  loader.loadTaglibFromProps(
-    loader.createTaglib(require.resolve("./math/marko.json")),
-    require("./math/marko.json")
-  )
-);
+register(require.resolve("./html/marko.json"), require("./html/marko.json"));
+register(require.resolve("./svg/marko.json"), require("./svg/marko.json"));
+register(require.resolve("./math/marko.json"), require("./math/marko.json"));
 
 export function buildLookup(dirname, translator) {
   if (!translator || !Array.isArray(translator.taglibs)) {
@@ -51,6 +40,12 @@ export function buildLookup(dirname, translator) {
   }
 
   return lookup;
+}
+
+export function register(id, props) {
+  registeredTaglibs.push(
+    loader.loadTaglibFromProps(loader.createTaglib(id), props)
+  );
 }
 
 export function clearCaches() {


### PR DESCRIPTION
## Description

Exposes the `taglib.register` API from the new `@marko/compiler` api. This allows for registering global, cross translator, taglibs.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
