### PR TITLE
chore: update htmljs parser, fix lerna issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2430,6 +2430,14 @@
 					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+							"dev": true
+						}
 					}
 				},
 				"inquirer": {
@@ -3471,6 +3479,14 @@
 			"requires": {
 				"escape-string-regexp": "^1.0.5",
 				"lasso-caching-fs": "^1.0.1"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				}
 			}
 		},
 		"babel-polyfill": {
@@ -3907,6 +3923,14 @@
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
 				"supports-color": "^5.3.0"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				}
 			}
 		},
 		"chardet": {
@@ -4664,11 +4688,31 @@
 						"yargs-parser": "^20.2.3"
 					}
 				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
+					}
 				}
 			}
 		},
@@ -4714,6 +4758,26 @@
 						"trim-newlines": "^3.0.0",
 						"type-fest": "^0.18.0",
 						"yargs-parser": "^20.2.3"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
 					}
 				}
 			}
@@ -5677,12 +5741,6 @@
 			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
 			"dev": true
 		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
 		"eslint": {
 			"version": "6.8.0",
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-6.8.0.tgz",
@@ -5807,6 +5865,12 @@
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
 					"integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+					"dev": true
+				},
+				"strip-json-comments": {
+					"version": "3.1.1",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+					"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 					"dev": true
 				},
 				"type-fest": {
@@ -6195,6 +6259,14 @@
 			"dev": true,
 			"requires": {
 				"escape-string-regexp": "^1.0.5"
+			},
+			"dependencies": {
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
+				}
 			}
 		},
 		"file-entry-cache": {
@@ -6796,6 +6868,26 @@
 						"trim-newlines": "^3.0.0",
 						"type-fest": "^0.18.0",
 						"yargs-parser": "^20.2.3"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"through2": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+					"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+					"dev": true,
+					"requires": {
+						"readable-stream": "3"
 					}
 				}
 			}
@@ -8520,6 +8612,14 @@
 						"has-ansi": "^2.0.0",
 						"strip-ansi": "^3.0.0",
 						"supports-color": "^2.0.0"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+							"dev": true
+						}
 					}
 				},
 				"figures": {
@@ -8530,6 +8630,14 @@
 					"requires": {
 						"escape-string-regexp": "^1.0.5",
 						"object-assign": "^4.1.0"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+							"dev": true
+						}
 					}
 				},
 				"indent-string": {
@@ -8592,6 +8700,14 @@
 					"dev": true,
 					"requires": {
 						"escape-string-regexp": "^1.0.5"
+					},
+					"dependencies": {
+						"escape-string-regexp": {
+							"version": "1.0.5",
+							"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+							"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+							"dev": true
+						}
 					}
 				},
 				"mimic-fn": {
@@ -9359,6 +9475,12 @@
 					"requires": {
 						"ms": "2.0.0"
 					}
+				},
+				"escape-string-regexp": {
+					"version": "1.0.5",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+					"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+					"dev": true
 				},
 				"glob": {
 					"version": "7.1.2",
@@ -11720,12 +11842,6 @@
 				"min-indent": "^1.0.0"
 			}
 		},
-		"strip-json-comments": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-			"dev": true
-		},
 		"strong-log-transformer": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/strong-log-transformer/-/strong-log-transformer-2.1.0.tgz",
@@ -11914,28 +12030,6 @@
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
 			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
 			"dev": true
-		},
-		"through2": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
-			"integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
-			"dev": true,
-			"requires": {
-				"readable-stream": "3"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
-			}
 		},
 		"tmp": {
 			"version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "build": "lerna exec --parallel -- babel ./src --out-dir ./dist --delete-dir-on-start --copy-files --config-file ../../babel.config.js --source-maps --env-name=production && npm run build:types",
     "build:watch": "npm run build -- --watch",
     "build:types": "node scripts/types-babel-types.js > packages/babel-types/dist/types.d.ts && node scripts/types-babel-traverse.js > packages/babel-types/dist/traverse.d.ts",
-    "postinstall": "lerna bootstrap --hoist --no-ci",
+    "postinstall": "lerna bootstrap --hoist",
     "prepack": "ENTRY=main:npm npm run set-entry",
     "postpack": "ENTRY=main:dev npm run set-entry",
     "release": "npm run build && lerna publish prerelease --preid=next --dist-tag=next",
@@ -14,7 +14,7 @@
     "clean": "lerna clean && rm -rf ./packages/*/dist",
     "format": "eslint -f visualstudio --fix . && prettier \"**/*.{json,md,js}\" --write",
     "lint": "eslint -f visualstudio . && prettier \"**/*.{js,json,css,md}\" -l",
-    "ci:test": "npm run lint && npm run build && cross-env MARKO_DEBUG=1 NODE_ENV=test nyc --reporter=text npm test",
+    "ci:test": "npm run lint && cross-env MARKO_DEBUG=1 NODE_ENV=test nyc --reporter=text npm test",
     "ci:codecov": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "report": "nyc report --reporter=html && open ./coverage/index.html",
     "set-entry": "lerna exec -- dot-json package.json main $\\(dot-json package.json $ENTRY\\)"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,7 +19,7 @@
     "complain": "^1.6.0",
     "enhanced-resolve": "5.0.0",
     "he": "^1.1.0",
-    "htmljs-parser": "^2.8.1",
+    "htmljs-parser": "^2.8.2",
     "jsesc": "^2.5.2",
     "lasso-package-root": "^1.0.1",
     "resolve-from": "^5.0.0",

--- a/packages/compiler/src/taglib/index.js
+++ b/packages/compiler/src/taglib/index.js
@@ -1,6 +1,8 @@
 let loader, finder, registeredTaglibs, TaglibLookup;
 
 if (
+  (process.env.MARKO_DEBUG != null &&
+    (process.env.MARKO_DEBUG !== "false" || process.env.MARKO_DEBUG !== "0")) ||
   process.env.NODE_ENV == null ||
   process.env.NODE_ENV === "development" ||
   process.env.NODE_ENV === "dev"


### PR DESCRIPTION
Lerna was not properly updating out package lock. This PR removes the `--no-ci` option which was preventing this.
Also upgrades htmljs-parser.