### PR TITLE
feat: relative import normalization now works better with node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"property-handlers": "^1.1.1",
 				"raptor-regexp": "^1.0.1",
 				"raptor-util": "^3.2.0",
+				"relative-import-path": "^1.0.0",
 				"resolve-from": "^5.0.0",
 				"self-closing-tags": "^1.0.1",
 				"strip-ansi": "^6.0.0",
@@ -12821,6 +12822,11 @@
 				"jsesc": "bin/jsesc"
 			}
 		},
+		"node_modules/relative-import-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.0.tgz",
+			"integrity": "sha512-ZvbtoduKQmD4PZeJPfH6Ql21qUWhaMxiHkIsH+FUnZqKDwNIXBtGg5zRZyHWomiGYk8n5+KMBPK7Mi4D0XWfNg=="
+		},
 		"node_modules/release-zalgo": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -24820,6 +24826,11 @@
 					"dev": true
 				}
 			}
+		},
+		"relative-import-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.0.tgz",
+			"integrity": "sha512-ZvbtoduKQmD4PZeJPfH6Ql21qUWhaMxiHkIsH+FUnZqKDwNIXBtGg5zRZyHWomiGYk8n5+KMBPK7Mi4D0XWfNg=="
 		},
 		"release-zalgo": {
 			"version": "1.0.0",

--- a/packages/babel-utils/package.json
+++ b/packages/babel-utils/package.json
@@ -6,7 +6,8 @@
   "bugs": "https://github.com/marko-js/marko/issues/new?template=Bug_report.md",
   "dependencies": {
     "@babel/runtime": "^7.16.0",
-    "jsesc": "^3.0.2"
+    "jsesc": "^3.0.2",
+    "relative-import-path": "^1.0.0"
   },
   "devDependencies": {
     "@marko/compiler": "^5.19.1"


### PR DESCRIPTION
## Description

There are a few cases where Marko's compilation doesn't do the best job of normalizing import paths for resolved custom tags within node_modules. Specifically adjacent node_modules and/or if things were scoped.

Technically this is not an issue, the paths we output are valid. However some of our setups rely on excluding node_modules for SSR builds and that typically works by doing a rough check on the request id to see if it looks like a node_module. In some cases Marko will currently output a relative require path to another node_module which causes these externalizers to fail.

This PR brings in a new module built to do a better job of this normalization (https://github.com/marko-js/relative-import-path) and uses it instead of our previous algorithm.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
