### PR TITLE
update to dynamic tag jump link

### DIFF
--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -583,7 +583,7 @@ As a shorthand you can also import components by providing it's html tag name wr
 import MyComponent from "<my-component>"
 ```
 
-This is especially useful with the [dynamic tag name syntax](#dynamic-tagname) and uses the same [component discovery](./custom-tags.md#how-tags-are-discovered) as if the tag was used in the template.
+This is especially useful with the [dynamic tag name syntax](./syntax.md#dynamic-tagname) and uses the same [component discovery](./custom-tags.md#how-tags-are-discovered) as if the tag was used in the template.
 
 ## Comments
 


### PR DESCRIPTION
## Description

For some reason, on the online [syntax doc](https://markojs.com/docs/syntax) the [dynamic tag jump-link](https://markojs.com/docs/syntax#dynamic-tag) second-to-last paragraph is breaking, trying to load a different page, and loading a 404. For some unknown reason, quotation marks are placed around the jumplink in the markdown. Propose making the relative link to the same page and adding the jump #.

This change could make the jump tag work in the doc. 

Fixes issue# [1773](https://github.com/marko-js/marko/issues/1773)

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
