### PR TITLE
fix: avoid template instance mutation in HMR mode

### DIFF
--- a/.changeset/soft-cups-punch.md
+++ b/.changeset/soft-cups-punch.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/compiler": patch
+"@marko/translator-default": patch
+---
+
+Avoid mutating component instance in HMR mode. (Improves support in tags api preview)

--- a/packages/marko/src/runtime/vdom/hot-reload.js
+++ b/packages/marko/src/runtime/vdom/hot-reload.js
@@ -7,6 +7,7 @@ var updateManager = require("../components/update-manager");
 var createTemplate = runtime.t;
 var createComponent = registry.___createComponent;
 var registered = {};
+var instancesByType = {};
 var queue;
 
 runtime.t = function (typeName) {
@@ -16,7 +17,7 @@ runtime.t = function (typeName) {
 
   var renderFn;
   var template = (registered[typeName] = createTemplate(typeName));
-  var instances = (template.___instances = []);
+  var instances = (instancesByType[typeName] = []);
   Object.defineProperty(template, "_", {
     get: function () {
       return renderFn && proxyRenderer;
@@ -75,11 +76,10 @@ runtime.t = function (typeName) {
 };
 
 registry.___createComponent = function (typeName, id) {
-  var template = registered[typeName];
+  var instances = instancesByType[typeName];
   var instance = createComponent(typeName, id);
 
-  if (template) {
-    var instances = template.___instances;
+  if (instances) {
     instances.push(instance);
     instance.once("destroy", function () {
       if (!instance.___hmrDestroyed) {


### PR DESCRIPTION
## Description
Currently the HMR implementation for the DOM mutates the template constructor keep track of all instances.
This mutation causes an issue when a template is passed around in the tags api preview where things are frozen.

This PR updates that logic to avoid mutating the instance.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
