### PR TITLE
fix: attr method shorthand source map position

### DIFF
--- a/.changeset/green-moons-smoke.md
+++ b/.changeset/green-moons-smoke.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix issue where attribute shorthand methods would have incorrect sourcemap position.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -326,12 +326,18 @@ export function parseMarko(file) {
     },
 
     onAttrMethod(part) {
-      const prefix = "function";
       currentAttr.end = part.end;
-      currentAttr.value = parseExpression(
-        file,
-        prefix + parser.read(part),
-        part.start - prefix.length
+      currentAttr.value = withLoc(
+        t.functionExpression(
+          undefined,
+          parseExpression(
+            file,
+            `${parser.read(part.params)}=>{}`,
+            part.params.start
+          ).params,
+          parseScript(file, parser.read(part.body), part.body.start).body[0]
+        ),
+        part
       );
     },
 


### PR DESCRIPTION
## Description
Turns out that babels parser really doesn't like it when you try to tell it that the start position while parsing is a negative integer and that we we're passing a negative integer when we were parsing the attr method shorthand (eg `<div onClick() {}>`).

This PR updates the parsing here to avoid using a prefix which could cause a negative start position by instead parsing the params and body separately. 

Indirectly this resolves https://github.com/marko-js/prettier/issues/7

## Checklist:


- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
