### PR TITLE
fix(babel-utils): child template analysis in nested node_modules

### DIFF
--- a/.changeset/cyan-bags-fry.md
+++ b/.changeset/cyan-bags-fry.md
@@ -1,0 +1,5 @@
+---
+"@marko/babel-utils": patch
+---
+
+Fix issue with child template analysis not properly resolving nested node_modules with components.

--- a/packages/babel-utils/src/tags.js
+++ b/packages/babel-utils/src/tags.js
@@ -1,7 +1,7 @@
-import { relative, resolve, basename } from "path";
+import { relative, resolve, basename, dirname } from "path";
+import resolveFrom from "resolve-from";
 import { createHash } from "crypto";
 import { types as t } from "@marko/compiler";
-import * as compilerModules from "@marko/compiler/modules";
 import { getRootDir } from "lasso-package-root";
 import { getTagDefForTagName } from "./taglib";
 import { resolveRelativePath } from "./imports";
@@ -190,7 +190,7 @@ export function loadFileForImport(file, request) {
     const filename =
       relativeRequest[0] === "."
         ? resolve(file.opts.filename, "..", relativeRequest)
-        : compilerModules.require.resolve(relativeRequest);
+        : resolveFrom(dirname(file.opts.filename), relativeRequest);
     return file.___getMarkoFile(
       fs.readFileSync(filename).toString("utf-8"),
       createNewFileOpts(file.opts, filename),


### PR DESCRIPTION
## Description
Currently in the child template analysis code it will in some cases use `require.resolve` in order to find a `node_module` that contains a Marko file. This is problematic for nested `node_modules` since that `require.resolve` would always be relative to wherever Marko is.

This PR updates this to work similarly to the way the taglib resolves these tags, by first checking if a normal `path.resolve` can work (if it is a relative path) and falling back to the `resolve-from` module.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
