### PR TITLE
Showcase interpolation in shorthand notation

### DIFF
--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -257,7 +257,7 @@ _HTML Output:_
 
 ### Shorthand attributes
 
-Marko provides a shorthand for declaring classes and ids on an element:
+Marko provides a shorthand for declaring classes and ids on an element, including interpolation.  Given `size` is the string `small`:
 
 _Marko Source:_
 
@@ -265,6 +265,7 @@ _Marko Source:_
 <div.my-class/>
 <span#my-id/>
 <button#submit.primary.large/>
+<button.button--${size}></button>
 ```
 
 Renders the following HTML:
@@ -276,6 +277,7 @@ _HTML Output:_
 <div class="my-class"></div>
 <span id="my-id"></span>
 <button id="submit" class="primary large"></button>
+<button class="button--small"></button>
 ```
 
 ## Parameters


### PR DESCRIPTION
## Description

`htmljs-parser` (and thus Marko) is capable of string interpolation in the shorthand notation. We should showcase this!

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
