### PR TITLE
Preserve gzip streaming in Koa integration example

### DIFF
--- a/packages/marko/docs/koa.md
+++ b/packages/marko/docs/koa.md
@@ -1,12 +1,12 @@
 # Koa + Marko
 
-See the [marko-koa](https://github.com/marko-js-samples/marko-koa) sample
-project for a fully-working example.
+See [the `marko-koa` sample project](https://github.com/marko-js-samples/marko-koa) for a fully-working example.
 
 ## Installation
 
-    npm install koa --save
-    npm install marko --save
+```sh
+npm install koa marko --save
+```
 
 ## Usage
 
@@ -34,7 +34,7 @@ You may also easily add `gzip` streaming support without additional dependencies
 
 ```javascript
 require("marko/node-require");
-const { createGzip } = require("zlib");
+const zlib = require("zlib");
 
 const Koa = require("koa");
 const app = new Koa();
@@ -52,7 +52,9 @@ app.use((ctx, next) => {
   ctx.vary("Accept-Encoding");
   if (ctx.acceptsEncodings("gzip")) {
     ctx.set("Content-Encoding", "gzip");
-    ctx.body = ctx.body.pipe(createGzip());
+    ctx.body = ctx.body.pipe(
+      zlib.createGzip({ flush: zlib.constants.Z_PARTIAL_FLUSH })
+    );
   }
 });
 


### PR DESCRIPTION
Without configuring the `flush` option in `createGzip()`, the example code will buffer a lot of HTML and more or less defeat the point.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] ~~I have added tests to cover my changes.~~
