### PR TITLE
Improve taglib hooks, support tag var hoisting.

### DIFF
--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -48,7 +48,7 @@ export default (api, markoOpts) => {
       setFS(markoOpts.fileSystem);
       try {
         const file = getMarkoFile(code, jsParseOptions, markoOpts);
-        const finalAst = t.cloneDeep(file.ast);
+        const finalAst = t.cloneNode(file.ast, true);
         SOURCE_FILES.set(finalAst, file);
         return finalAst;
       } finally {
@@ -65,16 +65,27 @@ export default (api, markoOpts) => {
 
         const { ast, metadata } = file;
         const sourceFile = SOURCE_FILES.get(ast);
-        metadata.marko = shallowClone(sourceFile.metadata.marko);
-
+        const taglibLookup = sourceFile.___taglibLookup;
+        const rootTranslators = [];
         const { buildCodeFrameError } = file;
         const { buildError } = file.hub;
+        metadata.marko = shallowClone(sourceFile.metadata.marko);
         file.buildCodeFrameError = MarkoFile.prototype.buildCodeFrameError;
         file.hub.buildError = file.buildCodeFrameError.bind(file);
         file.markoOpts = markoOpts;
-        file.___taglibLookup = sourceFile.___taglibLookup;
+        file.___taglibLookup = taglibLookup;
         file.___getMarkoFile = getMarkoFile;
-        traverseAll(file, translator.translate);
+
+        for (const id in taglibLookup.taglibsById) {
+          addPlugin(
+            metadata.marko,
+            rootTranslators,
+            taglibLookup.taglibsById[id].translator
+          );
+        }
+
+        rootTranslators.push(translator.translate);
+        traverseAll(file, rootTranslators);
         file.buildCodeFrameError = buildCodeFrameError;
         file.hub.buildError = buildError;
         file.markoOpts = file.___taglibLookup = file.___getMarkoFile = undefined;
@@ -153,9 +164,6 @@ export function getMarkoFile(code, jsParseOptions, markoOpts) {
     watchFiles: []
   });
 
-  const rootMigrators = [migrate];
-  const rootTransformers = [transform];
-
   file.markoOpts = markoOpts;
   file.___taglibLookup = taglibLookup;
   file.___getMarkoFile = getMarkoFile;
@@ -175,32 +183,28 @@ export function getMarkoFile(code, jsParseOptions, markoOpts) {
 
   file.path.scope.crawl(); // Initialize bindings.
 
+  const rootMigrators = [];
   for (const id in taglibLookup.taglibsById) {
-    const { migrators } = taglibLookup.taglibsById[id];
-    for (const migrator of migrators) {
-      if (migrator.path) {
-        meta.watchFiles.push(migrator.path);
-      }
-      rootMigrators.push(migrator.hook.default || migrator.hook);
+    for (const migrator of taglibLookup.taglibsById[id].migrators) {
+      addPlugin(meta, rootMigrators, migrator);
     }
   }
 
+  rootMigrators.push(migrate);
   traverseAll(file, rootMigrators);
 
   if (isMigrate) {
     return file;
   }
 
+  const rootTransformers = [];
   for (const id in taglibLookup.taglibsById) {
-    const { transformers } = taglibLookup.taglibsById[id];
-    for (const transformer of transformers) {
-      if (transformer.path) {
-        meta.watchFiles.push(transformer.path);
-      }
-      rootTransformers.push(transformer.hook.default || transformer.hook);
+    for (const transformer of taglibLookup.taglibsById[id].transformers) {
+      addPlugin(meta, rootTransformers, transformer);
     }
   }
 
+  rootTransformers.push(transform);
   traverseAll(file, rootTransformers);
 
   for (const taglibId in taglibLookup.taglibsById) {
@@ -288,6 +292,22 @@ function traverseAll(file, visitors) {
 
     if (Program && Program.exit) {
       program._call(Program.exit);
+    }
+  }
+}
+
+function addPlugin(meta, arr, plugin) {
+  if (plugin) {
+    const hook = plugin.hook.default || plugin.hook;
+
+    if (plugin.path) {
+      meta.watchFiles.push(plugin.path);
+    }
+
+    if (Array.isArray(hook)) {
+      arr.push(...hook);
+    } else {
+      arr.push(hook);
     }
   }
 }

--- a/packages/compiler/src/babel-plugin/plugins/migrate.js
+++ b/packages/compiler/src/babel-plugin/plugins/migrate.js
@@ -45,7 +45,7 @@ function getMigratorsForTag(path) {
           if (migrator.path) {
             watchFiles.push(migrator.path);
           }
-          migrators.push(migrator.hook);
+          migrators.push(migrator.hook.default || migrator.hook);
         }
       }
     };

--- a/packages/compiler/src/babel-plugin/plugins/transform.js
+++ b/packages/compiler/src/babel-plugin/plugins/transform.js
@@ -47,7 +47,7 @@ function getTransformersForTag(path) {
           if (transformer.path) {
             watchFiles.push(transformer.path);
           }
-          transformers.push(transformer.hook);
+          transformers.push(transformer.hook.default || transformer.hook);
         }
       }
     };

--- a/packages/compiler/src/babel-types/traverse/patch.js
+++ b/packages/compiler/src/babel-types/traverse/patch.js
@@ -31,30 +31,96 @@ MARKO_ALIAS_TYPES.forEach(aliasName => {
 // Adds a one time patch to the scope collector visitors to include
 // Marko bindings for params and tag vars.
 const originalCrawl = Scope.prototype.crawl;
+const patchedVisitors = new WeakSet();
+
 Scope.prototype.crawl = function () {
   const path = this.path;
   const originalTraverse = path.traverse;
-  path.traverse = function (visitor) {
-    Object.assign(
-      traverse.explode(visitor),
-      traverse.explode({
-        MarkoTagBody(body) {
-          for (const param of body.get("params")) {
-            body.scope.registerBinding("param", param);
+  path.traverse = function (visitor, state) {
+    path.traverse = originalTraverse;
+
+    if (!patchedVisitors.has(visitor)) {
+      patchedVisitors.add(visitor);
+      Object.assign(
+        traverse.explode(visitor),
+        traverse.explode({
+          MarkoTagBody(body) {
+            for (const param of body.get("params")) {
+              body.scope.registerBinding("param", param);
+            }
+          },
+          MarkoTag(tag) {
+            const tagVar = tag.get("var");
+            if (tagVar.node) {
+              tag.scope.registerBinding("local", tagVar, tag);
+              for (const name in tagVar.getBindingIdentifiers()) {
+                let curScope = tag.scope;
+                const binding = curScope.getBinding(name);
+
+                while ((curScope = curScope.parent)) {
+                  curScope.hoistableTagVars =
+                    curScope.hoistableTagVars ||
+                    (curScope.hoistableTagVars = {});
+                  const existingBinding = curScope.hoistableTagVars[name];
+
+                  if (existingBinding) {
+                    if (existingBinding !== binding) {
+                      curScope.hoistableTagVars[name] = true;
+                    }
+                  } else {
+                    curScope.hoistableTagVars[name] = binding;
+                  }
+                }
+              }
+            }
           }
-        },
-        MarkoTag(tag) {
-          if (tag.has("var")) {
-            tag.scope.registerBinding("local", tag.get("var"), tag);
+        })
+      );
+    }
+
+    this.traverse(visitor, state);
+
+    if (state.references.length) {
+      const movedBindings = new Map();
+      for (const ref of state.references) {
+        const { name } = ref.node;
+        let curScope = ref.scope;
+        if (curScope.hasBinding(name)) continue;
+
+        while ((curScope = curScope.parent)) {
+          const hoistableBinding =
+            curScope.hoistableTagVars && curScope.hoistableTagVars[name];
+          if (hoistableBinding) {
+            if (hoistableBinding === true) {
+              throw ref.buildCodeFrameError(
+                "Ambiguous reference, variable was defined in multiple places and was not shadowed."
+              );
+            }
+
+            const movedBinding = movedBindings.get(hoistableBinding);
+            if (
+              !movedBinding ||
+              getScopeDepth(movedBinding.scope) < getScopeDepth(curScope)
+            ) {
+              movedBindings.set(hoistableBinding, curScope);
+            }
           }
         }
-      })
-    );
+      }
 
-    path.traverse = originalTraverse;
-    return originalTraverse.apply(this, arguments);
+      for (const [binding, scope] of movedBindings) {
+        binding.scope.moveBindingTo(binding.identifier.name, scope);
+      }
+    }
   };
 
-  Scope.prototype.crawl = originalCrawl;
-  originalCrawl.apply(this, arguments);
+  originalCrawl.call(this);
+  path.traverse = originalTraverse;
 };
+
+function getScopeDepth(scope) {
+  let depth = 0;
+  let cur = scope;
+  while ((cur = cur.parent)) depth++;
+  return depth;
+}

--- a/packages/compiler/src/taglib/loader/loadTaglibFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTaglibFromProps.js
@@ -313,6 +313,13 @@ class TaglibLoader {
   }
 
   /**
+   * Exposes a babel visitor to perform additional translations on the entire ast.
+   */
+  translate(value) {
+    this.tag.translator = normalizeHook(this.dirname, value);
+  }
+
+  /**
    * Allows an ID to be explicitly assigned to a taglib.
    * The taglib ID is used to prevent the same taglib  (even if different versions)
    * from being loaded multiple times.


### PR DESCRIPTION
## Description
This PR contains two commits that are prerequisites for the upcoming [tags api preview](https://github.com/marko-js/marko/issues/1704).

1. It adds support for a taglib level `translate` hook. It also now supports exporting arrays from taglib compiler hooks which will automatically merge the visitors.
2. Supports hoisting tag variable bindings.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
