### PR TITLE
docs: update match-media install path on npm

### DIFF
--- a/packages/marko/docs/custom-tags.md
+++ b/packages/marko/docs/custom-tags.md
@@ -143,7 +143,7 @@ This allows you to create components that have other files associated with them 
 To use [tags from npm](https://www.npmjs.com/search?q=keywords%3Amarko%20components), ensure that the package is installed and listed in your `package.json` dependencies:
 
 ```
-npm install --save @marko/match-media
+npm install --save @marko-tags/match-media
 ```
 
 Marko discover tags from packages defined in your `package.json`, so you can start using them right away:


### PR DESCRIPTION
At the moment, `<match-media>` custom tag could be installed as follows:
`npm install --save @marko-tags/match-media`

## Description
Update installation directions for `<match-media>` custom tag package

## Checklist:
- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
