### PR TITLE
feat: add shorthand for dynamic tag names from identifier

### DIFF
--- a/packages/marko/docs/custom-tags.md
+++ b/packages/marko/docs/custom-tags.md
@@ -184,3 +184,18 @@ The [`<macro>`](./core-tags.md#macro) tag allows you to create custom tags in th
 <welcome-message name="Patrick"/>
 <welcome-message name="Austin"/>
 ```
+
+# From Variables
+
+If no other tag would be discovered Marko will check for an in scope variable that matches the tag name.
+
+```marko
+import SomeTag from "./somewhere.marko"
+
+$ const { renderBody } = input;
+$ const MyTag = input.href ? "a" : "button";
+
+<SomeTag/>
+<MyTag/>
+<renderBody/>
+```

--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -358,6 +358,16 @@ _HTML Output:_
 <button>Click me!</button>
 ```
 
+As a shorthand if there is a variable in scope and [no other matching tag is discovered](#how-tags-are-discovered) the wrapping `${}` is unnecessary.
+
+For example the following are equivalent:
+
+```marko
+$ const MyTag = href ? 'a' : 'button';
+<${MyTag}/>
+<MyTag/>
+```
+
 > **ProTip:**
 > If you find that you have a wrapper element that is conditional, but whose body should always be rendered then you can use a null dynamic tag. For example, to only render a wrapping `<a>` tag if there is a valid URL then you could do the following:
 >

--- a/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/components/test/index.marko
+++ b/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/components/test/index.marko
@@ -1,0 +1,2 @@
+$ const { renderBody } = input;
+<renderBody/>

--- a/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/index.marko
+++ b/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/index.marko
@@ -1,0 +1,12 @@
+import Test2 from "<test>";
+class {}
+
+<div key="root">
+    <test>
+        Hello
+    </test>
+    
+    <Test2>
+        Again
+    </Test2>
+</div>

--- a/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/test.js
+++ b/packages/marko/test/components-browser/fixtures/dynamic-tag-shorthand/test.js
@@ -1,0 +1,6 @@
+var expect = require("chai").expect;
+
+module.exports = function (helpers) {
+  var component = helpers.mount(require.resolve("./index"), {});
+  expect(component.getEl("root").textContent).to.equal("HelloAgain");
+};


### PR DESCRIPTION
## Description

Adds a shorthand for dynamic tags based on a single identifier. With this change if you have a tag that would not be discovered from the file system and an in scope identifier exists it will act as a dynamic tag.

eg:

```marko
import SomeTag from "./somewhere.marko"
$ const { renderBody } = input;
$ const MyTag = input.href ? "a" : "button";

<SomeTag/>
<MyTag/>
<renderBody/>
```

For backward compatibility in scope variables have been implemented to have the lowest priority in the tag discovery process. In Marko 6 this will be bumped to the highest priority. Currently this PR will log a deprecation warning if there is a conflict that will have a different behavior in Marko 6.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
