### PR TITLE
feat: add default attribute support

### DIFF
--- a/packages/babel-types/src/generator/patch.js
+++ b/packages/babel-types/src/generator/patch.js
@@ -74,20 +74,22 @@ Object.assign(Printer.prototype, {
     this.print(node.body, node);
   },
   MarkoAttribute(node) {
-    this.token(node.name);
+    if (!node.default) {
+      this.token(node.name);
 
-    if (node.modifier) {
-      this.token(":");
-      this.token(node.modifier);
+      if (node.modifier) {
+        this.token(":");
+        this.token(node.modifier);
+      }
+
+      if (node.arguments && node.arguments.length) {
+        this.token("(");
+        this.printList(node.arguments, node);
+        this.token(")");
+      }
     }
 
-    if (node.arguments && node.arguments.length) {
-      this.token("(");
-      this.printList(node.arguments, node);
-      this.token(")");
-    }
-
-    if (!t.isBooleanLiteral(node.value) || !node.value.value) {
+    if (node.default || !t.isBooleanLiteral(node.value) || !node.value.value) {
       this.token("=");
       printWithParansIfNeeded.call(this, node.value, node);
     }
@@ -167,7 +169,12 @@ Object.assign(Printer.prototype, {
       }
 
       if (node.attributes.length) {
-        this.token(" ");
+        if (
+          !(node.attributes && node.attributes[0] && node.attributes[0].default)
+        ) {
+          this.token(" ");
+        }
+
         this.printJoin(node.attributes, node, { separator: spaceSeparator });
       }
     }

--- a/packages/babel-types/src/types/definitions.js
+++ b/packages/babel-types/src/types/definitions.js
@@ -92,7 +92,7 @@ const MarkoDefinitions = {
 
   MarkoAttribute: {
     aliases: ["Marko", "Expression"],
-    builder: ["name", "value", "modifier", "arguments"],
+    builder: ["name", "value", "modifier", "arguments", "default"],
     visitor: ["value", "arguments"],
     fields: {
       name: {
@@ -111,6 +111,10 @@ const MarkoDefinitions = {
           assertValueType("array"),
           assertEach(assertNodeType("Expression", "SpreadElement"))
         ),
+        optional: true
+      },
+      default: {
+        validate: assertValueType("boolean"),
         optional: true
       }
     }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,7 +19,7 @@
     "complain": "^1.6.0",
     "enhanced-resolve": "5.0.0",
     "he": "^1.1.0",
-    "htmljs-parser": "^2.8.0",
+    "htmljs-parser": "^2.8.1",
     "jsesc": "^2.5.2",
     "lasso-package-root": "^1.0.1",
     "resolve-from": "^5.0.0",

--- a/packages/compiler/src/babel-plugin/util/parse-attributes.js
+++ b/packages/compiler/src/babel-plugin/util/parse-attributes.js
@@ -7,9 +7,11 @@ export default (file, attributes, startPos) => {
   let attrEndPos = startPos;
 
   return attributes.map(attr => {
-    const attrStartPos = code.indexOf(attr.name, attrEndPos);
+    const attrStartPos = attr.default
+      ? attr.pos
+      : code.indexOf(attr.name, attrEndPos);
 
-    if (attr.name.slice(0, 3) === "...") {
+    if (attr.name.startsWith("...")) {
       let attrExpression = attr.name.slice(3);
 
       if (attr.argument) {
@@ -54,7 +56,8 @@ export default (file, attributes, startPos) => {
         name,
         value,
         modifier,
-        parseArguments(file, attr.argument)
+        parseArguments(file, attr.argument),
+        Boolean(attr.default)
       ),
       attrStartPos,
       attrEndPos

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-error-expected.txt
@@ -1,0 +1,4 @@
+packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+> 1 | <div/myDiv/>
+    |      ^^^^^
+  2 | 

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr"));
+
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer"));
+
+var _html = require("marko/src/runtime/html");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const _marko_template = (0, _html.t)();
+
+var _default = _marko_template;
+exports.default = _default;
+const _marko_componentType = "packages/translator-default/test/fixtures/tag-with-default-attr/template.marko",
+      _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _component, component, state) {
+  out.w("<div default></div>");
+  out.w("<div></div>");
+  out.w(`<div${(0, _attr.default)("default", abc)}></div>`);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/generated-expected.marko
@@ -1,0 +1,3 @@
+<div=true/>
+<div=false/>
+<div=abc/>

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-error-expected.txt
@@ -1,0 +1,4 @@
+packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+> 1 | <div/myDiv/>
+    |      ^^^^^
+  2 | 

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
@@ -1,0 +1,16 @@
+const _marko_template = _t();
+
+export default _marko_template;
+import _marko_attr from "marko/src/runtime/html/helpers/attr";
+import _marko_renderer from "marko/src/runtime/components/renderer";
+import { t as _t } from "marko/src/runtime/html";
+const _marko_componentType = "packages/translator-default/test/fixtures/tag-with-default-attr/template.marko",
+      _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  out.w("<div default></div>");
+  out.w("<div></div>");
+  out.w(`<div${_marko_attr("default", abc)}></div>`);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,4 @@
+packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+> 1 | <div/myDiv/>
+    |      ^^^^^
+  2 | 

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
@@ -1,0 +1,14 @@
+const _marko_template = _t();
+
+export default _marko_template;
+import _marko_attr from "marko/dist/runtime/html/helpers/attr";
+import _marko_renderer from "marko/dist/runtime/components/renderer";
+import { t as _t } from "marko/dist/runtime/html";
+const _marko_componentType = "d4MwwGDt",
+      _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  out.w(`<div default></div><div></div><div${_marko_attr("default", abc)}></div>`);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-error-expected.txt
@@ -1,0 +1,4 @@
+packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+> 1 | <div/myDiv/>
+    |      ^^^^^
+  2 | 

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
@@ -1,0 +1,24 @@
+const _marko_template = _t();
+
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer";
+import { t as _t } from "marko/src/runtime/dom";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry-browser";
+
+const _marko_componentType = _marko_registerComponent("packages/translator-default/test/fixtures/tag-with-default-attr/template.marko", () => _marko_template),
+      _marko_component = {};
+
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  out.e("div", {
+    "default": ""
+  }, "0", component, 0, 0);
+  out.e("div", null, "1", component, 0, 0);
+  out.e("div", {
+    "default": abc
+  }, "2", component, 0, 0);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,4 @@
+packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+> 1 | <div/myDiv/>
+    |      ^^^^^
+  2 | 

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
@@ -1,0 +1,30 @@
+const _marko_template = _t();
+
+export default _marko_template;
+import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element";
+
+const _marko_node = _marko_createElement("div", {
+  "default": ""
+}, "0", null, 0, 0);
+
+const _marko_node2 = _marko_createElement("div", null, "1", null, 0, 0);
+
+import _marko_renderer from "marko/dist/runtime/components/renderer";
+import { t as _t } from "marko/dist/runtime/dom";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry-browser";
+
+const _marko_componentType = _marko_registerComponent("d4MwwGDt", () => _marko_template),
+      _marko_component = {};
+
+_marko_template._ = _marko_renderer(function (input, out, _component, component, state) {
+  out.n(_marko_node, component);
+  out.n(_marko_node2, component);
+  out.e("div", {
+    "default": abc
+  }, "2", component, 0, 0);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/template.marko
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/template.marko
@@ -1,0 +1,3 @@
+<div=true/>
+<div=false/>
+<div=abc/>


### PR DESCRIPTION
## Description
Adds parse and codegen support for the new default attribute syntax, eg:

```marko
<my-tag="x"/>
```

equivalent to:

```marko
<my-tag default="x"/>
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
