### PR TITLE
fix(marko): issue with dynamic tag name string and no renderbody

### DIFF
--- a/packages/marko/src/runtime/html/AsyncStream.js
+++ b/packages/marko/src/runtime/html/AsyncStream.js
@@ -519,9 +519,9 @@ var proto = (AsyncStream.prototype = {
     if (selfClosingTags.voidElements.indexOf(tagName) !== -1) {
       str += ">";
     } else if (selfClosingTags.svgElements.indexOf(tagName) !== -1) {
-      str += " />";
+      str += "/>";
     } else {
-      str += "</" + tagName + ">";
+      str += "></" + tagName + ">";
     }
 
     this.write(str);

--- a/packages/marko/test/render/fixtures/dynamic-tag-name/expected.html
+++ b/packages/marko/test/render/fixtures/dynamic-tag-name/expected.html
@@ -1,1 +1,1 @@
-<foo class="my-class" foo="bar">My nested content</foo>
+<foo class=my-class foo=bar>My nested content</foo><world class=my-class foo=bar></world>

--- a/packages/marko/test/render/fixtures/dynamic-tag-name/template.marko
+++ b/packages/marko/test/render/fixtures/dynamic-tag-name/template.marko
@@ -1,3 +1,5 @@
 <${input.foo ? 'foo' : 'bar'} class="my-class" foo="bar">
     My nested content
 </>
+
+<${input.myTagName} class="my-class" foo="bar"/>

--- a/packages/marko/test/render/fixtures/dynamic-tag-name/vdom-expected.html
+++ b/packages/marko/test/render/fixtures/dynamic-tag-name/vdom-expected.html
@@ -1,2 +1,3 @@
 <FOO class="my-class" foo="bar">
   "My nested content"
+<WORLD class="my-class" foo="bar">


### PR DESCRIPTION
## Description
This PR fixes a regression from https://github.com/marko-js/marko/commit/47a98341a2bdb4ae136495c5e3976dfe7c24a77c which impacts Marko >= `v5.0.0-next.39` (`v4` not impacted). 

Specifically when a non statically analyzable dynamic tag receives a string, and no renderBody content, it was not outputting the open tag correctly.

```marko
<!-- Broken! -->
<${dynamic}/>

<!-- Works fine -->
<${input.foo ? "a" : "div"}/>

<!-- Works fine -->
<${dynamic}>
  Nested content
</>
```

If the dynamic element was a void tag then it was also no effected.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
