### PR TITLE
feat: rename default attr

### DIFF
--- a/.changeset/hungry-olives-agree.md
+++ b/.changeset/hungry-olives-agree.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": minor
+"@marko/translator-default": minor
+"marko": minor
+---
+
+Changes the "default" attributes name to be "value". This is technically a breaking change, but it primarily only impacts the tags-api-preview which will also be getting a release to support this change.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -293,7 +293,7 @@ export function parseMarko(file) {
       endAttr();
       currentTag.node.attributes.push(
         (currentAttr = t.markoAttribute(
-          name || "default",
+          name || "value",
           t.booleanLiteral(true),
           modifier,
           undefined,

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/cjs-expected.js
@@ -26,7 +26,7 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     }
   }, out, _componentDef, "0");
   (0, _renderTag.default)(_customTag2.default, {
-    "default": function () {
+    "value": function () {
       console.log("again");
     }
   }, out, _componentDef, "1");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/html-expected.js
@@ -16,7 +16,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, out, _componentDef, "0");
 
   _marko_tag(_customTag, {
-    "default": function () {
+    "value": function () {
       console.log("again");
     }
   }, out, _componentDef, "1");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
@@ -16,7 +16,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, out, _componentDef, "0");
 
   _marko_tag(_customTag, {
-    "default": function () {
+    "value": function () {
       console.log("again");
     }
   }, out, _componentDef, "1");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdom-expected.js
@@ -20,7 +20,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, out, _componentDef, "0");
 
   _marko_tag(_customTag, {
-    "default": function () {
+    "value": function () {
       console.log("again");
     }
   }, out, _componentDef, "1");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
@@ -20,7 +20,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, out, _componentDef, "0");
 
   _marko_tag(_customTag, {
-    "default": function () {
+    "value": function () {
       console.log("again");
     }
   }, out, _componentDef, "1");

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
@@ -18,9 +18,9 @@ var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
-  out.w("<div default></div>");
+  out.w("<div value></div>");
   out.w("<div></div>");
-  out.w(`<div${(0, _attr.default)("default", abc)}></div>`);
+  out.w(`<div${(0, _attr.default)("value", abc)}></div>`);
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
@@ -8,9 +8,9 @@ import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
-  out.w("<div default></div>");
+  out.w("<div value></div>");
   out.w("<div></div>");
-  out.w(`<div${_marko_attr("default", abc)}></div>`);
+  out.w(`<div${_marko_attr("value", abc)}></div>`);
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
@@ -8,7 +8,7 @@ import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
-  out.w(`<div default></div><div></div><div${_marko_attr("default", abc)}></div>`);
+  out.w(`<div value></div><div></div><div${_marko_attr("value", abc)}></div>`);
 }, {
   t: _marko_componentType,
   i: true

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
@@ -12,11 +12,11 @@ _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {
-    "default": ""
+    "value": ""
   }, "0", _component, 0, 0);
   out.e("div", null, "1", _component, 0, 0);
   out.e("div", {
-    "default": abc
+    "value": abc
   }, "2", _component, 0, 0);
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
@@ -7,7 +7,7 @@ export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
 
 const _marko_node = _marko_createElement("div", {
-  "default": ""
+  "value": ""
 }, "0", null, 0, 0);
 
 const _marko_node2 = _marko_createElement("div", null, "1", null, 0, 0);
@@ -22,7 +22,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.n(_marko_node, _component);
   out.n(_marko_node2, _component);
   out.e("div", {
-    "default": abc
+    "value": abc
   }, "2", _component, 0, 0);
 }, {
   t: _marko_componentType,


### PR DESCRIPTION
## Description

Changes the "default" attributes name to be "value". This is technically a breaking change, but it primarily only impacts the tags-api-preview which will also be getting a release to support this change.
