### PR TITLE
fix: load correct taglib utils based on env

### DIFF
--- a/packages/translator-default/src/taglib/index.js
+++ b/packages/translator-default/src/taglib/index.js
@@ -1,12 +1,4 @@
-import loader from "marko/src/taglib/taglib-loader";
-
 export default [
-  loader.loadTaglibFromProps(
-    loader.createTaglib(require.resolve("./core/marko.json")),
-    require("./core/marko.json")
-  ),
-  loader.loadTaglibFromProps(
-    loader.createTaglib(require.resolve("./migrate/marko.json")),
-    require("./migrate/marko.json")
-  )
+  [require.resolve("./core/marko.json"), require("./core/marko.json")],
+  [require.resolve("./migrate/marko.json"), require("./migrate/marko.json")]
 ];


### PR DESCRIPTION
## Description

Currently Marko 5 always loads the taglib utils from `marko/src`. This can cause issues if other tools are using the taglib utils from `dist` to register tags.

This PR updates Marko 5 to always use the correct taglib utils import.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
