### PR TITLE
feat: support analyze field in marko.json

### DIFF
--- a/packages/babel-utils/index.d.ts
+++ b/packages/babel-utils/index.d.ts
@@ -50,10 +50,8 @@ export interface TagDefinition {
   template: string;
   renderer: string;
   deprecated: boolean;
-  isNestedTag: true;
-  isRepeated: boolean;
   openTagOnly: boolean;
-  targetProperty: string;
+  analyzer?: PluginDefinition;
   translator?: PluginDefinition;
   parser?: PluginDefinition;
   transformers?: PluginDefinition[];
@@ -77,6 +75,64 @@ export interface TaglibLookup {
     callback: (attr: AttributeDefinition, tag: TagDefinition) => void
   ): void;
 }
+
+export interface Attribute {
+  allowExpressions?: boolean;
+  type?: string;
+  html?: boolean;
+  enum?: string[];
+  pattern?: RegExp;
+  required?: boolean;
+  defaultValue?: unknown;
+  description?: string;
+  deprecated?: boolean;
+  autocomplete?: Array<{
+    displayText?: string;
+    snippet?: string;
+    description?: string;
+    descriptionMoreURL?: string;
+  }>;
+}
+
+export interface Tag {
+  attributeGroups?: string[];
+  patternAttributes?: Attribute[];
+  attributes?: { [x: string]: Attribute };
+  description?: string;
+  nestedTags?: {
+    [x: string]: Tag & {
+      isRepeated?: boolean;
+      targetProperty?: string;
+    };
+  };
+  autocomplete?: Array<{
+    displayText?: string;
+    snippet?: string;
+    description?: string;
+    descriptionMoreURL?: string;
+  }>;
+  htmlType?: "html" | "svg" | "math";
+  html?: boolean;
+  template?: string;
+  renderer?: string;
+  deprecated?: boolean;
+  openTagOnly: boolean;
+  analyze?: Plugin;
+  translate?: Plugin;
+  parse?: Plugin;
+  transform?: Plugin[];
+  migrate?: Plugin[];
+  parseOptions?: {
+    rootOnly?: boolean,
+    rawOpenTag?: boolean,
+    openTagOnly?: boolean,
+    ignoreAttributes?: boolean,
+    relaxRequireCommas?: boolean,
+    state?: "html" | "static-text" | "parsed-text" | "cdata"
+  }
+}
+
+export function defineTag<T extends Tag>(tag: T): T;
 
 export type FunctionPlugin = (path: t.NodePath<any>, types: typeof t) => void;
 type EnterExitPlugin = {

--- a/packages/babel-utils/src/index.js
+++ b/packages/babel-utils/src/index.js
@@ -33,3 +33,7 @@ export { parseScript, parseExpression } from "./parse";
 export { resolveRelativePath, importDefault, importNamed } from "./imports";
 
 export { getTaglibLookup, getTagDefForTagName } from "./taglib";
+
+export function defineTag(tag) {
+  return tag;
+} // just used for adding types for compiler plugins.

--- a/packages/compiler/src/taglib/loader/loadTagFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTagFromProps.js
@@ -417,6 +417,15 @@ class TagLoader {
   }
 
   /**
+   * A custom tag can be mapped to module that is is used
+   * to analyze code and cache the result in memory.
+   * This analysis data should be read by translate hooks.
+   */
+  analyze(value) {
+    this.tag.analyzer = normalizeHook(this.dirname, value);
+  }
+
+  /**
    * The tag type.
    */
   type(value) {

--- a/packages/marko/docs/compiler.md
+++ b/packages/marko/docs/compiler.md
@@ -361,6 +361,13 @@ At this stage, you are given a fully parsed and migrated AST to do what you will
 
 To hook into the `transform` stage you can use the `transform` option in the `marko.json` file.
 
+### Analyze
+
+Next up is the analyze stage. This stage is intended to do non mutative analysis of the entire AST in a way that is cached in memory.
+Meta data should be stored on the `.extra` property of nodes and typically read in the [translate](#translate) stage, or using the child template analysis helpers.
+
+To hook into the `analyze` stage you can use the `analyze` option in the `marko.json` file.
+
 ### Translate
 
 Finally, we have the translation stage. This stage is Marko's "Rosetta Stone" and is responsible for turning your beautiful Marko code into the optimized JavaScript you'd rather avoid writing.

--- a/packages/marko/docs/marko-json.md
+++ b/packages/marko/docs/marko-json.md
@@ -113,6 +113,7 @@ Typically, you should let Marko find these files automatically, but here is a re
   "parse": "./parse.js", // Used to augment parsing.
   "migrate": "./migrate.js", // Used for migrating deprecated features.
   "transform": "./transform.js", // Used to modify the AST before generating it.
+  "analyze": "./analyze.js" // Used to analyze metadata the entire ast before beginning to translate it.
   "translate": "./translate.js" // Used to generate custom JS.
 }
 ```


### PR DESCRIPTION
## Description

This PR adds support for a new field in `marko.json` files to define a function to handle the `analyze` stage of the compiler.
It also exposes types from `@marko/babel-utils` that better match a partial tag definition to aid in type completion for tag definitions defined in javascript/typescript.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
