### PR TITLE
feat: improve analysis for stateful tag parameters

### DIFF
--- a/packages/marko/test/components-browser/fixtures/tag-params-nested-tags/index.marko
+++ b/packages/marko/test/components-browser/fixtures/tag-params-nested-tags/index.marko
@@ -1,3 +1,4 @@
+class {}
 <name key="name">
     <@first|{ name }|>
         Hello, ${name}!

--- a/packages/marko/test/components-browser/fixtures/tag-params/index.marko
+++ b/packages/marko/test/components-browser/fixtures/tag-params/index.marko
@@ -1,3 +1,5 @@
+class {}
+
 <name|{ name }| key="name">
     Hello, ${name}!
 </name>

--- a/packages/marko/test/render/fixtures/dynamic-tag-arguments/expected.html
+++ b/packages/marko/test/render/fixtures/dynamic-tag-arguments/expected.html
@@ -1,1 +1,1 @@
-<!--M#s0--><!--F#0-->testPage http://ebay.com<div style=color:green></div><!--F/--><!--M/-->
+testPage http://ebay.com<div style=color:green></div>

--- a/packages/translator-default/src/tag/native-tag[html]/index.js
+++ b/packages/translator-default/src/tag/native-tag[html]/index.js
@@ -9,7 +9,6 @@ import {
 import write from "../../util/html-out-write";
 import { hasUserKey } from "../../util/key-manager";
 import translateAttributes from "./attributes";
-import getComponentFiles from "../../util/get-component-files";
 import withPreviousLocation from "../../util/with-previous-location";
 
 const EMPTY_OBJECT = {};
@@ -30,6 +29,7 @@ export default function(path, isNullable) {
   } = node;
   const tagProperties = [];
   const tagDef = getTagDef(path);
+  const meta = file.metadata.marko;
 
   if (tagDef) {
     const { parseOptions = EMPTY_OBJECT } = tagDef;
@@ -81,17 +81,11 @@ export default function(path, isNullable) {
   }
 
   if (isHTML) {
-    const componentFiles = getComponentFiles(path);
-    const isSplit = Boolean(componentFiles.componentBrowserFile);
-    const isImplicit = Boolean(
-      !file._inlineComponentClass &&
-        !componentFiles.componentFile &&
-        !file._hasTagParams
-    );
-
-    const needsDataMarkoAttr = isSplit || isImplicit || isPreserved(path);
-
-    if (needsDataMarkoAttr) {
+    if (
+      (!meta.hasStatefulTagParams &&
+        (meta.hasComponentBrowser || !meta.hasComponent)) ||
+      isPreserved(path)
+    ) {
       const dataMarkoArgs = [t.identifier("out"), file._componentDefIdentifier];
 
       if (tagProperties.length) {

--- a/packages/translator-default/src/tag/util.js
+++ b/packages/translator-default/src/tag/util.js
@@ -2,10 +2,7 @@ import { types as t } from "@marko/babel-types";
 import { getTagDef } from "@marko/babel-utils";
 
 export function getAttrs(path, noCamel, skipRenderBody) {
-  const {
-    node,
-    hub: { file }
-  } = path;
+  const { node } = path;
   const {
     attributes,
     body: { body, params },
@@ -76,12 +73,6 @@ export function getAttrs(path, noCamel, skipRenderBody) {
     }
 
     if (!hasDynamicAttrTags || endDynamicAttrTagsIndex !== childLen - 1) {
-      if (params.length) {
-        if (!file._hasTagParams && !isIgnoredTagParams(path)) {
-          file._hasTagParams = true;
-        }
-      }
-
       properties.push(
         t.objectProperty(
           t.stringLiteral("renderBody"),
@@ -186,25 +177,6 @@ export function evaluateAttr(attr) {
 
 function camelCase(string) {
   return string.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
-}
-
-function isIgnoredTagParams(path) {
-  const tagNamePath = path.get("name");
-
-  if (!tagNamePath.isStringLiteral()) {
-    return path.node._isMacroTagCall || false;
-  }
-
-  const tagName = tagNamePath.get("value").node;
-
-  return (
-    tagName === "for" ||
-    tagName === "macro" ||
-    ((tagName === "@then" || tagName === "@catch") &&
-      path.parentPath.parentPath
-        .get("name")
-        .isStringLiteral({ value: "await" }))
-  );
 }
 
 function findLastIndex(arr, check) {

--- a/packages/translator-default/src/taglib/core/parse-class.js
+++ b/packages/translator-default/src/taglib/core/parse-class.js
@@ -2,8 +2,6 @@ import { types as t } from "@marko/babel-types";
 import { parseExpression } from "@marko/babel-utils";
 import getComponentFiles from "../../util/get-component-files";
 
-const SEEN_INLINE_CLASS = new WeakSet();
-
 export default function(path) {
   const {
     node,
@@ -13,6 +11,7 @@ export default function(path) {
     rawValue: code,
     name: { start }
   } = node;
+  const meta = file.metadata.marko;
 
   if (getComponentFiles(path).componentFile) {
     throw path
@@ -22,7 +21,7 @@ export default function(path) {
       );
   }
 
-  if (SEEN_INLINE_CLASS.has(file)) {
+  if (meta.hasComponent) {
     throw path
       .get("name")
       .buildCodeFrameError(
@@ -56,6 +55,6 @@ export default function(path) {
     );
   }
 
-  SEEN_INLINE_CLASS.add(file);
+  meta.hasComponent = true;
   path.replaceWith(t.markoClass(parsed.body));
 }

--- a/packages/translator-default/src/util/get-component-files.js
+++ b/packages/translator-default/src/util/get-component-files.js
@@ -36,8 +36,10 @@ export default function getComponentFiles({ hub: { file } }) {
       packageFile = `./${file}`;
     } else if (!componentFile && componentMatch.test(file)) {
       componentFile = `./${file}`;
+      meta.hasComponent = true;
     } else if (!componentBrowserFile && splitComponentMatch.test(file)) {
       componentBrowserFile = `./${file}`;
+      meta.hasComponentBrowser = true;
     }
   }
 

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/cjs-expected.js
@@ -37,5 +37,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _component, com
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/html-expected.js
@@ -24,5 +24,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
@@ -23,5 +23,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "item": _item
   }, out, _component, "0");
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdom-expected.js
@@ -26,6 +26,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);
 import _marko_defineComponent from "marko/src/runtime/components/defineComponent";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
@@ -25,7 +25,8 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     "item": _item
   }, out, _component, "0");
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);
 import _marko_defineComponent from "marko/dist/runtime/components/defineComponent";
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/cjs-expected.js
@@ -37,5 +37,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _component, com
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/html-expected.js
@@ -24,5 +24,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
@@ -17,5 +17,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     }
   }, out, _component, "0");
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdom-expected.js
@@ -26,6 +26,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   }, out, _component, "0");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);
 import _marko_defineComponent from "marko/src/runtime/components/defineComponent";

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
@@ -25,7 +25,8 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     }
   }, out, _component, "0");
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);
 import _marko_defineComponent from "marko/dist/runtime/components/defineComponent";
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/cjs-expected.js
@@ -53,5 +53,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _component, com
   out.w("</div>");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/html-expected.js
@@ -41,5 +41,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.w("</div>");
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
@@ -33,5 +33,6 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   out.w("</div>");
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/vdom-expected.js
@@ -43,6 +43,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.ee();
 }, {
   t: _marko_componentType,
+  i: true,
   d: true
 }, _marko_component);
 import _marko_defineComponent from "marko/src/runtime/components/defineComponent";

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
@@ -42,7 +42,8 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
 
   out.ee();
 }, {
-  t: _marko_componentType
+  t: _marko_componentType,
+  i: true
 }, _marko_component);
 import _marko_defineComponent from "marko/dist/runtime/components/defineComponent";
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);


### PR DESCRIPTION
## Description

Currently whenever tag params are used on an implicit component it forces it to become a stateful component with the exception being the built-in tags (eg `for|param|`).

This PR updates that logic to use child template analysis and our new analysis stage in order to first check to see if the tag param provider component is stateful. This means that stateless components that provide tag parameters no longer cause their parent component to become treated stateful.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
