### PR TITLE
Fix broken link on line 586

### DIFF
--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -583,7 +583,7 @@ As a shorthand you can also import components by providing it's html tag name wr
 import MyComponent from "<my-component>"
 ```
 
-This is especially useful with the [dynamic tag name syntax]("#dynamic-tagname") and uses the same [component discovery](./custom-tags.md#how-tags-are-discovered) as if the tag was used in the template.
+This is especially useful with the [dynamic tag name syntax](#dynamic-tagname) and uses the same [component discovery](./custom-tags.md#how-tags-are-discovered) as if the tag was used in the template.
 
 ## Comments
 


### PR DESCRIPTION
The location was wrapped in double quotes causing the link to not work.

P.S. the JS Foundation CLA link in the [CONTRIBUTING.md file](https://github.com/marko-js/marko/blob/7e3f7d66ef94f1aa76a00eabefdd20a7bf48c0a3/.github/CONTRIBUTING.md#pull-requests-are-always-welcome) is showing the following error:
```
Error

There is no CLA to sign for marko-js/marko

({"message":"Must specify access token via Authorization header. https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param","documentation_url":"https://docs.github.com/v3/#oauth2-token-sent-in-a-header"})
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
