### PR TITLE
feat(babel-utils): expose import and id utils

### DIFF
--- a/packages/babel-utils/index.d.ts
+++ b/packages/babel-utils/index.d.ts
@@ -170,3 +170,6 @@ export function importNamed(
 
 export function getTaglibLookup(file: BabelFile): TaglibLookup;
 export function getTagDefForTagName(file: BabelFile, tagName: string): TagDefinition | undefined;
+
+export function getTemplateId(optimize: boolean, request: string): string;
+export function resolveTagImport(path: NodePath<any>, request: string): string | undefined;

--- a/packages/babel-utils/src/index.js
+++ b/packages/babel-utils/src/index.js
@@ -11,7 +11,9 @@ export {
   findParentTag,
   findAttributeTags,
   getArgOrSequence,
-  loadFileForTag
+  loadFileForTag,
+  getTemplateId,
+  resolveTagImport
 } from "./tags";
 export {
   assertAllowedAttributes,


### PR DESCRIPTION
## Description

Exposes a utility to get the template id.
Exposes a utility to resolve `<tag>` style imports.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
