### PR TITLE
Node esm loader support

### DIFF
--- a/packages/compiler/loader.mjs
+++ b/packages/compiler/loader.mjs
@@ -1,0 +1,34 @@
+import { URL, pathToFileURL, fileURLToPath } from "url";
+import { cwd } from "process";
+import compiler from "@marko/compiler";
+
+const baseURL = pathToFileURL(`${cwd()}/`).href;
+const extensionRegex = /\.marko$/;
+const format = { format: "module" };
+
+export function resolve(specifier, context, defaultResolve) {
+  const { parentURL = baseURL } = context;
+  return extensionRegex.test(specifier)
+    ? {
+        url: new URL(specifier, parentURL).href
+      }
+    : defaultResolve(specifier, context, defaultResolve);
+}
+
+export function getFormat(url, context, defaultGetFormat) {
+  return extensionRegex.test(url)
+    ? format
+    : defaultGetFormat(url, context, defaultGetFormat);
+}
+
+export function transformSource(source, context, defaultTransformSource) {
+  const { url } = context;
+
+  return extensionRegex.test(url)
+    ? {
+        source: compiler.compileSync(source, fileURLToPath(url), {
+          sourceMaps: "inline"
+        }).code
+      }
+    : defaultTransformSource(source, context, defaultTransformSource);
+}

--- a/packages/compiler/loader.mjs
+++ b/packages/compiler/loader.mjs
@@ -4,7 +4,6 @@ import compiler from "@marko/compiler";
 
 const baseURL = pathToFileURL(`${cwd()}/`).href;
 const extensionRegex = /\.marko$/;
-const format = { format: "module" };
 
 export function resolve(specifier, context, defaultResolve) {
   const { parentURL = baseURL } = context;
@@ -15,20 +14,13 @@ export function resolve(specifier, context, defaultResolve) {
     : defaultResolve(specifier, context, defaultResolve);
 }
 
-export function getFormat(url, context, defaultGetFormat) {
+export function load(url, context, defaultLoad) {
   return extensionRegex.test(url)
-    ? format
-    : defaultGetFormat(url, context, defaultGetFormat);
-}
-
-export function transformSource(source, context, defaultTransformSource) {
-  const { url } = context;
-
-  return extensionRegex.test(url)
-    ? {
-        source: compiler.compileSync(source, fileURLToPath(url), {
-          sourceMaps: "inline"
-        }).code
-      }
-    : defaultTransformSource(source, context, defaultTransformSource);
+  ? {
+      format: "module",
+      source: compiler.compileFileSync(fileURLToPath(url), {
+        sourceMaps: "inline"
+      }).code
+    }
+  : defaultLoad(url, context, defaultLoad);
 }

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -33,6 +33,7 @@
   },
   "files": [
     "dist",
+    "loader.mjs",
     "modules.js",
     "index.d.ts",
     "babel-types.d.ts",


### PR DESCRIPTION
## Description

Resolves https://github.com/marko-js/marko/issues/1727

Adds support for loading Marko files directly as ESM via a node [ESM Loader hook](https://nodejs.org/api/esm.html#esm_hooks).

This means you can run node like
```terminal
node --experimental-loader @marko/compiler/loader.mjs ./server.js
```

And importing Marko files will work as is.

---

Primarily this PR contains two main changes.
1. Adds a `loader.mjs` file to the compiler package.
2. Updating any `imports` added when compiling a Marko template to have the filename (including extension) to be more native esm friendly.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
