### PR TITLE
fix: cast result of readFile to string

### DIFF
--- a/packages/compiler/src/taglib/loader/json-file-reader.js
+++ b/packages/compiler/src/taglib/loader/json-file-reader.js
@@ -2,7 +2,7 @@ var taglibFS = require("../fs");
 var stripJsonComments = require("strip-json-comments");
 var fsReadOptions = { encoding: "utf8" };
 
-exports.readFileSync = function(path) {
+exports.readFileSync = function (path) {
   var json = String(taglibFS.curFS.readFileSync(path, fsReadOptions));
 
   try {

--- a/packages/compiler/src/taglib/loader/json-file-reader.js
+++ b/packages/compiler/src/taglib/loader/json-file-reader.js
@@ -2,8 +2,8 @@ var taglibFS = require("../fs");
 var stripJsonComments = require("strip-json-comments");
 var fsReadOptions = { encoding: "utf8" };
 
-exports.readFileSync = function (path) {
-  var json = taglibFS.curFS.readFileSync(path, fsReadOptions);
+exports.readFileSync = function(path) {
+  var json = String(taglibFS.curFS.readFileSync(path, fsReadOptions));
 
   try {
     var taglibProps = JSON.parse(stripJsonComments(json));

--- a/packages/compiler/src/taglib/loader/scanTagsDir.js
+++ b/packages/compiler/src/taglib/loader/scanTagsDir.js
@@ -182,9 +182,11 @@ module.exports = function scanTagsDir(
       }
 
       if (!hasTagJson && (tagDef.renderer || tagDef.template)) {
-        let templateCode = taglibFS.curFS.readFileSync(
-          tagDef.renderer || tagDef.template,
-          fsReadOptions
+        let templateCode = String(
+          taglibFS.curFS.readFileSync(
+            tagDef.renderer || tagDef.template,
+            fsReadOptions
+          )
         );
         let extractedTagDef = tagDefFromCode.extractTagDef(templateCode);
         if (extractedTagDef) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

We call `.readFileSync` and pass `{ encoding:"utf-8" }` but a custom filesystem may not honor that (webpack, looking at you).  So this adds an additional cast to string.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
