### PR TITLE
fix(marko): issue with delegating events from text nodes

### DIFF
--- a/packages/marko/src/runtime/components/event-delegation.js
+++ b/packages/marko/src/runtime/components/event-delegation.js
@@ -3,6 +3,8 @@ var runtimeId = componentsUtil.___runtimeId;
 var componentLookup = componentsUtil.___componentLookup;
 var getMarkoPropsFromEl = componentsUtil.___getMarkoPropsFromEl;
 
+var TEXT_NODE = 3;
+
 // We make our best effort to allow multiple marko runtimes to be loaded in the
 // same window. Each marko runtime will get its own unique runtime ID.
 var listenersAttachedKey = "$MDE" + runtimeId;
@@ -92,10 +94,14 @@ function addDelegatedEventHandlerToDoc(eventType, doc) {
           return;
         }
 
-        // event.target of an SVGElementInstance does not have a
-        // `getAttribute` function in IE 11.
-        // See https://github.com/marko-js/marko/issues/796
-        curNode = curNode.correspondingUseElement || curNode;
+        curNode =
+          // event.target of an SVGElementInstance does not have a
+          // `getAttribute` function in IE 11.
+          // See https://github.com/marko-js/marko/issues/796
+          curNode.correspondingUseElement ||
+          // in some browsers the event target can be a text node
+          // one example being dragenter in firefox.
+          (curNode.nodeType === TEXT_NODE ? curNode.parentNode : curNode);
 
         // Search up the tree looking DOM events mapped to target
         // component methods


### PR DESCRIPTION
## Description
In some browsers the event target can be a text node, for example, `dragenter` in firefox can do this.
When that happens, currently our event delegation breaks down since it expects a regular element node.

This PR adds a check for text nodes during event delegation and uses the parent element to check for event handlers.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
