### PR TITLE
Expose will rerender in browser (internal use)

### DIFF
--- a/packages/marko/src/runtime/components/beginComponent/index.js
+++ b/packages/marko/src/runtime/components/beginComponent/index.js
@@ -29,6 +29,7 @@ module.exports = function beginComponent(
   // On the server
   if (!componentsContext.___isPreserved && ownerWillRerender) {
     componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER;
+    componentDef._wrr = true;
     return componentDef;
   }
 
@@ -49,6 +50,7 @@ module.exports = function beginComponent(
 
   if (isSplitComponent === false && out.global.noBrowserRerender !== true) {
     componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER;
+    componentDef._wrr = true;
     componentsContext.___isPreserved = false;
   }
 


### PR DESCRIPTION
This exposes the `willRerenderInTheBrowser` flag in a way that doesn't get garbled by our production build process. Still for internal usage only but will help with some patterns around synchronizing hydration for conditionally async things.

## Checklist:


- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
