### PR TITLE
fix: ensure host element always a document or shadow root

### DIFF
--- a/packages/marko/src/runtime/RenderResult.js
+++ b/packages/marko/src/runtime/RenderResult.js
@@ -1,6 +1,12 @@
 var domInsert = require("./dom-insert");
 var complain = "MARKO_DEBUG" && require("complain");
 
+function getRootNode(el) {
+  var cur = el;
+  while (cur.parentNode) cur = cur.parentNode;
+  return cur;
+}
+
 function getComponentDefs(result) {
   var componentDefs = result.___components;
 
@@ -97,9 +103,9 @@ Object.defineProperty(proto, "context", {
 domInsert(
   proto,
   function getEl(renderResult, referenceEl) {
-    return renderResult.getNode(referenceEl);
+    return renderResult.getNode(getRootNode(referenceEl));
   },
   function afterInsert(renderResult, referenceEl) {
-    return renderResult.afterInsert(referenceEl);
+    return renderResult.afterInsert(getRootNode(referenceEl));
   }
 );


### PR DESCRIPTION
## Description

Fixes a regression caused by https://github.com/marko-js/marko/commit/955ea006b89ee303d25f415d88962cd3b6f020f8 which ultimately made it so that event handlers could be added more than once. The intent of that PR was update naming of places where "document" was incorrectly used to denote the host element, which is actually either a document or a shadow root.

In that PR I made the incorrect assumption that it'd make the most sense to delegate events as low in the tree as possible. In practice this means that (with nested roots) multiple of the same event can be registered for the same element.

In this PR that is fixed by saving the "root" node (either shadow root or document) instead of the closest parent which is similar to the old behavior. This does however now mean that if you render within a child node of a shadow root (not just directly) it should propagate events to the shadow root which was previously broken.

Fixes #1750 

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
