### PR TITLE
fix: no longer use fragments for preserved native els

### DIFF
--- a/packages/marko/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
+++ b/packages/marko/src/compiler/ast/HtmlElement/vdom/HtmlElementVDOM.js
@@ -115,7 +115,7 @@ class HtmlElementVDOM extends Node {
 
     var hasSimpleAttrs = true;
 
-    if (properties && properties.noupdate) {
+    if (properties && properties.pa) {
       // Preserving attributes requires extra logic that we cannot
       // shortcircuit
       hasSimpleAttrs = false;

--- a/packages/marko/src/core-tags/components/TransformHelper/handleComponentPreserve.js
+++ b/packages/marko/src/core-tags/components/TransformHelper/handleComponentPreserve.js
@@ -4,11 +4,9 @@ function addPreserve(transformHelper, bodyOnly, condition) {
   let el = transformHelper.el;
   let context = transformHelper.context;
   let builder = transformHelper.builder;
-
-  let preserveAttrs = {};
+  var isCustomTag = el.type !== "HtmlElement";
 
   if (bodyOnly) {
-    preserveAttrs["body-only"] = builder.literal(bodyOnly);
     el.forEachChild(child => {
       child._canBePreserved = true;
     });
@@ -16,14 +14,27 @@ function addPreserve(transformHelper, bodyOnly, condition) {
     el._canBePreserved = true;
   }
 
-  if (condition) {
-    preserveAttrs["if"] = condition;
+  var preserveAttrs = {
+    key: transformHelper.assignComponentId().nestedIdExpression
+  };
+
+  if (isCustomTag) {
+    preserveAttrs.key = builder.concat(
+      builder.literal("p_"),
+      preserveAttrs.key
+    );
+  } else {
+    preserveAttrs.n = builder.literal(true);
+
+    if (bodyOnly) {
+      preserveAttrs.b = builder.literal(true);
+    }
   }
 
-  preserveAttrs.key = builder.concat(
-    builder.literal("p_"),
-    transformHelper.assignComponentId().nestedIdExpression
-  );
+  if (condition) {
+    preserveAttrs.i = condition;
+  }
+
   let preserveNode = context.createNodeForEl("_preserve", preserveAttrs);
 
   if (bodyOnly) {

--- a/packages/marko/src/core-tags/components/TransformHelper/handleComponentPreserveAttrs.js
+++ b/packages/marko/src/core-tags/components/TransformHelper/handleComponentPreserveAttrs.js
@@ -29,7 +29,7 @@ module.exports = function handleComponentPreserveAttrs() {
   });
 
   if (noUpdateAttrs.length) {
-    el.setPropertyValue("noupdate", builder.literal(noUpdateAttrs));
+    el.setPropertyValue("pa", builder.literal(noUpdateAttrs));
 
     if (!context.isFlagSet(PRESERVE_ATTRS_HELPER_ADDED)) {
       context.setFlag(PRESERVE_ATTRS_HELPER_ADDED);

--- a/packages/marko/src/core-tags/components/marko.json
+++ b/packages/marko/src/core-tags/components/marko.json
@@ -104,10 +104,9 @@
   },
   "<_preserve>": {
     "renderer": "./preserve-tag.js",
-    "@cid": "string",
-    "@preserveKey": "string",
-    "@if": "boolean",
-    "@body-only": "boolean",
+    "@n": "boolean",
+    "@i": "boolean",
+    "@b": "boolean",
     "autocomplete": []
   },
   "<no-update>": {

--- a/packages/marko/src/core-tags/components/preserve-tag-browser.js
+++ b/packages/marko/src/core-tags/components/preserve-tag-browser.js
@@ -1,20 +1,49 @@
+var autoKeyReg = /^\d[\d[\]]*$/;
+
 module.exports = function render(input, out) {
   var componentsContext = out.___components;
   var isHydrate =
     componentsContext && componentsContext.___globalContext.___isHydrate;
-  var ownerComponentDef = out.___assignedComponentDef;
-  var ownerComponent = ownerComponentDef.___component;
+  var ownerComponent = out.___assignedComponentDef.___component;
+  var shouldPreserve = !("i" in input) || input.i;
+  var referenceComponent = ownerComponent;
   var key = out.___assignedKey;
-  var shouldPreserve = !("if" in input) || input["if"];
-  var isPreserved = Boolean(
-    shouldPreserve && (isHydrate || ownerComponent.___keyedElements[key])
-  );
+  var checkKey = key;
 
-  out.bf(key, ownerComponent, shouldPreserve);
-
-  if (!isPreserved && input.renderBody) {
-    input.renderBody(out);
+  if (autoKeyReg.test(key)) {
+    var parentComponent = componentsContext.___componentDef.___component;
+    if (ownerComponent !== parentComponent) {
+      referenceComponent = parentComponent;
+      checkKey += ":" + ownerComponent.id;
+    }
+  } else if (input.n) {
+    key = checkKey = "@" + key;
   }
 
-  out.ef();
+  var isPreserved = Boolean(
+    shouldPreserve &&
+      (isHydrate || referenceComponent.___keyedElements[checkKey])
+  );
+
+  if (input.n) {
+    if (isPreserved) {
+      if (input.b) {
+        out.___parent.___preserveBody = true;
+      } else {
+        out.beginElement("", null, key, ownerComponent);
+        out.___parent.___preserve = true;
+        out.endElement();
+      }
+    } else {
+      input.renderBody(out);
+    }
+  } else {
+    out.bf(key, ownerComponent, shouldPreserve);
+
+    if (!isPreserved) {
+      input.renderBody(out);
+    }
+
+    out.ef();
+  }
 };

--- a/packages/marko/src/core-tags/components/preserve-tag.js
+++ b/packages/marko/src/core-tags/components/preserve-tag.js
@@ -2,20 +2,24 @@ var ComponentsContext = require("../../runtime/components/ComponentsContext");
 var getComponentsContext = ComponentsContext.___getComponentsContext;
 
 module.exports = function render(input, out) {
-  var shouldPreserve = Boolean(!("if" in input) || input["if"]);
-  var ownerComponentDef = out.___assignedComponentDef;
-  var ownerComponent = ownerComponentDef.___component;
-  var key = out.___assignedKey;
+  var shouldPreserve = Boolean(!("i" in input) || input.i);
+  var isComponent = !input.n;
 
-  out.bf(key, ownerComponent, true);
-
-  if (input.renderBody) {
-    var componentsContext = getComponentsContext(out);
-    var parentPreserved = componentsContext.___isPreserved;
-    componentsContext.___isPreserved = parentPreserved || shouldPreserve;
-    input.renderBody(out);
-    componentsContext.___isPreserved = parentPreserved;
+  if (isComponent) {
+    out.bf(out.___assignedKey, out.___assignedComponentDef.___component, true);
   }
 
-  out.ef();
+  if (shouldPreserve) {
+    var componentsContext = getComponentsContext(out);
+    var parentPreserved = componentsContext.___isPreserved;
+    componentsContext.___isPreserved = true;
+    input.renderBody(out);
+    componentsContext.___isPreserved = parentPreserved;
+  } else {
+    input.renderBody(out);
+  }
+
+  if (isComponent) {
+    out.ef();
+  }
 };

--- a/packages/marko/src/runtime/components/init-components-browser.js
+++ b/packages/marko/src/runtime/components/init-components-browser.js
@@ -6,7 +6,7 @@ var win = window;
 var defaultDocument = document;
 var createFragmentNode = require("../vdom/morphdom/fragment")
   .___createFragmentNode;
-var componentsUtil = require("./util");
+var componentsUtil = require("./util-browser");
 var componentLookup = componentsUtil.___componentLookup;
 var addComponentRootToKeyedElements =
   componentsUtil.___addComponentRootToKeyedElements;
@@ -90,7 +90,7 @@ function indexServerComponentBoundaries(node, runtimeId, stack) {
     } else if (node.nodeType === 1) {
       // HTML element node
       var markoKey = node.getAttribute("data-marko-key");
-      var markoProps = node.getAttribute("data-marko");
+      var markoProps = componentsUtil.___getMarkoPropsFromEl(node);
       if (markoKey) {
         var separatorIndex = markoKey.indexOf(" ");
         ownerId = markoKey.substring(separatorIndex + 1);
@@ -105,7 +105,6 @@ function indexServerComponentBoundaries(node, runtimeId, stack) {
         keyedElements[markoKey] = node;
       }
       if (markoProps) {
-        markoProps = JSON.parse(markoProps);
         Object.keys(markoProps).forEach(function(key) {
           if (key.slice(0, 2) === "on") {
             eventDelegation.___addDelegatedEventHandler(key.slice(2));

--- a/packages/marko/src/runtime/vdom/VElement.js
+++ b/packages/marko/src/runtime/vdom/VElement.js
@@ -2,6 +2,7 @@
 
 var complain = "MARKO_DEBUG" && require("complain");
 var domData = require("../components/dom-data");
+var componentsUtil = require("../components/util");
 var vElementByDOMNode = domData.___vElementByDOMNode;
 var VNode = require("./VNode");
 var inherit = require("raptor-util/inherit");
@@ -109,6 +110,8 @@ function VElement(
   this.___nodeName = tagName;
   this.___valueInternal = null;
   this.___constId = constId;
+  this.___preserve = false;
+  this.___preserveBody = false;
 }
 
 VElement.prototype = {
@@ -248,16 +251,18 @@ function virtualizeElement(node, virtualizeChildNodes, ownerComponent) {
   var attributes = node.attributes;
   var attrCount = attributes.length;
 
-  var attrs;
+  var attrs = null;
+  var props = null;
 
   if (attrCount) {
     attrs = {};
     for (var i = 0; i < attrCount; i++) {
       var attr = attributes[i];
       var attrName = attr.name;
-      if (!xmlnsRegExp.test(attrName) && attrName !== "data-marko") {
-        var attrNamespaceURI = attr.namespaceURI;
-        if (attrNamespaceURI === NS_XLINK) {
+      if (!xmlnsRegExp.test(attrName)) {
+        if (attrName === "data-marko") {
+          props = componentsUtil.___getMarkoPropsFromEl(node);
+        } else if (attr.namespaceURI === NS_XLINK) {
           attrs[ATTR_XLINK_HREF] = attr.value;
         } else {
           attrs[attrName] = attr.value;
@@ -279,7 +284,7 @@ function virtualizeElement(node, virtualizeChildNodes, ownerComponent) {
     ownerComponent,
     0 /*child count*/,
     0 /*flags*/,
-    null /*props*/
+    props
   );
 
   if (vdomEl.___nodeName === "textarea") {

--- a/packages/marko/src/runtime/vdom/VNode.js
+++ b/packages/marko/src/runtime/vdom/VNode.js
@@ -52,7 +52,7 @@ VNode.prototype = {
       if (child.___Text) {
         var childValue = child.___nodeValue;
         this.___valueInternal = (this.___valueInternal || "") + childValue;
-      } else if (child.___preserve) {
+      } else if (child.___preserve || child.___preserveBody) {
         this.___preserveTextAreaValue = true;
       } else {
         throw TypeError();

--- a/packages/marko/src/runtime/vdom/preserve-attrs.js
+++ b/packages/marko/src/runtime/vdom/preserve-attrs.js
@@ -1,7 +1,7 @@
 var extend = require("raptor-util/extend");
 
 function removePreservedAttributes(attrs, props) {
-  var preservedAttrs = props && props.noupdate;
+  var preservedAttrs = props && props.pa;
   if (preservedAttrs) {
     attrs = extend({}, attrs);
     preservedAttrs.forEach(function(preservedAttrName) {

--- a/packages/marko/test/compiler/fixtures-html/no-update-multiple/expected.js
+++ b/packages/marko/test/compiler/fixtures-html/no-update-multiple/expected.js
@@ -13,14 +13,14 @@ function render(input, out, __component, component, state) {
 
   out.w("<div><input" +
     marko_dataMarko(out, __component, {
-      noupdate: [
+      pa: [
         "value"
       ]
     }) +
     marko_attr("value", input.defaultValue) +
     "><input" +
     marko_dataMarko(out, __component, {
-      noupdate: [
+      pa: [
         "value"
       ]
     }) +

--- a/packages/marko/test/compiler/fixtures-html/no-update/expected.js
+++ b/packages/marko/test/compiler/fixtures-html/no-update/expected.js
@@ -13,7 +13,7 @@ function render(input, out, __component, component, state) {
 
   out.w("<input" +
     marko_dataMarko(out, __component, {
-      noupdate: [
+      pa: [
         "value"
       ]
     }) +

--- a/packages/marko/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
+++ b/packages/marko/test/components-compilation/fixtures-html-deprecated/auto-key-els/expected.js
@@ -31,11 +31,12 @@ function render(input, out, __component, component, state) {
   out.w("</ul><p>");
 
   _preserve_tag({
-      bodyOnly: true,
+      n: true,
+      b: true,
       renderBody: function(out) {
         out.w(marko_escapeXml(Date.now()));
       }
-    }, out, __component, "p_preservedP");
+    }, out, __component, "preservedP");
 
   out.w("</p></div><span>B</span>");
 

--- a/packages/marko/test/components-compilation/fixtures-html/auto-key-els/expected.js
+++ b/packages/marko/test/components-compilation/fixtures-html/auto-key-els/expected.js
@@ -31,11 +31,12 @@ function render(input, out, __component, component, state) {
   out.w("</ul><p>");
 
   _preserve_tag({
-      bodyOnly: true,
+      n: true,
+      b: true,
       renderBody: function(out) {
         out.w(marko_escapeXml(Date.now()));
       }
-    }, out, __component, "p_preservedP");
+    }, out, __component, "preservedP");
 
   out.w("</p></div><span>B</span>");
 

--- a/packages/marko/test/render/fixtures/await-no-update-content/expected.html
+++ b/packages/marko/test/render/fixtures/await-no-update-content/expected.html
@@ -1,1 +1,1 @@
-<!--F#p_abc--><button data-marko='{"onclick":"handleClick s0 false"}' data-marko-key="@abc s0">Click Me</button><!--F/-->
+<button data-marko='{"onclick":"handleClick s0 false"}' data-marko-key="@abc s0">Click Me</button>


### PR DESCRIPTION
## Description

https://github.com/marko-js/marko/pull/1480 made it so that `no-update` would preserve server rendered content. To achieve this it used preserved fragment markers.

This caused a regression specifically when people are relying on those markers not being there in order to just set `innerHTML` or similar for child nodes like `<div no-update-body>`.

This PR treats native elements with `no-update` specially and doesn't introduce any new nodes to do so.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
