### PR TITLE
feat: add typescript types for babel-types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 *.marko.js
 *actual.*
 dist
-packages/babel-types/traverse.d.ts
 
 ### Node ###
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.marko.js
 *actual.*
 dist
+packages/babel-types/traverse.d.ts
 
 ### Node ###
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2887,6 +2887,15 @@
 			"integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
 			"dev": true
 		},
+		"@types/babel__traverse": {
+			"version": "7.0.15",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.15.tgz",
+			"integrity": "sha512-Pzh9O3sTK8V6I1olsXpCfj2k/ygO2q1X0vhhnDrEQyYLHZesWz+zMZMVcwXLCYf0U36EtmyYaFGPfXlTtDHe3A==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "marko-project",
   "private": true,
   "scripts": {
-    "build": "lerna exec --parallel -- babel ./src --out-dir ./dist --delete-dir-on-start --copy-files --config-file ../../babel.config.js --source-maps --env-name=production",
+    "build": "lerna exec --parallel -- babel ./src --out-dir ./dist --delete-dir-on-start --copy-files --config-file ../../babel.config.js --source-maps --env-name=production && npm run build:types",
     "build:watch": "npm run build -- --watch",
+    "build:types": "node scripts/types-babel-types.js > packages/babel-types/dist/types.d.ts && node scripts/types-babel-traverse.js",
     "postinstall": "lerna bootstrap --hoist --no-ci",
     "prepack": "ENTRY=main:npm npm run set-entry",
     "postpack": "ENTRY=main:dev npm run set-entry",
@@ -35,6 +36,7 @@
     "@commitlint/config-conventional": "^8.2.0",
     "@commitlint/config-lerna-scopes": "^8.2.0",
     "@ebay/browserslist-config": "^1.0.1",
+    "@types/babel__traverse": "^7.0.15",
     "babel-plugin-istanbul": "^6.0.0",
     "babel-plugin-minprops": "^2.0.1",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "lerna exec --parallel -- babel ./src --out-dir ./dist --delete-dir-on-start --copy-files --config-file ../../babel.config.js --source-maps --env-name=production && npm run build:types",
     "build:watch": "npm run build -- --watch",
-    "build:types": "node scripts/types-babel-types.js > packages/babel-types/dist/types.d.ts && node scripts/types-babel-traverse.js",
+    "build:types": "node scripts/types-babel-types.js > packages/babel-types/dist/types.d.ts && node scripts/types-babel-traverse.js > packages/babel-types/dist/traverse.d.ts",
     "postinstall": "lerna bootstrap --hoist --no-ci",
     "prepack": "ENTRY=main:npm npm run set-entry",
     "postpack": "ENTRY=main:dev npm run set-entry",

--- a/packages/babel-types/index.d.ts
+++ b/packages/babel-types/index.d.ts
@@ -4,4 +4,5 @@ declare module "./dist/types" {
   export const MARKO_TYPES: string[];
 }
 
+export * from "./dist/traverse";
 export { types };

--- a/packages/babel-types/index.d.ts
+++ b/packages/babel-types/index.d.ts
@@ -1,2 +1,7 @@
 import * as types from "./dist/types";
+
+declare module "./dist/types" {
+  export const MARKO_TYPES: string[];
+}
+
 export { types };

--- a/packages/babel-types/index.d.ts
+++ b/packages/babel-types/index.d.ts
@@ -1,0 +1,2 @@
+import * as types from "./dist/types";
+export { types };

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -14,7 +14,9 @@
     "self-closing-tags": "^1.0.1"
   },
   "files": [
-    "dist"
+    "dist",
+    "index.d.ts",
+    "traverse.d.ts"
   ],
   "homepage": "https://github.com/marko-js/marko/blob/master/packages/babel-types/README.md",
   "keywords": [
@@ -29,6 +31,7 @@
   "main": "src/index.js",
   "main:dev": "src/index.js",
   "main:npm": "dist/index.js",
+  "types": "index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/marko-js/marko/tree/master/packages/babel-types"

--- a/packages/babel-types/package.json
+++ b/packages/babel-types/package.json
@@ -15,8 +15,7 @@
   },
   "files": [
     "dist",
-    "index.d.ts",
-    "traverse.d.ts"
+    "index.d.ts"
   ],
   "homepage": "https://github.com/marko-js/marko/blob/master/packages/babel-types/README.md",
   "keywords": [

--- a/scripts/types-babel-traverse.js
+++ b/scripts/types-babel-traverse.js
@@ -1,22 +1,57 @@
 const fs = require("fs");
 const path = require("path");
+require("../packages/babel-types/dist/types/patch");
+const {
+  MARKO_TYPES
+} = require("../packages/babel-types/dist/types/definitions");
+
+const IMPORT = "import * as t from '@babel/types'";
+const IS =
+  "//#region ------------------------- isXXX -------------------------";
+const ASSERT =
+  "//#region ------------------------- assertXXX -------------------------";
+const BREAK = "\n    ";
 
 fs.readFile(
   path.join(__dirname, "../node_modules/@types/babel__traverse/index.d.ts"),
   "utf8",
   (err, data) => {
-    if (err) return console.log(err);
-    var result = data.replace(
-      `import * as t from '@babel/types';`,
-      `import { types as t } from '@marko/babel-types';`
-    );
+    if (err) return console.error(err);
+
+    [IMPORT, IS, ASSERT].forEach(str => {
+      if (data.indexOf(str) === -1) {
+        console.error(
+          `Unable to find \`${str}\` in @types/babel__traverse/index.d.ts`
+        );
+        process.exit(1);
+      }
+    });
+
+    var result = data
+      .replace(IMPORT, `import { types as t } from '@marko/babel-types'`)
+      .replace(
+        IS,
+        IS +
+          BREAK +
+          MARKO_TYPES.map(
+            t => `is${t}(props?: object | null): this is NodePath<t.${t}>;`
+          ).join(BREAK)
+      )
+      .replace(
+        ASSERT,
+        ASSERT +
+          BREAK +
+          MARKO_TYPES.map(t => `assert${t}(props?: object | null): void;`).join(
+            BREAK
+          )
+      );
 
     fs.writeFile(
       path.join(__dirname, "../packages/babel-types/traverse.d.ts"),
       result,
       "utf8",
       err => {
-        if (err) return console.log(err);
+        if (err) return console.error(err);
       }
     );
   }

--- a/scripts/types-babel-traverse.js
+++ b/scripts/types-babel-traverse.js
@@ -46,13 +46,6 @@ fs.readFile(
           )
       );
 
-    fs.writeFile(
-      path.join(__dirname, "../packages/babel-types/traverse.d.ts"),
-      result,
-      "utf8",
-      err => {
-        if (err) return console.error(err);
-      }
-    );
+    process.stdout.write(result);
   }
 );

--- a/scripts/types-babel-traverse.js
+++ b/scripts/types-babel-traverse.js
@@ -1,0 +1,23 @@
+const fs = require("fs");
+const path = require("path");
+
+fs.readFile(
+  path.join(__dirname, "../node_modules/@types/babel__traverse/index.d.ts"),
+  "utf8",
+  (err, data) => {
+    if (err) return console.log(err);
+    var result = data.replace(
+      `import * as t from '@babel/types';`,
+      `import { types as t } from '@marko/babel-types';`
+    );
+
+    fs.writeFile(
+      path.join(__dirname, "../packages/babel-types/traverse.d.ts"),
+      result,
+      "utf8",
+      err => {
+        if (err) return console.log(err);
+      }
+    );
+  }
+);

--- a/scripts/types-babel-types.js
+++ b/scripts/types-babel-types.js
@@ -1,0 +1,2 @@
+require("../packages/babel-types/dist/types/patch.js");
+require("@babel/types/scripts/generators/typescript");


### PR DESCRIPTION
## Description
Adds TypeScript definitions for Babel Types that include Marko's custom types.
Also creates a modified types definitions for Babel Traverse.
These definitions are generated at build time via scripts.

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
