### PR TITLE
fix: auto enable hmr mode when using browser-refresh client and @mark…

### DIFF
--- a/.changeset/khaki-boats-count.md
+++ b/.changeset/khaki-boats-count.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix browser-refresh client support when using @marko/compiler/register

--- a/packages/compiler/src/register.js
+++ b/packages/compiler/src/register.js
@@ -1,7 +1,9 @@
 "use strict";
 
 const compiler = require(".");
+const shouldOptimize = require("./util/should-optimize").default;
 const requiredOptions = { modules: "cjs" };
+const isDev = !shouldOptimize();
 
 module.exports = register;
 register();
@@ -14,8 +16,9 @@ function register({ extensions = require.extensions, ...options } = {}) {
         Object.assign(
           {
             meta: true,
+            hot: process.env.BROWSER_REFRESH_URL !== undefined,
             // eslint-disable-next-line no-constant-condition
-            sourceMaps: "MARKO_DEBUG" ? "inline" : false
+            sourceMaps: isDev ? "inline" : false
           },
           options,
           requiredOptions


### PR DESCRIPTION
## Description
Enables the `hot` (hot module reload api) compiler option if we detect we are running in a `browser-refresh` environment (https://github.com/patrick-steele-idem/browser-refresh).

This change is specific to `@marko/compiler/register` (previously `marko/node-require` would do something similar).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
