### PR TITLE
feat: improve shadow root support

### DIFF
--- a/packages/marko/src/runtime/RenderResult.js
+++ b/packages/marko/src/runtime/RenderResult.js
@@ -40,19 +40,19 @@ var proto = (RenderResult.prototype = {
     return components;
   },
 
-  afterInsert: function (doc) {
+  afterInsert: function (host) {
     var out = this.___out;
     var componentsContext = out.___components;
     if (componentsContext) {
-      this.___components = componentsContext.___initComponents(doc);
+      this.___components = componentsContext.___initComponents(host);
     } else {
       this.___components = null;
     }
 
     return this;
   },
-  getNode: function (doc) {
-    return this.___out.___getNode(doc);
+  getNode: function (host) {
+    return this.___out.___getNode(host);
   },
   getOutput: function () {
     return this.___out.___getOutput();
@@ -60,7 +60,7 @@ var proto = (RenderResult.prototype = {
   toString: function () {
     return this.___out.toString();
   },
-  document: typeof document != "undefined" && document
+  document: typeof window === "object" && document
 });
 
 Object.defineProperty(proto, "html", {
@@ -97,13 +97,9 @@ Object.defineProperty(proto, "context", {
 domInsert(
   proto,
   function getEl(renderResult, referenceEl) {
-    return renderResult.getNode(referenceEl.ownerDocument);
+    return renderResult.getNode(referenceEl);
   },
   function afterInsert(renderResult, referenceEl) {
-    var isShadow =
-      typeof ShadowRoot === "function" && referenceEl instanceof ShadowRoot;
-    return renderResult.afterInsert(
-      isShadow ? referenceEl : referenceEl.ownerDocument
-    );
+    return renderResult.afterInsert(referenceEl);
   }
 );

--- a/packages/marko/src/runtime/components/Component.js
+++ b/packages/marko/src/runtime/components/Component.js
@@ -184,7 +184,7 @@ function Component(id) {
   this.___updateQueued = false;
   this.___dirty = false;
   this.___settingInput = false;
-  this.___document = undefined;
+  this.___host = undefined;
 
   var ssrKeyedElements = keyedElementsByComponentId[id];
 
@@ -526,21 +526,21 @@ Component.prototype = componentProto = {
     var input = this.___renderInput || this.___input;
 
     updateManager.___batchUpdate(function () {
-      self.___rerender(input, false).afterInsert(self.___document);
+      self.___rerender(input, false).afterInsert(self.___host);
     });
 
     this.___reset();
   },
 
   ___rerender: function (input, isHydrate) {
-    var doc = this.___document;
+    var host = this.___host;
     var globalData = this.___global;
     var rootNode = this.___rootNode;
     var renderer = this.___renderer;
     var createOut = renderer.createOut || defaultCreateOut;
     var out = createOut(globalData);
     out.sync();
-    out.___document = this.___document;
+    out.___host = this.___host;
     out[CONTEXT_KEY] = this.___context;
 
     var componentsContext = getComponentsContext(out);
@@ -554,7 +554,7 @@ Component.prototype = componentProto = {
 
     var targetNode = out.___getOutput().___firstChild;
 
-    morphdom(rootNode, targetNode, doc, componentsContext);
+    morphdom(rootNode, targetNode, host, componentsContext);
 
     return result;
   },

--- a/packages/marko/src/runtime/components/ComponentsContext.js
+++ b/packages/marko/src/runtime/components/ComponentsContext.js
@@ -35,10 +35,10 @@ function ComponentsContext(out, parentComponentsContext) {
 }
 
 ComponentsContext.prototype = {
-  ___initComponents: function (doc) {
+  ___initComponents: function (host) {
     var componentDefs = this.___components;
 
-    ComponentsContext.___initClientRendered(componentDefs, doc);
+    ComponentsContext.___initClientRendered(componentDefs, host);
 
     this.___out.emit("___componentsInitialized");
 

--- a/packages/marko/src/runtime/components/event-delegation.js
+++ b/packages/marko/src/runtime/components/event-delegation.js
@@ -72,11 +72,11 @@ function addDelegatedEventHandler(eventType) {
   }
 }
 
-function addDelegatedEventHandlerToDoc(eventType, doc) {
-  var body = doc.body || doc;
-  var listeners = (doc[listenersAttachedKey] = doc[listenersAttachedKey] || {});
+function addDelegatedEventHandlerToHost(eventType, host) {
+  var listeners = (host[listenersAttachedKey] =
+    host[listenersAttachedKey] || {});
   if (!listeners[eventType]) {
-    body.addEventListener(
+    host.addEventListener(
       eventType,
       (listeners[eventType] = function (event) {
         var propagationStopped = false;
@@ -133,8 +133,8 @@ exports.___handleNodeDetach = noop;
 exports.___delegateEvent = delegateEvent;
 exports.___getEventFromEl = getEventFromEl;
 exports.___addDelegatedEventHandler = addDelegatedEventHandler;
-exports.___init = function (doc) {
+exports.___init = function (host) {
   Object.keys(delegatedEvents).forEach(function (eventType) {
-    addDelegatedEventHandlerToDoc(eventType, doc);
+    addDelegatedEventHandlerToHost(eventType, host);
   });
 };

--- a/packages/marko/src/runtime/components/registry/index-browser.js
+++ b/packages/marko/src/runtime/components/registry/index-browser.js
@@ -35,13 +35,13 @@ function register(type, def) {
   return type;
 }
 
-function addPendingDef(def, type, meta, doc, runtimeId) {
+function addPendingDef(def, type, meta, host, runtimeId) {
   if (!pendingDefs) {
     pendingDefs = {};
 
     // eslint-disable-next-line no-constant-condition
     if ("MARKO_DEBUG") {
-      doc.addEventListener("load", function () {
+      document.addEventListener("load", function () {
         var pendingComponentIds = Object.keys(pendingDefs);
         if (pendingComponentIds.length) {
           complain(
@@ -54,7 +54,7 @@ function addPendingDef(def, type, meta, doc, runtimeId) {
   (pendingDefs[type] = pendingDefs[type] || []).push([
     def,
     meta,
-    doc,
+    host,
     runtimeId
   ]);
 }

--- a/packages/marko/src/runtime/components/util/index-browser.js
+++ b/packages/marko/src/runtime/components/util/index-browser.js
@@ -8,12 +8,13 @@ var runtimeId = markoUID.i++;
 
 var componentLookup = {};
 
-var defaultDocument = document;
 var EMPTY_OBJECT = {};
 
-function getComponentForEl(el, doc) {
+function getComponentForEl(el, host) {
   var node =
-    typeof el == "string" ? (doc || defaultDocument).getElementById(el) : el;
+    typeof el == "string"
+      ? ((host ? host.ownerDocument : host) || document).getElementById(el)
+      : el;
   var component;
   var vElement;
 
@@ -158,11 +159,11 @@ if ("MARKO_DEBUG") {
       };
     }
   };
-  exports.___startDOMManipulationWarning = function () {
-    document.addEventListener("DOMNodeRemoved", warnNodeRemoved);
+  exports.___startDOMManipulationWarning = function (host) {
+    host.addEventListener("DOMNodeRemoved", warnNodeRemoved);
   };
-  exports.___stopDOMManipulationWarning = function () {
-    document.removeEventListener("DOMNodeRemoved", warnNodeRemoved);
+  exports.___stopDOMManipulationWarning = function (host) {
+    host.removeEventListener("DOMNodeRemoved", warnNodeRemoved);
   };
 }
 

--- a/packages/marko/src/runtime/html/AsyncStream.js
+++ b/packages/marko/src/runtime/html/AsyncStream.js
@@ -2,7 +2,6 @@
 var EventEmitter = require("events-light");
 var StringWriter = require("./StringWriter");
 var BufferedWriter = require("./BufferedWriter");
-var defaultDocument = typeof document != "undefined" && document;
 var RenderResult = require("../RenderResult");
 var attrsHelper = require("./helpers/attrs");
 var markoAttr = require("./helpers/data-marko");
@@ -115,7 +114,7 @@ AsyncStream.enableAsyncStackTrace = function () {
 
 var proto = (AsyncStream.prototype = {
   constructor: AsyncStream,
-  ___document: defaultDocument,
+  ___host: typeof window === "object" && document,
   ___isOut: true,
 
   sync: function () {
@@ -603,17 +602,16 @@ var proto = (AsyncStream.prototype = {
     }
   },
 
-  ___getNode: function (doc) {
+  ___getNode: function (host) {
     var node = this._node;
-    var nextEl;
-    var fragment;
-    var html = this.___getOutput();
-
-    if (!doc) {
-      doc = this.___document;
-    }
 
     if (!node) {
+      var nextEl;
+      var fragment;
+      var html = this.___getOutput();
+      if (!host) host = this.___host;
+      var doc = host.ownerDocument || host;
+
       if (html) {
         node = parseHTML(html);
 

--- a/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
+++ b/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
@@ -7,7 +7,6 @@ var VComponent = vdom.___VComponent;
 var VFragment = vdom.___VFragment;
 var virtualizeHTML = vdom.___virtualizeHTML;
 var RenderResult = require("../RenderResult");
-var defaultDocument = vdom.___defaultDocument;
 var morphdom = require("./morphdom");
 var attrsHelper = require("./helpers/attrs");
 
@@ -54,7 +53,7 @@ function AsyncVDOMBuilder(globalData, parentNode, parentOut) {
 
 var proto = (AsyncVDOMBuilder.prototype = {
   ___isOut: true,
-  ___document: defaultDocument,
+  ___host: typeof window === "object" && document,
 
   bc: function (component, key, ownerComponent) {
     var vComponent = new VComponent(component, key, ownerComponent);
@@ -136,11 +135,7 @@ var proto = (AsyncVDOMBuilder.prototype = {
 
   html: function (html, ownerComponent) {
     if (html != null) {
-      var vdomNode = virtualizeHTML(
-        html,
-        this.___document || document,
-        ownerComponent
-      );
+      var vdomNode = virtualizeHTML(html, ownerComponent);
       this.node(vdomNode);
     }
 
@@ -389,20 +384,20 @@ var proto = (AsyncVDOMBuilder.prototype = {
     return this;
   },
 
-  ___getNode: function (doc) {
+  ___getNode: function (host) {
     var node = this.___vnode;
     if (!node) {
       var vdomTree = this.___getOutput();
-      // Create the root document fragment node
-      doc = doc || this.___document || document;
-      this.___vnode = node = vdomTree.___actualize(doc, null);
-      morphdom(node, vdomTree, doc, this.___components);
+
+      if (!host) host = this.___host;
+      this.___vnode = node = vdomTree.___actualize(host, null);
+      morphdom(node, vdomTree, host, this.___components);
     }
     return node;
   },
 
-  toString: function (doc) {
-    var docFragment = this.___getNode(doc);
+  toString: function (host) {
+    var docFragment = this.___getNode(host);
     var html = "";
 
     var child = docFragment.firstChild;

--- a/packages/marko/src/runtime/vdom/VDocumentFragment.js
+++ b/packages/marko/src/runtime/vdom/VDocumentFragment.js
@@ -22,8 +22,8 @@ VDocumentFragment.prototype = {
     return new VDocumentFragmentClone(this);
   },
 
-  ___actualize: function (doc) {
-    return doc.createDocumentFragment();
+  ___actualize: function (host) {
+    return (host.ownerDocument || host).createDocumentFragment();
   }
 };
 

--- a/packages/marko/src/runtime/vdom/VElement.js
+++ b/packages/marko/src/runtime/vdom/VElement.js
@@ -151,13 +151,16 @@ VElement.prototype = {
     return this.___finishChild();
   },
 
-  ___actualize: function (doc, parentNamespaceURI) {
+  ___actualize: function (host, parentNamespaceURI) {
     var tagName = this.___nodeName;
     var attributes = this.___attributes;
     var namespaceURI = DEFAULT_NS[tagName] || parentNamespaceURI || NS_HTML;
 
     var flags = this.___flags;
-    var el = doc.createElementNS(namespaceURI, tagName);
+    var el = (host.ownerDocument || host).createElementNS(
+      namespaceURI,
+      tagName
+    );
 
     if (flags & FLAG_CUSTOM_ELEMENT) {
       assign(el, attributes);

--- a/packages/marko/src/runtime/vdom/VText.js
+++ b/packages/marko/src/runtime/vdom/VText.js
@@ -11,8 +11,8 @@ VText.prototype = {
 
   ___nodeType: 3,
 
-  ___actualize: function (doc) {
-    return doc.createTextNode(this.___nodeValue);
+  ___actualize: function (host) {
+    return (host.ownerDocument || host).createTextNode(this.___nodeValue);
   },
 
   ___cloneNode: function () {

--- a/packages/marko/src/runtime/vdom/hot-reload.js
+++ b/packages/marko/src/runtime/vdom/hot-reload.js
@@ -60,7 +60,7 @@ runtime.t = function (typeName) {
             instance.__proto__ = newProto;
             instance
               .___rerender(instance.___input, false)
-              .afterInsert(instance.___document);
+              .afterInsert(instance.___host);
           });
         });
       }

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -56,7 +56,7 @@ function onNodeAdded(node, componentsContext) {
   }
 }
 
-function morphdom(fromNode, toNode, doc, componentsContext) {
+function morphdom(fromNode, toNode, host, componentsContext) {
   var globalComponentsContext;
   var isHydrate = false;
   var keySequences = Object.create(null);
@@ -74,7 +74,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
     ownerComponent,
     parentComponent
   ) {
-    var realNode = vNode.___actualize(doc, parentEl.namespaceURI);
+    var realNode = vNode.___actualize(host, parentEl.namespaceURI);
     insertBefore(realNode, referenceEl, parentEl);
 
     if (
@@ -678,7 +678,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
   // eslint-disable-next-line no-constant-condition
   if ("MARKO_DEBUG") {
-    componentsUtil.___stopDOMManipulationWarning();
+    componentsUtil.___stopDOMManipulationWarning(host);
   }
 
   morphChildren(fromNode, toNode, toNode.___component);
@@ -707,7 +707,7 @@ function morphdom(fromNode, toNode, doc, componentsContext) {
 
   // eslint-disable-next-line no-constant-condition
   if ("MARKO_DEBUG") {
-    componentsUtil.___startDOMManipulationWarning();
+    componentsUtil.___startDOMManipulationWarning(host);
   }
 }
 

--- a/packages/marko/src/runtime/vdom/vdom.js
+++ b/packages/marko/src/runtime/vdom/vdom.js
@@ -6,7 +6,6 @@ var VComponent = require("./VComponent");
 var VFragment = require("./VFragment");
 var parseHTML = require("./parse-html");
 
-var defaultDocument = typeof document != "undefined" && document;
 var specialHtmlRegexp = /[&<]/;
 
 function virtualizeChildNodes(node, vdomParent, ownerComponent) {
@@ -30,7 +29,7 @@ function virtualize(node, ownerComponent) {
   }
 }
 
-function virtualizeHTML(html, doc, ownerComponent) {
+function virtualizeHTML(html, ownerComponent) {
   if (!specialHtmlRegexp.test(html)) {
     return new VText(html, ownerComponent);
   }
@@ -61,7 +60,7 @@ Node_prototype.t = function (value) {
       value = "";
     } else if (type === "object") {
       if (value.toHTML) {
-        vdomNode = virtualizeHTML(value.toHTML(), document);
+        vdomNode = virtualizeHTML(value.toHTML());
       }
     }
   }
@@ -81,4 +80,3 @@ exports.___VComponent = VComponent;
 exports.___VFragment = VFragment;
 exports.___virtualize = virtualize;
 exports.___virtualizeHTML = virtualizeHTML;
-exports.___defaultDocument = defaultDocument;


### PR DESCRIPTION
## Description

This PR normalizes the naming for places referred to as "document" when in actuality it could have also been a shadow root.
Now instead of passing the `ownerDocument` through the tree, we instead pass a the `host` element through in those places. The `host` element defaults to `document`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
