### PR TITLE
Small syntax update

### DIFF
--- a/packages/marko/docs/marko-vs-react.md
+++ b/packages/marko/docs/marko-vs-react.md
@@ -633,7 +633,7 @@ response stream:
 require("./components/hello").render({ name: "John" }, res);
 ```
 
-> The user’s of a Marko UI component do not need to know that the component was
+> The users of a Marko UI component do not need to know that the component was
 > implemented using Marko.
 
 Contrast this with React as an example:


### PR DESCRIPTION
Apologies for the two tiny updates. The docs look really good. It's just an incorrect apostrophe.

## Description

Solves a typo. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
