### PR TITLE
Use-cases for `<await>` attributes

### DIFF
--- a/packages/marko/docs/core-tags.md
+++ b/packages/marko/docs/core-tags.md
@@ -265,8 +265,16 @@ Optional attributes for `<await>`:
 | ---------------: | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |        `timeout` | integer | An optional timeout. If reached, rejects the promise with a `TimeoutError`.                                                                                                   |
 |           `name` | string  | Improves debugging and ensures ordering with the `show-after` attribute.                                                                                                      |
-|     `show-after` | string  | Another `<await>` tag’s `name`. With `client-reorder`, ensures that the current `<await>` block will always show after the named `<await>`.                                   |
+|     `show-after` | string  | Another `<await>` tag’s `name`. Use with `client-reorder` to ensure that the current `<await>` will always render alongside or after the named `<await>`.                     |
 | `client-reorder` | boolean | If true, anything after this `<await>` will be server-rendered before the Promise completes, then the fulfilled Promise’s result will be updated with client-side JavaScript. |
+
+Regardless of these attributes, the promise is executed as eagerly as possible. The attributes control how to coordinate rendering with the rest of the page:
+
+- `client-reorder` prevents `<await>` blocks from delaying the HTTP stream, at the expense of making their rendering rely on client-side JS. Useful for making non-critical page sections not block HTML streaming of important content.
+
+- Using `show-after` with `client-reorder` ensures that the current `<await>` block will always render simultaneously with or after the named `<await>`. Useful for cutting down on [layout shift](https://web.dev/debug-layout-shifts/). `<@placeholder>`s can help fine-tune the user experience while loading.
+
+- `timeout` is useful for limiting non-critical content from slowing down the rest of the page too much.
 
 > **Pro Tip**: When using `timeout`, you can distinguish between `TimeoutError`s and promise rejections by checking the error’s `name`:
 >


### PR DESCRIPTION
Prompted by [this Discord conversation](https://discord.com/channels/725013179465203793/725013179926708226/990598962962640946):

> [8:46 AM] vwong: What is the intended use case for `<await show-after>`? I'm reading the docs, and am just wondering what use-case drove this feature?
> [8:49 AM] mpeg: If you do out of order client rendering with client-reorder I guess you could still want to have certain `<await>` blocks to wait for others to finish before showing
> [8:51 AM] vwong: Yeah, I get that it's only for client rendering, since server rendering is basically HTML order (or CSS if you flip it around). But example scenario?
> [8:52 AM] mpeg: Seems pretty niche for UX reasons, maybe say you want your `<await>` for product recommendations to show only after showing the product info
> [8:53 AM] mpeg: Or comments after the main content loads
> [8:53 AM] mpeg: But I’m not sure you’d even want to use client-reorder in neither of those cases 😅
> [8:57 AM] mpeg: https://github.com/search?q=show-after+extension%3Amarko&type=code
> 
> Not many examples out there, I wonder if they added that for a very specific eBay usecase
> [8:57 AM] vwong: Wondering if it delays the execution of the promise, or just delaying the visual appearance of it. I can see a use case for the former. I guess I can test that out myself.
> [11:27 AM] DylanPiercey: @vwong regardless of show after, client reorder, or in order, execution is always as eager as possible. Show after is just a tool to help you avoid layout shift in some cases while still eagerly rendering
> [11:37 AM] Tigt: I should probably make a todo item to put this in the docs
> [5:35 PM] vwong: Ah, so `show-after` can be paired with `<@placeholder>` to reduce/eliminate layout shift. Gotcha!

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] N/A ~~I have added tests to cover my changes.~~
