### PR TITLE
fix: issue with return statement inside attr method shorthand

### DIFF
--- a/.changeset/happy-sheep-drum.md
+++ b/.changeset/happy-sheep-drum.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"marko": patch
+"@marko/translator-default": patch
+---
+
+Fix issue where shorthand attribute methods could not have a "return" statement.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -334,7 +334,11 @@ export function parseMarko(file) {
             `${parser.read(part.params)}=>{}`,
             part.params.start
           ).params,
-          parseScript(file, parser.read(part.body), part.body.start).body[0]
+          parseExpression(
+            file,
+            `()=>${parser.read(part.body)}`,
+            part.params.start + "()=>".length
+          ).body
         ),
         part
       );

--- a/packages/translator-default/test/fixtures/attr-method-with-return/components/test.marko
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/components/test.marko
@@ -1,0 +1,3 @@
+<div>
+  ${input.doThing()}
+</div>

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/cjs-expected.js
@@ -1,0 +1,32 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _index = require("marko/src/runtime/html/index.js");
+
+var _test2 = _interopRequireDefault(require("./components/test.marko"));
+
+var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
+
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
+      _marko_template = (0, _index.t)(_marko_componentType);
+
+var _default = _marko_template;
+exports.default = _default;
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
+  (0, _renderTag.default)(_test2.default, {
+    "doThing": function () {
+      return 1;
+    }
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/generated-expected.marko
@@ -1,0 +1,3 @@
+<test doThing() {
+  return 1;
+}/>

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/html-expected.js
@@ -1,0 +1,21 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+
+const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _test from "./components/test.marko";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  _marko_tag(_test, {
+    "doThing": function () {
+      return 1;
+    }
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
@@ -1,0 +1,20 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+
+const _marko_componentType = "+mnrnsox",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _test from "./components/test.marko";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  _marko_tag(_test, {
+    "doThing": function () {
+      return 1;
+    }
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdom-expected.js
@@ -1,0 +1,27 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+
+const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _test from "./components/test.marko";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
+
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  _marko_tag(_test, {
+    "doThing": function () {
+      return 1;
+    }
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
@@ -1,0 +1,26 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+
+const _marko_componentType = "+mnrnsox",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _test from "./components/test.marko";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
+
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  _marko_tag(_test, {
+    "doThing": function () {
+      return 1;
+    }
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/attr-method-with-return/template.marko
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/template.marko
@@ -1,0 +1,3 @@
+<test doThing() {
+  return 1;
+}/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix issue where shorthand attribute methods could not have a "return" statement.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
