### PR TITLE
Fixed "docs" url in the README.md

### DIFF
--- a/packages/marko/README.md
+++ b/packages/marko/README.md
@@ -15,7 +15,7 @@
 </p>
 
 <p align="center">
-    <a href="https://markojs.com/docs/">Docs</a> ∙ <a href="https://markojs.com/try-online/">Try Online</a> ∙ <a href="#contributors">Contribute</a> ∙ <a href="#community--support">Get Support</a>
+    <a href="https://markojs.com/docs/getting-started/">Docs</a> ∙ <a href="https://markojs.com/try-online/">Try Online</a> ∙ <a href="#contributors">Contribute</a> ∙ <a href="#community--support">Get Support</a>
 </p>
 
 # Intro


### PR DESCRIPTION
Fixed wrong "docs" url in the README.md 

## Description
This change is required because if you click on "docs" url, you will end up with 404 page. 

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated / added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
