### PR TITLE
feat(compiler): use default translator for buildLookup api

### DIFF
--- a/packages/compiler/src/taglib/index.js
+++ b/packages/compiler/src/taglib/index.js
@@ -1,6 +1,7 @@
 import loader from "./loader";
 import finder from "./finder";
 import Lookup from "./lookup";
+import tryLoadTranslator from "../util/try-load-translator";
 
 export const excludeDir = finder.excludeDir;
 export const excludePackage = finder.excludePackage;
@@ -13,7 +14,8 @@ register(require.resolve("./marko-html.json"), require("./marko-html.json"));
 register(require.resolve("./marko-svg.json"), require("./marko-svg.json"));
 register(require.resolve("./marko-math.json"), require("./marko-math.json"));
 
-export function buildLookup(dirname, translator) {
+export function buildLookup(dirname, requestedTranslator) {
+  const translator = tryLoadTranslator(requestedTranslator);
   if (!translator || !Array.isArray(translator.taglibs)) {
     throw new Error(
       "@marko/compiler: Invalid translator provided to buildLookup(dir, translator)"


### PR DESCRIPTION
## Description
Makes it easier to use `compiler.taglib.buildLookup` by making the `translator` argument use the default translator when not provided.

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
