### PR TITLE
fix: issue with tag var scope hoisting

### DIFF
--- a/packages/compiler/src/babel-types/traverse/patch.js
+++ b/packages/compiler/src/babel-types/traverse/patch.js
@@ -87,7 +87,7 @@ Scope.prototype.crawl = function () {
         let curScope = ref.scope;
         if (curScope.hasBinding(name)) continue;
 
-        while ((curScope = curScope.parent)) {
+        do {
           const hoistableBinding =
             curScope.hoistableTagVars && curScope.hoistableTagVars[name];
           if (hoistableBinding) {
@@ -105,7 +105,7 @@ Scope.prototype.crawl = function () {
               movedBindings.set(hoistableBinding, curScope);
             }
           }
-        }
+        } while ((curScope = curScope.parent));
       }
 
       for (const [binding, scope] of movedBindings) {

--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -216,6 +216,7 @@ export const translate = {
         });
 
       file._renderBlock = renderBlock;
+      path.scope.crawl();
     },
     exit(path) {
       const {


### PR DESCRIPTION
## Description
Currently the tag var scope hoisting logic doesn't account for the current scope of the reference and just checks parent scopes. This logic is fixed in this PR.

This PR also contains a fix where (by moving content into the default render function) the scope information was off during the rest of the translate phase.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
