### PR TITLE
feat: expose api to get runtime entry files for translator

### DIFF
--- a/packages/compiler/index.d.ts
+++ b/packages/compiler/index.d.ts
@@ -82,6 +82,8 @@ export function compileFileSync(
   config?: Config
 ): CompileResult;
 
+export function getRuntimeEntryFiles(output: string, translator?: string | undefined): string[];
+
 export namespace taglib {
   export function excludeDir(dirname: string): void;
   export function excludePackage(packageName: string): void;

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -3,6 +3,8 @@ import * as babel from "@babel/core";
 import corePlugin from "./babel-plugin";
 import defaultConfig from "./config";
 import * as taglib from "./taglib";
+import shouldOptimize from "./util/should-optimize";
+import tryLoadTranslator from "./util/try-load-translator";
 export { taglib };
 
 let globalConfig = { ...defaultConfig };
@@ -39,6 +41,15 @@ export async function compileFile(filename, config) {
 export function compileFileSync(filename, config) {
   const src = getFs(config).readFileSync(filename, "utf-8");
   return compileSync(src, filename, config);
+}
+
+export function getRuntimeEntryFiles(output, requestedTranslator) {
+  const translator = tryLoadTranslator(requestedTranslator);
+  if (translator && translator.getRuntimeEntryFiles) {
+    return translator.getRuntimeEntryFiles(output, shouldOptimize());
+  }
+
+  return [];
 }
 
 function loadBabelConfig(filename, config) {

--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -430,6 +430,55 @@ export const translate = {
   }
 };
 
+export function getRuntimeEntryFiles(output, optimize) {
+  const base = `marko/${optimize ? "dist" : "src"}/`;
+
+  return [
+    `${base}runtime/components`,
+    `${base}runtime/components/defineComponent`,
+    `${base}runtime/components/renderer`,
+    `${base}runtime/components/registry`,
+    `${base}runtime/components/attach-detach`,
+    `${base}runtime/helpers/assign`,
+    `${base}runtime/helpers/class-value`,
+    `${base}runtime/helpers/dynamic-tag`,
+    `${base}runtime/helpers/load-nested-tag`,
+    `${base}runtime/helpers/merge`,
+    `${base}runtime/helpers/render-tag`,
+    `${base}runtime/helpers/style-value`,
+    `${base}runtime/helpers/to-string`,
+    `${base}core-tags/components/preserve-tag`,
+    `${base}core-tags/components/init-components-tag`,
+    `${base}core-tags/components/preferred-script-location-tag`,
+    `${base}core-tags/core/__flush_here_and_after__`,
+    `${base}core-tags/core/await/renderer`,
+    `${base}core-tags/core/await/reorderer-renderer`,
+    ...(output === "html"
+      ? [
+          `${base}runtime/html`,
+          `${base}runtime/html/helpers/attr`,
+          `${base}runtime/html/helpers/attrs`,
+          `${base}runtime/html/helpers/class-attr`,
+          `${base}runtime/html/helpers/data-marko`,
+          `${base}runtime/html/helpers/escape-quotes`,
+          `${base}runtime/html/helpers/escape-script-placeholder`,
+          `${base}runtime/html/helpers/escape-style-placeholder`,
+          `${base}runtime/html/helpers/escape-xml`,
+          `${base}runtime/html/helpers/merge-attrs`,
+          `${base}runtime/html/helpers/props-script`,
+          `${base}runtime/html/helpers/style-attr`
+        ]
+      : [
+          `${base}runtime/vdom`,
+          `${base}runtime/vdom/helpers/attrs`,
+          `${base}runtime/vdom/helpers/const`,
+          `${base}runtime/vdom/helpers/v-element`,
+          `${base}runtime/vdom/helpers/v-text`,
+          `${base}runtime/vdom/preserve-attrs`
+        ])
+  ];
+}
+
 function isRenderContent(path) {
   const { node } = path;
   return t.MARKO_TYPES.includes(node.type) && !node.static;


### PR DESCRIPTION
## Description

This exposes an api from the compiler (`getRuntimeEntryFiles(output, translator)`) which returns a list of runtime entry files that can be loaded from that translator. This is useful for bundlers like `Vite` which perform optimizations on these assets during dev server startup.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
