### PR TITLE
fix: improve support for @lasso/marko-taglib and @marko/compiler/register

### DIFF
--- a/.changeset/brave-rice-wink.md
+++ b/.changeset/brave-rice-wink.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Enable the meta option for the compiler when @marko/compiler/register is used. This makes usage with lasso easier.

--- a/packages/compiler/src/register.js
+++ b/packages/compiler/src/register.js
@@ -12,8 +12,11 @@ function register({ extensions = require.extensions, ...options } = {}) {
       compiler.compileFileSync(
         filename,
         Object.assign(
-          // eslint-disable-next-line no-constant-condition
-          { sourceMaps: "MARKO_DEBUG" ? "inline" : false },
+          {
+            meta: true,
+            // eslint-disable-next-line no-constant-condition
+            sourceMaps: "MARKO_DEBUG" ? "inline" : false
+          },
           options,
           requiredOptions
         )


### PR DESCRIPTION
## Description

Currently to use `@lasso/marko-taglib` with the new `@marko/compiler/register` api the `meta` option must be enabled.
In order to improve support for that case we change this option to be enabled by default.

## Checklist:
- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
