### PR TITLE
feat: switch to espree from esprima

### DIFF
--- a/packages/marko/package-lock.json
+++ b/packages/marko/package-lock.json
@@ -273,6 +273,11 @@
                 }
             }
         },
+        "acorn-jsx": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.2.0.tgz",
+            "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ=="
+        },
         "acorn-walk": {
             "version": "6.2.0",
             "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -1146,10 +1151,33 @@
                 }
             }
         },
+        "eslint-visitor-keys": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ=="
+        },
+        "espree": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+            "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+            "requires": {
+                "acorn": "^7.4.0",
+                "acorn-jsx": "^5.2.0",
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+                    "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w=="
+                }
+            }
+        },
         "esprima": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+            "dev": true
         },
         "estraverse": {
             "version": "4.3.0",

--- a/packages/marko/package.json
+++ b/packages/marko/package.json
@@ -12,7 +12,7 @@
         "complain": "^1.6.0",
         "deresolve": "^1.1.2",
         "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
+        "espree": "^7.3.0",
         "estraverse": "^4.3.0",
         "events-light": "^1.0.0",
         "he": "^1.1.0",

--- a/packages/marko/src/compiler/util/isCompoundExpression.js
+++ b/packages/marko/src/compiler/util/isCompoundExpression.js
@@ -1,6 +1,6 @@
 function isCompoundExpression(expression) {
   if (typeof expression === "string") {
-    // TBD: Should we use Esprima to parse the expression string to see if it is a compount expression?
+    // TBD: Should we use Espree to parse the expression string to see if it is a compount expression?
     return true;
   }
 

--- a/packages/marko/src/core-tags/components/TransformHelper/handleRootNodes.js
+++ b/packages/marko/src/core-tags/components/TransformHelper/handleRootNodes.js
@@ -3,9 +3,13 @@
 let path = require("path");
 let getComponentFiles = require("./getComponentFiles");
 
-const esprima = require("esprima");
+const espree = require("espree");
 const escodegen = require("escodegen");
 const FLAG_COMPONENT_STYLE = Symbol("COMPONENT_STYLE");
+const espreeOptions = {
+  sourceType: "script",
+  ecmaVersion: espree.latestEcmaVersion
+};
 
 function handleStyleElement(styleEl, transformHelper) {
   if (styleEl.bodyText) {
@@ -109,13 +113,13 @@ function handleClassDeclaration(classEl, transformHelper) {
   let wrappedSrc = "(" + classEl.tagString + "\n)";
 
   try {
-    tree = esprima.parseScript(wrappedSrc);
+    tree = espree.parse(wrappedSrc, espreeOptions);
   } catch (err) {
     let message = "Unable to parse JavaScript for component class. " + err;
 
     if (err.index != null) {
       let errorIndex = err.index;
-      // message += '\n' + err.description;
+      // message += '\n' + err.message;
       if (errorIndex != null && errorIndex >= 0) {
         transformHelper.context.addError({
           pos: classEl.pos + errorIndex,

--- a/packages/marko/test/parseFor/fixtures/forEach-invalid-option2/expected.json
+++ b/packages/marko/test/parseFor/fixtures/forEach-invalid-option2/expected.json
@@ -1,3 +1,3 @@
 {
-  "error": "Invalid status-var option: \nUnexpected identifier: test foo\n                             ^"
+  "error": "Invalid status-var option: Unexpected token foo:\n\ntest foo\n     ^"
 }

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-attr-separator/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-attr-separator/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "separator" expression:');
-  expect(message).to.contain("Unexpected identifier");
+  expect(message).to.contain("Unexpected token foo");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-attr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-attr/test.js
@@ -8,7 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "in" expression:');
-  expect(message).to.contain(
-    "Unexpected identifier: ['red', 'blue', 'green'] foo"
-  );
+  expect(message).to.contain("Unexpected token foo");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-props/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-props/test.js
@@ -8,7 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "in" expression:');
-  expect(message).to.contain(
-    "Unexpected identifier: {'foo': 'low', 'bar': 'high'} foo"
-  );
+  expect(message).to.contain("Unexpected token foo");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range-step/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range-step/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "step" expression:');
-  expect(message).to.contain("Unexpected number: 0 0");
+  expect(message).to.contain("Unexpected token 0");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range-to-expr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range-to-expr/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "to" expression:');
-  expect(message).to.contain("Unexpected number: 'abc'.length 1");
+  expect(message).to.contain("Unexpected token 1");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-for-range/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain('Invalid "from" expression:');
-  expect(message).to.contain("Unexpected identifier: 0 too 9");
+  expect(message).to.contain("Unexpected token too");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-if-attr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sdsds");
+  expect(message).to.contain("Unexpected token sdsds");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-attr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-attr/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
   var message = e.toString();
   // expect(message).to.contain('Error: Unable to compile template at path');
-  expect(message).to.contain("Unexpected number: input.foo === dasda 0");
+  expect(message).to.contain("Unexpected token 0");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-if-attr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sds");
+  expect(message).to.contain("Unexpected token sds");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-if-else-attr/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-if-else-if-else-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected token =: input.foo ==== 1");
+  expect(message).to.contain("Unexpected token =");
 };

--- a/packages/marko/test/render/fixtures-deprecated/error-invalid-unless-tag/test.js
+++ b/packages/marko/test/render/fixtures-deprecated/error-invalid-unless-tag/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sdsds");
+  expect(message).to.contain("Unexpected token sdsds");
 };

--- a/packages/marko/test/render/fixtures/error-bad-expression/test.js
+++ b/packages/marko/test/render/fixtures/error-bad-expression/test.js
@@ -13,5 +13,5 @@ exports.checkError = function(e) {
   expect(message).to.contain(
     'Invalid JavaScript expression for attribute "class"'
   );
-  expect(message).to.contain("Unexpected identifier: (this is not valid)");
+  expect(message).to.contain("Unexpected token is");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-else-if-tag/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-else-if-tag/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
   var message = e.toString();
   expect(message).to.contain("else-if");
-  expect(message).to.contain("Unexpected identifier: true invalid");
+  expect(message).to.contain("Unexpected token invalid");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-attr/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sdsds");
+  expect(message).to.contain("Unexpected token sdsds");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-else-attr/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-else-attr/test.js
@@ -5,5 +5,5 @@ exports.templateData = {};
 exports.checkError = function(e) {
   var message = e.toString();
   // expect(message).to.contain('Error: Unable to compile template at path');
-  expect(message).to.contain("Unexpected number: input.foo === dasda 0");
+  expect(message).to.contain("Unexpected token 0");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-else-if-attr/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-else-if-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sds");
+  expect(message).to.contain("Unexpected token sds");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-else-if-else-attr/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-else-if-else-attr/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected token =: input.foo ==== 1");
+  expect(message).to.contain("Unexpected token =");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-else-if-else-tag/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-else-if-else-tag/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain("Invalid expression for if statement:");
-  expect(message).to.contain("Unexpected identifier: false foo");
+  expect(message).to.contain("Unexpected token foo");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-else-if-tag/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-else-if-tag/test.js
@@ -8,5 +8,5 @@ exports.checkError = function(e) {
     "An error occurred while trying to compile template at path"
   );
   expect(message).to.contain("Invalid expression for else-if statement:");
-  expect(message).to.contain("Unexpected identifier: true foo");
+  expect(message).to.contain("Unexpected token foo");
 };

--- a/packages/marko/test/render/fixtures/error-invalid-if-tag/test.js
+++ b/packages/marko/test/render/fixtures/error-invalid-if-tag/test.js
@@ -4,5 +4,5 @@ exports.templateData = {};
 
 exports.checkError = function(e) {
   var message = e.toString();
-  expect(message).to.contain("Unexpected identifier: true sdsds");
+  expect(message).to.contain("Unexpected token sdsds");
 };


### PR DESCRIPTION
## Description
esprima seems to no longer be maintained. This PR switches Marko 4 to use the fork that is maintained by the eslint team called espree.

For the most part, these are compatible, and this means Marko 4 can now parse more modern JavaScript.

Fixes https://github.com/marko-js/marko/issues/1450

https://github.com/marko-js/marko/issues/1450 is also already fixed in Marko 5 with babel now being used as the parser.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
