### PR TITLE
fix(esm): use file extension and directory index

### DIFF
--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -250,7 +250,7 @@ export const translate = {
         path.scope.generateUidIdentifier("marko_template");
       const rendererIdentifier = importDefault(
         file,
-        "marko/src/runtime/components/renderer",
+        "marko/src/runtime/components/renderer.js",
         "marko_renderer"
       );
       const templateRendererMember = t.memberExpression(
@@ -280,7 +280,7 @@ export const translate = {
             t.stringLiteral(
               `marko/${markoOpts.optimize ? "dist" : "src"}/runtime/${
                 isHTML ? "html" : "vdom"
-              }${markoOpts.hot ? "/hot-reload" : ""}`
+              }${markoOpts.hot ? "/hot-reload" : ""}/index.js`
             )
           ),
           t.variableDeclaration("const", [

--- a/packages/translator-default/src/tag/native-tag[html]/attributes.js
+++ b/packages/translator-default/src/tag/native-tag[html]/attributes.js
@@ -58,7 +58,7 @@ export default function (path, attrs) {
         t.callExpression(
           importDefault(
             file,
-            "marko/src/runtime/html/helpers/attr",
+            "marko/src/runtime/html/helpers/attr.js",
             "marko_attr"
           ),
           args


### PR DESCRIPTION
This PR is tangential to https://github.com/marko-js/marko/issues/1727 and attempts to allow ESM to be used by fixing issues with [mandatory-file-extensions](https://nodejs.org/api/esm.html#mandatory-file-extensions).

For ES Modules, we need to specify `/index.js` when requiring a directory and `.js` when requiring a file without the use of one of the [experimental flags](https://nodejs.org/api/esm.html#customizing-esm-specifier-resolution-algorithm).

The following template was compiled with the `meta` option disabled ( which uses __filename; also not supported by ESM ).

```marko
$ const foo = 'bar';
<h1 data-foo=foo>Hello World</h1>

```

```diff
  // Compiled using marko@5.17.3 - DO NOT EDIT
- import { t as _t } from "marko/src/runtime/html/index.js";
+ import { t as _t } from "marko/src/runtime/html/index.js";
  
  const _marko_componentType = "components/hello-world.marko",
        _marko_template = _t(_marko_componentType);
  
  export default _marko_template;
- import _marko_attr from "marko/src/runtime/html/helpers/attr";
+ import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
- import _marko_renderer from "marko/src/runtime/components/renderer";
+ import _marko_renderer from "marko/src/runtime/components/renderer.js";
  const _marko_component = {};
  _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
    out.w(`<h1${_marko_attr("data-foo", input.bar)}>`);
    out.w("Hello World");
    out.w("</h1>");
  }, {
    t: _marko_componentType,
    i: true,
    d: true
  }, _marko_component);
```

This is only one portion of what would be required to support ES Modules, but it's a start 😄 