### PR TITLE
Fix: Allow attribute tags inside of else-if tags

### DIFF
--- a/packages/babel-utils/src/tags.js
+++ b/packages/babel-utils/src/tags.js
@@ -4,7 +4,14 @@ import { types as t } from "@marko/babel-types";
 import { getRootDir } from "lasso-package-root";
 import { getTagDefForTagName } from "./taglib";
 import { resolveRelativePath } from "./imports";
-const TRANSPARENT_TAGS = new Set(["for", "while", "if", "else", "_no-update"]);
+const TRANSPARENT_TAGS = new Set([
+  "for",
+  "while",
+  "if",
+  "else",
+  "else-if",
+  "_no-update"
+]);
 
 let ROOT = process.cwd();
 try {

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
@@ -38,13 +38,22 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _component, com
           out.w("foo");
         }
       });
-    } else {
+    } else if (y) {
       _items.push({
         "style": {
           color
         },
         "renderBody": out => {
           out.w("bar");
+        }
+      });
+    } else {
+      _items.push({
+        "style": {
+          color
+        },
+        "renderBody": out => {
+          out.w("baz");
         }
       });
     }

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/generated-expected.marko
@@ -8,11 +8,18 @@
           foo
         </@item>
       </if>
-      <else>
+      <else-if(y)>
         <@item style={
           color
         }>
           bar
+        </@item>
+      </else-if>
+      <else>
+        <@item style={
+          color
+        }>
+          baz
         </@item>
       </else>
     </for>

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
@@ -25,13 +25,22 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
           out.w("foo");
         }
       });
-    } else {
+    } else if (y) {
       _items.push({
         "style": {
           color
         },
         "renderBody": out => {
           out.w("bar");
+        }
+      });
+    } else {
+      _items.push({
+        "style": {
+          color
+        },
+        "renderBody": out => {
+          out.w("baz");
         }
       });
     }

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
@@ -25,13 +25,22 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
           out.w("foo");
         }
       });
-    } else {
+    } else if (y) {
       _items.push({
         "style": {
           color
         },
         "renderBody": out => {
           out.w("bar");
+        }
+      });
+    } else {
+      _items.push({
+        "style": {
+          color
+        },
+        "renderBody": out => {
+          out.w("baz");
         }
       });
     }

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
@@ -27,13 +27,22 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
           out.t("foo", component);
         }
       });
-    } else {
+    } else if (y) {
       _items.push({
         "style": {
           color
         },
         "renderBody": out => {
           out.t("bar", component);
+        }
+      });
+    } else {
+      _items.push({
+        "style": {
+          color
+        },
+        "renderBody": out => {
+          out.t("baz", component);
         }
       });
     }

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
@@ -27,13 +27,22 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
           out.t("foo", component);
         }
       });
-    } else {
+    } else if (y) {
       _items.push({
         "style": {
           color
         },
         "renderBody": out => {
           out.t("bar", component);
+        }
+      });
+    } else {
+      _items.push({
+        "style": {
+          color
+        },
+        "renderBody": out => {
+          out.t("baz", component);
         }
       });
     }

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/template.marko
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/template.marko
@@ -4,8 +4,11 @@
             <if(x)>
                 <@item style={ color }>foo</@item>
             </if>
-            <else>
+            <else-if(y)>
                 <@item style={ color }>bar</@item>
+            </else-if>
+            <else>
+                <@item style={ color }>baz</@item>
             </else>
         </for>
 

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
@@ -144,11 +144,11 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.ee();
   out.e("div", {
     "b": "1"
-  }, "24", component, 0, 0);
-  out.be("div", null, "25", component, null, 0);
+  }, "23", component, 0, 0);
+  out.be("div", null, "24", component, null, 0);
   out.t("123 abc 123", component);
   out.ee();
-  out.e("span", _marko_attrs(abc), "26", component, 0, 4);
+  out.e("span", _marko_attrs(abc), "25", component, 0, 4);
 
   if (cond) {
     out.t("Hello ", component);
@@ -160,7 +160,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const _keyScope = `[${i}]`;
     out.e("div", {
       "c": "1"
-    }, "27" + _keyScope, component, 0, 0);
+    }, "26" + _keyScope, component, 0, 0);
   }
 
   for (const key in obj) {
@@ -168,7 +168,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const _keyScope2 = `[${key}]`;
     out.e("div", {
       "c": "1"
-    }, "28" + _keyScope2, component, 0, 0);
+    }, "27" + _keyScope2, component, 0, 0);
   }
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
@@ -43,9 +43,9 @@ import _marko_attrs from "marko/dist/runtime/vdom/helpers/attrs";
 
 const _marko_node9 = _marko_createElement("div", {
   "b": "1"
-}, "24", null, 0, 0);
+}, "23", null, 0, 0);
 
-const _marko_node10 = _marko_createElement("div", null, "25", null, 1, 0).t("123 abc 123");
+const _marko_node10 = _marko_createElement("div", null, "24", null, 1, 0).t("123 abc 123");
 
 import _marko_renderer from "marko/dist/runtime/components/renderer";
 import { t as _t } from "marko/dist/runtime/vdom";
@@ -171,7 +171,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
   out.ee();
   out.n(_marko_node9, component);
   out.n(_marko_node10, component);
-  out.e("span", _marko_attrs(abc), "26", component, 0, 4);
+  out.e("span", _marko_attrs(abc), "25", component, 0, 4);
 
   if (cond) {
     out.t("Hello ", component);
@@ -183,7 +183,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const _keyScope = `[${i}]`;
     out.e("div", {
       "c": "1"
-    }, "27" + _keyScope, component, 0, 0);
+    }, "26" + _keyScope, component, 0, 0);
   }
 
   for (const key in obj) {
@@ -191,7 +191,7 @@ _marko_template._ = _marko_renderer(function (input, out, _component, component,
     const _keyScope2 = `[${key}]`;
     out.e("div", {
       "c": "1"
-    }, "28" + _keyScope2, component, 0, 0);
+    }, "27" + _keyScope2, component, 0, 0);
   }
 }, {
   t: _marko_componentType


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Fixes a bug where you aren't able to use attribute tags inside of an `<else-if>` tag.

Adds else-if to TRANSPARENT_TAGS Set in @marko/babel-utils

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
