### PR TITLE
V4 improve tagdir folder scan cache

### DIFF
--- a/packages/marko/package-lock.json
+++ b/packages/marko/package-lock.json
@@ -6,7 +6,7 @@
     "packages": {
         "": {
             "name": "marko",
-            "version": "4.24.2",
+            "version": "4.24.5",
             "license": "MIT",
             "dependencies": {
                 "acorn": "^7.4.0",

--- a/packages/marko/src/taglib/taglib-finder/index.js
+++ b/packages/marko/src/taglib/taglib-finder/index.js
@@ -3,8 +3,6 @@ var taglibLoader = require("../taglib-loader");
 var nodePath = require("path");
 var lassoPackageRoot = require("lasso-package-root");
 var resolveFrom = require("resolve-from");
-var scanTagsDir = require("../taglib-loader/scanTagsDir");
-var DependencyChain = require("../taglib-loader/DependencyChain");
 var lassoCachingFS = require("lasso-caching-fs");
 
 var findCache = {};
@@ -69,9 +67,6 @@ function find(dirname, registeredTaglibs) {
   var added = {};
 
   var helper = {
-    alreadyAdded: function(taglibId) {
-      return added.hasOwnProperty(taglibId);
-    },
     addTaglib: function(taglib) {
       if (added[taglib.id]) {
         return;
@@ -105,20 +100,8 @@ function find(dirname, registeredTaglibs) {
       if (!taglib || taglib.tagsDir === undefined) {
         let componentsPath = nodePath.join(curDirname, "components");
 
-        if (
-          existsCached(componentsPath) &&
-          !excludedDirs[componentsPath] &&
-          !helper.alreadyAdded(componentsPath)
-        ) {
-          let taglib = taglibLoader.createTaglib(componentsPath);
-          scanTagsDir(
-            componentsPath,
-            nodePath.dirname(componentsPath),
-            "components",
-            taglib,
-            new DependencyChain([componentsPath])
-          );
-          helper.addTaglib(taglib);
+        if (existsCached(componentsPath) && !excludedDirs[componentsPath]) {
+          helper.addTaglib(taglibLoader.loadTaglibFromDir(curDirname));
         }
       }
     }

--- a/packages/marko/src/taglib/taglib-loader/index.js
+++ b/packages/marko/src/taglib/taglib-loader/index.js
@@ -12,6 +12,10 @@ function loadTaglibFromFile(filePath) {
   return loaders.loadTaglibFromFile(filePath);
 }
 
+function loadTaglibFromDir(filePath) {
+  return loaders.loadTaglibFromDir(filePath);
+}
+
 function clearCache() {
   cache.clear();
 }
@@ -34,4 +38,5 @@ exports.clearCache = clearCache;
 exports.createTaglib = createTaglib;
 exports.loadTaglibFromProps = loadTaglibFromProps;
 exports.loadTaglibFromFile = loadTaglibFromFile;
+exports.loadTaglibFromDir = loadTaglibFromDir;
 exports.loadTag = loadTag;

--- a/packages/marko/src/taglib/taglib-loader/loadTaglibFromDir.js
+++ b/packages/marko/src/taglib/taglib-loader/loadTaglibFromDir.js
@@ -1,0 +1,32 @@
+var nodePath = require("path");
+var types = require("./types");
+var cache = require("./cache");
+var DependencyChain = require("./DependencyChain");
+var scanTagsDir = require("./scanTagsDir");
+
+var ok = require("assert").ok;
+
+function loadFromDir(dir) {
+  ok(dir, '"dir" is required');
+
+  var componentsPath = nodePath.join(dir, "components");
+  var taglib = cache.get(componentsPath);
+
+  // Only load a taglib once by caching the loaded taglibs using the file
+  // system file path as the key
+  if (!taglib) {
+    taglib = new types.Taglib(componentsPath);
+    cache.put(componentsPath, taglib);
+    scanTagsDir(
+      componentsPath,
+      dir,
+      "components",
+      taglib,
+      new DependencyChain([componentsPath])
+    );
+  }
+
+  return taglib;
+}
+
+module.exports = loadFromDir;

--- a/packages/marko/src/taglib/taglib-loader/loaders.js
+++ b/packages/marko/src/taglib/taglib-loader/loaders.js
@@ -18,6 +18,7 @@ exports.loadTagFromProps = require("./loadTagFromProps");
 exports.loadTagFromFile = require("./loadTagFromFile");
 exports.loadTaglibFromProps = require("./loadTaglibFromProps");
 exports.loadTaglibFromFile = require("./loadTaglibFromFile");
+exports.loadTaglibFromDir = require("./loadTaglibFromDir");
 exports.loadAttributes = require("./loadAttributes");
 exports.isSupportedAttributeProperty = isSupportedAttributeProperty;
 exports.isSupportedTagProperty = isSupportedTagProperty;


### PR DESCRIPTION
## Description

This PR improves the performance of the taglib scanning for the `components` directories. This was not correctly being cached previously.
