### PR TITLE
fix: set default value for textarea when created

### DIFF
--- a/packages/marko/src/runtime/vdom/VElement.js
+++ b/packages/marko/src/runtime/vdom/VElement.js
@@ -190,7 +190,7 @@ VElement.prototype = {
       }
 
       if (tagName === "textarea") {
-        el.value = this.___value;
+        el.defaultValue = el.value = this.___value;
       }
     }
 

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -88,7 +88,9 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
         ] = realNode;
       }
 
-      morphChildren(realNode, vNode, parentComponent);
+      if (vNode.___nodeName !== "textarea") {
+        morphChildren(realNode, vNode, parentComponent);
+      }
     }
 
     onNodeAdded(realNode, componentsContext);

--- a/packages/marko/test/components-browser/fixtures/form-controls-default-value/index.marko
+++ b/packages/marko/test/components-browser/fixtures/form-controls-default-value/index.marko
@@ -1,0 +1,6 @@
+class {}
+
+<input key="a" type="checkbox" value="abc" checked/>
+<input key="b" type="checkbox" value="abc"/>
+<input key="c" type="text" value="abc"/>
+<textarea key="d">abc</textarea>

--- a/packages/marko/test/components-browser/fixtures/form-controls-default-value/test.js
+++ b/packages/marko/test/components-browser/fixtures/form-controls-default-value/test.js
@@ -1,0 +1,14 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+  var component = helpers.mount(require.resolve("./index.marko"));
+
+  expect(component.getEl("a")).has.property("defaultValue", "abc");
+  expect(component.getEl("a")).has.property("defaultChecked", true);
+
+  expect(component.getEl("b")).has.property("defaultValue", "abc");
+  expect(component.getEl("b")).has.property("defaultChecked", false);
+
+  expect(component.getEl("c")).has.property("defaultValue", "abc");
+  expect(component.getEl("d")).has.property("defaultValue", "abc");
+};


### PR DESCRIPTION
## Description

Currently, when actualizing a viritual `textarea` element (IE not server-rendered) we do not properly assign the `defaultValue` property. 

This PR sets both `defaultValue` and `value` in this case.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
