### PR TITLE
fix: issue with hydrating adjacent text nodes

### DIFF
--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -564,6 +564,17 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
             isCompatible = true;
             // Simply update nodeValue on the original node to
             // change the text value
+
+            if (
+              isHydrate === true &&
+              toNextSibling &&
+              curFromNodeType === TEXT_NODE &&
+              toNextSibling.___nodeType === TEXT_NODE
+            ) {
+              fromNextSibling = curFromNodeChild.splitText(
+                curToNodeChild.___nodeValue.length
+              );
+            }
             if (curFromNodeChild.nodeValue !== curToNodeChild.___nodeValue) {
               curFromNodeChild.nodeValue = curToNodeChild.___nodeValue;
             }


### PR DESCRIPTION
## Description

Currently during hydration if there are adjacent text nodes (for example caused by placeholders after static text) the first node is set to it's original value, then subsequent nodes are rebuilt.

This PR normalizes this text during hydration to avoid rebuilding nodes in the case of the mismatch.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
