### PR TITLE
feat: add support for new binding shorthand syntax

### DIFF
--- a/packages/compiler/src/babel-plugin/util/parse-attributes.js
+++ b/packages/compiler/src/babel-plugin/util/parse-attributes.js
@@ -57,7 +57,8 @@ export default (file, attributes, startPos) => {
         value,
         modifier,
         parseArguments(file, attr.argument),
-        Boolean(attr.default)
+        Boolean(attr.default),
+        Boolean(attr.bound)
       ),
       attrStartPos,
       attrEndPos

--- a/packages/compiler/src/babel-types/generator/patch.js
+++ b/packages/compiler/src/babel-types/generator/patch.js
@@ -92,7 +92,7 @@ Object.assign(Printer.prototype, {
     }
 
     if (node.default || !t.isBooleanLiteral(node.value) || !node.value.value) {
-      this.token("=");
+      this.token(node.bound ? ":=" : "=");
       printWithParansIfNeeded.call(this, node.value, node);
     }
   },

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -87,7 +87,7 @@ const MarkoDefinitions = {
 
   MarkoAttribute: {
     aliases: ["Marko"],
-    builder: ["name", "value", "modifier", "arguments", "default"],
+    builder: ["name", "value", "modifier", "arguments", "default", "bound"],
     visitor: ["value", "arguments"],
     fields: {
       name: {
@@ -108,6 +108,10 @@ const MarkoDefinitions = {
         optional: true
       },
       default: {
+        validate: assertValueType("boolean"),
+        optional: true
+      },
+      bound: {
         validate: assertValueType("boolean"),
         optional: true
       }

--- a/packages/translator-default/src/tag/attribute/index.js
+++ b/packages/translator-default/src/tag/attribute/index.js
@@ -100,6 +100,12 @@ export default {
         `Unsupported arguments on the "${name}" attribute.`
       );
     }
+
+    if (attr.node.bound) {
+      throw attr.buildCodeFrameError(
+        `The binding syntax (:=) is only supported when using the "Tags API".`
+      );
+    }
   }
 };
 


### PR DESCRIPTION
## Description
Adds support for a `bound` property on the attribute ast node and code generator.
This maps to a yet to be released version of `htmljs-parser` that handles the a new attribute binding shorthand syntax and will be used by the ["Tags API preview"](https://github.com/marko-js/marko/issues/1704).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
