### PR TITLE
Legacy helpers perf

### DIFF
--- a/packages/marko/helpers/empty-browser.marko
+++ b/packages/marko/helpers/empty-browser.marko
@@ -1,0 +1,10 @@
+<module-code(function(require) {
+  var isDebug = require('../env').isDebug;
+  return `module.exports = require("../${isDebug ? 'src' : 'dist'}/legacy-helpers/empty");\n`;
+})/>
+
+// What's going on here? We are using Marko to do JavaScript code generation
+// during the module bundling phase to conditionally export either the
+// "src" or the "dist" folder based on whether or not we are doing a
+// debug or non-debug build. We are using Marko since we know the Marko compiler
+// is enabled already (no extra babel transform required).

--- a/packages/marko/helpers/empty.js
+++ b/packages/marko/helpers/empty.js
@@ -1,6 +1,3 @@
-var notEmpty = require("./notEmpty");
-
-module.exports = function(o) {
-  require("complain")("empty is deprecated.");
-  return !notEmpty(o);
-};
+module.exports = require("../env").isDebug
+  ? require("../src/legacy-helpers/empty")
+  : require("../dist/legacy-helpers/empty");

--- a/packages/marko/helpers/notEmpty-browser.marko
+++ b/packages/marko/helpers/notEmpty-browser.marko
@@ -1,0 +1,10 @@
+<module-code(function(require) {
+  var isDebug = require('../env').isDebug;
+  return `module.exports = require("../${isDebug ? 'src' : 'dist'}/legacy-helpers/notEmpty");\n`;
+})/>
+
+// What's going on here? We are using Marko to do JavaScript code generation
+// during the module bundling phase to conditionally export either the
+// "src" or the "dist" folder based on whether or not we are doing a
+// debug or non-debug build. We are using Marko since we know the Marko compiler
+// is enabled already (no extra babel transform required).

--- a/packages/marko/helpers/notEmpty.js
+++ b/packages/marko/helpers/notEmpty.js
@@ -1,13 +1,3 @@
-module.exports = function notEmpty(o) {
-  require("complain")("notEmpty is deprecated.");
-
-  if (o == null) {
-    return false;
-  } else if (Array.isArray(o)) {
-    return !!o.length;
-  } else if (o === "") {
-    return false;
-  }
-
-  return true;
-};
+module.exports = require("../env").isDebug
+  ? require("../src/legacy-helpers/notEmpty")
+  : require("../dist/legacy-helpers/notEmpty");

--- a/packages/marko/package.json
+++ b/packages/marko/package.json
@@ -52,6 +52,8 @@
     "browser": {
         "./compiler.js": "./compiler-browser.marko",
         "./components.js": "./components-browser.marko",
+        "./helpers/empty.js": "./helpers/empty-browser.marko",
+        "./helpers/notEmpty.js": "./helpers/notEmpty-browser.marko",
         "./index.js": "./index-browser.marko",
         "./legacy-components.js": "./legacy-components-browser.marko"
     },

--- a/packages/marko/src/legacy-helpers/empty.js
+++ b/packages/marko/src/legacy-helpers/empty.js
@@ -1,0 +1,9 @@
+var notEmpty = require("./notEmpty");
+module.exports = function empty(o) {
+  // eslint-disable-next-line no-constant-condition
+  if ("MARKO_DEBUG") {
+    require("complain")("empty is deprecated.");
+  }
+
+  return !notEmpty(o);
+};

--- a/packages/marko/src/legacy-helpers/notEmpty.js
+++ b/packages/marko/src/legacy-helpers/notEmpty.js
@@ -1,0 +1,16 @@
+module.exports = function(o) {
+  // eslint-disable-next-line no-constant-condition
+  if ("MARKO_DEBUG") {
+    require("complain")("notEmpty is deprecated.");
+  }
+
+  if (o == null) {
+    return false;
+  } else if (Array.isArray(o)) {
+    return !!o.length;
+  } else if (o === "") {
+    return false;
+  }
+
+  return true;
+};

--- a/packages/marko/src/loader/index-browser.js
+++ b/packages/marko/src/loader/index-browser.js
@@ -1,14 +1,4 @@
 "use strict";
-module.exports = function load(templatePath) {
-  // We make the assumption that the template path is a
-  // fully resolved module path and that the module exists
-  // as a CommonJS module
+module.exports =
   // eslint-disable-next-line no-undef
-  if (typeof __webpack_require__ !== "undefined") {
-    // In webpack we can accept paths from `require.resolve`.
-    // eslint-disable-next-line no-undef
-    return __webpack_require__(templatePath);
-  } else {
-    return require(templatePath);
-  }
-};
+  typeof __webpack_require__ !== "undefined" ? __webpack_require__ : require;


### PR DESCRIPTION
## Description

Prevents loading the complain module when legacy helpers (`marko/helpers`) are loaded.
This PR also contains a minor optimization for the `.load` api when used in the browser.

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
