### PR TITLE
Changed <await> doc

### DIFF
--- a/packages/marko/docs/core-tags.md
+++ b/packages/marko/docs/core-tags.md
@@ -257,11 +257,11 @@ The `<await>` tag **renders markup asynchronously using a [Promise](https://deve
 - Its optional `<@placeholder>` attribute tag displays while the Promise is pending.
 
 ```marko
-$ const personRequest = new Promise((resolve, reject) => {
+$ const personPromise = new Promise((resolve, reject) => {
   setTimeout(() => resolve({ name: 'Frank' }), 1000);
 });
 
-<await(personPromise)>
+<await(personPromise) client-reorder=true>
   <@placeholder>
     <!-- Displays while promise is pending -->
     <label>Loading…


### PR DESCRIPTION
-Correcting a variable (typo)
-Added client-reorder so the placeholder tag actually gets used in the example

<!--- Why is this change required? What problem does it solve? -->
Makes the example work aswell as displaying the placeholder property in action