### PR TITLE
Marko 5: Expose watch file meta data

### DIFF
--- a/packages/babel-utils/src/tags.js
+++ b/packages/babel-utils/src/tags.js
@@ -36,27 +36,23 @@ export function getMacroIdentifier(path) {
 }
 
 export function getTagDef(path) {
-  const cached = path.get("tagDef");
-
-  if (cached.node !== undefined) {
-    return cached.node;
-  }
-
   const {
+    node,
     hub: { file }
   } = path;
-  const { _lookup } = file;
-  let tagName;
 
-  if (!(isMacroTag(path) || isDynamicTag(path))) {
-    tagName = isAttributeTag(path)
-      ? getFullyResolvedTagName(path)
-      : path.get("name.value").node;
+  if (!node.tagDef) {
+    if (isDynamicTag(path) || isMacroTag(path)) {
+      node.tagDef = null;
+    } else {
+      node.tagDef =
+        file.getTagDef(
+          isAttributeTag(path) ? getFullyResolvedTagName(path) : node.name.value
+        ) || null;
+    }
   }
 
-  const tagDef = (tagName && _lookup.getTag(tagName)) || null;
-  path.set("tagDef", tagDef);
-  return tagDef;
+  return node.tagDef;
 }
 
 export function getFullyResolvedTagName(path) {

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -157,7 +157,7 @@ export function parse(file) {
       const tagName = event.tagName || "div";
       const [, tagNameExpression] =
         /^\$\{([\s\S]*)\}/.exec(tagName) || EMPTY_ARRAY;
-      const tagDef = !tagNameExpression && file._lookup.getTag(tagName);
+      const tagDef = !tagNameExpression && file.getTagDef(tagName);
       const tagNameStartPos = pos + (event.concise ? 0 : 1); // Account for leading `<`.
 
       handledTagName = true;
@@ -300,6 +300,7 @@ export function parse(file) {
 
       if (tagDef && tagDef.nodeFactoryPath) {
         const module = markoModules.require(tagDef.nodeFactoryPath);
+        file._watchFiles.add(tagDef.nodeFactoryPath);
         /* istanbul ignore next */
         (module.default || module)(tag, t);
       }

--- a/packages/marko/src/taglib/taglib-loader/Taglib.js
+++ b/packages/marko/src/taglib/taglib-loader/Taglib.js
@@ -35,7 +35,6 @@ class Taglib {
     this.transformers = [];
     this.attributes = {};
     this.patternAttributes = [];
-    this.inputFilesLookup = {};
     this.imports = null;
     this.importsLookup = null;
   }

--- a/packages/marko/src/taglib/taglib-lookup/TaglibLookup.js
+++ b/packages/marko/src/taglib/taglib-lookup/TaglibLookup.js
@@ -77,7 +77,6 @@ class TaglibLookup {
       attributeGroups: {}
     };
     this.taglibsById = {};
-    this._inputFiles = null;
 
     this._sortedTags = undefined;
   }
@@ -223,18 +222,12 @@ class TaglibLookup {
   }
 
   getTag(element) {
-    if (typeof element === "string") {
-      element = {
-        tagName: element
-      };
-    }
     var tags = this.merged.tags;
     if (!tags) {
       return;
     }
 
-    var tagName = element.tagName;
-    return tags[tagName];
+    return tags[element.tagName || element];
   }
 
   getAttribute(element, attr) {
@@ -431,7 +424,7 @@ class TaglibLookup {
   }
 
   toString() {
-    return "lookup: " + this.getInputFiles().join(", ");
+    return "lookup: " + Object.keys(this.taglibsById).join(", ");
   }
 }
 

--- a/packages/translator-default/src/optimize.js
+++ b/packages/translator-default/src/optimize.js
@@ -33,7 +33,7 @@ export const visitor = {
 
       if (source.value[0] === "<") {
         const tagName = source.value.slice(1, -1);
-        const tagDef = file._lookup.getTag(tagName);
+        const tagDef = file.getTagDef(tagName);
         const tagEntry = tagDef && (tagDef.renderer || tagDef.template);
         const relativePath = tagEntry && file.resolveRelativePath(tagEntry);
 

--- a/packages/translator-default/src/tag/index.js
+++ b/packages/translator-default/src/tag/index.js
@@ -23,7 +23,11 @@ export default {
 
     if (tagDef) {
       if (tagDef.codeGeneratorModulePath) {
-        const { node } = path;
+        const {
+          node,
+          hub: { file }
+        } = path;
+        file._watchFiles.add(tagDef.codeGeneratorModulePath);
         tagDef.codeGenerator = markoModules.require(
           tagDef.codeGeneratorModulePath
         );

--- a/packages/translator-default/src/util/with-previous-location.js
+++ b/packages/translator-default/src/util/with-previous-location.js
@@ -1,4 +1,6 @@
 export default function withPreviousLocation(newNode, originalNode) {
-  const { start, end, loc } = originalNode;
-  return Object.assign(newNode, { start, end, loc });
+  newNode.start = originalNode.start;
+  newNode.loc = originalNode.loc;
+  newNode.end = originalNode.end;
+  return newNode;
 }


### PR DESCRIPTION
## Description

Exposes a new `metadata` property that lists some files which tools such as the `WebpackDevServer` should include as a dependency for the compiled Marko file. This is not an exhaustive list, but hopefully good enough for practical purposes. 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
