### PR TITLE
fix: regexp for swapping dev/prod runtimes

### DIFF
--- a/.changeset/red-spoons-flash.md
+++ b/.changeset/red-spoons-flash.md
@@ -1,0 +1,8 @@
+---
+"@marko/babel-utils": patch
+"@marko/compiler": patch
+"marko": patch
+"@marko/translator-default": patch
+---
+
+Fix issue where Marko runtime was being incorrectly matched when swapping from dev to prod runtimes.

--- a/packages/babel-utils/src/imports.js
+++ b/packages/babel-utils/src/imports.js
@@ -11,7 +11,10 @@ export function resolveRelativePath(file, request) {
   }
 
   if (file.markoOpts.optimize) {
-    request = request.replace(/(^|\/)marko\/src\//, "$1marko/dist/");
+    request = request.replace(
+      /(^|\/node-modules\/)marko\/src\//,
+      "$1marko/dist/"
+    );
   }
 
   return request;


### PR DESCRIPTION
Our existing regex for swapping dev/prod runtimes was too eager and would match stuff like `./anything/marko/src/`. Now it will only match `marko` in `node_modules`.