### PR TITLE
fix: diffing dynamic attributes with mismatched keys

### DIFF
--- a/packages/marko/src/compiler/CompileContext.js
+++ b/packages/marko/src/compiler/CompileContext.js
@@ -26,6 +26,7 @@ const isDebug = require("../build.json").isDebug;
 
 // const FLAG_SIMPLE_ATTRS = 1;
 const FLAG_CUSTOM_ELEMENT = 2;
+// const FLAG_SPREAD_ATTRS = 4;
 
 const FLAG_PRESERVE_WHITESPACE = "PRESERVE_WHITESPACE";
 

--- a/packages/marko/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
+++ b/packages/marko/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
@@ -5,6 +5,7 @@ const vdomUtil = require("../../../util/vdom");
 
 const FLAG_SIMPLE_ATTRS = 1;
 // const FLAG_CUSTOM_ELEMENT = 2;
+const FLAG_SPREAD_ATTRS = 4;
 
 let CREATE_ARGS_COUNT = 0;
 const INDEX_TAG_NAME = CREATE_ARGS_COUNT++;
@@ -189,6 +190,8 @@ class HtmlElementVDOM extends Node {
       this.hasSimpleAttrs = true;
     }
 
+    this.hasSpreadAttributes = hasSpreadAttributes;
+
     this.hasAttributes = hasNamedAttributes;
 
     this.attributesArg = attributesArg;
@@ -240,6 +243,10 @@ class HtmlElementVDOM extends Node {
 
     if (this.hasSimpleAttrs) {
       flags |= FLAG_SIMPLE_ATTRS;
+    }
+
+    if (this.hasSpreadAttributes) {
+      flags |= FLAG_SPREAD_ATTRS;
     }
 
     if (this.runtimeFlags) {

--- a/packages/marko/src/runtime/vdom/VElement.js
+++ b/packages/marko/src/runtime/vdom/VElement.js
@@ -18,6 +18,7 @@ var DEFAULT_NS = {
 
 var FLAG_SIMPLE_ATTRS = 1;
 var FLAG_CUSTOM_ELEMENT = 2;
+var FLAG_SPREAD_ATTRS = 4;
 
 var defineProperty = Object.defineProperty;
 
@@ -382,14 +383,14 @@ VElement.___morphAttrs = function(fromEl, vFromEl, toEl) {
   // If there are any old attributes that are not in the new set of attributes
   // then we need to remove those attributes from the target node
   //
-  // NOTE: We can skip this if the the element is keyed because if the element
-  //       is keyed then we know we already processed all of the attributes for
+  // NOTE: We can skip this if the the element is keyed and didn't have spread attributes
+  //       because we know we already processed all of the attributes for
   //       both the target and original element since target VElement nodes will
   //       have all attributes declared. However, we can only skip if the node
   //       was not a virtualized node (i.e., a node that was not rendered by a
   //       Marko template, but rather a node that was created from an HTML
   //       string or a real DOM node).
-  if (toEl.___key === null) {
+  if (toEl.___key === null || fromFlags & FLAG_SPREAD_ATTRS) {
     for (attrName in oldAttrs) {
       if (!(attrName in attrs)) {
         if (attrName === ATTR_XLINK_HREF) {

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -36,6 +36,7 @@ var DOCTYPE_NODE = 10;
 
 // var FLAG_SIMPLE_ATTRS = 1;
 // var FLAG_CUSTOM_ELEMENT = 2;
+// var FLAG_SPREAD_ATTRS = 4;
 
 function isAutoKey(key) {
   return key[0] !== "@";

--- a/packages/marko/test/components-browser/fixtures/diffpatch-dynamic-attributes/index.marko
+++ b/packages/marko/test/components-browser/fixtures/diffpatch-dynamic-attributes/index.marko
@@ -1,0 +1,19 @@
+class {
+    onCreate() {
+        this.state = { test: true };
+    }
+    toggleTest() {
+        this.state.test = !this.state.test;
+    }
+}
+
+$ {
+	const attrs = {};
+	if(state.test) {
+		attrs.href = "https://example.com"
+	} else {
+		attrs["aria-disabled"] = true
+	}
+}
+
+<a ...attrs>some text</a>

--- a/packages/marko/test/components-browser/fixtures/diffpatch-dynamic-attributes/test.js
+++ b/packages/marko/test/components-browser/fixtures/diffpatch-dynamic-attributes/test.js
@@ -1,0 +1,11 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+  var component = helpers.mount(require.resolve("./index"), {});
+  expect(component.el.hasAttribute("href")).to.equal(true);
+  expect(component.el.hasAttribute("aria-disabled")).to.equal(false);
+  component.toggleTest();
+  component.update();
+  expect(component.el.hasAttribute("href")).to.equal(false);
+  expect(component.el.hasAttribute("aria-disabled")).to.equal(true);
+};

--- a/packages/marko/test/vdom-compiler/fixtures-deprecated/attrs-dynamic-object-literal/expected.js
+++ b/packages/marko/test/vdom-compiler/fixtures-deprecated/attrs-dynamic-object-literal/expected.js
@@ -16,7 +16,7 @@ function render(input, out, __component, component, state) {
   out.e("div", marko_attrs({
       foo: "bar",
       hello: "world"
-    }), null, null, 3)
+    }), null, null, 3, 4)
     .t("Hello ")
     .t(name, component)
     .t("!");

--- a/packages/marko/test/vdom-compiler/fixtures-deprecated/attrs-dynamic/expected.js
+++ b/packages/marko/test/vdom-compiler/fixtures-deprecated/attrs-dynamic/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
     hello: "world"
   }
 
-  out.e("div", marko_attrs(attrs), null, null, 3)
+  out.e("div", marko_attrs(attrs), null, null, 3, 4)
     .t("Hello ")
     .t(name, component)
     .t("!");

--- a/packages/marko/test/vdom-compiler/fixtures/attrs-dynamic-object-literal/expected.js
+++ b/packages/marko/test/vdom-compiler/fixtures/attrs-dynamic-object-literal/expected.js
@@ -16,7 +16,7 @@ function render(input, out, __component, component, state) {
   out.e("div", marko_attrs({
       foo: "bar",
       hello: "world"
-    }), null, null, 3)
+    }), null, null, 3, 4)
     .t("Hello ")
     .t(name, component)
     .t("!");

--- a/packages/marko/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
+++ b/packages/marko/test/vdom-compiler/fixtures/attrs-dynamic/expected.js
@@ -18,7 +18,7 @@ function render(input, out, __component, component, state) {
     hello: "world"
 };
 
-  out.e("div", marko_attrs(attrs), null, null, 3)
+  out.e("div", marko_attrs(attrs), null, null, 3, 4)
     .t("Hello ")
     .t(name, component)
     .t("!");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

```marko
$ {
	const attrs = {};
	if(someCondition) {
		attrs.href = "https://someCoolUrl"
	} else {
		attrs["aria-disabled"] = true
	}
}
<a ...attrs>some text</a>
```

When `someCondition` changes, the old attribute doesn't currently get removed.  This PR fixes this issue.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [x] I have added tests to cover my changes.
