### PR TITLE
feat: include input as a binding when crawling

### DIFF
--- a/packages/babel-types/src/types/patch.js
+++ b/packages/babel-types/src/types/patch.js
@@ -46,8 +46,7 @@ const originalIsReferenced = referencedValidators.default;
 referencedValidators.default = (node, parent, grandparent) => {
   if (
     parent.type === "MarkoTag" &&
-    parent.params &&
-    parent.params.includes(node)
+    (parent.var === node || (parent.params && parent.params.includes(node)))
   ) {
     return false;
   }


### PR DESCRIPTION
## Description
Currently babel sees `input` as a global variable when analyzing the scopes of the ast.
This PR makes it so that we register `input` as a normal `const` binding, allowing us to track references more easily.

Also fixes an issue where tag variable identifiers were not marked as referenced.

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
