### PR TITLE
chore: upgrade htmljs-parser

### DIFF
--- a/.changeset/six-coats-visit.md
+++ b/.changeset/six-coats-visit.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"marko": patch
+---
+
+Upgrade HTMLJS-Parser.

--- a/package-lock.json
+++ b/package-lock.json
@@ -4918,9 +4918,9 @@
       "dev": true
     },
     "node_modules/htmljs-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.0.4.tgz",
-      "integrity": "sha512-BYRbxp5c4WcEsDU78cUQs5zs3VzuQhKSp5ChK79CW1n1GGfd2yayOR7UnmE4+rbsnMGzaNpGE6a+IzNGx9DyZw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.1.1.tgz",
+      "integrity": "sha512-MjfvfsReMd1Nd5A29zTYxAkrvSEB/gl7Vm8XC1erONAMvnpgRbryeKBAW2u8dthBAiga/DMiy06cZlYv8XW3mg=="
     },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
@@ -9927,7 +9927,7 @@
         "@marko/babel-utils": "^5.21.1",
         "complain": "^1.6.0",
         "he": "^1.2.0",
-        "htmljs-parser": "^5.0.4",
+        "htmljs-parser": "^5.1.1",
         "jsesc": "^3.0.2",
         "lasso-package-root": "^1.0.1",
         "property-handlers": "^1.1.1",
@@ -11639,7 +11639,7 @@
         "@marko/translator-default": "^5.21.3",
         "complain": "^1.6.0",
         "he": "^1.2.0",
-        "htmljs-parser": "^5.0.4",
+        "htmljs-parser": "^5.1.1",
         "jsesc": "^3.0.2",
         "lasso-package-root": "^1.0.1",
         "property-handlers": "^1.1.1",
@@ -13790,9 +13790,9 @@
       "dev": true
     },
     "htmljs-parser": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.0.4.tgz",
-      "integrity": "sha512-BYRbxp5c4WcEsDU78cUQs5zs3VzuQhKSp5ChK79CW1n1GGfd2yayOR7UnmE4+rbsnMGzaNpGE6a+IzNGx9DyZw=="
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.1.1.tgz",
+      "integrity": "sha512-MjfvfsReMd1Nd5A29zTYxAkrvSEB/gl7Vm8XC1erONAMvnpgRbryeKBAW2u8dthBAiga/DMiy06cZlYv8XW3mg=="
     },
     "htmlparser2": {
       "version": "3.10.1",

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -18,7 +18,7 @@
     "@marko/babel-utils": "^5.21.1",
     "complain": "^1.6.0",
     "he": "^1.2.0",
-    "htmljs-parser": "^5.0.4",
+    "htmljs-parser": "^5.1.1",
     "jsesc": "^3.0.2",
     "lasso-package-root": "^1.0.1",
     "property-handlers": "^1.1.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Upgrades the `htmljs-parser` to bring in https://github.com/marko-js/htmljs-parser/pull/127
