### PR TITLE
fix: prevent bubbling non bubbling events

### DIFF
--- a/packages/marko/test/components-browser/fixtures/event-handler-non-bubbling-multiple-listeners/index.marko
+++ b/packages/marko/test/components-browser/fixtures/event-handler-non-bubbling-multiple-listeners/index.marko
@@ -1,0 +1,16 @@
+class {
+	onCreate() {
+		this.rootCallCount = 0;
+		this.fooCallCount = 0;
+	}
+	focusRoot() {
+		this.rootCallCount++;
+	}
+	focusFoo() {
+		this.fooCallCount++;
+	}
+}
+
+<div key="root" tabindex=-1 onFocus("focusRoot")>
+	<input key="foo" type="text" onFocus("focusFoo")>
+</div>

--- a/packages/marko/test/components-browser/fixtures/event-handler-non-bubbling-multiple-listeners/test.js
+++ b/packages/marko/test/components-browser/fixtures/event-handler-non-bubbling-multiple-listeners/test.js
@@ -1,0 +1,13 @@
+var expect = require("chai").expect;
+
+module.exports = function (helpers) {
+  var component = helpers.mount(require.resolve("./index"), {});
+
+  component.getEl("foo").focus();
+  expect(component.fooCallCount).to.equal(1);
+  expect(component.rootCallCount).to.equal(0);
+
+  component.getEl("root").focus();
+  expect(component.fooCallCount).to.equal(1);
+  expect(component.rootCallCount).to.equal(1);
+};


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/marko-js/marko/pull/1104 which caused non bubbling events to propagate up to any parent tag handler if the same event was registered there.

Resolves #1780

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
