### PR TITLE
fix: duplicate export 'registerOptimizer'

### DIFF
--- a/packages/marko/src/compiler/util/vdom/index.js
+++ b/packages/marko/src/compiler/util/vdom/index.js
@@ -16,4 +16,3 @@ function registerOptimizer(context) {
 
 exports.registerOptimizer = registerOptimizer;
 exports.isStaticValue = isStaticValue;
-exports.registerOptimizer = registerOptimizer;


### PR DESCRIPTION
Deleted duplicate string for export 'registerOptimizer'

## Description

The problem occurs when using the 'rollup'. The duplicate caused a compilation error:
```
[!] Error: Duplicate export 'registerOptimizer'
node_modules/marko/dist/compiler/util/vdom/index.js (36:32)
34: export { registerOptimizer_1 as registerOptimizer };
35: export { isStaticValue_1 as isStaticValue };
36: export { registerOptimizer_2 as registerOptimizer };
```

After the fix everything works

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
