### PR TITLE
fix(marko): issue with async hydrate after final flush

### DIFF
--- a/packages/marko/src/runtime/components/init-components-browser.js
+++ b/packages/marko/src/runtime/components/init-components-browser.js
@@ -265,10 +265,28 @@ function initServerRendered(renderedComponents, doc) {
 
     renderedComponents = win[globalKey];
 
+    // eslint-disable-next-line no-constant-condition
+    if ("MARKO_DEBUG") {
+      if (
+        renderedComponents &&
+        renderedComponents.i !== undefined &&
+        renderedComponents.i !== componentsUtil.___runtimeId
+      ) {
+        console.warn(
+          "Multiple instances of Marko have attached to the same runtime id. This could mean that more than one copy of Marko is loaded on the page, or that the script containing Marko has executed more than once."
+        );
+      }
+    }
+
     var fakeArray = (win[globalKey] = {
       r: runtimeId,
       concat: initServerRendered
     });
+
+    // eslint-disable-next-line no-constant-condition
+    if ("MARKO_DEBUG") {
+      fakeArray.i = componentsUtil.___runtimeId;
+    }
 
     if (renderedComponents && renderedComponents.forEach) {
       renderedComponents.forEach(function (renderedComponent) {
@@ -345,7 +363,13 @@ function initServerRendered(renderedComponents, doc) {
 
       return registry.___isRegistered(typeName)
         ? tryHydrateComponent(componentDef, meta, doc, runtimeId)
-        : registry.___addPendingDef(componentDef, typeName, doc, runtimeId);
+        : registry.___addPendingDef(
+            componentDef,
+            typeName,
+            meta,
+            doc,
+            runtimeId
+          );
     })
     .reverse()
     .forEach(tryInvoke);

--- a/packages/marko/src/runtime/components/registry-browser.js
+++ b/packages/marko/src/runtime/components/registry-browser.js
@@ -24,9 +24,9 @@ function register(type, def) {
       pendingForType.forEach(function (args) {
         initComponents.___tryHydrateComponent(
           args[0],
-          type,
           args[1],
-          args[2]
+          args[2],
+          args[3]
         )();
       });
     });
@@ -35,7 +35,7 @@ function register(type, def) {
   return type;
 }
 
-function addPendingDef(def, type, doc, runtimeId) {
+function addPendingDef(def, type, meta, doc, runtimeId) {
   if (!pendingDefs) {
     pendingDefs = {};
 
@@ -51,7 +51,12 @@ function addPendingDef(def, type, doc, runtimeId) {
       });
     }
   }
-  (pendingDefs[type] = pendingDefs[type] || []).push([def, doc, runtimeId]);
+  (pendingDefs[type] = pendingDefs[type] || []).push([
+    def,
+    meta,
+    doc,
+    runtimeId
+  ]);
 }
 
 function isRegistered(type) {


### PR DESCRIPTION
## Description
Fixes an issue where if a component is hydrated async after the final flush from the server the metadata needed to initialize the component could be gone.

This PR also adds a more helpful warning when it is detected multiple copies of Marko are initializing without unique runtimeId's.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
