### PR TITLE
fix: upgrade htmljs-parser

### DIFF
--- a/.changeset/wet-jeans-double.md
+++ b/.changeset/wet-jeans-double.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Pin a newer version of htmljs-parser that fixes some parser bugs. See: https://github.com/marko-js/htmljs-parser/pull/103

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches: [main, v3, v4]
     paths-ignore: ["**.md"]
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name == 'pull_request_target' && github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   format:
     runs-on: ubuntu-latest
@@ -61,14 +65,14 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: [format, test]
-    if: ${{ github.repository == 'marko-js/marko' && github.event_name == 'push' }}
+    if: "${{ github.repository_owner == 'marko-js' && github.event_name == 'push' }}"
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 16
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -76,7 +80,6 @@ jobs:
         id: changesets
         uses: changesets/action@v1
         with:
-          createGithubReleases: true
           version: npm run version
           publish: npm run publish
           commit: "[ci] release"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4890,9 +4890,9 @@
       "dev": true
     },
     "node_modules/htmljs-parser": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-3.3.2.tgz",
-      "integrity": "sha512-gUAcF1JDuY37kerWoLo9/puIW0bj4lKuN5iRJwrHxtJu62z+h9E2pYtE/m9JTb03Y9DQMjA9ZBwWSj3K57TIlg=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-3.3.4.tgz",
+      "integrity": "sha512-zFj2WYq4iQEqH1E5ru0PCIf01GnuzCrfiAJtb5t5IPk1i0L42Ovdeiz+uXlM4YhMPtMgwlJZ3N0J1YB7poa35A=="
     },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
@@ -9905,7 +9905,7 @@
         "@marko/babel-utils": "^5.21.1",
         "complain": "^1.6.0",
         "he": "^1.2.0",
-        "htmljs-parser": "^3.3.2",
+        "htmljs-parser": "^3.3.4",
         "jsesc": "^3.0.2",
         "lasso-package-root": "^1.0.1",
         "property-handlers": "^1.1.1",
@@ -9955,7 +9955,7 @@
     },
     "packages/translator-default": {
       "name": "@marko/translator-default",
-      "version": "5.21.1",
+      "version": "5.21.2",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.16.0",
@@ -11576,7 +11576,7 @@
         "@marko/translator-default": "^5.21.1",
         "complain": "^1.6.0",
         "he": "^1.2.0",
-        "htmljs-parser": "^3.3.2",
+        "htmljs-parser": "^3.3.4",
         "jsesc": "^3.0.2",
         "lasso-package-root": "^1.0.1",
         "property-handlers": "^1.1.1",
@@ -13726,9 +13726,9 @@
       "dev": true
     },
     "htmljs-parser": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-3.3.2.tgz",
-      "integrity": "sha512-gUAcF1JDuY37kerWoLo9/puIW0bj4lKuN5iRJwrHxtJu62z+h9E2pYtE/m9JTb03Y9DQMjA9ZBwWSj3K57TIlg=="
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-3.3.4.tgz",
+      "integrity": "sha512-zFj2WYq4iQEqH1E5ru0PCIf01GnuzCrfiAJtb5t5IPk1i0L42Ovdeiz+uXlM4YhMPtMgwlJZ3N0J1YB7poa35A=="
     },
     "htmlparser2": {
       "version": "3.10.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci:report": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
     "report": "nyc report --reporter=html && open ./coverage/index.html",
     "set-entry": "npm exec --ws -c 'dot-json package.json main $(dot-json package.json $ENTRY)'",
-    "version": "changeset version"
+    "version": "changeset version && npm i --package-lock-only"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -16,7 +16,7 @@
     "@marko/babel-utils": "^5.21.1",
     "complain": "^1.6.0",
     "he": "^1.2.0",
-    "htmljs-parser": "^3.3.2",
+    "htmljs-parser": "^3.3.4",
     "jsesc": "^3.0.2",
     "lasso-package-root": "^1.0.1",
     "property-handlers": "^1.1.1",


### PR DESCRIPTION
## Description
Pin a newer version of htmljs-parser that fixes some parser bugs. See: https://github.com/marko-js/htmljs-parser/pull/103

This PR also contains some small cleanup to the GitHub Actions CI config.

Resolves #1796

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
