### PR TITLE
fix: remove empty const/let/var declarations caused by removal of MARKO_DEBUG expressions

### DIFF
--- a/scripts/babel-plugin-marko-debug.js
+++ b/scripts/babel-plugin-marko-debug.js
@@ -67,6 +67,10 @@ function replaceMarkoDebug(path, test, consequent, alternate) {
       path.replaceWith(alternate);
     }
   } else {
-    path.remove();
+    if (path.parentPath.node.type === "VariableDeclarator") {
+      path.parentPath.remove();
+    } else {
+      path.remove();
+    }
   }
 }


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes #1742

The tool that strips out `MARKO_DEBUG` could leave behind invalid code:

**Example:**

`const complain = "MARKO_DEBUG" && require("complain");` => `const complain;`

**Fix:**

This PR removes the entire `VariableDeclarator` if the value is being removed.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
