### PR TITLE
Update URLs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code of Conduct
 
-This project adheres to the [eBay Code of Conduct](http://ebay.github.io/codeofconduct).
+This project adheres to the [eBay Code of Conduct](https://github.com/eBay/.github/blob/main/CODE_OF_CONDUCT.md).
 By participating in this project you agree to abide by its terms.
 
 - Be friendly and patient.
@@ -19,4 +19,4 @@ By participating in this project you agree to abide by its terms.
 
 - Remember that we’re different. The strength of our community comes from its diversity, people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn’t mean that they’re wrong. Don’t forget that it is human to err and blaming each other doesn’t get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
 
-Please visit http://ebay.github.io/codeofconduct for the full code of conduct.
+Please visit https://github.com/eBay/.github/blob/main/CODE_OF_CONDUCT.md for the full code of conduct.

--- a/packages/marko/docs/10-awesome-marko-features.md
+++ b/packages/marko/docs/10-awesome-marko-features.md
@@ -6,7 +6,7 @@
 
 # 10 Awesome Marko Features
 
-[Marko](http://markojs.com/) is a friendly and super fast UI library that makes
+[Marko](https://markojs.com/) is a friendly and super fast UI library that makes
 building web apps<br> fun! In celebration of rapidly approaching [5,000 stars on
 GitHub](https://github.com/marko-js/marko) (the ultimate open source vanity
 metric), here are 10 features that will make you more productive in no
@@ -89,7 +89,7 @@ Do you see references to “Marko” in the snippet above? Yeah, me neither.
 
 Is your component becoming too large? Do you prefer separating your CSS,
 JavaScript, and markup code? No problem. You can easily [rip out your code into
-multiple files](http://markojs.com/docs/class-components/#multi-file-components):
+multiple files](https://markojs.com/docs/class-components/#multi-file-components):
 
 ```
 components/
@@ -223,7 +223,7 @@ $ {
 Node.js is asynchronous. Browsers are asynchronous. Why should rendering be
 synchronous? Pass your promise along to your template and Marko will
 asynchronously render parts of your view. Turns out, [this is good for
-performance](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/).
+performance](https://tech.ebayinc.com/engineering/async-fragments-rediscovering-progressive-html-rendering-with-marko/).
 
 ```marko
 $ const searchResultsPromise = searchService.performSearch(keywords);

--- a/packages/marko/docs/class-components.md
+++ b/packages/marko/docs/class-components.md
@@ -24,7 +24,7 @@ Marko makes it easy to keep your component’s class and styles next to the HTML
 
 - **View** - The HTML template for your UI component. Receives input properties and states, and renders to either server-side HTML or browser-side virtual DOM nodes.
 - **Client-side behavior** - A JavaScript `class` with methods and properties for initialization, event handling (including DOM events, custom events and lifecycle events), and state management.
-- **Styles** - Cascading StyleSheets, including support for CSS preprocessors like [Less](http://lesscss.org/) or [Sass](https://sass-lang.com/).
+- **Styles** - Cascading StyleSheets, including support for CSS preprocessors like [Less](https://lesscss.org/) or [Sass](https://sass-lang.com/).
 
 ## Server-side rendering
 

--- a/packages/marko/docs/express.md
+++ b/packages/marko/docs/express.md
@@ -25,7 +25,7 @@ npm install marko express @marko/express --save
 
 ### Skip the view engine
 
-Express’s builtin view engine may be asynchronous, but it doesn’t support streaming — see [Rediscovering Progressive HTML Rendering](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/) for why that’s important. So instead, we [bypass Express’s view engine](https://strongloop.com/strongblog/bypassing-express-view-rendering-for-speed-and-modularity/) to use `@marko/express` instead.
+Express’s builtin view engine may be asynchronous, but it doesn’t support streaming — see [Rediscovering Progressive HTML Rendering](https://tech.ebayinc.com/engineering/async-fragments-rediscovering-progressive-html-rendering-with-marko/) for why that’s important. So instead, we [bypass Express’s view engine](https://strongloop.com/strongblog/bypassing-express-view-rendering-for-speed-and-modularity/) to use `@marko/express` instead.
 
 [The `@marko/express` package](https://www.npmjs.com/package/@marko/express) adds a `res.marko()` method to [Express’s response object](https://expressjs.com/en/api.html#res). This method works like [`res.render()`](https://expressjs.com/en/api.html#res.render), but without the restrictions of Express’s view engine, letting you take full advantage of Marko’s streaming and modular template organization.
 

--- a/packages/marko/docs/marko-vs-react.md
+++ b/packages/marko/docs/marko-vs-react.md
@@ -7,7 +7,7 @@
 > This article was published March 2017. Both frameworks have gone through several updates since. You can find the original ["Marko vs React: An In-depth Look" article here](https://hackernoon.com/marko-vs-react-an-in-depth-look-767de0a5f9a6)!
 
 In this article we will take an in-depth look at the differences and
-similarities between [Marko](http://markojs.com/) and React from the perspective
+similarities between [Marko](https://markojs.com/) and React from the perspective
 of the maintainers of Marko.
 
 On the surface, Marko and React have a lot in common and both are trying to
@@ -27,7 +27,7 @@ weight:
 Because the Marko JavaScript library is much smaller than React, it will require
 less time to load and parse and this will drastically improve page load times on
 slow connections or on older devices. Based on [our
-benchmarks](http://markojs.com/#benchmarks), Marko consistently outperforms
+benchmarks](https://markojs.com/#benchmarks), Marko consistently outperforms
 React by a significant margin on both the server and in the browser.
 
 ### Example
@@ -82,7 +82,7 @@ class Counter extends React.Component {
 }
 ```
 
-<span class="figcaption_hack">[▶ Try Online](http://codepen.io/mlrawlings/pen/wJXOWR?editors=0010)</span>
+<span class="figcaption_hack">[▶ Try Online](https://codepen.io/mlrawlings/pen/wJXOWR?editors=0010)</span>
 
 #### Marko
 
@@ -115,7 +115,7 @@ $ var count = state.count;
 ```
 
 <span class="figcaption_hack">[▶ Try
-Online](http://markojs.com/try-online/?gist=8fe46bc5866605aca0dfeec202604011)</span>
+Online](https://markojs.com/try-online/?gist=8fe46bc5866605aca0dfeec202604011)</span>
 
 ### Similarities
 
@@ -151,7 +151,7 @@ At a high level here are some differences:
   targets).
 - **Improved performance:** Marko supports asynchronous rendering with [early
   flushing of
-  HTML](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/)
+  HTML](https://tech.ebayinc.com/engineering/async-fragments-rediscovering-progressive-html-rendering-with-marko/)
   for improvements in actual and perceived page load times.
 - **Improved performance:** React requires an additional client-side re-render if
   a page is initially rendered on the server while Marko does not.
@@ -164,7 +164,7 @@ At a high level here are some differences:
 #### Differences in syntax
 
 - **Improved ease of use:** Marko uses the
-  [HTML-JS](http://markojs.com/docs/syntax/) syntax and the
+  [HTML-JS](https://markojs.com/docs/syntax/) syntax and the
   [JSX](https://facebook.github.io/react/docs/jsx-in-depth.html) syntax is offered
   for React.
 - **Improved ease of use:** Marko supports both a concise syntax and a familiar
@@ -246,9 +246,9 @@ At a high level here are some differences:
 - **Marko limitation:** Marko has no support for native mobile similar to React
   Native (although with Marko VDOM rendering, this is possible).
 - **Marko limitation:** Marko requires a JavaScript module bundler (such as
-  [Lasso](http://markojs.com/docs/lasso/),
-  [Webpack](http://markojs.com/docs/webpack/),
-  [Rollup](http://markojs.com/docs/rollup/)
+  [Lasso](https://markojs.com/docs/lasso/),
+  [Webpack](https://markojs.com/docs/webpack/),
+  [Rollup](https://markojs.com/docs/rollup/)
   since Marko UI components compile down to JavaScript modules. (we consider using
   a JavaScript module bundler a best practice)
 
@@ -261,7 +261,7 @@ between Marko and React.
 
 Both Marko and React JSX allow HTML markup and JavaScript to be combined into a
 single file and both support building web applications based on UI components.
-Marko utilizes an [HTML-JS syntax](http://markojs.com/docs/syntax/) while most
+Marko utilizes an [HTML-JS syntax](https://markojs.com/docs/syntax/) while most
 React apps use the JSX syntax.
 
 > React JSX makes JavaScript more like HTML and Marko makes HTML more like
@@ -372,7 +372,7 @@ documentation](https://facebook.github.io/react/docs/introducing-jsx.html#specif
 > For example, `class` becomes `className` in JSX, and `tabindex` becomes `tabIndex`.
 
 As a result of this caveat for React, [tools for converting HTML to JSX
-exist](http://magic.reactjs.net/htmltojsx.htm).
+exist](https://magic.reactjs.net/htmltojsx.htm).
 
 #### React JSX
 
@@ -679,7 +679,7 @@ export default function HelloGoodBye(props) {
 #### Marko
 
 Marko supports a mechanism for [automatically discovering custom
-tags](http://markojs.com/docs/custom-tags/#discovering-tags) for UI components
+tags](https://markojs.com/docs/custom-tags/#discovering-tags) for UI components
 based on the project directory structure. Marko walks up the directory tree to
 discover all directories and it will also automatically discover custom tags
 exported by installed packages. This approach negates the need for explicitly
@@ -710,7 +710,7 @@ tags.
 ### Async
 
 Even after rendering has started, Marko allows parts of the view to be rendered
-asynchronously using the [`<await>`](http://markojs.com/docs/core-tags#await)
+asynchronously using the [`<await>`](https://markojs.com/docs/core-tags#await)
 tag as shown in the following Marko template:
 
 ```marko
@@ -828,7 +828,7 @@ your code readable.
 ### Why Marko?
 
 Here are just a few reasons you should consider using
-[Marko](http://markojs.com/) over React:
+[Marko](https://markojs.com/) over React:
 
 - Marko requires much less boilerplate.
 - Marko has much better performance based on our benchmarks.
@@ -849,6 +849,6 @@ Here are just a few reasons you should consider using
   [Discord](https://discord.gg/RFGxYGs).
 
 Interested in learning more about Marko? If so, you can get additional
-information on the [Marko website](http://markojs.com/). Join the conversation
+information on the [Marko website](https://markojs.com/). Join the conversation
 and contribute on [GitHub](https://github.com/marko-js/marko) and follow us on
 [Twitter](https://twitter.com/MarkoDevTeam).

--- a/packages/marko/docs/styles.md
+++ b/packages/marko/docs/styles.md
@@ -12,7 +12,7 @@ style {
 <div>Hello World</div>
 ```
 
-These blocks add global css to the page. The above example will not style just the `<div>` in the component, but all divs on the page. Because of this we recommend following a naming convention such as [BEM](http://getbem.com/introduction/). Marko will likely provide a way to automatically scope these styles to the current component [in the future](https://github.com/marko-js/marko/issues/666).
+These blocks add global css to the page. The above example will not style just the `<div>` in the component, but all divs on the page. Because of this we recommend following a naming convention such as [BEM](https://getbem.com/introduction/). Marko will likely provide a way to automatically scope these styles to the current component [in the future](https://github.com/marko-js/marko/issues/666).
 
 > **Note:** Style blocks (unlike `<style>` tags) do not support `${placeholders}` and must be static.
 

--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -257,7 +257,7 @@ _HTML Output:_
 
 ### Shorthand attributes
 
-Marko provides a shorthand for declaring classes and ids on an element, including interpolation.  Given `size` is the string `small`:
+Marko provides a shorthand for declaring classes and ids on an element, including interpolation. Given `size` is the string `small`:
 
 _Marko Source:_
 

--- a/packages/marko/docs/troubleshooting-streaming.md
+++ b/packages/marko/docs/troubleshooting-streaming.md
@@ -16,7 +16,7 @@
 
 ### NGiNX
 
-Most of NGiNX’s relevant parameters are inside [its builtin `http_proxy` module](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering):
+Most of NGiNX’s relevant parameters are inside [its builtin `http_proxy` module](https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_buffering):
 
 ```nginx
 proxy_http_version 1.1; # 1.0 by default

--- a/packages/marko/docs/why-is-marko-fast.md
+++ b/packages/marko/docs/why-is-marko-fast.md
@@ -6,11 +6,11 @@
 
 > This article was published in May 2017. You can find the original ["Why is Marko Fast?" article here](https://medium.com/@psteeleidem/why-is-marko-fast-a20796cb8ae3)!
 
-At eBay we are using [Marko](http://markojs.com/) to render over a billion
+At eBay we are using [Marko](https://markojs.com/) to render over a billion
 requests every day and this has required us to finely tune Marko, our open
 source UI library. We have heavily optimized Marko for fast rendering, [advanced
 performance
-techniques](http://www.ebaytechblog.com/2014/12/08/async-fragments-rediscovering-progressive-html-rendering-with-marko/)
+techniques](https://tech.ebayinc.com/engineering/async-fragments-rediscovering-progressive-html-rendering-with-marko/)
 and to achieve a minimal page weight (~10kb gzipped). Performance is only one
 concern because we have also had to scale Marko to support development across
 hundreds of teams in a way that allows developers to efficiently create

--- a/packages/marko/package.json
+++ b/packages/marko/package.json
@@ -27,7 +27,7 @@
     "bin": {
         "markoc": "bin/markoc"
     },
-    "homepage": "http://markojs.com/",
+    "homepage": "https://markojs.com/",
     "logo": {
         "url": "https://raw.githubusercontent.com/marko-js/branding/master/marko-logo-small.png"
     },

--- a/packages/translator-default/src/taglib/core/index.js
+++ b/packages/translator-default/src/taglib/core/index.js
@@ -368,8 +368,7 @@ export default {
     autocomplete: [
       {
         snippet: "await-reorderer",
-        descriptionMoreURL:
-          "http://markojs.com/docs/marko/async-taglib/#<code>&ltawait-reorderer><code>"
+        descriptionMoreURL: "https://markojs.com/docs/core-tags/#await"
       }
     ]
   },
@@ -391,12 +390,10 @@ export default {
         {
           displayText: 'key="<method>"',
           snippet: 'key="${1:method}"',
-          descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/get-started/#referencing-nested-components"
+          descriptionMoreURL: "https://markojs.com/docs/class-components/#key"
         },
         {
-          descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/get-started/#referencing-nested-components"
+          descriptionMoreURL: "https://markojs.com/docs/class-components/#key"
         }
       ]
     },
@@ -434,7 +431,7 @@ export default {
       autocomplete: [
         {
           descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/#preserving-dom-nodes-during-re-render"
+            "https://markojs.com/docs/class-components/#no-update"
         }
       ]
     },
@@ -444,7 +441,7 @@ export default {
       autocomplete: [
         {
           descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/#preserving-dom-nodes-during-re-render"
+            "https://markojs.com/docs/class-components/#no-update-body"
         }
       ]
     },
@@ -454,7 +451,7 @@ export default {
         {
           snippet: "no-update-if(${1:condition})",
           descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/#preserving-dom-nodes-during-re-render"
+            "https://markojs.com/docs/class-components/#no-update-if"
         }
       ]
     },
@@ -464,7 +461,7 @@ export default {
         {
           snippet: "no-update-body-if(${1:condition})",
           descriptionMoreURL:
-            "http://markojs.com/docs/marko-components/#preserving-dom-nodes-during-re-render"
+            "https://markojs.com/docs/class-components/#no-update-body-if"
         }
       ]
     }


### PR DESCRIPTION
## Description

- `http://`→`https://`
- Fixed the broken Code of Conduct links
- Updated stale reference URLs in the core taglib definition to point at current docs pages
- `www.ebaytechblog.com` started redirecting to `tech.ebayinc.com`, so I updated those URLs too

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- ~~N/A I have added tests to cover my changes.~~
