### PR TITLE
test: once-update failing test case

### DIFF
--- a/packages/marko/test/components-browser/fixtures/event-attach-el-once-copy/index.marko
+++ b/packages/marko/test/components-browser/fixtures/event-attach-el-once-copy/index.marko
@@ -1,0 +1,7 @@
+class {
+    onMount() {
+        this.numberOfInvocations = 1;
+    }
+}
+
+<div>${input.color}</div>

--- a/packages/marko/test/components-browser/fixtures/event-attach-el-once-copy/test.js
+++ b/packages/marko/test/components-browser/fixtures/event-attach-el-once-copy/test.js
@@ -1,0 +1,23 @@
+var expect = require("chai").expect;
+
+module.exports = function(helpers) {
+  var component = helpers.mount(require.resolve("./index"), {
+    color: "red"
+  });
+
+  var OFFSET = helpers.isHydrate ? -1 : 0;
+
+  component.once("update", () => component.numberOfInvocations++);
+
+  expect(component.numberOfInvocations).to.equal(OFFSET + 1);
+
+  component.input = {
+    color: "blue"
+  };
+
+  component.update();
+
+  expect(component.numberOfInvocations).to.equal(OFFSET + 1);
+};
+
+exports.fails = "issue xxxx";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
This is a failing test case to demonstrate an unknown issue.

In `marko@4.23.9` we see `beforeEach` timeouts in local tests, possibly due to swallowed errors:
```
beforeEach(function(done) {
        this.timeout(10000);
        sandbox = sinon.sandbox.create();
        widget = carousel.renderSync(mockModel({ breakPoints: { medium: 3, small: 2 } })).appendTo(document.body).getComponent();
        widget.once('update', () => {
            requestAnimationFrame(() => done());
        });
    });
```

This behavior begins in `4.23.5`. After reviewing these changes, it appears the issue may be related to how `.once('update', ...)` is registered (attached ?) with the component. 

Relevant code: https://github.com/marko-js/marko/pull/1610/files#diff-a33f88801acda91978cbc233cbdcb4380365907e0bdc51dc5b4f99522aef35efL44

If this test setup can be done differently or better, please let me know. 

Finally, this is my first look into `marko` codebase so I have a feeling that my PR might not be 100%. Ready to learn though!

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
