### PR TITLE
fix: performance hit in development mode because continually parsing stacktrace

### DIFF
--- a/packages/marko/src/runtime/html/AsyncStream.js
+++ b/packages/marko/src/runtime/html/AsyncStream.js
@@ -216,9 +216,7 @@ var proto = (AsyncStream.prototype = {
       timeout = AsyncStream.DEFAULT_TIMEOUT;
     }
 
-    newStream._stack = AsyncStream.INCLUDE_STACK
-      ? getNonMarkoStack(new Error())
-      : null;
+    newStream._stack = AsyncStream.INCLUDE_STACK ? new Error() : null;
     newStream.name = name;
 
     if (timeout > 0) {
@@ -455,6 +453,7 @@ var proto = (AsyncStream.prototype = {
   error: function (e) {
     var name = this.name;
     var stack = this._stack;
+    if (stack) stack = getNonMarkoStack(stack);
 
     if (!(e instanceof Error)) {
       e = new Error(JSON.stringify(e));


### PR DESCRIPTION

## Description

In dev mode the Marko call the `prepareStackTrace` each time a component is rendered. `prepareStackTrace` is called when an errorstack trace is stringfied (by accessing the `.stack`  in the `Error`). That trigger a the sourcemap logic that can be very CPU intensive. 

We have a table with a lot of nested component that takes 40 seconds to render with full 100% CPU. After profiling the CPU with a flamegraph it is clear that during marko rendering `node` spends a considerable amount of time in `prepareStackTrace`.

This PR just save a new Error()  and do the `getNonMarkoStack(error.stack)`  only when an error occur.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
