### PR TITLE
feat: allow string translator config

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -15,7 +15,6 @@
     "@babel/types": "^7.7.4",
     "@marko/babel-types": "^5.0.0-next.71",
     "@marko/babel-utils": "^5.0.0-next.71",
-    "@marko/translator-default": "^5.0.0-next.71",
     "complain": "^1.6.0",
     "enhanced-resolve": "5.0.0",
     "he": "^1.1.0",
@@ -27,6 +26,7 @@
     "strip-ansi": "^5.2.0"
   },
   "devDependencies": {
+    "@marko/translator-default": "^5.0.0-next.71",
     "marko": "^5.0.0-next.71"
   },
   "files": [

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -14,8 +14,25 @@ const SOURCE_FILES = new WeakMap();
 
 export default (api, markoOpts) => {
   api.assertVersion(7);
-  const translator = markoOpts.translator;
+  let translator = markoOpts.translator;
 
+  if (typeof translator === "string") {
+    try {
+      translator = markoModules.require(translator);
+    } catch (err) {
+      try {
+        translator = markoModules.require(`@marko/translator-${translator}`);
+      } catch {
+        try {
+          translator = markoModules.require(`marko-translator-${translator}`);
+        } catch {
+          throw err;
+        }
+      }
+    }
+  }
+
+  markoOpts.translator = translator;
   markoOpts.output = markoOpts.output || "html";
 
   if (markoOpts.optimize === undefined) {


### PR DESCRIPTION
## Description

Updates the Marko 5 compiler to no longer bring in `@marko/translator-default` as a dep. The default translator is now inferred from your installed node_modules instead.

This PR also makes it possible to pass in a string matching `@marko/translator-`, `marko-translator-` or a module name to use as the translator instead of only allowing passing the translator itself.

Eg the following are now all possible

```
compile(src, { translator: require("@marko/translator-default") });
compile(src, { translator: "@marko/translator-default" });
compile(src, { translator: "marko-translator-default" });
compile(src, { translator: "default" }); // either `@marko/translator-default`, `marko-translator-default` or a module called `default`
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
