### PR TITLE
fix(compiler): issue with getters on taglibs not properly merging

### DIFF
--- a/packages/compiler/src/babel-plugin/file.js
+++ b/packages/compiler/src/babel-plugin/file.js
@@ -35,7 +35,6 @@ export class MarkoFile extends File {
     }: ${msg}\n${frame || ""}`;
 
     const err = new Error();
-    err.loc = loc;
 
     // Prevent babel from changing our error message.
     Object.defineProperty(err, "message", {


### PR DESCRIPTION
## Description
When taglibs are merged together the previous merge logic would simply iterate over all properties on the taglib and copy them into a new object.

This PR updates the logic to account for when the properties are getter/setters and instead copies over the property definition.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
