### PR TITLE
chore: add release notes for markoc

### DIFF
--- a/.changeset/eighty-pandas-relate.md
+++ b/.changeset/eighty-pandas-relate.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Update markoc cli to allow striping types.


### PR DESCRIPTION
## Description

The `markoc` cli was given the ability to strip typescript types, however it (accidentally) was not released with the previous changes. This adds release notes for the `marko` package so that it can now be published.

