### PR TITLE
fix(babel-utils): resolve node_module templates to relative paths

### DIFF
--- a/packages/babel-utils/src/imports.js
+++ b/packages/babel-utils/src/imports.js
@@ -2,6 +2,7 @@ import path from "path";
 import { types as t } from "@marko/babel-types";
 
 const IMPORTS_KEY = Symbol();
+const FS_ROOT_DIR = path.parse(process.cwd()).root;
 
 const toPosix =
   path.sep === "/"
@@ -17,7 +18,7 @@ const toPosix =
       };
 
 export function resolveRelativePath(file, request) {
-  if (request[0] === ".") {
+  if (!request.startsWith(FS_ROOT_DIR)) {
     return request;
   }
 


### PR DESCRIPTION
## Description

Fixes a regression in Marko 5 that was causing import paths to templates in node_modules to be incorrect.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
