### PR TITLE
fix(compiler): use provided FS for taglib building

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -19,7 +19,6 @@
     "he": "^1.2.0",
     "htmljs-parser": "^2.9.1",
     "jsesc": "^3.0.2",
-    "lasso-caching-fs": "^1.0.2",
     "lasso-package-root": "^1.0.1",
     "property-handlers": "^1.1.1",
     "raptor-regexp": "^1.0.1",

--- a/packages/compiler/src/config.js
+++ b/packages/compiler/src/config.js
@@ -141,3 +141,6 @@ if (globalThis[MARKO_CONFIG_KEY]) {
 }
 
 export default config;
+
+import { setFS } from "./taglib/fs";
+setFS(config.fileSystem);

--- a/packages/compiler/src/taglib/finder/index.js
+++ b/packages/compiler/src/taglib/finder/index.js
@@ -1,7 +1,7 @@
 "use strict";
 var nodePath = require("path");
-var lassoCachingFS = require("lasso-caching-fs");
 var resolveFrom = require("resolve-from").silent;
+var taglibFS = require("../fs");
 var taglibLoader = require("../loader");
 var lassoPackageRoot = require("lasso-package-root");
 var scanTagsDir = require("../loader/scanTagsDir");
@@ -93,7 +93,7 @@ function find(dirname, registeredTaglibs) {
       let taglibPath = nodePath.join(curDirname, "marko.json");
       let taglib;
 
-      if (lassoCachingFS.existsSync(taglibPath)) {
+      if (existsSync(taglibPath)) {
         taglib = taglibLoader.loadTaglibFromFile(taglibPath);
         helper.addTaglib(taglib);
       }
@@ -102,7 +102,7 @@ function find(dirname, registeredTaglibs) {
         let componentsPath = nodePath.join(curDirname, "components");
 
         if (
-          lassoCachingFS.existsSync(componentsPath) &&
+          existsSync(componentsPath) &&
           !excludedDirs[componentsPath] &&
           !helper.alreadyAdded(componentsPath)
         ) {
@@ -154,7 +154,6 @@ function find(dirname, registeredTaglibs) {
 }
 
 function clearCache() {
-  lassoCachingFS.clearCaches();
   findCache = {};
 }
 
@@ -164,6 +163,15 @@ function excludeDir(dir) {
 
 function excludePackage(name) {
   excludedPackages[name] = true;
+}
+
+function existsSync(file) {
+  try {
+    taglibFS.curFS.statSync(file);
+    return true;
+  } catch (_) {
+    return false;
+  }
 }
 
 exports.reset = reset;

--- a/packages/compiler/src/taglib/fs.js
+++ b/packages/compiler/src/taglib/fs.js
@@ -1,0 +1,4 @@
+export let curFS;
+export function setFS(fs) {
+  curFS = fs;
+}

--- a/packages/compiler/src/taglib/loader/json-file-reader.js
+++ b/packages/compiler/src/taglib/loader/json-file-reader.js
@@ -1,9 +1,9 @@
-var fs = require("fs");
+var taglibFS = require("../fs");
 var stripJsonComments = require("strip-json-comments");
 var fsReadOptions = { encoding: "utf8" };
 
 exports.readFileSync = function (path) {
-  var json = fs.readFileSync(path, fsReadOptions);
+  var json = taglibFS.curFS.readFileSync(path, fsReadOptions);
 
   try {
     var taglibProps = JSON.parse(stripJsonComments(json));

--- a/packages/compiler/src/taglib/loader/loadTagFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTagFromProps.js
@@ -2,12 +2,12 @@
 
 var ok = require("assert").ok;
 var resolveFrom = require("resolve-from").silent;
-var lassoCachingFS = require("lasso-caching-fs");
 var propertyHandlers = require("property-handlers");
 var isObjectEmpty = require("raptor-util/isObjectEmpty");
 var nodePath = require("path");
 var forEachEntry = require("raptor-util/forEachEntry");
 var createError = require("raptor-util/createError");
+var taglibFS = require("../fs");
 var types = require("./types");
 var loaders = require("./loaders");
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -344,10 +344,13 @@ class TagLoader {
     var dirname = this.dirname;
 
     var path = nodePath.resolve(dirname, value);
-    if (!lassoCachingFS.existsSync(path)) {
+
+    try {
+      taglibFS.curFS.statSync(path);
+      tag.template = path;
+    } catch (_) {
       throw new Error('Template at path "' + path + '" does not exist.');
     }
-    tag.template = path;
   }
 
   /**

--- a/packages/compiler/src/taglib/loader/loadTaglibFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTaglibFromProps.js
@@ -2,9 +2,9 @@
 
 var ok = require("assert").ok;
 var resolveFrom = require("resolve-from").silent;
-var lassoCachingFS = require("lasso-caching-fs");
-var types = require("./types");
 var nodePath = require("path");
+var types = require("./types");
+var taglibFS = require("../fs");
 var scanTagsDir = require("./scanTagsDir");
 var propertyHandlers = require("property-handlers");
 var jsonFileReader = require("./json-file-reader");
@@ -106,7 +106,9 @@ class TaglibLoader {
     if (typeof value === "string") {
       tagFilePath = nodePath.resolve(this.dirname, value);
 
-      if (!lassoCachingFS.existsSync(tagFilePath)) {
+      try {
+        taglibFS.curFS.statSync(tagFilePath);
+      } catch (_) {
         throw new Error(
           'Tag at path "' +
             tagFilePath +

--- a/packages/marko/src/node-require/index.js
+++ b/packages/marko/src/node-require/index.js
@@ -2,8 +2,6 @@
 
 const path = require("path");
 const resolveFrom = require("resolve-from");
-const fs = require("fs");
-const fsReadOptions = { encoding: "utf8" };
 const requiredCompilerOptions = { modules: "cjs" };
 const defaultCompilerOptions = {
   // eslint-disable-next-line no-constant-condition
@@ -20,9 +18,7 @@ function normalizeExtension(extension) {
 }
 
 function compile(templatePath, markoCompiler, userCompilerOptions) {
-  var templateSrc = fs.readFileSync(templatePath, fsReadOptions);
-  return markoCompiler.compileSync(
-    templateSrc,
+  return markoCompiler.compileFileSync(
     templatePath,
     Object.assign(
       {},


### PR DESCRIPTION
## Description
Changes all taglib apis to move away from `lasso-caching-fs` to instead use the `options.fileSystem`passed to the compiler.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
