### PR TITLE
fix(translator-default): issue when MarkoClass added via compiler hook

### DIFF
--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -36,7 +36,14 @@ export const analyze = {
   Program: {
     enter(program) {
       // Pre populate metadata for component files.
+      const meta = program.hub.file.metadata.marko;
       getComponentFiles(program);
+
+      if (!meta.hasComponent && !meta.hasComponentBrowser) {
+        meta.hasComponent = program
+          .get("body")
+          .some(child => child.isMarkoClass());
+      }
     },
     exit(program) {
       const { file } = program.hub;


### PR DESCRIPTION
## Description

Fixes an issue with the default translator where if a compile hook added a `MarkoClass` node it would not properly track that the child was a stateful component.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
