### PR TITLE
fix: comments or whitespace between else/else-if tags

### DIFF
--- a/.changeset/four-dogs-shout.md
+++ b/.changeset/four-dogs-shout.md
@@ -1,0 +1,5 @@
+---
+"@marko/translator-default": patch
+---
+
+Fix issue where there was whitespace or a comment between else/else-if tags.

--- a/packages/translator-default/src/taglib/core/conditional/util.js
+++ b/packages/translator-default/src/taglib/core/conditional/util.js
@@ -16,6 +16,15 @@ export function buildIfStatement(path, args) {
 
   let nextPath = path.getNextSibling();
 
+  while (
+    nextPath.isMarkoComment() ||
+    (nextPath.isMarkoText() && /^\s*$/.test(nextPath.node.value))
+  ) {
+    const ignorePath = nextPath;
+    nextPath = nextPath.getNextSibling();
+    ignorePath.remove();
+  }
+
   // Provide the if statement to the next part of the if chain.
   if (nextPath.isMarkoTag()) {
     const nextTagName = nextPath.get("name");

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/cjs-expected.js
@@ -1,0 +1,24 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+
+var _index = require("marko/src/runtime/html/index.js");
+
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
+      _marko_template = (0, _index.t)(_marko_componentType);
+
+var _default = _marko_template;
+exports.default = _default;
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
+  if (x) {} else if (y) {} else {}
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/generated-expected.marko
@@ -1,0 +1,5 @@
+<if(x)/>
+<else-if(y)/>
+<!-- Comments are okay also! -->
+<!-- Comments are okay also!-->
+<else/>

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/html-expected.js
@@ -1,0 +1,15 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+
+const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  if (x) {} else if (y) {} else {}
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
@@ -1,0 +1,14 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+
+const _marko_componentType = "GzjO/FF7",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  if (x) {} else if (y) {} else {}
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdom-expected.js
@@ -1,0 +1,21 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+
+const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
+
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  if (x) {} else if (y) {} else {}
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
@@ -1,0 +1,20 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+
+const _marko_componentType = "GzjO/FF7",
+      _marko_template = _t(_marko_componentType);
+
+export default _marko_template;
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
+
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
+  if (x) {} else if (y) {} else {}
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko
@@ -1,0 +1,9 @@
+<if(x)>
+</if>
+   
+<else-if(y)>
+</else-if>
+<!-- Comments are okay also! -->
+// Comments are okay also!
+<else>
+</else>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fix issue where there was whitespace or a comment between else/else-if tags.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
