### PR TITLE
feat: expose @marko/compiler/register api

### DIFF
--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -35,7 +35,9 @@
     "dist",
     "modules.js",
     "index.d.ts",
-    "babel-types.d.ts"
+    "babel-types.d.ts",
+    "register.js",
+    "register.d.ts"
   ],
   "homepage": "https://github.com/marko-js/marko/blob/main/packages/marko/docs/compiler.md",
   "keywords": [

--- a/packages/compiler/register.d.ts
+++ b/packages/compiler/register.d.ts
@@ -1,0 +1,6 @@
+import { Config } from ".";
+
+type Extensions = typeof require.extensions;
+export default function register(
+  config: Config & { extensions?: Extensions }
+): Extensions;

--- a/packages/compiler/register.js
+++ b/packages/compiler/register.js
@@ -1,0 +1,1 @@
+module.exports = require("./dist/register");

--- a/packages/compiler/src/register.js
+++ b/packages/compiler/src/register.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const compiler = require(".");
+const requiredOptions = { modules: "cjs" };
+
+module.exports = register;
+register();
+
+function register({ extensions = require.extensions, ...options } = {}) {
+  extensions[".marko"] = (module, filename) =>
+    module._compile(
+      compiler.compileFileSync(
+        filename,
+        Object.assign(
+          // eslint-disable-next-line no-constant-condition
+          { sourceMaps: "MARKO_DEBUG" ? "inline" : false },
+          options,
+          requiredOptions
+        )
+      ).code,
+      filename
+    );
+  return extensions;
+}

--- a/packages/marko/docs/10-awesome-marko-features.md
+++ b/packages/marko/docs/10-awesome-marko-features.md
@@ -248,7 +248,7 @@ components](http://markojs.com/docs/server-side-rendering/) rendered on the
 server when the page loads in the browser):
 
 ```js
-require("marko/node-require").install(); // require .marko files!
+require("@marko/compiler/register"); // require .marko files!
 
 const http = require("http");
 const template = require("./template");

--- a/packages/marko/docs/express.md
+++ b/packages/marko/docs/express.md
@@ -16,15 +16,15 @@ The built in view engine for express may be asynchronous, but it doesn't support
 
 ## Usage
 
-Marko provides a submodule (`marko/express`) to add a `res.marko` method to the express response object. This function works much like `res.render`, but doesn't impose the restrictions of the express view engine and allows you to take full advantage of Marko's streaming and modular approach to templates.
+Marko provides a package (`@marko/express`) to add a `res.marko` method to the express response object. This function works much like `res.render`, but doesn't impose the restrictions of the express view engine and allows you to take full advantage of Marko's streaming and modular approach to templates.
 
 By using `res.marko` you'll automatically have access to `req`, `res`, `app`, `app.locals`, and `res.locals` from within your Marko template and custom tags. These values are added to `out.global`.
 
 ```javascript
-require("marko/node-require"); // Allow Node.js to require and load `.marko` files
+require("@marko/compiler/register"); // Allow Node.js to require and load `.marko` files
 
 var express = require("express");
-var markoExpress = require("marko/express");
+var markoExpress = require("@marko/express");
 var template = require("./template");
 
 var app = express();

--- a/packages/marko/docs/http.md
+++ b/packages/marko/docs/http.md
@@ -12,7 +12,7 @@ npm install marko --save
 ## Usage
 
 ```js
-require("marko/node-require").install();
+require("@marko/compiler/register");
 
 const http = require("http");
 const server = http.createServer();

--- a/packages/marko/docs/koa.md
+++ b/packages/marko/docs/koa.md
@@ -11,7 +11,7 @@ npm install koa marko --save
 ## Usage
 
 ```javascript
-require("marko/node-require");
+require("@marko/compiler/register");
 
 const Koa = require("koa");
 const app = new Koa();
@@ -33,7 +33,7 @@ app.listen(8080);
 You may also easily add `gzip` streaming support without additional dependencies:
 
 ```javascript
-require("marko/node-require");
+require("@marko/compiler/register");
 const zlib = require("zlib");
 
 const Koa = require("koa");

--- a/packages/marko/src/node-require/index.js
+++ b/packages/marko/src/node-require/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const complain = "MARKO_DEBUG" && require("complain");
 const path = require("path");
 const resolveFrom = require("resolve-from");
 const requiredCompilerOptions = { modules: "cjs" };
@@ -9,6 +10,13 @@ const defaultCompilerOptions = {
   meta: true
 };
 const MARKO_EXTENSIONS = Symbol("MARKO_EXTENSIONS");
+
+// eslint-disable-next-line no-constant-condition
+if ("MARKO_DEBUG") {
+  complain(
+    'Using "marko/node-require" has been replaced with "@marko/compiler/register".'
+  );
+}
 
 function normalizeExtension(extension) {
   if (extension.charAt(0) !== ".") {


### PR DESCRIPTION
## Description

Currently the `marko/node-require` api is exposed from the `marko` package which is intended for runtime code only that will eventually be replaced with the new `fluurt` runtime.

The `node-require` api is still useful however and is not coupled to the runtime, just the compiler. This API has now been moved into the compiler and exposed via `@marko/compiler/register` and a deprecation is logged when using the old path.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
