### PR TITLE
docs: refresh multiple server / bundler docs

### DIFF
--- a/packages/marko/docs/cloudflare-workers.md
+++ b/packages/marko/docs/cloudflare-workers.md
@@ -1,0 +1,34 @@
+# Marko + Cloudflare Workers
+
+See the [the cloudflare sample](https://github.com/marko-js/examples/tree/master/examples/vite-cloudflare)
+project for a working example.
+
+## Usage
+
+When using Marko with [Cloudflare Workers](https://workers.cloudflare.com/) you need to make sure that Marko is loaded with a `worker` [export condition](https://nodejs.org/api/packages.html#conditional-exports). Most bundlers support the ability to define export conditions.
+
+After that point the `template.stream` will now return a worker compatible [`ReadableStream`](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream).
+
+You can then simply respond with the returned stream.
+
+```js
+import template from "./index.marko";
+
+addEventListener("fetch", event => {
+  event.respondWith(handleRequest(event.request));
+});
+
+async function handleRequest(request) {
+  return new Response(template.stream(), {
+    headers: {
+      status: 200,
+      headers: { "content-type": "text/html;charset=UTF-8" }
+    }
+  });
+}
+```
+
+### BYOB (Bring your own bundler)
+
+For the large portion of Marko's API a bundler is required. The example code above assumes that Marko templates can be loaded in your environment.
+Marko supports a number of bundlers, [take a look through our supported bundlers](#bundler-integrations) and pick what works best for you.

--- a/packages/marko/docs/express.md
+++ b/packages/marko/docs/express.md
@@ -1,38 +1,40 @@
-# Express + Marko
+# Marko + Express
 
-See the [marko-express](https://github.com/marko-js/examples/tree/master/examples/lasso-express) sample
+## Quick Start
+
+```terminal
+npm init marko -- --template vite-express
+```
+
+See the [the express sample](https://github.com/marko-js/examples/tree/master/examples/vite-express)
 project for a working example.
 
-## Installation
+## From Scratch
 
-Need to install mark as well as the express-related marko package:
+First install Marko and the express related dependencies:
 
-```
-npm install express --save
-npm install marko --save
-npm install @marko/express --save
+```terminal
+npm install marko @marko/express express --save
 ```
 
-## Skip the view engine
+### Skip the view engine
 
-The built in view engine for express may be asynchronous, but it doesn't support streaming (check out [Rediscovering Progressive HTML Rendering](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/) to see why this is so important). So instead we'll [bypass the view engine](https://strongloop.com/strongblog/bypassing-express-view-rendering-for-speed-and-modularity/).
+The built in view engine for express may be asynchronous, but it doesn't support streaming (check out [Rediscovering Progressive HTML Rendering](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/) to see why this is so important). So instead we'll [bypass the view engine](https://strongloop.com/strongblog/bypassing-express-view-rendering-for-speed-and-modularity/) and use [`@marko/express`](https://github.com/marko-js/express/).
 
-## Usage
+### Usage
 
-Marko provides a package (`@marko/express`) to add a `res.marko` method to the express response object. This function works much like `res.render`, but doesn't impose the restrictions of the express view engine and allows you to take full advantage of Marko's streaming and modular approach to templates.
+The [`@marko/express`](https://github.com/marko-js/express/) adds a `res.marko` method to the express response object. This function works much like `res.render`, but doesn't impose the restrictions of the express view engine and allows you to take full advantage of Marko's streaming and modular approach to templates.
 
 By using `res.marko` you'll automatically have access to `req`, `res`, `app`, `app.locals`, and `res.locals` from within your Marko template and custom tags. These values are added to `out.global`.
 
 ```javascript
-require("@marko/compiler/register"); // Allow Node.js to require and load `.marko` files
+import express from "express";
+import markoPlugin from "@marko/express";
+import template from "./template.marko";
 
-var express = require("express");
-var markoExpress = require("@marko/express");
-var template = require("./template");
+const app = express();
 
-var app = express();
-
-app.use(markoExpress()); //enable res.marko(template, data)
+app.use(markoPlugin()); //enable res.marko(template, data)
 
 app.get("/", function (req, res) {
   res.marko(template, {
@@ -44,3 +46,8 @@ app.get("/", function (req, res) {
 
 app.listen(8080);
 ```
+
+### BYOB (Bring your own bundler)
+
+For the large portion of Marko's API a bundler is required. The example code above assumes that Marko templates can be loaded in your environment.
+Marko supports a number of bundlers, [take a look through our supported bundlers](#bundler-integrations) and pick what works best for you.

--- a/packages/marko/docs/fastify.md
+++ b/packages/marko/docs/fastify.md
@@ -1,37 +1,47 @@
-# Fastify + Marko
+# Marko + Fastify
 
-See the [lasso-fastify](https://github.com/marko-js/examples/tree/master/examples/lasso-fastify) sample
-project for a fully-working example.
+## Quick Start
 
-## Installation
-
-```bash
-npm install fastify --save
-npm install point-of-view --save
-npm install marko --save
+```terminal
+npm init marko -- --template vite-fastify
 ```
 
-## Usage
+See the [the fastify sample](https://github.com/marko-js/examples/tree/master/examples/vite-fastify)
+project for a working example.
 
-```js
-const fastify = require("fastify")();
+## From Scratch
 
-fastify.register(require("point-of-view"), {
-  engine: {
-    marko: require("marko")
-  }
-});
+First install Marko and the fastify related dependencies:
 
-fastify.get("/", (req, reply) => {
-  reply.view("/index.marko", {
-    name: "Frank",
-    count: 30,
-    colors: ["red", "green", "blue"]
-  });
-});
-
-fastify.listen(8080, err => {
-  if (err) throw err;
-  console.log(`Server listening on ${fastify.server.address().port}`);
-});
+```terminal
+npm install marko @marko/fastify fastify --save
 ```
+
+### Usage
+
+The [`@marko/fastify`](https://github.com/marko-js/fastify/) adds a `reply.marko` decorator to the `reply` object. This function allows us to pass in a Marko template and supports Marko's streaming and modular approach to templates.
+
+By using `reply.marko` you'll automatically have access to `app.locals`, and `reply.locals` from within your Marko template and custom tags. These values are added to `out.global`.
+
+```javascript
+import fastify from "fastify";
+import markoPlugin from "@marko/fastify";
+import Template from "./template.marko";
+
+const app = fastify();
+
+app.register(markoPlugin);
+
+app.get("/", (request, reply) => {
+  // Streams Marko template into the response.
+  // Forwards errors into fa error handler.
+  reply.marko(Template, { hello: "world" });
+});
+
+await fastify.listen(3000);
+```
+
+### BYOB (Bring your own bundler)
+
+For the large portion of Marko's API a bundler is required. The example code above assumes that Marko templates can be loaded in your environment.
+Marko supports a number of bundlers, [take a look through our supported bundlers](#bundler-integrations) and pick what works best for you.

--- a/packages/marko/docs/http.md
+++ b/packages/marko/docs/http.md
@@ -1,27 +1,19 @@
 # Marko + HTTP Server
 
-See the [marko-http](https://github.com/marko-js/examples/tree/master/examples/http) sample
+See the [the http sample](https://github.com/marko-js/examples/tree/master/examples/vite-http)
 project for a working example.
-
-## Installation
-
-```bash
-npm install marko --save
-```
 
 ## Usage
 
 ```js
-require("@marko/compiler/register");
-
-const http = require("http");
-const server = http.createServer();
+import http from "http";
+import template from "./index.marko";
 
 const port = 8080;
-const indexTemplate = require("./index.marko");
+const server = http.createServer();
 
 server.on("request", (req, res) => {
-  indexTemplate.render(
+  template.render(
     {
       name: "Frank",
       count: 30,
@@ -35,3 +27,8 @@ server.listen(port, () => {
   console.log(`Successfully started server on port ${port}`);
 });
 ```
+
+### BYOB (Bring your own bundler)
+
+For the large portion of Marko's API a bundler is required. The example code above assumes that Marko templates can be loaded in your environment.
+Marko supports a number of bundlers, [take a look through our supported bundlers](#bundler-integrations) and pick what works best for you.

--- a/packages/marko/docs/koa.md
+++ b/packages/marko/docs/koa.md
@@ -1,22 +1,21 @@
-# Koa + Marko
+# Marko + Koa
 
-See [the `marko-koa` sample project](https://github.com/marko-js/examples/tree/master/examples/lasso-koa) for a fully-working example.
+See the [the koa sample](https://github.com/marko-js/examples/tree/master/examples/vite-koa)
+project for a working example.
 
 ## Installation
 
-```sh
+```terminal
 npm install koa marko --save
 ```
 
 ## Usage
 
 ```javascript
-require("@marko/compiler/register");
+import Koa from "koa";
+import template from "./index.marko";
 
-const Koa = require("koa");
 const app = new Koa();
-
-const template = require("./index.marko");
 
 app.use((ctx, next) => {
   ctx.type = "html";
@@ -30,33 +29,7 @@ app.use((ctx, next) => {
 app.listen(8080);
 ```
 
-You may also easily add `gzip` streaming support without additional dependencies:
+### BYOB (Bring your own bundler)
 
-```javascript
-require("@marko/compiler/register");
-const zlib = require("zlib");
-
-const Koa = require("koa");
-const app = new Koa();
-
-const template = require("./index.marko");
-
-app.use((ctx, next) => {
-  ctx.type = "html";
-  ctx.body = template.stream({
-    name: "Frank",
-    count: 30,
-    colors: ["red", "green", "blue"]
-  });
-
-  ctx.vary("Accept-Encoding");
-  if (ctx.acceptsEncodings("gzip")) {
-    ctx.set("Content-Encoding", "gzip");
-    ctx.body = ctx.body.pipe(
-      zlib.createGzip({ flush: zlib.constants.Z_PARTIAL_FLUSH })
-    );
-  }
-});
-
-app.listen(8080);
-```
+For the large portion of Marko's API a bundler is required. The example code above assumes that Marko templates can be loaded in your environment.
+Marko supports a number of bundlers, [take a look through our supported bundlers](#bundler-integrations) and pick what works best for you.

--- a/packages/marko/docs/rollup.md
+++ b/packages/marko/docs/rollup.md
@@ -1,22 +1,16 @@
 # Marko + Rollup
 
-The [@marko/rollup](https://github.com/marko-js/rollup) transform can be used in conjunction with [rollup](https://github.com/rollup/rollup) to automatically compile Marko templates that are required by other modules.
+# Installation
 
-<!-- The [rollup](https://github.com/marko-js/examples/tree/master/examples/rollup) sample app demonstrates how to use Marko with Rollup. Run `npx @marko/create --template rollup` to use this sample as a starting point for a new app. -->
-
-## Manual Installation
-
-```bash
-npm install rollup @rollup/plugin-commonjs @rollup/plugin-node-resolve @marko/rollup --save-dev
+```console
+npm install @marko/rollup rollup @rollup/plugin-node-resolve @rollup/plugin-commonjs -D
 ```
 
-## Configuration
+# Basic example config
 
-The following is the minimal recommend configuration to use Rollup with Marko:
+**Note: The Marko runtime is authored in commonjs, this means the `@rollup/plugin-commonjs` is required!**
 
-_rollup.config.js_
-
-```js
+```javascript
 import nodeResolve from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
 import marko from "@marko/rollup";
@@ -24,12 +18,12 @@ import marko from "@marko/rollup";
 export default {
   ...,
   plugins: [
-    marko(),
+    marko.browser(),
     nodeResolve({
       browser: true,
       extensions: [".js", ".marko"]
     }),
-    // NOTE: Marko 4 compiles to commonjs, this plugin is also required.
+    // NOTE: The Marko runtime uses commonjs so this plugin is also required.
     commonjs({
       extensions: [".js", ".marko"]
     }),
@@ -41,12 +35,166 @@ export default {
 };
 ```
 
-## Usage
+Likewise, if bundling the components for the server use `marko.server()` as the plugin.
 
-```bash
-# Development:
-rollup -c rollup.config.js
+# Linked config
 
-# Production:
-NODE_ENV=production rollup -c rollup.config.js
+If you use _both_ the `server` and `browser` plugins (in a [multi rollup config setup](https://rollupjs.org/guide/en/#configuration-files:~:text=export%20an%20array)) `@marko/rollup` will go into a _linked_ mode.
+In the linked mode you will have access to the [`<rollup>` tag](#rollup-tag) on the server, and the browser config
+will automatically have the [`input`](https://rollupjs.org/guide/en/#input) option set.
+
+```javascript
+export default [{
+  // Config object for bundling server assets.
+  input: "src/your-server-entry.js",
+  plugins: [
+    marko.server()
+    ...
+  ]
+}, {
+  // Config object for bundling browser assets.
+  plugins: [
+    marko.browser()
+    ...
+  ]
+}];
+```
+
+## `<rollup>` tag
+
+In a [linked setup](#linked-config) you have access to the `<rollup>` tag which will provide two [tag parameters](https://markojs.com/docs/syntax/#parameters) that allow you to write out the asset links for your server rendered app.
+
+The first parameter `entry` is the generated `input` name that the server plugin gave to the browser compiler.
+You can use it to find the corresponding entry chunk from rollups build.
+
+The second parameter `output` is an array of `AssetInfo | ChunkInfo` objects with most of the same properties returned from rollup's [`generateBundle` hook](https://rollupjs.org/guide/en/#generatebundle). Some properties have been stripped, notably `code` and `map` since they would be too large to inline directly. A `size` property is also available for all chunks to allow you to be able to filter out empty chunks, or inline chunks of certain size.
+
+```marko
+<head>
+  <rollup|entry, output|>
+    $ const entryChunk = output.find(chunk => chunk.name === entry);
+
+    <if(entryChunk.size /* skip scripts all together if empty js file */)>
+      <for|fileName| of=entryChunk.imports>
+        <link rel="modulepreload" href=fileName/>
+      </for>
+
+      <script async type="module" src=entryChunk.fileName/>
+    </if>
+  </rollup>
+</head>
+```
+
+Ultimately it is up to you to map the chunk data (sometimes referred to as a manifest) into the `<link>`'s and `<script>`'s rendered by your application.
+
+If your rollup browser config contains multiple `output` options, or you have multiple browser configs, all of the `chunks` for each `output` are passed into the `<rollup>` tag.
+
+For example if you have an `esm` and `iife` build:
+
+```javascript
+{
+  plugins: [
+    marko.browser()
+    ...
+  ],
+  output: [
+    { dir: 'dist/iife', format: 'iife' },
+    { dir: 'dist/esm', format: 'esm' }
+  ]
+}
+```
+
+we could access the assets from both builds:
+
+```marko
+<head>
+  <rollup|entry, iifeOutput, esmOutput|>
+    $ const iifeEntryChunk = iifeOutput.find(chunk => chunk.name === entry);
+    $ const esmEntryChunk = esmOutput.find(chunk => chunk.name === entry);
+
+    <script async type="module" src=esmEntryChunk.fileName/>
+    <script nomodule src=iifeEntryChunk.fileName></script>
+  </rollup>
+</head>
+```
+
+and _boom_ you now have a [`module/nomodule` setup](https://philipwalton.com/articles/using-native-javascript-modules-in-production-today/).
+
+# Top level components
+
+Marko was designed to send as little JavaScript to the browser as possible. One of the ways we do this is by automatically determining which templates in your app should be shipped to the browser. When rendering a template on the server, it is only necessary to bundle the styles and interactive components rendered by that template.
+
+To send the minimal amount of Marko templates to the browser you can provide a Marko template directly as the `input`.
+This will also automatically invoke code to initialize the components in the browser, so there is no need to call
+`template.render` yourself in the browser.
+
+> Note: if you are using _linked_ plugins then the server plugin will automatically tell the browser compiler which Marko templates to load.
+
+```js
+export default {
+  input: "./my-marko-page.marko",
+  plugins: [
+    marko.browser(),
+    ...
+  ],
+  ...
+}
+```
+
+## Options
+
+Both the `server` and `browser` plugins can receive the same options.
+
+### options.babelConfig
+
+You can manually override the Babel configuration used by passing a `babelConfig` object to the `@marko/rollup` plugin. By default Babels regular [config file resolution](https://babeljs.io/docs/en/config-files) will be used.
+
+```javascript
+marko.browser({
+  babelConfig: {
+    presets: ["@babel/preset-env"]
+  }
+});
+```
+
+### options.runtimeId
+
+In some cases you may want to embed multiple isolated copies of Marko on the page. Since Marko relies on some `window` properties to initialize this can cause issues. For example, by default Marko will read the server rendered hydration code from `window.$components`. In Marko you can change these `window` properties by rendering with `{ $global: { runtimeId: "MY_MARKO_RUNTIME_ID" } }` as input on the server side.
+
+This plugin exposes a `runtimeId` option produces output that automatically sets `$global.runtimeId` on the server side and initializes properly in the browser.
+
+```js
+const runtimeId = "MY_MARKO_RUNTIME_ID";
+// Make sure the `runtimeId` is the same across all of your plugins!
+marko.server({ runtimeId });
+marko.browser({ runtimeId });
+```
+
+### options.serialize
+
+This option is only available for the `browser` plugin. It allows you to transform the list of chunks serialzed in a [_linked config_](#linked-config) to include whatever you like.
+For example if you _did_ want to include the `code` property from the rollup chunk, to say inline some content, the following would work:
+
+```js
+marko.browser({
+  serialize(output) {
+    return output.map(chunk =>
+      chunk.type === "asset"
+        ? {
+            type: "asset",
+            fileName: chunk.fileName
+          }
+        : {
+            type: "chunk",
+            name: chunk.name,
+            isEntry: chunk.isEntry,
+            fileName: chunk.fileName,
+            code:
+              chunk.code.replace(/^\s+$/, "").length < 1024
+                ? chunk.code
+                : undefined // only inline small code chunks
+          }
+    );
+  }
+});
 ```

--- a/packages/marko/docs/structure.json
+++ b/packages/marko/docs/structure.json
@@ -10,7 +10,8 @@
       "Styles",
       "Events",
       "Body content",
-      "Marko 5 upgrade"
+      "Marko 5 upgrade",
+      "Troubleshooting Streaming"
     ]
   },
   {
@@ -30,11 +31,11 @@
   },
   {
     "title": "Bundler Integrations",
-    "docs": ["Webpack", "Rollup", "Lasso"]
+    "docs": ["Vite", "Webpack", "Rollup", "Lasso"]
   },
   {
     "title": "Server Integrations",
-    "docs": ["Express", "Koa", "HTTP", "Fastify"]
+    "docs": ["Cloudflare Workers", "Express", "Fastify", "Koa", "HTTP"]
   },
   {
     "title": "Tooling",

--- a/packages/marko/docs/troubleshooting-streaming.md
+++ b/packages/marko/docs/troubleshooting-streaming.md
@@ -34,7 +34,7 @@ Content Delivery Networks (CDNs) consider efficient streaming one of their best 
 - For Fastly or another provider that uses VCL configuration, check [if backend responses have `beresp.do_stream = true` set](https://developer.fastly.com/reference/vcl/variables/backend-response/beresp-do-stream/).
 
 - Some [Akamai features designed to mitigate slow backends can ironically slow down fast chunked responses](https://community.akamai.com/customers/s/question/0D50f00006n975d/enabling-chunked-transfer-encoding-responses). Try toggling off Adaptive Acceleration, Ion, mPulse, Prefetch, and/or similar performance features. Also check for the following in the configuration:
-  
+
   ```html
   <network:http.buffer-response-v2>off</network:http.buffer-response-v2>
   ```
@@ -47,12 +47,16 @@ For extreme cases where [Node streams very small HTML chunks with its built-in c
 const http = require("http");
 const zlib = require("zlib");
 
-const markoTemplate = require ("./something.marko");
+const markoTemplate = require("./something.marko");
 
-http.createServer(function (request, response) {
-  response.writeHead(200, { 'content-type': 'text/html;charset=utf-8' });    
-  const templateStream = markoTemplate.stream({});
-  const gzipStream = zlib.createGzip({ flush: zlib.constants.Z_PARTIAL_FLUSH });
-  templateStream.pipe(outputStream).pipe(response);
-}).listen(80);
+http
+  .createServer(function (request, response) {
+    response.writeHead(200, { "content-type": "text/html;charset=utf-8" });
+    const templateStream = markoTemplate.stream({});
+    const gzipStream = zlib.createGzip({
+      flush: zlib.constants.Z_PARTIAL_FLUSH
+    });
+    templateStream.pipe(outputStream).pipe(response);
+  })
+  .listen(80);
 ```

--- a/packages/marko/docs/vite.md
+++ b/packages/marko/docs/vite.md
@@ -1,0 +1,86 @@
+# Marko + Vite
+
+# Installation
+
+```console
+npm install @marko/vite vite
+```
+
+# Example config
+
+```javascript
+import { defineConfig } from "vite";
+import marko from "@marko/vite";
+export default defineConfig({
+  plugins: [marko()]
+});
+```
+
+# Linked Mode
+
+By default this plugin operates in `linked` mode (you can disabled this by passing [`linked: false` as an option](#options.linked)). In `linked` mode the plugin automatically discovers all of the entry `.marko` files while compiling the server, and tells `Vite` which modules to load in the browser.
+
+With this you _do not_ create `.html` files for `Vite`, it's Marko all the way down!
+Scripts, styles and other content that _would have_ been injected into the `.html` files is instead automatically injected into your `.marko` templates.
+
+In this mode you must use the [Vite SSR API](https://vitejs.dev/guide/ssr.html#setting-up-the-dev-server).
+
+Here's an example using `express`.
+
+```js
+import { createServer } from "vite";
+
+const app = express();
+let loadTemplate;
+
+if (process.env.NODE_ENV === "production") {
+  // Use Vite's built asset in prod mode.
+  loadTemplate = () => import("./dist");
+} else {
+  // Hookup the vite dev server.
+  const vite = await createViteServer({
+    server: { middlewareMode: true }
+  });
+
+  app.use(vite.middlewares);
+  loadTemplate = () => vite.ssrLoadModule("./template.marko");
+}
+
+app.get("/", async (req, res) => {
+  const template = (await loadTemplate()).default;
+  // When the template is loaded, it will automaticall have `vite` assets inlined.
+  template.render({ hello: "world" }, res);
+);
+
+app.listen(3000);
+```
+
+> For a more real world setup check out our [vite express](https://github.com/marko-js/examples/tree/master/examples/vite-express) example app.
+
+# Options
+
+### options.babelConfig
+
+You can manually override Marko's Babel configuration by passing a `babelConfig` object to the `@marko/vite` plugin. By default Babel's regular [config file resolution](https://babeljs.io/docs/en/config-files) will be used.
+
+```javascript
+marko({
+  babelConfig: {
+    presets: ["@babel/preset-env"]
+  }
+});
+```
+
+### options.runtimeId
+
+In some cases you may want to embed multiple isolated copies of Marko on the page. Since Marko relies on some `window` properties to initialize this can cause issues. For example, by default Marko will read the server rendered hydration code from `window.$components`. In Marko you can change these `window` properties by rendering with `{ $global: { runtimeId: "MY_MARKO_RUNTIME_ID" } }` as input on the server side.
+
+This plugin exposes a `runtimeId` option produces output that automatically sets `$global.runtimeId` on the server side and initializes properly in the browser.
+
+```js
+marko({ runtimeId: "MY_MARKO_RUNTIME_ID" });
+```
+
+### options.linked
+
+Set this to `false` to opt out of [linked mode](#linked-mode). When this is false, the plugin will only handle resolving and transforming `.marko` files.


### PR DESCRIPTION
## Description

Cleans up and updates a bunch of the server and bundler docs.
Also adds vite + cloudflare docs.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
