### PR TITLE
fix(marko): simplify client-reorder runtime loading login to inline code

### DIFF
--- a/packages/marko/src/core-tags/core/await/client-reorder-runtime.min.js
+++ b/packages/marko/src/core-tags/core/await/client-reorder-runtime.min.js
@@ -1,1 +1,0 @@
-function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b<f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b<f;b++)c(a[b])}}

--- a/packages/marko/src/core-tags/core/await/client-reorder.js
+++ b/packages/marko/src/core-tags/core/await/client-reorder.js
@@ -1,14 +1,6 @@
-var code;
-var fs = require("fs");
-
 exports.isSupported = true;
 
 exports.getCode = function() {
-  if (!code) {
-    code = fs.readFileSync(
-      require.resolve("./client-reorder-runtime.min.js"),
-      "utf8"
-    );
-  }
-  return code;
+  // Minified version of ./client-reorder-runtime.js
+  return `function $af(d,a,e,l,g,h,k,b,f,c){c=$af;if(a&&!c[a])(c[a+="$"]||(c[a]=[])).push(d);else{e=document;l=e.getElementById("af"+d);g=e.getElementById("afph"+d);h=e.createDocumentFragment();k=l.childNodes;b=0;for(f=k.length;b<f;b++)h.appendChild(k.item(0));g&&g.parentNode.replaceChild(h,g);c[d]=1;if(a=c[d+"$"])for(b=0,f=a.length;b<f;b++)c(a[b])}}`;
 };


### PR DESCRIPTION
## Description
This PR simplifies the loading of the `client-reorder-runtime` code.
Instead of having the minified code in a separate file it is now just inlined.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
