### PR TITLE
fix: source map for shorthand attr methods

### DIFF
--- a/.changeset/twenty-games-perform.md
+++ b/.changeset/twenty-games-perform.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"marko": patch
+---
+
+Fix issue with source map position for shorthand attribute methods.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -337,7 +337,7 @@ export function parseMarko(file) {
           parseExpression(
             file,
             `()=>${parser.read(part.body)}`,
-            part.params.start + "()=>".length
+            part.body.start - 4
           ).body
         ),
         part


### PR DESCRIPTION
## Description

There was a regression recently where the source map positions for shorthand attribute methods were off.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
