### PR TITLE
fix: issue with only renderBody being serialized

### DIFF
--- a/packages/marko/src/runtime/components/ComponentDef.js
+++ b/packages/marko/src/runtime/components/ComponentDef.js
@@ -91,7 +91,7 @@ ComponentDef.prototype.nk = ComponentDef.prototype.___nextKey;
 ComponentDef.___deserialize = function(o, types, global, registry) {
   var id = o[0];
   var typeName = types[o[1]];
-  var input = o[2] || null;
+  var input = o[2] || (flags & FLAG_HAS_RENDER_BODY ? {} : null);
   var extra = o[3] || EMPTY_OBJECT;
 
   var state = extra.s;


### PR DESCRIPTION
## Description
Fixes an exception that was being thrown when trying to deserialize a components input where the input only contained the warp 10 renderBody and was assumed to be empty.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
