### PR TITLE
Added fix for webpack's file system not converting buffer properly

### DIFF
--- a/packages/babel-utils/src/tags.js
+++ b/packages/babel-utils/src/tags.js
@@ -166,7 +166,7 @@ export function loadFileForTag(tag) {
 
   if (sourceFileName) {
     return file.___getMarkoFile(
-      fs.readFileSync(sourceFileName, "utf-8"),
+      fs.readFileSync(sourceFileName).toString("utf-8"),
       { ...file.opts, sourceFileName, filename: sourceFileName },
       file.markoOpts
     );

--- a/packages/translator-default/src/taglib/core/translate-include-content.js
+++ b/packages/translator-default/src/taglib/core/translate-include-content.js
@@ -43,7 +43,7 @@ export function enter(path) {
 
   path.replaceWith(
     t.markoPlaceholder(
-      t.stringLiteral(fs.readFileSync(fullPath, "utf-8")),
+      t.stringLiteral(fs.readFileSync(fullPath).toString("utf-8")),
       tagName === "include-text"
     )
   );


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

After working with @DylanPiercey to debug an issue related to Webpack/Marko, he found that `fs.readFileSync` is not the native node version, but rather Webpack's custom version. What was happening was that it would read the file as a buffer rather than a string, erroring out when Webpack would do its bundling

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes. **n/a**
