### PR TITLE
chore: upgrade magic-string module and lock file

### DIFF
--- a/.changeset/popular-frogs-switch.md
+++ b/.changeset/popular-frogs-switch.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"marko": patch
+"@marko/compiler": patch
+---
+
+Upgrades "magic-string" module (used for css sourcemaps) to avoid deprecation warning.

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,16 +57,16 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.10.tgz",
-      "integrity": "sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.20.7.tgz",
+      "integrity": "sha512-WylgcELHB66WwQqItxNILsMlaTd8/SO6SgTTjMp4uCI7P4QyH1r3nqgFmO3BfM4AtfniHgFMH3EpYFj/zynBkQ==",
       "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "^0.3.8",
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.0.0",
+        "glob": "^7.2.0",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0"
       },
@@ -86,43 +86,43 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "dependencies": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw==",
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz",
-      "integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "dependencies": {
         "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.12",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helpers": "^7.17.9",
-        "@babel/parser": "^7.17.12",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.12",
-        "@babel/types": "^7.17.12",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -134,12 +134,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
-      "integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "dependencies": {
-        "@babel/types": "^7.17.12",
-        "@jridgewell/gen-mapping": "^0.3.0",
+        "@babel/types": "^7.20.7",
+        "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
       "engines": {
@@ -147,11 +147,11 @@
       }
     },
     "node_modules/@babel/generator/node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-      "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
       "dependencies": {
-        "@jridgewell/set-array": "^1.0.0",
+        "@jridgewell/set-array": "^1.0.1",
         "@jridgewell/sourcemap-codec": "^1.4.10",
         "@jridgewell/trace-mapping": "^0.3.9"
       },
@@ -160,37 +160,38 @@
       }
     },
     "node_modules/@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
-      "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz",
+      "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-explode-assignable-expression": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-explode-assignable-expression": "^7.18.6",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
-      "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.20.2",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -201,17 +202,18 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.12.tgz",
-      "integrity": "sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
+      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -221,13 +223,13 @@
       }
     },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.12.tgz",
-      "integrity": "sha512-b2aZrV4zvutr9AIa6/gA3wsZKRwTKYoDxYiFKcESS3Ug2GTXzwBEvMuuFLhCQpEnRXs1zng4ISAXSUxxKBIcxw==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.20.5.tgz",
+      "integrity": "sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "regexpu-core": "^5.0.1"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "regexpu-core": "^5.2.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -237,15 +239,13 @@
       }
     },
     "node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
-      "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -256,223 +256,232 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-explode-assignable-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
-      "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
+      "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
-      "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
+      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
       "dependencies": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-      "integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.12",
-        "@babel/types": "^7.17.12"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-remap-async-to-generator": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz",
-      "integrity": "sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz",
+      "integrity": "sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-wrap-function": "^7.16.8",
-        "@babel/types": "^7.16.8"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-wrap-function": "^7.18.9",
+        "@babel/types": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
+      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
       "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "dependencies": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-      "dev": true,
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
+      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "dependencies": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "dependencies": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-wrap-function": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz",
-      "integrity": "sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.20.5.tgz",
+      "integrity": "sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.8",
-        "@babel/types": "^7.16.8"
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.9",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       },
@@ -481,9 +490,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
-      "integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -492,12 +501,12 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.17.12.tgz",
-      "integrity": "sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.18.6.tgz",
+      "integrity": "sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -507,14 +516,14 @@
       }
     },
     "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.17.12.tgz",
-      "integrity": "sha512-/vt0hpIw0x4b6BLKUkwlvEoiGZYYLNZ96CzyHYPbtG2jZGz6LBe7/V+drYrc/d+ovrF9NBi0pmtvmNb/FsWtRQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -524,13 +533,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.17.12.tgz",
-      "integrity": "sha512-RWVvqD1ooLKP6IqWTA5GyFVX2isGEgC5iFxKzfYOIy/QEFdxYyCybBDtIGjipHpb9bDWHzcqGqFakf+mVmBTdQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
+      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-remap-async-to-generator": "^7.16.8",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       },
       "engines": {
@@ -541,13 +551,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.17.12.tgz",
-      "integrity": "sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -557,13 +567,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-class-static-block": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.12.tgz",
-      "integrity": "sha512-8ILyDG6eL14F8iub97dVc8q35Md0PJYAnA5Kz9NACFOkt6ffCcr0FISyUPKHsvuAy36fkpIitxZ9bVYPFMGQHA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+      "integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       },
       "engines": {
@@ -574,12 +584,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz",
+      "integrity": "sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       },
       "engines": {
@@ -590,12 +600,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.17.12.tgz",
-      "integrity": "sha512-j7Ye5EWdwoXOpRmo5QmRyHPsDIe6+u70ZYZrd7uz+ebPYFKfRcLcNu3Ro0vOlJ5zuv8rU7xa+GttNiRzX56snQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       },
       "engines": {
@@ -606,12 +616,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.17.12.tgz",
-      "integrity": "sha512-rKJ+rKBoXwLnIn7n6o6fulViHMrOThz99ybH+hKHcOZbnN14VuMnH9fo2eHE69C8pO4uX1Q7t2HYYIDmv8VYkg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.18.6.tgz",
+      "integrity": "sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       },
       "engines": {
@@ -622,12 +632,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.17.12.tgz",
-      "integrity": "sha512-EqFo2s1Z5yy+JeJu7SFfbIUtToJTVlC61/C7WLKDntSw4Sz6JNAIfL7zQ74VvirxpjB5kz/kIx0gCcb+5OEo2Q==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
+      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       },
       "engines": {
@@ -638,12 +648,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.17.12.tgz",
-      "integrity": "sha512-ws/g3FSGVzv+VH86+QvgtuJL/kR67xaEIF2x0iPqdDfYW6ra6JF3lKVBkWynRLcNtIC1oCTfDRVxmm2mKzy+ag==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       },
       "engines": {
@@ -654,12 +664,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
+      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       },
       "engines": {
@@ -670,16 +680,16 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.12.tgz",
-      "integrity": "sha512-6l9cO3YXXRh4yPCPRA776ZyJ3RobG4ZKJZhp7NDRbKIOeV3dBPG8FXCF7ZtiO2RTCIOkQOph1xDDcc01iWVNjQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.17.12"
+        "@babel/plugin-transform-parameters": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -689,12 +699,12 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
-      "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
+      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "engines": {
@@ -705,13 +715,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.17.12.tgz",
-      "integrity": "sha512-7wigcOs/Z4YWlK7xxjkvaIw84vGhDv/P1dFGQap0nHkc8gFKY/r+hXc8Qzf5k1gY7CvGIcHqAnOagVKJJ1wVOQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "engines": {
@@ -722,13 +732,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-methods": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.17.12.tgz",
-      "integrity": "sha512-SllXoxo19HmxhDWm3luPz+cPhtoTSKLJE9PXshsfrOzBqs60QP0r8OaJItrPhAj0d7mZMnNF0Y1UUggCDgMz1A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -738,14 +748,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.17.12.tgz",
-      "integrity": "sha512-/6BtVi57CJfrtDNKfK5b66ydK2J5pXUKBKSPD2G1whamMuEnZWgoOIfO8Vf9F/DoD4izBLD/Au4NMQfruzzykg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
+      "integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       },
       "engines": {
@@ -756,13 +766,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.17.12.tgz",
-      "integrity": "sha512-Wb9qLjXf3ZazqXA7IvI7ozqRIXIGPtSo+L5coFmEkhTQK18ao4UDDD0zdTGAarmbLj2urpRwrc6893cu5Bfh0A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
+      "integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=4"
@@ -829,6 +839,21 @@
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-assertions": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
+      "integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -949,9 +974,56 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
+      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-arrow-functions": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
+      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-async-to-generator": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz",
+      "integrity": "sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-block-scoped-functions": {
       "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
-      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
+      "integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
+      "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -962,60 +1034,13 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/plugin-transform-arrow-functions": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.17.12.tgz",
-      "integrity": "sha512-PHln3CNi/49V+mza4xMwrg+WGYevSF1oaiXaC2EQfdp4HWlSjRsrDXWJiQBKpP7749u6vQ9mcry2uuFOv5CXvA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-async-to-generator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.17.12.tgz",
-      "integrity": "sha512-J8dbrWIOO3orDzir57NRsjg4uxucvhby0L/KZuGsWDj0g7twWK3g7JhJhOrXtuXiw8MeiSdJ3E0OW9H8LYEzLQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-remap-async-to-generator": "^7.16.8"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
-      "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "node_modules/@babel/plugin-transform-block-scoping": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.17.12.tgz",
-      "integrity": "sha512-jw8XW/B1i7Lqwqj2CbrViPcZijSxfguBWZP2aN59NHgxUyO/OcO1mfdCxH13QhN5LbWhPkX+f+brKGhZTiqtZQ==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
+      "integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1025,18 +1050,19 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.17.12.tgz",
-      "integrity": "sha512-cvO7lc7pZat6BsvH6l/EGaI8zpl8paICaoGk+7x7guvtfak/TbIf66nYmJOH13EuG0H+Xx3M+9LQDtSvZFKXKw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
+      "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1047,12 +1073,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-computed-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.17.12.tgz",
-      "integrity": "sha512-a7XINeplB5cQUWMg1E/GI1tFz3LfK021IjV1rj1ypE+R7jHm+pIHmHl25VNkZxtx9uuYp7ThGk8fur1HHG7PgQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
+      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1062,12 +1089,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-destructuring": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.12.tgz",
-      "integrity": "sha512-P8pt0YiKtX5UMUL5Xzsc9Oyij+pJE6JuC+F1k0/brq/OOGs5jDa1If3OY0LRWGvJsJhI+8tsiecL3nJLc0WTlg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
+      "integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1077,13 +1104,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-dotall-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
-      "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.18.6.tgz",
+      "integrity": "sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1093,12 +1120,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-duplicate-keys": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.17.12.tgz",
-      "integrity": "sha512-EA5eYFUG6xeerdabina/xIoB95jJ17mAkR8ivx6ZSu9frKShBjpOGZPn511MTDTkiCO+zXnzNczvUM69YSf3Zw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.18.9.tgz",
+      "integrity": "sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1108,13 +1135,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
-      "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.18.6.tgz",
+      "integrity": "sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1124,12 +1151,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-for-of": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.17.12.tgz",
-      "integrity": "sha512-76lTwYaCxw8ldT7tNmye4LLwSoKDbRCBzu6n/DcK/P3FOR29+38CIIaVIZfwol9By8W/QHORYEnYSLuvcQKrsg==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
+      "integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1139,14 +1166,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
-      "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
+      "integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1156,12 +1183,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-literals": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.17.12.tgz",
-      "integrity": "sha512-8iRkvaTjJciWycPIZ9k9duu663FT7VrBdNqNgxnVXEFwOIp55JWcZd23VBRySYbnS3PwQ3rGiabJBBBGj5APmQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
+      "integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1171,12 +1198,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-member-expression-literals": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
-      "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
+      "integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1186,14 +1213,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-amd": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.17.12.tgz",
-      "integrity": "sha512-p5rt9tB5Ndcc2Za7CeNxVf7YAjRcUMR6yi8o8tKjb9KhRkEvXwa+C0hj6DA5bVDkKRxB0NYhMUGbVKoFu4+zEA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz",
+      "integrity": "sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1203,14 +1229,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.12.tgz",
-      "integrity": "sha512-tVPs6MImAJz+DiX8Y1xXEMdTk5Lwxu9jiPjlS+nv5M2A59R7+/d1+9A8C/sbuY0b3QjIxqClkj6KAplEtRvzaA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
+      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-simple-access": "^7.17.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1220,16 +1245,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.12.tgz",
-      "integrity": "sha512-NVhDb0q00hqZcuLduUf/kMzbOQHiocmPbIxIvk23HLiEqaTKC/l4eRxeC7lO63M72BmACoiKOcb9AkOAJRerpw==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.20.11.tgz",
+      "integrity": "sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-identifier": "^7.19.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1239,13 +1263,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.17.12.tgz",
-      "integrity": "sha512-BnsPkrUHsjzZGpnrmJeDFkOMMljWFHPjDc9xDcz71/C+ybF3lfC3V4m3dwXPLZrE5b3bgd4V+3/Pj+3620d7IA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.6.tgz",
+      "integrity": "sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-module-transforms": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1255,13 +1279,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.17.12.tgz",
-      "integrity": "sha512-vWoWFM5CKaTeHrdUJ/3SIOTRV+MBVGybOC9mhJkaprGNt5demMymDW24yC74avb915/mIRe3TgNb/d8idvnCRA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.20.5.tgz",
+      "integrity": "sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-regexp-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1271,12 +1295,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-new-target": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.17.12.tgz",
-      "integrity": "sha512-CaOtzk2fDYisbjAD4Sd1MTKGVIpRtx9bWLyj24Y/k6p4s4gQ3CqDGJauFJxt8M/LEx003d0i3klVqnN73qvK3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.18.6.tgz",
+      "integrity": "sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1286,13 +1310,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-object-super": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
-      "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
+      "integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1302,12 +1326,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-parameters": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.17.12.tgz",
-      "integrity": "sha512-6qW4rWo1cyCdq1FkYri7AHpauchbGLXpdwnYsfxFb+KtddHENfsY5JZb35xUwkK5opOLcJ3BNd2l7PhRYGlwIA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
+      "integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1317,12 +1341,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-property-literals": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
-      "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
+      "integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1332,12 +1356,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
-      "integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
+      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
       "dev": true,
       "dependencies": {
-        "regenerator-transform": "^0.15.0"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "regenerator-transform": "^0.15.1"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1347,12 +1372,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-reserved-words": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.17.12.tgz",
-      "integrity": "sha512-1KYqwbJV3Co03NIi14uEHW8P50Md6KqFgt0FfpHdK6oyAHQVTosgPuPSiWud1HX0oYJ1hGRRlk0fP87jFpqXZA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.18.6.tgz",
+      "integrity": "sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1362,16 +1387,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.12.tgz",
-      "integrity": "sha512-xsl5MeGjWnmV6Ui9PfILM2+YRpa3GqLOrczPpXV3N2KCgQGU+sU8OfzuMbjkIdfvZEZIm+3y0V7w58sk0SGzlw==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
+      "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "babel-plugin-polyfill-corejs2": "^0.3.0",
-        "babel-plugin-polyfill-corejs3": "^0.5.0",
-        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1382,12 +1407,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
-      "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
+      "integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1397,13 +1422,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.17.12.tgz",
-      "integrity": "sha512-9pgmuQAtFi3lpNUstvG9nGfk9DkrdmWNp9KeKPFmuZCpEnxRzYlS8JgwPjYj+1AWDOSvoGN0H30p1cBOmT/Svg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
+      "integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1413,12 +1438,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-sticky-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
-      "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.18.6.tgz",
+      "integrity": "sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1428,12 +1453,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-template-literals": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.17.12.tgz",
-      "integrity": "sha512-kAKJ7DX1dSRa2s7WN1xUAuaQmkTpN+uig4wCKWivVXIObqGbVTUlSavHyfI2iZvz89GFAMGm9p2DBJ4Y1Tp0hw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
+      "integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1443,12 +1468,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-typeof-symbol": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.17.12.tgz",
-      "integrity": "sha512-Q8y+Jp7ZdtSPXCThB6zjQ74N3lj0f6TDh1Hnf5B+sYlzQ8i5Pjp8gW0My79iekSpT4WnI06blqP6DT0OmaXXmw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.18.9.tgz",
+      "integrity": "sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1458,13 +1483,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-typescript": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.0.tgz",
-      "integrity": "sha512-dNUn7RSt1dykzFTquwm7qND+dQ8u0SRhZpPFsm1GYAad+EEAirNTjqu/fnqB0zVPwjcZQd//DYWszVKoCrQuoQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.7.tgz",
+      "integrity": "sha512-m3wVKEvf6SoszD8pu4NZz3PvfKRCMgk6D6d0Qi9hNnlM5M6CFS92EgF4EiHVLKbU0r/r7ty1hg7NPZwE7WRbYw==",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-typescript": "^7.16.0"
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-typescript": "^7.20.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1474,12 +1499,12 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-escapes": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
-      "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
+      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1489,13 +1514,13 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
-      "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.18.6.tgz",
+      "integrity": "sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1505,37 +1530,38 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.17.12.tgz",
-      "integrity": "sha512-Kke30Rj3Lmcx97bVs71LO0s8M6FmJ7tUAQI9fNId62rf0cYG1UAWwdNO9/sE0/pLEahAw1MqMorymoD12bj5Fg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.17.12",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.17.12",
-        "@babel/plugin-proposal-async-generator-functions": "^7.17.12",
-        "@babel/plugin-proposal-class-properties": "^7.17.12",
-        "@babel/plugin-proposal-class-static-block": "^7.17.12",
-        "@babel/plugin-proposal-dynamic-import": "^7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "^7.17.12",
-        "@babel/plugin-proposal-json-strings": "^7.17.12",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.17.12",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.17.12",
-        "@babel/plugin-proposal-numeric-separator": "^7.16.7",
-        "@babel/plugin-proposal-object-rest-spread": "^7.17.12",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "^7.17.12",
-        "@babel/plugin-proposal-private-methods": "^7.17.12",
-        "@babel/plugin-proposal-private-property-in-object": "^7.17.12",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.17.12",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-class-static-block": "^7.18.6",
+        "@babel/plugin-proposal-dynamic-import": "^7.18.6",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-proposal-json-strings": "^7.18.6",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
+        "@babel/plugin-proposal-numeric-separator": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -1545,44 +1571,44 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.17.12",
-        "@babel/plugin-transform-async-to-generator": "^7.17.12",
-        "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
-        "@babel/plugin-transform-block-scoping": "^7.17.12",
-        "@babel/plugin-transform-classes": "^7.17.12",
-        "@babel/plugin-transform-computed-properties": "^7.17.12",
-        "@babel/plugin-transform-destructuring": "^7.17.12",
-        "@babel/plugin-transform-dotall-regex": "^7.16.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.17.12",
-        "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
-        "@babel/plugin-transform-for-of": "^7.17.12",
-        "@babel/plugin-transform-function-name": "^7.16.7",
-        "@babel/plugin-transform-literals": "^7.17.12",
-        "@babel/plugin-transform-member-expression-literals": "^7.16.7",
-        "@babel/plugin-transform-modules-amd": "^7.17.12",
-        "@babel/plugin-transform-modules-commonjs": "^7.17.12",
-        "@babel/plugin-transform-modules-systemjs": "^7.17.12",
-        "@babel/plugin-transform-modules-umd": "^7.17.12",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.17.12",
-        "@babel/plugin-transform-new-target": "^7.17.12",
-        "@babel/plugin-transform-object-super": "^7.16.7",
-        "@babel/plugin-transform-parameters": "^7.17.12",
-        "@babel/plugin-transform-property-literals": "^7.16.7",
-        "@babel/plugin-transform-regenerator": "^7.17.9",
-        "@babel/plugin-transform-reserved-words": "^7.17.12",
-        "@babel/plugin-transform-shorthand-properties": "^7.16.7",
-        "@babel/plugin-transform-spread": "^7.17.12",
-        "@babel/plugin-transform-sticky-regex": "^7.16.7",
-        "@babel/plugin-transform-template-literals": "^7.17.12",
-        "@babel/plugin-transform-typeof-symbol": "^7.17.12",
-        "@babel/plugin-transform-unicode-escapes": "^7.16.7",
-        "@babel/plugin-transform-unicode-regex": "^7.16.7",
+        "@babel/plugin-transform-arrow-functions": "^7.18.6",
+        "@babel/plugin-transform-async-to-generator": "^7.18.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
+        "@babel/plugin-transform-computed-properties": "^7.18.9",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
+        "@babel/plugin-transform-dotall-regex": "^7.18.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.18.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
+        "@babel/plugin-transform-for-of": "^7.18.8",
+        "@babel/plugin-transform-function-name": "^7.18.9",
+        "@babel/plugin-transform-literals": "^7.18.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.18.6",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
+        "@babel/plugin-transform-modules-umd": "^7.18.6",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+        "@babel/plugin-transform-new-target": "^7.18.6",
+        "@babel/plugin-transform-object-super": "^7.18.6",
+        "@babel/plugin-transform-parameters": "^7.20.1",
+        "@babel/plugin-transform-property-literals": "^7.18.6",
+        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/plugin-transform-reserved-words": "^7.18.6",
+        "@babel/plugin-transform-shorthand-properties": "^7.18.6",
+        "@babel/plugin-transform-spread": "^7.19.0",
+        "@babel/plugin-transform-sticky-regex": "^7.18.6",
+        "@babel/plugin-transform-template-literals": "^7.18.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.18.9",
+        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.17.12",
-        "babel-plugin-polyfill-corejs2": "^0.3.0",
-        "babel-plugin-polyfill-corejs3": "^0.5.0",
-        "babel-plugin-polyfill-regenerator": "^0.3.0",
-        "core-js-compat": "^3.22.1",
+        "@babel/types": "^7.20.2",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
+        "core-js-compat": "^3.25.1",
         "semver": "^6.3.0"
       },
       "engines": {
@@ -1609,9 +1635,9 @@
       }
     },
     "node_modules/@babel/register": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.17.7.tgz",
-      "integrity": "sha512-fg56SwvXRifootQEDQAu1mKdjh5uthPzdO0N6t358FktfL4XjAVXuH58ULoiW8mesxiOgNIrxiImqEwv0+hRRA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.9.tgz",
+      "integrity": "sha512-ZlbnXDcNYHMR25ITwwNKT88JiaukkdVj/nG7r3wnuXkOTHc60Uy05PwMCPre0hSkY68E6zK3xz+vUJSP2jWmcw==",
       "dev": true,
       "dependencies": {
         "clone-deep": "^4.0.1",
@@ -1628,42 +1654,42 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
-      "integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "dependencies": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.12",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.12",
-        "@babel/types": "^7.17.12",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -1672,11 +1698,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
-      "integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1684,36 +1711,24 @@
       }
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.0.0.tgz",
-      "integrity": "sha512-gp6nIdVdfYdwKww2+f8whckKmvfE4JEm4jJgBhTmooi0uzHWhnxvk6JIzQi89qEAMINN0SeVNnXiAtbFY0Mj3w==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.3.tgz",
+      "integrity": "sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/config": "^2.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/config": "^2.3.0",
         "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^1.3.2",
-        "@changesets/types": "^5.0.0",
+        "@changesets/git": "^2.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
         "lodash.startcase": "^4.4.0",
         "outdent": "^0.5.0",
-        "prettier": "^1.19.1",
+        "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
         "semver": "^5.4.1"
-      }
-    },
-    "node_modules/@changesets/apply-release-plan/node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@changesets/apply-release-plan/node_modules/semver": {
@@ -1726,15 +1741,15 @@
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.1.2.tgz",
-      "integrity": "sha512-nOFyDw4APSkY/vh5WNwGEtThPgEjVShp03PKVdId6wZTJALVcAALCSLmDRfeqjE2z9EsGJb7hZdDlziKlnqZgw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.3.tgz",
+      "integrity": "sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
-        "@changesets/types": "^5.0.0",
+        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "semver": "^5.4.1"
       }
@@ -1749,48 +1764,49 @@
       }
     },
     "node_modules/@changesets/changelog-git": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.11.tgz",
-      "integrity": "sha512-sWJvAm+raRPeES9usNpZRkooeEB93lOpUN0Lmjz5vhVAb7XGIZrHEJ93155bpE1S0c4oJ5Di9ZWgzIwqhWP/Wg==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
+      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.0.0"
+        "@changesets/types": "^5.2.1"
       }
     },
     "node_modules/@changesets/changelog-github": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.4.tgz",
-      "integrity": "sha512-htSILqCkyYtTB5/LoVKwx7GCJQGxAiBcYbfUKWiz/QoDARuM01owYtMXhV6/iytJZq/Dqqz3PjMZUNB4MphpbQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.8.tgz",
+      "integrity": "sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==",
       "dev": true,
       "dependencies": {
-        "@changesets/get-github-info": "^0.5.0",
-        "@changesets/types": "^5.0.0",
+        "@changesets/get-github-info": "^0.5.2",
+        "@changesets/types": "^5.2.1",
         "dotenv": "^8.1.0"
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.22.0.tgz",
-      "integrity": "sha512-4bA3YoBkd5cm5WUxmrR2N9WYE7EeQcM+R3bVYMUj2NvffkQVpU3ckAI+z8UICoojq+HRl2OEwtz+S5UBmYY4zw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.0.tgz",
+      "integrity": "sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/apply-release-plan": "^6.0.0",
-        "@changesets/assemble-release-plan": "^5.1.2",
-        "@changesets/changelog-git": "^0.1.11",
-        "@changesets/config": "^2.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/apply-release-plan": "^6.1.3",
+        "@changesets/assemble-release-plan": "^5.2.3",
+        "@changesets/changelog-git": "^0.1.14",
+        "@changesets/config": "^2.3.0",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
-        "@changesets/get-release-plan": "^3.0.8",
-        "@changesets/git": "^1.3.2",
+        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/get-release-plan": "^3.0.16",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.11",
-        "@changesets/read": "^0.5.5",
-        "@changesets/types": "^5.0.0",
-        "@changesets/write": "^0.1.8",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
+        "@changesets/write": "^0.2.3",
         "@manypkg/get-packages": "^1.1.3",
         "@types/is-ci": "^3.0.0",
         "@types/semver": "^6.0.0",
+        "ansi-colors": "^4.1.3",
         "chalk": "^2.1.0",
         "enquirer": "^2.3.0",
         "external-editor": "^3.1.0",
@@ -1805,7 +1821,7 @@
         "semver": "^5.4.1",
         "spawndamnit": "^2.0.0",
         "term-size": "^2.1.0",
-        "tty-table": "^2.8.10"
+        "tty-table": "^4.1.5"
       },
       "bin": {
         "changeset": "bin.js"
@@ -1821,15 +1837,15 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.0.0.tgz",
-      "integrity": "sha512-r5bIFY6CN3K6SQ+HZbjyE3HXrBIopONR47mmX7zUbORlybQXtympq9rVAOzc0Oflbap8QeIexc+hikfZoREXDg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.0.tgz",
+      "integrity": "sha512-EgP/px6mhCx8QeaMAvWtRrgyxW08k/Bx2tpGT+M84jEdX37v3VKfh4Cz1BkwrYKuMV2HZKeHOh8sHvja/HcXfQ==",
       "dev": true,
       "dependencies": {
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
+        "@changesets/get-dependents-graph": "^1.3.5",
         "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
         "micromatch": "^4.0.2"
@@ -1845,12 +1861,12 @@
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.2.tgz",
-      "integrity": "sha512-tsqA6qZRB86SQuApSoDvI8yEWdyIlo/WLI4NUEdhhxLMJ0dapdeT6rUZRgSZzK1X2nv5YwR0MxQBbDAiDibKrg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.5.tgz",
+      "integrity": "sha512-w1eEvnWlbVDIY8mWXqWuYE9oKhvIaBhzqzo4ITSJY9hgoqQ3RoBqwlcAzg11qHxv/b8ReDWnMrpjpKrW6m1ZTA==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
@@ -1867,9 +1883,9 @@
       }
     },
     "node_modules/@changesets/get-github-info": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.0.tgz",
-      "integrity": "sha512-vm5VgHwrxkMkUjFyn3UVNKLbDp9YMHd3vMf1IyJoa/7B+6VpqmtAaXyDS0zBLfN5bhzVCHrRnj4GcZXXcqrFTw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.2.tgz",
+      "integrity": "sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==",
       "dev": true,
       "dependencies": {
         "dataloader": "^1.4.0",
@@ -1877,17 +1893,17 @@
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.8.tgz",
-      "integrity": "sha512-TJYiWNuP0Lzu2dL/KHuk75w7TkiE5HqoYirrXF7SJIxkhlgH9toQf2C7IapiFTObtuF1qDN8HJAX1CuIOwXldg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.16.tgz",
+      "integrity": "sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/assemble-release-plan": "^5.1.2",
-        "@changesets/config": "^2.0.0",
-        "@changesets/pre": "^1.0.11",
-        "@changesets/read": "^0.5.5",
-        "@changesets/types": "^5.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/assemble-release-plan": "^5.2.3",
+        "@changesets/config": "^2.3.0",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
@@ -1898,16 +1914,17 @@
       "dev": true
     },
     "node_modules/@changesets/git": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-1.3.2.tgz",
-      "integrity": "sha512-p5UL+urAg0Nnpt70DLiBe2iSsMcDubTo9fTOD/61krmcJ466MGh71OHwdAwu1xG5+NKzeysdy1joRTg8CXcEXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
+      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.2",
         "spawndamnit": "^2.0.0"
       }
     },
@@ -1921,73 +1938,61 @@
       }
     },
     "node_modules/@changesets/parse": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.13.tgz",
-      "integrity": "sha512-wh9Ifa0dungY6d2nMz6XxF6FZ/1I7j+mEgPAqrIyKS64nifTh1Ua82qKKMMK05CL7i4wiB2NYc3SfnnCX3RVeA==",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
+      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
       "dev": true,
       "dependencies": {
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.11.tgz",
-      "integrity": "sha512-CXZnt4SV9waaC9cPLm7818+SxvLKIDHUxaiTXnJYDp1c56xIexx1BNfC1yMuOdzO2a3rAIcZua5Odxr3dwSKfg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
+      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.5.tgz",
-      "integrity": "sha512-bzonrPWc29Tsjvgh+8CqJ0apQOwWim0zheeD4ZK44ApSa/GudnZJTODtA3yNOOuQzeZmL0NUebVoHIurtIkA7w==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
+      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/git": "^1.3.2",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.13",
-        "@changesets/types": "^5.0.0",
+        "@changesets/parse": "^0.3.16",
+        "@changesets/types": "^5.2.1",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
         "p-filter": "^2.1.0"
       }
     },
     "node_modules/@changesets/types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.0.0.tgz",
-      "integrity": "sha512-IT1kBLSbAgTS4WtpU6P5ko054hq12vk4tgeIFRVE7Vnm4a/wgbNvBalgiKP0MjEXbCkZbItiGQHkCGxYWR55sA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==",
       "dev": true
     },
     "node_modules/@changesets/write": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.1.8.tgz",
-      "integrity": "sha512-oIHeFVMuP6jf0TPnKPpaFpvvAf3JBc+s2pmVChbeEgQTBTALoF51Z9kqxQfG4XONZPHZnqkmy564c7qohhhhTQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
+      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
       "dev": true,
       "dependencies": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/types": "^5.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/types": "^5.2.1",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
-        "prettier": "^1.19.1"
-      }
-    },
-    "node_modules/@changesets/write/node_modules/prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true,
-      "bin": {
-        "prettier": "bin-prettier.js"
-      },
-      "engines": {
-        "node": ">=4"
+        "prettier": "^2.7.1"
       }
     },
     "node_modules/@ebay/browserslist-config": {
@@ -2017,9 +2022,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2101,33 +2106,33 @@
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/set-array": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "engines": {
         "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "node_modules/@manypkg/find-root": {
@@ -2254,9 +2259,9 @@
       }
     },
     "node_modules/@types/babel__traverse": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
-      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
+      "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
@@ -2278,9 +2283,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "12.20.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-      "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -2451,9 +2456,9 @@
       }
     },
     "node_modules/anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -2515,6 +2520,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -2547,12 +2570,16 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
-    "node_modules/babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "dependencies": {
-        "object.assign": "^4.1.0"
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/babel-plugin-istanbul": {
@@ -2582,13 +2609,13 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
-      "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       },
       "peerDependencies": {
@@ -2596,25 +2623,25 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
-      "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "core-js-compat": "^3.21.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/babel-plugin-polyfill-regenerator": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
-      "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -2653,9 +2680,9 @@
       "dev": true
     },
     "node_modules/body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
       "dependencies": {
         "bytes": "3.1.2",
@@ -2666,7 +2693,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -2688,7 +2715,7 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/brace-expansion": {
@@ -2739,9 +2766,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "funding": [
         {
           "type": "opencollective",
@@ -2753,11 +2780,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -2824,6 +2850,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -2868,9 +2895,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA==",
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow==",
       "funding": [
         {
           "type": "opencollective",
@@ -2883,14 +2910,14 @@
       ]
     },
     "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -2957,10 +2984,19 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-      "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
-      "dev": true
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/clean-stack": {
       "version": "2.2.0",
@@ -3013,7 +3049,7 @@
     "node_modules/clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true,
       "engines": {
         "node": ">=0.8"
@@ -3044,12 +3080,12 @@
     "node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -3076,7 +3112,7 @@
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "node_modules/compare-versions": {
@@ -3096,7 +3132,7 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -3109,26 +3145,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/content-disposition/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/content-type": {
       "version": "1.0.4",
@@ -3149,12 +3165,9 @@
       }
     },
     "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "node_modules/cookie": {
       "version": "0.5.0",
@@ -3168,36 +3181,26 @@
     "node_modules/cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "node_modules/core-js-compat": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
-      "integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.1.tgz",
+      "integrity": "sha512-Dg91JFeCDA17FKnneN7oCMz4BkQ4TcffkgHP4OWwp9yx3pi7ubqMDXXSacfNak1PQqjc95skyt+YBLHQJnkJwA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.20.3",
-        "semver": "7.0.0"
+        "browserslist": "^4.21.4"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-js-compat/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      }
-    },
     "node_modules/cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -3351,16 +3354,16 @@
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "dependencies": {
         "decamelize": "^1.1.0",
@@ -3368,39 +3371,42 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/decamelize-keys/node_modules/map-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-      "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "node_modules/dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "dependencies": {
         "type-detect": "^4.0.0"
       },
       "engines": {
-        "node": ">=0.12"
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -3410,30 +3416,37 @@
       "dev": true
     },
     "node_modules/default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "dependencies": {
         "strip-bom": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dev": true,
       "dependencies": {
         "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/define-properties": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
       "dependencies": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -3448,7 +3461,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
@@ -3515,7 +3528,7 @@
     "node_modules/docopt": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "integrity": "sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -3636,13 +3649,13 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3653,7 +3666,7 @@
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -3696,11 +3709,97 @@
       }
     },
     "node_modules/error-stack-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
-      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "dependencies": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.0",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.0",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "dependencies": {
+        "has": "^1.0.3"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/es6-error": {
@@ -3720,13 +3819,13 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
@@ -3765,7 +3864,7 @@
     "node_modules/escodegen/node_modules/levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2",
@@ -3795,7 +3894,7 @@
     "node_modules/escodegen/node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
@@ -3804,7 +3903,7 @@
     "node_modules/escodegen/node_modules/type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
       "dev": true,
       "dependencies": {
         "prelude-ls": "~1.1.2"
@@ -3871,9 +3970,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
       "dev": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
@@ -3999,9 +4098,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-      "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+      "version": "13.19.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+      "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -4022,10 +4121,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/eslint/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4060,6 +4171,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/eslint/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/espree": {
       "version": "7.3.1",
@@ -4160,7 +4277,7 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4169,7 +4286,7 @@
     "node_modules/events-light": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
-      "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+      "integrity": "sha512-jF51LJzg5W+tkJgfZbjlbFCLcyVFEtOjU+xMCBylrXG13X5XHvfp6lNGfyBLF9u1mRTpUsMVYqSDukvpZff1mQ==",
       "dependencies": {
         "chai": "^3.5.0"
       }
@@ -4190,7 +4307,7 @@
     "node_modules/events-light/node_modules/deep-eql": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
       "dependencies": {
         "type-detect": "0.1.1"
       },
@@ -4201,7 +4318,7 @@
     "node_modules/events-light/node_modules/deep-eql/node_modules/type-detect": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA==",
       "engines": {
         "node": "*"
       }
@@ -4209,7 +4326,7 @@
     "node_modules/events-light/node_modules/type-detect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-      "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
+      "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA==",
       "engines": {
         "node": "*"
       }
@@ -4238,14 +4355,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -4264,7 +4381,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -4291,28 +4408,8 @@
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
-    },
-    "node_modules/express/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
     },
     "node_modules/extendable-error": {
       "version": "0.1.7",
@@ -4341,9 +4438,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4365,13 +4462,13 @@
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4431,7 +4528,7 @@
     "node_modules/finalhandler/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/find-cache-dir": {
@@ -4521,10 +4618,19 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "dependencies": {
+        "is-callable": "^1.1.3"
+      }
     },
     "node_modules/foreground-child": {
       "version": "2.0.0",
@@ -4565,7 +4671,7 @@
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -4614,7 +4720,7 @@
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "node_modules/fsevents": {
@@ -4634,13 +4740,41 @@
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "dev": true
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -4662,20 +4796,21 @@
     "node_modules/get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4709,6 +4844,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/glob": {
@@ -4751,6 +4902,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -4772,9 +4938,9 @@
       }
     },
     "node_modules/globby/node_modules/ignore": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -4787,6 +4953,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/graceful-fs": {
@@ -4823,6 +5001,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.1"
       },
@@ -4830,10 +5009,19 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
       }
@@ -4842,8 +5030,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4853,6 +5054,22 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4918,9 +5135,9 @@
       "dev": true
     },
     "node_modules/htmljs-parser": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.1.5.tgz",
-      "integrity": "sha512-9ndiIymg6huRu6fIKhsUlbB7mij8MdVUOBvvh3tjq18JBhBPaoh5eSmkp24U8t5b+wWXGehX3lGkORJuJh1dVw=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.2.1.tgz",
+      "integrity": "sha512-nqhepseEMIjmESQRnqgMYTzdrrKtlj1WyvDE9NJ1tjTRLk5LnSTWlDOeHHvElEgbBCBSH1yT/Wfj5S4LHAop5Q=="
     },
     "node_modules/htmlparser2": {
       "version": "3.10.1",
@@ -5231,7 +5448,7 @@
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
@@ -5249,7 +5466,7 @@
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "dependencies": {
         "once": "^1.3.0",
@@ -5261,6 +5478,20 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/internal-slot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5274,7 +5505,7 @@
     "node_modules/is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "integrity": "sha512-7Kr05z5LkcOpoMvxHN1PC11WbPabdNFmMYYo0eZvWu3BfVS0T03yoqYDczoCBx17xqk2x1XAZrcKiFVL88jxlQ==",
       "dev": true,
       "dependencies": {
         "is-relative": "^0.2.1",
@@ -5287,17 +5518,43 @@
     "node_modules/is-absolute/node_modules/is-windows": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-      "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+      "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "node_modules/is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "dependencies": {
+        "has-bigints": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -5309,6 +5566,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-ci": {
@@ -5324,9 +5609,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "dependencies": {
         "has": "^1.0.3"
@@ -5335,10 +5620,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5365,6 +5665,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5374,10 +5686,25 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5386,7 +5713,7 @@
     "node_modules/is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5410,10 +5737,26 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "node_modules/is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5422,13 +5765,25 @@
     "node_modules/is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "integrity": "sha512-9AMzjRmLqcue629b4ezEVSK6kJsYJlUIhMcygmYORUgwUNJiavHcC3HkaGx0XYpyVKQSOqFbMEZmW42cY87sYw==",
       "dev": true,
       "dependencies": {
         "is-unc-path": "^0.1.1"
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-stream": {
@@ -5443,6 +5798,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "dependencies": {
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-subdir": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-subdir/-/is-subdir-1.2.0.tgz",
@@ -5455,16 +5825,50 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "node_modules/is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "integrity": "sha512-HhLc5VDMH4pu3oMtIuunz/DFQUIoR561kMME3U3Afhj8b7vH085vkIkemrz1kLXCEIuoMAmO3yVmafWdSbGW8w==",
       "dev": true,
       "dependencies": {
         "unc-path-regex": "^0.1.0"
@@ -5485,6 +5889,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -5497,13 +5913,13 @@
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "node_modules/isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5531,9 +5947,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.12.3",
@@ -5547,36 +5963,20 @@
       }
     },
     "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "dependencies": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo/node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-processinfo/node_modules/p-map": {
@@ -5656,9 +6056,9 @@
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -5746,22 +6146,22 @@
       }
     },
     "node_modules/jsdom-context-require": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-4.0.4.tgz",
-      "integrity": "sha512-DlkAZsR0G6FfUiHKYahKAyDOJjBKW5h6x5z6iCft9cmXEJw6RhvwZ1JVFyH41on63cPEQrC/8N26ESxDAFHizw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-4.0.6.tgz",
+      "integrity": "sha512-8J9izACVQv6amd6GlouJ5noGivQHOfJ6jeOKZr1MLtRtwshYUuW0elixrwmmyjmI0MIrntakAUO2T2rsE2f6yg==",
       "dev": true,
       "dependencies": {
         "context-require": "^1.1.0",
         "lasso-resolve-from": "^1.2.0"
       },
       "peerDependencies": {
-        "jsdom": "11 - 19"
+        "jsdom": "11 - 20"
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -5796,13 +6196,13 @@
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "node_modules/json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -5813,7 +6213,7 @@
     "node_modules/jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
@@ -5828,10 +6228,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/lasso-caching-fs": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
-      "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+      "integrity": "sha512-mudop0s8U3tLm3Fn9lhiZsiELpLeJToEo6RlDLdph7vWRxL9Sz0o+9WUw1IwlpCYXv/P0CLsMYWFgPwIKWEYvg==",
       "dependencies": {
         "raptor-async": "^1.1.2"
       }
@@ -5839,7 +6248,7 @@
     "node_modules/lasso-package-root": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
-      "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+      "integrity": "sha512-j6LnauNCldqSDvOxoKpD6sTzudPGMiwcZQbySoF9KvJ0lD9Dp2t6QZF8kC0jbUDHuQPiAo5RuQ/mC3AGXscUYA==",
       "dependencies": {
         "lasso-caching-fs": "^1.0.0"
       }
@@ -5847,7 +6256,7 @@
     "node_modules/lasso-resolve-from": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/lasso-resolve-from/-/lasso-resolve-from-1.2.0.tgz",
-      "integrity": "sha1-v7I0Rnr7abUwn1aLpFnMgyBiHG4=",
+      "integrity": "sha512-WPDAQi5uYRDous353yxouFjD8g3GL07v0RTq/RUgAv2KVcNST9rts33pLAN0VS6FFs4FIBU1g8wUsBHQMWp1IA==",
       "dev": true,
       "dependencies": {
         "is-absolute": "^0.2.3",
@@ -5856,16 +6265,10 @@
         "resolve-from": "^2.0.0"
       }
     },
-    "node_modules/lasso-resolve-from/node_modules/raptor-util": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
-      "integrity": "sha1-8u6AdqmuPq4uZWcuRqIgB0+i3/M=",
-      "dev": true
-    },
     "node_modules/lasso-resolve-from/node_modules/resolve-from": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+      "integrity": "sha512-qpFcKaXsq8+oRoLilkwyc7zHGF5i9Q2/25NIgLQQ/+VVv9rU4qvr6nXVAw1DsnXJyQkZsR4Ytfbtg5ehfcUssQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -6001,7 +6404,7 @@
     "node_modules/listener-tracker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/listener-tracker/-/listener-tracker-2.0.0.tgz",
-      "integrity": "sha1-OWCLQ1wJAfpVECF8FFJyjWvBm18="
+      "integrity": "sha512-U6NLzBRyrAsJs9AAjuBYifXtNYnAIDPIp81rNpxNoypXBR7qi/LhsuUWX5399zuTg1sBEQyOnWDYFrBQ28vk/w=="
     },
     "node_modules/listr2": {
       "version": "3.14.0",
@@ -6048,7 +6451,7 @@
     "node_modules/load-yaml-file/node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -6069,13 +6472,13 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "node_modules/lodash.merge": {
@@ -6087,13 +6490,13 @@
     "node_modules/lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
     "node_modules/log-symbols": {
@@ -6265,32 +6668,31 @@
       }
     },
     "node_modules/loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "dependencies": {
         "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
+        "yallist": "^3.0.2"
       }
     },
     "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "dependencies": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/make-dir": {
@@ -6334,7 +6736,7 @@
     "node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -6380,7 +6782,7 @@
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "node_modules/merge-stream": {
@@ -6401,7 +6803,7 @@
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true,
       "engines": {
         "node": ">= 0.6"
@@ -6889,7 +7291,7 @@
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/negotiator": {
@@ -6924,19 +7326,19 @@
     "node_modules/node-fetch/node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
     "node_modules/node-fetch/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
     "node_modules/node-fetch/node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
@@ -6956,9 +7358,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -7003,9 +7405,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
     "node_modules/nyc": {
@@ -7207,9 +7609,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -7219,18 +7621,20 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
     },
     "node_modules/object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
       "dependencies": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       },
       "engines": {
@@ -7255,7 +7659,7 @@
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "dependencies": {
         "wrappy": "1"
@@ -7305,7 +7709,7 @@
     "node_modules/os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7461,7 +7865,7 @@
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -7485,7 +7889,7 @@
     "node_modules/path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "node_modules/path-type": {
@@ -7593,7 +7997,7 @@
     "node_modules/pkg-dir/node_modules/path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -7694,9 +8098,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -7732,7 +8136,7 @@
     "node_modules/property-handlers": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/property-handlers/-/property-handlers-1.1.1.tgz",
-      "integrity": "sha1-yyDTIqq32U//rCj0bJGGvVlHtLQ="
+      "integrity": "sha512-bPlermJL6CETDwI6SxODyMzr1a0aXzbXpNGCW9SnsnetEMJdjon1mdgLbidSN7o47B2oqLOwXYzGyyIQHsQrmw=="
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
@@ -7750,13 +8154,13 @@
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "node_modules/psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "node_modules/pump": {
@@ -7779,9 +8183,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -7792,6 +8196,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -7843,17 +8253,18 @@
     "node_modules/raptor-async": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
-      "integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+      "integrity": "sha512-VZCxygWMjW9lKqnApK9D2QbfyzRn7ehiTqnXWwMCLBXANSy+xbnYfbX/5f8YX3bZXu+g+JESmqWPchIQrZj2ig=="
     },
     "node_modules/raptor-regexp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/raptor-regexp/-/raptor-regexp-1.0.1.tgz",
-      "integrity": "sha1-7PD2bGZxwM2fXkjDcFAmxVCZlcA="
+      "integrity": "sha512-DqC7ViHJUs3jLIxJI1/HVvCu3yPJaP8CM7PGsHvjimg7yJ3lLOdCBxlPE0G2Q8OJgUA8Pe7nvhm6lcQ3hZepow=="
     },
     "node_modules/raptor-util": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
-      "integrity": "sha1-I7DIA8jxrIocrmfZpjiLSRYcl1g="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
+      "integrity": "sha512-y3aISuv1oFMzEscN0U8kd5J/lrW4pTiJuBU6v4uksXBecfshYNrZ8h5ODg9J+CfRyuujZ84UEbuu3KnvswjnEA==",
+      "dev": true
     },
     "node_modules/raw-body": {
       "version": "2.5.1",
@@ -7938,7 +8349,7 @@
     "node_modules/read-yaml-file/node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -7991,9 +8402,9 @@
       "dev": true
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-      "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
       "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2"
@@ -8003,17 +8414,34 @@
       }
     },
     "node_modules/regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regenerator-transform": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.0.tgz",
-      "integrity": "sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
+      "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "dev": true,
       "dependencies": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/regexpp": {
@@ -8029,32 +8457,32 @@
       }
     },
     "node_modules/regexpu-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz",
-      "integrity": "sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
+      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
       "dev": true,
       "dependencies": {
         "regenerate": "^1.4.2",
-        "regenerate-unicode-properties": "^10.0.1",
-        "regjsgen": "^0.6.0",
-        "regjsparser": "^0.8.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsgen": "^0.7.1",
+        "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.0.0"
+        "unicode-match-property-value-ecmascript": "^2.1.0"
       },
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/regjsgen": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-      "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+      "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
       "dev": true
     },
     "node_modules/regjsparser": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-      "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
       "dev": true,
       "dependencies": {
         "jsesc": "~0.5.0"
@@ -8066,7 +8494,7 @@
     "node_modules/regjsparser/node_modules/jsesc": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-      "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+      "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
       "dev": true,
       "bin": {
         "jsesc": "bin/jsesc"
@@ -8080,7 +8508,7 @@
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "dependencies": {
         "es6-error": "^4.0.1"
@@ -8092,7 +8520,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8113,13 +8541,19 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -8206,18 +8640,47 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -8256,7 +8719,7 @@
     "node_modules/semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
     },
     "node_modules/semver-regex": {
@@ -8307,7 +8770,7 @@
     "node_modules/send/node_modules/debug/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "node_modules/send/node_modules/ms": {
@@ -8343,7 +8806,7 @@
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "node_modules/setprototypeof": {
@@ -8386,10 +8849,13 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
-      "dev": true
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -8468,12 +8934,12 @@
       "dev": true
     },
     "node_modules/smartwrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-1.2.5.tgz",
-      "integrity": "sha512-bzWRwHwu0RnWjwU7dFy7tF68pDAx/zMSu3g7xr9Nx5J0iSImYInglwEVExyHLxXljy6PWMjkSAbwF7t2mPnRmg==",
-      "deprecated": "Backported compatibility to node > 6",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-2.0.2.tgz",
+      "integrity": "sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==",
       "dev": true,
       "dependencies": {
+        "array.prototype.flat": "^1.2.3",
         "breakword": "^1.0.5",
         "grapheme-splitter": "^1.0.4",
         "strip-ansi": "^6.0.0",
@@ -8482,6 +8948,9 @@
       },
       "bin": {
         "smartwrap": "src/terminal-adapter.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/smartwrap/node_modules/ansi-styles": {
@@ -8589,11 +9058,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "node_modules/spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -8639,7 +9103,7 @@
     "node_modules/spawndamnit/node_modules/cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^4.0.1",
@@ -8660,7 +9124,7 @@
     "node_modules/spawndamnit/node_modules/shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
       "dev": true,
       "dependencies": {
         "shebang-regex": "^1.0.0"
@@ -8672,7 +9136,7 @@
     "node_modules/spawndamnit/node_modules/shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8693,7 +9157,7 @@
     "node_modules/spawndamnit/node_modules/yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
       "dev": true
     },
     "node_modules/spdx-correct": {
@@ -8723,21 +9187,21 @@
       }
     },
     "node_modules/spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "node_modules/stackframe": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
-      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -8766,26 +9230,6 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/string-argv": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.1.tgz",
@@ -8807,6 +9251,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/stringify-object": {
@@ -8905,9 +9377,9 @@
       "dev": true
     },
     "node_modules/table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
       "dependencies": {
         "ajv": "^8.0.1",
@@ -8921,9 +9393,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+      "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -9021,13 +9493,13 @@
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "node_modules/through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "node_modules/through2": {
@@ -9054,7 +9526,7 @@
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
       "engines": {
         "node": ">=4"
       }
@@ -9081,17 +9553,27 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
       "dev": true,
       "dependencies": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -9116,29 +9598,30 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "node_modules/tty-table": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-2.8.13.tgz",
-      "integrity": "sha512-eVV/+kB6fIIdx+iUImhXrO22gl7f6VmmYh0Zbu6C196fe1elcHXd7U6LcLXu0YoVPc2kNesWiukYcdK8ZmJ6aQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.1.6.tgz",
+      "integrity": "sha512-kRj5CBzOrakV4VRRY5kUWbNYvo/FpOsz65DzI5op9P+cHov3+IqPbo1JE1ZnQGkHdZgNFDsrEjrfqqy/Ply9fw==",
       "dev": true,
       "dependencies": {
-        "chalk": "^3.0.0",
-        "csv": "^5.3.1",
-        "smartwrap": "^1.2.3",
+        "chalk": "^4.1.2",
+        "csv": "^5.5.0",
+        "kleur": "^4.1.4",
+        "smartwrap": "^2.0.2",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1",
-        "yargs": "^15.1.0"
+        "yargs": "^17.1.1"
       },
       "bin": {
         "tty-table": "adapters/terminal-adapter.js"
       },
       "engines": {
-        "node": ">=8.16.0"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/tty-table/node_modules/ansi-styles": {
@@ -9157,27 +9640,33 @@
       }
     },
     "node_modules/tty-table/node_modules/chalk": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/tty-table/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "dev": true,
       "dependencies": {
         "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tty-table/node_modules/color-convert": {
@@ -9219,46 +9708,31 @@
         "node": ">=8"
       }
     },
-    "node_modules/tty-table/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+    "node_modules/tty-table/node_modules/yargs": {
+      "version": "17.6.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
       "dev": true,
       "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
-    "node_modules/tty-table/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/tty-table/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+    "node_modules/tty-table/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/type-check": {
@@ -9307,6 +9781,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -9316,25 +9804,40 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/underscore": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "node_modules/underscore-keypath": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/underscore-keypath/-/underscore-keypath-0.0.22.tgz",
-      "integrity": "sha1-SKUoOSu278QkvhyqVtpLX6zPJk0=",
+      "integrity": "sha512-fU7aYj1J2LQd+jqdQ67AlCOZKK3Pl+VErS8fGYcgZG75XB9/bY+RLM+F2xEcKHhHNtLvqqFyXAoZQlLYfec3Xg==",
       "dev": true,
       "dependencies": {
         "underscore": "*"
@@ -9363,18 +9866,18 @@
       }
     },
     "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
       "dev": true,
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/unicode-property-aliases-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -9392,10 +9895,35 @@
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        }
+      ],
+      "dependencies": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      },
+      "bin": {
+        "browserslist-lint": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
       }
     },
     "node_modules/uri-js": {
@@ -9407,29 +9935,38 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true,
       "engines": {
         "node": ">= 0.4.0"
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -9451,7 +9988,7 @@
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true,
       "engines": {
         "node": ">= 0.8"
@@ -9461,6 +9998,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
       "integrity": "sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==",
+      "deprecated": "Use your platform's native performance.now() and performance.timeOrigin.",
       "dev": true,
       "dependencies": {
         "browser-process-hrtime": "^1.0.0"
@@ -9486,7 +10024,7 @@
     "node_modules/wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
@@ -9562,10 +10100,26 @@
         "node": ">= 8"
       }
     },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "dependencies": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "node_modules/which-pm": {
@@ -9590,6 +10144,26 @@
         "node": ">=4"
       }
     },
+    "node_modules/which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "dependencies": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
@@ -9611,7 +10185,7 @@
     "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -9633,7 +10207,7 @@
     "node_modules/wide-align/node_modules/strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
       "dev": true,
       "dependencies": {
         "ansi-regex": "^3.0.0"
@@ -9710,7 +10284,7 @@
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "node_modules/write-file-atomic": {
@@ -9726,16 +10300,16 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -9771,10 +10345,9 @@
       }
     },
     "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -9900,8 +10473,7 @@
     },
     "packages/babel-utils/node_modules/jsesc": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -9942,30 +10514,20 @@
         "@marko/translator-default": "^5.22.0"
       }
     },
-    "packages/compiler/node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
-      "integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
-      "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
-      }
-    },
     "packages/compiler/node_modules/jsesc": {
       "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
+      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
         "node": ">=6"
       }
+    },
+    "packages/compiler/node_modules/raptor-util": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+      "integrity": "sha512-uEDMMkBCJvjTqYMBnJNxn+neiS6a0rhybQNA9RaexGor1uvKjwyHA5VcbZMZEuqXhKUWbL+WNS7PhuZVZNB7pw=="
     },
     "packages/marko": {
       "version": "5.22.0",
@@ -9989,6 +10551,11 @@
         "markoc": "bin/markoc"
       }
     },
+    "packages/marko/node_modules/raptor-util": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+      "integrity": "sha512-uEDMMkBCJvjTqYMBnJNxn+neiS6a0rhybQNA9RaexGor1uvKjwyHA5VcbZMZEuqXhKUWbL+WNS7PhuZVZNB7pw=="
+    },
     "packages/translator-default": {
       "name": "@marko/translator-default",
       "version": "5.22.0",
@@ -9997,7 +10564,7 @@
         "@babel/runtime": "^7.16.0",
         "@marko/babel-utils": "^5.21.3",
         "escape-string-regexp": "^4.0.0",
-        "magic-string": "^0.25.7",
+        "magic-string": "^0.27.0",
         "self-closing-tags": "^1.0.1"
       },
       "devDependencies": {
@@ -10011,8 +10578,7 @@
     },
     "packages/translator-default/node_modules/escape-string-regexp": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -10032,9 +10598,9 @@
       }
     },
     "@babel/cli": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.17.10.tgz",
-      "integrity": "sha512-OygVO1M2J4yPMNOW9pb+I6kFGpQK77HmG44Oz3hg8xQIl5L/2zq+ZohwAdSaqYgVwM0SfmPHZHphH4wR8qzVYw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.20.7.tgz",
+      "integrity": "sha512-WylgcELHB66WwQqItxNILsMlaTd8/SO6SgTTjMp4uCI7P4QyH1r3nqgFmO3BfM4AtfniHgFMH3EpYFj/zynBkQ==",
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.8",
@@ -10043,62 +10609,62 @@
         "commander": "^4.0.1",
         "convert-source-map": "^1.1.0",
         "fs-readdir-recursive": "^1.1.0",
-        "glob": "^7.0.0",
+        "glob": "^7.2.0",
         "make-dir": "^2.1.0",
         "slash": "^2.0.0"
       }
     },
     "@babel/code-frame": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
-      "integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+      "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
       "requires": {
-        "@babel/highlight": "^7.16.7"
+        "@babel/highlight": "^7.18.6"
       }
     },
     "@babel/compat-data": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.10.tgz",
-      "integrity": "sha512-GZt/TCsG70Ms19gfZO1tM4CVnXsPgEPBCpJu+Qz3L0LUDsY5nZqFZglIoPC1kIYOtNBZlrnFT+klg12vFGZXrw=="
+      "version": "7.20.10",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.20.10.tgz",
+      "integrity": "sha512-sEnuDPpOJR/fcafHMjpcpGN5M2jbUGUHwmuWKM/YdPzeEDJg8bgmbcWQFUfE32MQjti1koACvoPVsDe8Uq+idg=="
     },
     "@babel/core": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.12.tgz",
-      "integrity": "sha512-44ODe6O1IVz9s2oJE3rZ4trNNKTX9O7KpQpfAP4t8QII/zwrVRHL7i2pxhqtcY7tqMLrrKfMlBKnm1QlrRFs5w==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.20.12.tgz",
+      "integrity": "sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==",
       "requires": {
         "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.12",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helpers": "^7.17.9",
-        "@babel/parser": "^7.17.12",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.12",
-        "@babel/types": "^7.17.12",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helpers": "^7.20.7",
+        "@babel/parser": "^7.20.7",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.12",
+        "@babel/types": "^7.20.7",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
-        "json5": "^2.2.1",
+        "json5": "^2.2.2",
         "semver": "^6.3.0"
       }
     },
     "@babel/generator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.12.tgz",
-      "integrity": "sha512-V49KtZiiiLjH/CnIW6OjJdrenrGoyh6AmKQ3k2AZFKozC1h846Q4NYlZ5nqAigPDUXfGzC88+LOUuG8yKd2kCw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.20.7.tgz",
+      "integrity": "sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==",
       "requires": {
-        "@babel/types": "^7.17.12",
-        "@jridgewell/gen-mapping": "^0.3.0",
+        "@babel/types": "^7.20.7",
+        "@jridgewell/gen-mapping": "^0.3.2",
         "jsesc": "^2.5.1"
       },
       "dependencies": {
         "@jridgewell/gen-mapping": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.1.tgz",
-          "integrity": "sha512-GcHwniMlA2z+WFPWuY8lp3fsza0I8xPFMWL5+n8LYyP6PSvPrXf4+n8stDHZY2DM0zy9sVkRDy1jDI4XGzYVqg==",
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+          "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
           "requires": {
-            "@jridgewell/set-array": "^1.0.0",
+            "@jridgewell/set-array": "^1.0.1",
             "@jridgewell/sourcemap-codec": "^1.4.10",
             "@jridgewell/trace-mapping": "^0.3.9"
           }
@@ -10106,68 +10672,68 @@
       }
     },
     "@babel/helper-annotate-as-pure": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz",
-      "integrity": "sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.18.6.tgz",
+      "integrity": "sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.16.7.tgz",
-      "integrity": "sha512-C6FdbRaxYjwVu/geKW4ZeQ0Q31AftgRcdSnZ5/jsH6BzCJbtvXvhpfkbkThYSuutZA7nCXpPR6AD9zd1dprMkA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.18.9.tgz",
+      "integrity": "sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==",
       "dev": true,
       "requires": {
-        "@babel/helper-explode-assignable-expression": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-explode-assignable-expression": "^7.18.6",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.17.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz",
-      "integrity": "sha512-gh3RxjWbauw/dFiU/7whjd0qN9K6nPJMqe6+Er7rOavFh0CQUSwhAE3IcTho2rywPJFxej6TUUHDkWcYI6gGqQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.20.7.tgz",
+      "integrity": "sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==",
       "requires": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.20.2",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-validator-option": "^7.18.6",
+        "browserslist": "^4.21.3",
+        "lru-cache": "^5.1.1",
         "semver": "^6.3.0"
       }
     },
     "@babel/helper-create-class-features-plugin": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.17.12.tgz",
-      "integrity": "sha512-sZoOeUTkFJMyhqCei2+Z+wtH/BehW8NVKQt7IRUQlRiOARuXymJYfN/FCcI8CvVbR0XVyDM6eLFOlR7YtiXnew==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.20.12.tgz",
+      "integrity": "sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==",
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-member-expression-to-functions": "^7.17.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/helper-split-export-declaration": "^7.18.6"
       }
     },
     "@babel/helper-create-regexp-features-plugin": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.17.12.tgz",
-      "integrity": "sha512-b2aZrV4zvutr9AIa6/gA3wsZKRwTKYoDxYiFKcESS3Ug2GTXzwBEvMuuFLhCQpEnRXs1zng4ISAXSUxxKBIcxw==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.20.5.tgz",
+      "integrity": "sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "regexpu-core": "^5.0.1"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "regexpu-core": "^5.2.1"
       }
     },
     "@babel/helper-define-polyfill-provider": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.1.tgz",
-      "integrity": "sha512-J9hGMpJQmtWmj46B3kBHmL38UhJGhYX7eqkcq+2gsstyYt341HmPeWspihX43yVRA0mS+8GGk2Gckc7bY/HCmA==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.3.tgz",
+      "integrity": "sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==",
       "dev": true,
       "requires": {
-        "@babel/helper-compilation-targets": "^7.13.0",
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/traverse": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-plugin-utils": "^7.16.7",
         "debug": "^4.1.1",
         "lodash.debounce": "^4.0.8",
         "resolve": "^1.14.2",
@@ -10175,354 +10741,358 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
-      "integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
+      "integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg=="
     },
     "@babel/helper-explode-assignable-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.16.7.tgz",
-      "integrity": "sha512-KyUenhWMC8VrxzkGP0Jizjo4/Zx+1nNZhgocs+gLzyZyB8SHidhoq9KK/8Ato4anhwsivfkBLftky7gvzbZMtQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.18.6.tgz",
+      "integrity": "sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.17.9.tgz",
-      "integrity": "sha512-7cRisGlVtiVqZ0MW0/yFB4atgpGLWEHUVYnb448hZK4x+vih0YO5UoS11XIYtZYqHd0dIPMdUSv8q5K4LdMnIg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.19.0.tgz",
+      "integrity": "sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==",
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.18.10",
+        "@babel/types": "^7.19.0"
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
-      "integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
+      "integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.17.7.tgz",
-      "integrity": "sha512-thxXgnQ8qQ11W2wVUObIqDL4p148VMxkt5T/qpN5k2fboRyzFGFmKsTGViquyM5QHKUy48OZoca8kw4ajaDPyw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.20.7.tgz",
+      "integrity": "sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==",
       "requires": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
+      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.12.tgz",
-      "integrity": "sha512-t5s2BeSWIghhFRPh9XMn6EIGmvn8Lmw5RVASJzkIx1mSemubQQBNIZiQD7WzaFmaHIrjAec4x8z9Yx8SjJ1/LA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.20.11.tgz",
+      "integrity": "sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.12",
-        "@babel/types": "^7.17.12"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-simple-access": "^7.20.2",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.10",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-optimise-call-expression": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.16.7.tgz",
-      "integrity": "sha512-EtgBhg7rd/JcnpZFXpBy0ze1YRfdm7BnBX4uKMBd3ixa3RGAE002JZB66FJyNH7g0F38U05pXmA5P8cBh7z+1w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.18.6.tgz",
+      "integrity": "sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.18.9.tgz",
-      "integrity": "sha512-aBXPT3bmtLryXaoJLyYPXPlSD4p1ld9aYeR+sJNOZjJJGiOpb+fKfh3NkcCu7J54nUJwCERPBExCCpyCOHnu/w=="
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.20.2.tgz",
+      "integrity": "sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ=="
     },
     "@babel/helper-remap-async-to-generator": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.16.8.tgz",
-      "integrity": "sha512-fm0gH7Flb8H51LqJHy3HJ3wnE1+qtYR2A99K06ahwrawLdOFsCEWjZOrYricXJHoPSudNKxrMBUPEIPxiIIvBw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-remap-async-to-generator/-/helper-remap-async-to-generator-7.18.9.tgz",
+      "integrity": "sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-wrap-function": "^7.16.8",
-        "@babel/types": "^7.16.8"
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-wrap-function": "^7.18.9",
+        "@babel/types": "^7.18.9"
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.16.7.tgz",
-      "integrity": "sha512-y9vsWilTNaVnVh6xiJfABzsNpgDPKev9HnAgz6Gb1p6UUwf9NepdlsV7VXGCftJM+jqD5f7JIEubcpLjZj5dBw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.20.7.tgz",
+      "integrity": "sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==",
       "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-member-expression-to-functions": "^7.16.7",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/traverse": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-member-expression-to-functions": "^7.20.7",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.20.2.tgz",
+      "integrity": "sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==",
       "requires": {
-        "@babel/types": "^7.17.0"
+        "@babel/types": "^7.20.2"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.16.0.tgz",
-      "integrity": "sha512-+il1gTy0oHwUsBQZyJvukbB4vPMdcYBrFHa0Uc4AizLxbq6BOYC51Rv4tWocX9BLBDLZ4kc6qUFpQ6HRgL+3zw==",
-      "dev": true,
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.20.0.tgz",
+      "integrity": "sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==",
       "requires": {
-        "@babel/types": "^7.16.0"
+        "@babel/types": "^7.20.0"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
-      "integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
+      "integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
       "requires": {
-        "@babel/types": "^7.16.7"
+        "@babel/types": "^7.18.6"
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz",
+      "integrity": "sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw=="
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
-      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
+      "integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw=="
     },
     "@babel/helper-wrap-function": {
-      "version": "7.16.8",
-      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.16.8.tgz",
-      "integrity": "sha512-8RpyRVIAW1RcDDGTA+GpPAwV22wXCfKOoM9bet6TLkGIFTkRQSkH1nMQ5Yet4MpoXe1ZwHPVtNasc2w0uZMqnw==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.20.5.tgz",
+      "integrity": "sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.16.8",
-        "@babel/types": "^7.16.8"
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/template": "^7.18.10",
+        "@babel/traverse": "^7.20.5",
+        "@babel/types": "^7.20.5"
       }
     },
     "@babel/helpers": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.9.tgz",
-      "integrity": "sha512-cPCt915ShDWUEzEp3+UNRktO2n6v49l5RSnG9M5pS24hA+2FAc5si+Pn1i4VVbQQ+jh+bIZhPFQOJOzbrOYY1Q==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.20.7.tgz",
+      "integrity": "sha512-PBPjs5BppzsGaxHQCDKnZ6Gd9s6xl8bBCluz3vEInLGRJmnZan4F6BYCeqtyXqkk4W5IlPmjK4JlOuZkpJ3xZA==",
       "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.9",
-        "@babel/types": "^7.17.0"
+        "@babel/template": "^7.20.7",
+        "@babel/traverse": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/highlight": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.17.12.tgz",
-      "integrity": "sha512-7yykMVF3hfZY2jsHZEEgLc+3x4o1O+fYyULu11GynEUQNwB6lua+IIQn1FiJxNucd5UlyJryrwsOh8PL9Sn8Qg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
         "js-tokens": "^4.0.0"
       }
     },
     "@babel/parser": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.12.tgz",
-      "integrity": "sha512-FLzHmN9V3AJIrWfOpvRlZCeVg/WLdicSnTMsLur6uDj9TT8ymUlG9XxURdW/XvuygK+2CW0poOJABdA4m/YKxA=="
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.20.7.tgz",
+      "integrity": "sha512-T3Z9oHybU+0vZlY9CiDSJQTD5ZapcW18ZctFMi0MOAl/4BjFF4ul7NVSARLdbGO5vDqy9eQiGTV0LtKfvCYvcg=="
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.17.12.tgz",
-      "integrity": "sha512-xCJQXl4EeQ3J9C4yOmpTrtVGmzpm2iSzyxbkZHw7UCnZBftHpF/hpII80uWVyVrc40ytIClHjgWGTG1g/yB+aw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/-/plugin-bugfix-safari-id-destructuring-collision-in-function-expression-7.18.6.tgz",
+      "integrity": "sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.17.12.tgz",
-      "integrity": "sha512-/vt0hpIw0x4b6BLKUkwlvEoiGZYYLNZ96CzyHYPbtG2jZGz6LBe7/V+drYrc/d+ovrF9NBi0pmtvmNb/FsWtRQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
-        "@babel/plugin-proposal-optional-chaining": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
+        "@babel/plugin-proposal-optional-chaining": "^7.20.7"
       }
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.17.12.tgz",
-      "integrity": "sha512-RWVvqD1ooLKP6IqWTA5GyFVX2isGEgC5iFxKzfYOIy/QEFdxYyCybBDtIGjipHpb9bDWHzcqGqFakf+mVmBTdQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.20.7.tgz",
+      "integrity": "sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-remap-async-to-generator": "^7.16.8",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9",
         "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-class-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.17.12.tgz",
-      "integrity": "sha512-U0mI9q8pW5Q9EaTHFPwSVusPMV/DV9Mm8p7csqROFLtIE9rBF5piLqyrBGigftALrBcsBGu4m38JneAe7ZDLXw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.18.6.tgz",
+      "integrity": "sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-class-static-block": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.17.12.tgz",
-      "integrity": "sha512-8ILyDG6eL14F8iub97dVc8q35Md0PJYAnA5Kz9NACFOkt6ffCcr0FISyUPKHsvuAy36fkpIitxZ9bVYPFMGQHA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-static-block/-/plugin-proposal-class-static-block-7.20.7.tgz",
+      "integrity": "sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-class-static-block": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.16.7.tgz",
-      "integrity": "sha512-I8SW9Ho3/8DRSdmDdH3gORdyUuYnk1m4cMxUAdu5oy4n3OfN8flDEH+d60iG7dUfi0KkYwSvoalHzzdRzpWHTg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.18.6.tgz",
+      "integrity": "sha512-1auuwmK+Rz13SJj36R+jqFPMJWyKEDd7lLSdOj4oJK0UTgGueSAtkrCvz9ewmgyU/P941Rv2fQwZJN8s6QruXw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.17.12.tgz",
-      "integrity": "sha512-j7Ye5EWdwoXOpRmo5QmRyHPsDIe6+u70ZYZrd7uz+ebPYFKfRcLcNu3Ro0vOlJ5zuv8rU7xa+GttNiRzX56snQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz",
+      "integrity": "sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.9",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.17.12.tgz",
-      "integrity": "sha512-rKJ+rKBoXwLnIn7n6o6fulViHMrOThz99ybH+hKHcOZbnN14VuMnH9fo2eHE69C8pO4uX1Q7t2HYYIDmv8VYkg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.18.6.tgz",
+      "integrity": "sha512-lr1peyn9kOdbYc0xr0OdHTZ5FMqS6Di+H0Fz2I/JwMzGmzJETNeOFq2pBySw6X/KFL5EWDjlJuMsUGRFb8fQgQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-json-strings": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.17.12.tgz",
-      "integrity": "sha512-EqFo2s1Z5yy+JeJu7SFfbIUtToJTVlC61/C7WLKDntSw4Sz6JNAIfL7zQ74VvirxpjB5kz/kIx0gCcb+5OEo2Q==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.20.7.tgz",
+      "integrity": "sha512-y7C7cZgpMIjWlKE5T7eJwp+tnRYM89HmRvWM5EQuB5BoHEONjmQ8lSNmBUwOyy/GFRsohJED51YBF79hE1djug==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.17.12.tgz",
-      "integrity": "sha512-ws/g3FSGVzv+VH86+QvgtuJL/kR67xaEIF2x0iPqdDfYW6ra6JF3lKVBkWynRLcNtIC1oCTfDRVxmm2mKzy+ag==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.18.6.tgz",
+      "integrity": "sha512-wQxQzxYeJqHcfppzBDnm1yAY0jSRkUXR2z8RePZYrKwMKgMlE8+Z6LUno+bd6LvbGh8Gltvy74+9pIYkr+XkKA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.16.7.tgz",
-      "integrity": "sha512-vQgPMknOIgiuVqbokToyXbkY/OmmjAzr/0lhSIbG/KmnzXPGwW/AdhdKpi+O4X/VkWiWjnkKOBiqJrTaC98VKw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.18.6.tgz",
+      "integrity": "sha512-ozlZFogPqoLm8WBr5Z8UckIoE4YQ5KESVcNudyXOR8uqIkliTEgJ3RoketfG6pmzLdeZF0H/wjE9/cCEitBl7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.17.12.tgz",
-      "integrity": "sha512-6l9cO3YXXRh4yPCPRA776ZyJ3RobG4ZKJZhp7NDRbKIOeV3dBPG8FXCF7ZtiO2RTCIOkQOph1xDDcc01iWVNjQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
+      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/compat-data": "^7.20.5",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.17.12"
+        "@babel/plugin-transform-parameters": "^7.20.7"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.16.7.tgz",
-      "integrity": "sha512-eMOH/L4OvWSZAE1VkHbr1vckLG1WUcHGJSLqqQwl2GaUqG6QjddvrOaTUMNYiv77H5IKPMZ9U9P7EaHwvAShfA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.18.6.tgz",
+      "integrity": "sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
+        "@babel/helper-plugin-utils": "^7.18.6",
         "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.17.12.tgz",
-      "integrity": "sha512-7wigcOs/Z4YWlK7xxjkvaIw84vGhDv/P1dFGQap0nHkc8gFKY/r+hXc8Qzf5k1gY7CvGIcHqAnOagVKJJ1wVOQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.20.7.tgz",
+      "integrity": "sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0",
         "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-private-methods": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.17.12.tgz",
-      "integrity": "sha512-SllXoxo19HmxhDWm3luPz+cPhtoTSKLJE9PXshsfrOzBqs60QP0r8OaJItrPhAj0d7mZMnNF0Y1UUggCDgMz1A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-methods/-/plugin-proposal-private-methods-7.18.6.tgz",
+      "integrity": "sha512-nutsvktDItsNn4rpGItSNV2sz1XwS+nfU0Rg8aCx3W3NOKVzdMjJRu0O5OkgDp3ZGICSTbgRpxZoWsxoKRvbeA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-class-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.17.12.tgz",
-      "integrity": "sha512-/6BtVi57CJfrtDNKfK5b66ydK2J5pXUKBKSPD2G1whamMuEnZWgoOIfO8Vf9F/DoD4izBLD/Au4NMQfruzzykg==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.20.5.tgz",
+      "integrity": "sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-create-class-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
       }
     },
     "@babel/plugin-proposal-unicode-property-regex": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.17.12.tgz",
-      "integrity": "sha512-Wb9qLjXf3ZazqXA7IvI7ozqRIXIGPtSo+L5coFmEkhTQK18ao4UDDD0zdTGAarmbLj2urpRwrc6893cu5Bfh0A==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-unicode-property-regex/-/plugin-proposal-unicode-property-regex-7.18.6.tgz",
+      "integrity": "sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-syntax-async-generators": {
@@ -10568,6 +11138,15 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-import-assertions": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.20.0.tgz",
+      "integrity": "sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
     "@babel/plugin-syntax-json-strings": {
@@ -10652,383 +11231,384 @@
       }
     },
     "@babel/plugin-syntax-typescript": {
+      "version": "7.20.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.20.0.tgz",
+      "integrity": "sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.19.0"
+      }
+    },
+    "@babel/plugin-transform-arrow-functions": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.20.7.tgz",
+      "integrity": "sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.20.2"
+      }
+    },
+    "@babel/plugin-transform-async-to-generator": {
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.20.7.tgz",
+      "integrity": "sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-remap-async-to-generator": "^7.18.9"
+      }
+    },
+    "@babel/plugin-transform-block-scoped-functions": {
       "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.18.6.tgz",
-      "integrity": "sha512-mAWAuq4rvOepWCBid55JuRNvpTNf2UGVgoz4JV0fXEKolsVZDzsa4NqCef758WZJj/GDu0gVGItjKFiClTAmZA==",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.18.6.tgz",
+      "integrity": "sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
-    "@babel/plugin-transform-arrow-functions": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.17.12.tgz",
-      "integrity": "sha512-PHln3CNi/49V+mza4xMwrg+WGYevSF1oaiXaC2EQfdp4HWlSjRsrDXWJiQBKpP7749u6vQ9mcry2uuFOv5CXvA==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
-      }
-    },
-    "@babel/plugin-transform-async-to-generator": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.17.12.tgz",
-      "integrity": "sha512-J8dbrWIOO3orDzir57NRsjg4uxucvhby0L/KZuGsWDj0g7twWK3g7JhJhOrXtuXiw8MeiSdJ3E0OW9H8LYEzLQ==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-remap-async-to-generator": "^7.16.8"
-      }
-    },
-    "@babel/plugin-transform-block-scoped-functions": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.16.7.tgz",
-      "integrity": "sha512-JUuzlzmF40Z9cXyytcbZEZKckgrQzChbQJw/5PuEHYeqzCsvebDx0K0jWnIIVcmmDOAVctCgnYs0pMcrYj2zJg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
-      }
-    },
     "@babel/plugin-transform-block-scoping": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.17.12.tgz",
-      "integrity": "sha512-jw8XW/B1i7Lqwqj2CbrViPcZijSxfguBWZP2aN59NHgxUyO/OcO1mfdCxH13QhN5LbWhPkX+f+brKGhZTiqtZQ==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.20.11.tgz",
+      "integrity": "sha512-tA4N427a7fjf1P0/2I4ScsHGc5jcHPbb30xMbaTke2gxDuWpUfXDuX1FEymJwKk4tuGUvGcejAR6HdZVqmmPyw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-classes": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.17.12.tgz",
-      "integrity": "sha512-cvO7lc7pZat6BsvH6l/EGaI8zpl8paICaoGk+7x7guvtfak/TbIf66nYmJOH13EuG0H+Xx3M+9LQDtSvZFKXKw==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.20.7.tgz",
+      "integrity": "sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-annotate-as-pure": "^7.16.7",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-optimise-call-expression": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-replace-supers": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-compilation-targets": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-optimise-call-expression": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-replace-supers": "^7.20.7",
+        "@babel/helper-split-export-declaration": "^7.18.6",
         "globals": "^11.1.0"
       }
     },
     "@babel/plugin-transform-computed-properties": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.17.12.tgz",
-      "integrity": "sha512-a7XINeplB5cQUWMg1E/GI1tFz3LfK021IjV1rj1ypE+R7jHm+pIHmHl25VNkZxtx9uuYp7ThGk8fur1HHG7PgQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.20.7.tgz",
+      "integrity": "sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/template": "^7.20.7"
       }
     },
     "@babel/plugin-transform-destructuring": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.17.12.tgz",
-      "integrity": "sha512-P8pt0YiKtX5UMUL5Xzsc9Oyij+pJE6JuC+F1k0/brq/OOGs5jDa1If3OY0LRWGvJsJhI+8tsiecL3nJLc0WTlg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.20.7.tgz",
+      "integrity": "sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-dotall-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.16.7.tgz",
-      "integrity": "sha512-Lyttaao2SjZF6Pf4vk1dVKv8YypMpomAbygW+mU5cYP3S5cWTfCJjG8xV6CFdzGFlfWK81IjL9viiTvpb6G7gQ==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.18.6.tgz",
+      "integrity": "sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-duplicate-keys": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.17.12.tgz",
-      "integrity": "sha512-EA5eYFUG6xeerdabina/xIoB95jJ17mAkR8ivx6ZSu9frKShBjpOGZPn511MTDTkiCO+zXnzNczvUM69YSf3Zw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-keys/-/plugin-transform-duplicate-keys-7.18.9.tgz",
+      "integrity": "sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-exponentiation-operator": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.16.7.tgz",
-      "integrity": "sha512-8UYLSlyLgRixQvlYH3J2ekXFHDFLQutdy7FfFAMm3CPZ6q9wHCwnUyiXpQCe3gVVnQlHc5nsuiEVziteRNTXEA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.18.6.tgz",
+      "integrity": "sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==",
       "dev": true,
       "requires": {
-        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-builder-binary-assignment-operator-visitor": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-for-of": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.17.12.tgz",
-      "integrity": "sha512-76lTwYaCxw8ldT7tNmye4LLwSoKDbRCBzu6n/DcK/P3FOR29+38CIIaVIZfwol9By8W/QHORYEnYSLuvcQKrsg==",
+      "version": "7.18.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.18.8.tgz",
+      "integrity": "sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-function-name": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.16.7.tgz",
-      "integrity": "sha512-SU/C68YVwTRxqWj5kgsbKINakGag0KTgq9f2iZEXdStoAbOzLHEBRYzImmA6yFo8YZhJVflvXmIHUO7GWHmxxA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.18.9.tgz",
+      "integrity": "sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-compilation-targets": "^7.16.7",
-        "@babel/helper-function-name": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-compilation-targets": "^7.18.9",
+        "@babel/helper-function-name": "^7.18.9",
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-literals": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.17.12.tgz",
-      "integrity": "sha512-8iRkvaTjJciWycPIZ9k9duu663FT7VrBdNqNgxnVXEFwOIp55JWcZd23VBRySYbnS3PwQ3rGiabJBBBGj5APmQ==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-literals/-/plugin-transform-literals-7.18.9.tgz",
+      "integrity": "sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-member-expression-literals": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.16.7.tgz",
-      "integrity": "sha512-mBruRMbktKQwbxaJof32LT9KLy2f3gH+27a5XSuXo6h7R3vqltl0PgZ80C8ZMKw98Bf8bqt6BEVi3svOh2PzMw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.18.6.tgz",
+      "integrity": "sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-modules-amd": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.17.12.tgz",
-      "integrity": "sha512-p5rt9tB5Ndcc2Za7CeNxVf7YAjRcUMR6yi8o8tKjb9KhRkEvXwa+C0hj6DA5bVDkKRxB0NYhMUGbVKoFu4+zEA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-amd/-/plugin-transform-modules-amd-7.20.11.tgz",
+      "integrity": "sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.17.12.tgz",
-      "integrity": "sha512-tVPs6MImAJz+DiX8Y1xXEMdTk5Lwxu9jiPjlS+nv5M2A59R7+/d1+9A8C/sbuY0b3QjIxqClkj6KAplEtRvzaA==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.20.11.tgz",
+      "integrity": "sha512-S8e1f7WQ7cimJQ51JkAaDrEtohVEitXjgCGAS2N8S31Y42E+kWwfSz83LYz57QdBm7q9diARVqanIaH2oVgQnw==",
       "requires": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-simple-access": "^7.17.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-simple-access": "^7.20.2"
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.17.12.tgz",
-      "integrity": "sha512-NVhDb0q00hqZcuLduUf/kMzbOQHiocmPbIxIvk23HLiEqaTKC/l4eRxeC7lO63M72BmACoiKOcb9AkOAJRerpw==",
+      "version": "7.20.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.20.11.tgz",
+      "integrity": "sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "babel-plugin-dynamic-import-node": "^2.3.3"
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-module-transforms": "^7.20.11",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-identifier": "^7.19.1"
       }
     },
     "@babel/plugin-transform-modules-umd": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.17.12.tgz",
-      "integrity": "sha512-BnsPkrUHsjzZGpnrmJeDFkOMMljWFHPjDc9xDcz71/C+ybF3lfC3V4m3dwXPLZrE5b3bgd4V+3/Pj+3620d7IA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-umd/-/plugin-transform-modules-umd-7.18.6.tgz",
+      "integrity": "sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-transforms": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-module-transforms": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-named-capturing-groups-regex": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.17.12.tgz",
-      "integrity": "sha512-vWoWFM5CKaTeHrdUJ/3SIOTRV+MBVGybOC9mhJkaprGNt5demMymDW24yC74avb915/mIRe3TgNb/d8idvnCRA==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.20.5.tgz",
+      "integrity": "sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.17.12",
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-create-regexp-features-plugin": "^7.20.5",
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-new-target": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.17.12.tgz",
-      "integrity": "sha512-CaOtzk2fDYisbjAD4Sd1MTKGVIpRtx9bWLyj24Y/k6p4s4gQ3CqDGJauFJxt8M/LEx003d0i3klVqnN73qvK3w==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-new-target/-/plugin-transform-new-target-7.18.6.tgz",
+      "integrity": "sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-object-super": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.16.7.tgz",
-      "integrity": "sha512-14J1feiQVWaGvRxj2WjyMuXS2jsBkgB3MdSN5HuC2G5nRspa5RK9COcs82Pwy5BuGcjb+fYaUj94mYcOj7rCvw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.18.6.tgz",
+      "integrity": "sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7",
-        "@babel/helper-replace-supers": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6",
+        "@babel/helper-replace-supers": "^7.18.6"
       }
     },
     "@babel/plugin-transform-parameters": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.17.12.tgz",
-      "integrity": "sha512-6qW4rWo1cyCdq1FkYri7AHpauchbGLXpdwnYsfxFb+KtddHENfsY5JZb35xUwkK5opOLcJ3BNd2l7PhRYGlwIA==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.20.7.tgz",
+      "integrity": "sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.20.2"
       }
     },
     "@babel/plugin-transform-property-literals": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.16.7.tgz",
-      "integrity": "sha512-z4FGr9NMGdoIl1RqavCqGG+ZuYjfZ/hkCIeuH6Do7tXmSm0ls11nYVSJqFEUOSJbDab5wC6lRE/w6YjVcr6Hqw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.18.6.tgz",
+      "integrity": "sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-regenerator": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.17.9.tgz",
-      "integrity": "sha512-Lc2TfbxR1HOyn/c6b4Y/b6NHoTb67n/IoWLxTu4kC7h4KQnWlhCq2S8Tx0t2SVvv5Uu87Hs+6JEJ5kt2tYGylQ==",
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.20.5.tgz",
+      "integrity": "sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==",
       "dev": true,
       "requires": {
-        "regenerator-transform": "^0.15.0"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "regenerator-transform": "^0.15.1"
       }
     },
     "@babel/plugin-transform-reserved-words": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.17.12.tgz",
-      "integrity": "sha512-1KYqwbJV3Co03NIi14uEHW8P50Md6KqFgt0FfpHdK6oyAHQVTosgPuPSiWud1HX0oYJ1hGRRlk0fP87jFpqXZA==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-reserved-words/-/plugin-transform-reserved-words-7.18.6.tgz",
+      "integrity": "sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-runtime": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.17.12.tgz",
-      "integrity": "sha512-xsl5MeGjWnmV6Ui9PfILM2+YRpa3GqLOrczPpXV3N2KCgQGU+sU8OfzuMbjkIdfvZEZIm+3y0V7w58sk0SGzlw==",
+      "version": "7.19.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.19.6.tgz",
+      "integrity": "sha512-PRH37lz4JU156lYFW1p8OxE5i7d6Sl/zV58ooyr+q1J1lnQPyg5tIiXlIwNVhJaY4W3TmOtdc8jqdXQcB1v5Yw==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "babel-plugin-polyfill-corejs2": "^0.3.0",
-        "babel-plugin-polyfill-corejs3": "^0.5.0",
-        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "@babel/helper-module-imports": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.19.0",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
         "semver": "^6.3.0"
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
-      "integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.18.6.tgz",
+      "integrity": "sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-spread": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.17.12.tgz",
-      "integrity": "sha512-9pgmuQAtFi3lpNUstvG9nGfk9DkrdmWNp9KeKPFmuZCpEnxRzYlS8JgwPjYj+1AWDOSvoGN0H30p1cBOmT/Svg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.20.7.tgz",
+      "integrity": "sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-skip-transparent-expression-wrappers": "^7.16.0"
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.20.0"
       }
     },
     "@babel/plugin-transform-sticky-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.16.7.tgz",
-      "integrity": "sha512-NJa0Bd/87QV5NZZzTuZG5BPJjLYadeSZ9fO6oOUoL4iQx+9EEuw/eEM92SrsT19Yc2jgB1u1hsjqDtH02c3Drw==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.18.6.tgz",
+      "integrity": "sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/plugin-transform-template-literals": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.17.12.tgz",
-      "integrity": "sha512-kAKJ7DX1dSRa2s7WN1xUAuaQmkTpN+uig4wCKWivVXIObqGbVTUlSavHyfI2iZvz89GFAMGm9p2DBJ4Y1Tp0hw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.18.9.tgz",
+      "integrity": "sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-typeof-symbol": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.17.12.tgz",
-      "integrity": "sha512-Q8y+Jp7ZdtSPXCThB6zjQ74N3lj0f6TDh1Hnf5B+sYlzQ8i5Pjp8gW0My79iekSpT4WnI06blqP6DT0OmaXXmw==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.18.9.tgz",
+      "integrity": "sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.17.12"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-typescript": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.16.0.tgz",
-      "integrity": "sha512-dNUn7RSt1dykzFTquwm7qND+dQ8u0SRhZpPFsm1GYAad+EEAirNTjqu/fnqB0zVPwjcZQd//DYWszVKoCrQuoQ==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.20.7.tgz",
+      "integrity": "sha512-m3wVKEvf6SoszD8pu4NZz3PvfKRCMgk6D6d0Qi9hNnlM5M6CFS92EgF4EiHVLKbU0r/r7ty1hg7NPZwE7WRbYw==",
       "requires": {
-        "@babel/helper-create-class-features-plugin": "^7.16.0",
-        "@babel/helper-plugin-utils": "^7.14.5",
-        "@babel/plugin-syntax-typescript": "^7.16.0"
+        "@babel/helper-create-class-features-plugin": "^7.20.7",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-typescript": "^7.20.0"
       }
     },
     "@babel/plugin-transform-unicode-escapes": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.16.7.tgz",
-      "integrity": "sha512-TAV5IGahIz3yZ9/Hfv35TV2xEm+kaBDaZQCn2S/hG9/CZ0DktxJv9eKfPc7yYCvOYR4JGx1h8C+jcSOvgaaI/Q==",
+      "version": "7.18.10",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-escapes/-/plugin-transform-unicode-escapes-7.18.10.tgz",
+      "integrity": "sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-plugin-utils": "^7.18.9"
       }
     },
     "@babel/plugin-transform-unicode-regex": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.16.7.tgz",
-      "integrity": "sha512-oC5tYYKw56HO75KZVLQ+R/Nl3Hro9kf8iG0hXoaHP7tjAyCpvqBiSNe6vGrZni1Z6MggmUOC6A7VP7AVmw225Q==",
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.18.6.tgz",
+      "integrity": "sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==",
       "dev": true,
       "requires": {
-        "@babel/helper-create-regexp-features-plugin": "^7.16.7",
-        "@babel/helper-plugin-utils": "^7.16.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.18.6",
+        "@babel/helper-plugin-utils": "^7.18.6"
       }
     },
     "@babel/preset-env": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.17.12.tgz",
-      "integrity": "sha512-Kke30Rj3Lmcx97bVs71LO0s8M6FmJ7tUAQI9fNId62rf0cYG1UAWwdNO9/sE0/pLEahAw1MqMorymoD12bj5Fg==",
+      "version": "7.20.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.20.2.tgz",
+      "integrity": "sha512-1G0efQEWR1EHkKvKHqbG+IN/QdgwfByUpM5V5QroDzGV2t3S/WXNQd693cHiHTlCFMpr9B6FkPFXDA2lQcKoDg==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.17.10",
-        "@babel/helper-compilation-targets": "^7.17.10",
-        "@babel/helper-plugin-utils": "^7.17.12",
-        "@babel/helper-validator-option": "^7.16.7",
-        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.17.12",
-        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.17.12",
-        "@babel/plugin-proposal-async-generator-functions": "^7.17.12",
-        "@babel/plugin-proposal-class-properties": "^7.17.12",
-        "@babel/plugin-proposal-class-static-block": "^7.17.12",
-        "@babel/plugin-proposal-dynamic-import": "^7.16.7",
-        "@babel/plugin-proposal-export-namespace-from": "^7.17.12",
-        "@babel/plugin-proposal-json-strings": "^7.17.12",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.17.12",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.17.12",
-        "@babel/plugin-proposal-numeric-separator": "^7.16.7",
-        "@babel/plugin-proposal-object-rest-spread": "^7.17.12",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.16.7",
-        "@babel/plugin-proposal-optional-chaining": "^7.17.12",
-        "@babel/plugin-proposal-private-methods": "^7.17.12",
-        "@babel/plugin-proposal-private-property-in-object": "^7.17.12",
-        "@babel/plugin-proposal-unicode-property-regex": "^7.17.12",
+        "@babel/compat-data": "^7.20.1",
+        "@babel/helper-compilation-targets": "^7.20.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/helper-validator-option": "^7.18.6",
+        "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.18.6",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-async-generator-functions": "^7.20.1",
+        "@babel/plugin-proposal-class-properties": "^7.18.6",
+        "@babel/plugin-proposal-class-static-block": "^7.18.6",
+        "@babel/plugin-proposal-dynamic-import": "^7.18.6",
+        "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
+        "@babel/plugin-proposal-json-strings": "^7.18.6",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.18.9",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.18.6",
+        "@babel/plugin-proposal-numeric-separator": "^7.18.6",
+        "@babel/plugin-proposal-object-rest-spread": "^7.20.2",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.18.6",
+        "@babel/plugin-proposal-optional-chaining": "^7.18.9",
+        "@babel/plugin-proposal-private-methods": "^7.18.6",
+        "@babel/plugin-proposal-private-property-in-object": "^7.18.6",
+        "@babel/plugin-proposal-unicode-property-regex": "^7.18.6",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
         "@babel/plugin-syntax-class-static-block": "^7.14.5",
         "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+        "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
         "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
@@ -11038,44 +11618,44 @@
         "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
-        "@babel/plugin-transform-arrow-functions": "^7.17.12",
-        "@babel/plugin-transform-async-to-generator": "^7.17.12",
-        "@babel/plugin-transform-block-scoped-functions": "^7.16.7",
-        "@babel/plugin-transform-block-scoping": "^7.17.12",
-        "@babel/plugin-transform-classes": "^7.17.12",
-        "@babel/plugin-transform-computed-properties": "^7.17.12",
-        "@babel/plugin-transform-destructuring": "^7.17.12",
-        "@babel/plugin-transform-dotall-regex": "^7.16.7",
-        "@babel/plugin-transform-duplicate-keys": "^7.17.12",
-        "@babel/plugin-transform-exponentiation-operator": "^7.16.7",
-        "@babel/plugin-transform-for-of": "^7.17.12",
-        "@babel/plugin-transform-function-name": "^7.16.7",
-        "@babel/plugin-transform-literals": "^7.17.12",
-        "@babel/plugin-transform-member-expression-literals": "^7.16.7",
-        "@babel/plugin-transform-modules-amd": "^7.17.12",
-        "@babel/plugin-transform-modules-commonjs": "^7.17.12",
-        "@babel/plugin-transform-modules-systemjs": "^7.17.12",
-        "@babel/plugin-transform-modules-umd": "^7.17.12",
-        "@babel/plugin-transform-named-capturing-groups-regex": "^7.17.12",
-        "@babel/plugin-transform-new-target": "^7.17.12",
-        "@babel/plugin-transform-object-super": "^7.16.7",
-        "@babel/plugin-transform-parameters": "^7.17.12",
-        "@babel/plugin-transform-property-literals": "^7.16.7",
-        "@babel/plugin-transform-regenerator": "^7.17.9",
-        "@babel/plugin-transform-reserved-words": "^7.17.12",
-        "@babel/plugin-transform-shorthand-properties": "^7.16.7",
-        "@babel/plugin-transform-spread": "^7.17.12",
-        "@babel/plugin-transform-sticky-regex": "^7.16.7",
-        "@babel/plugin-transform-template-literals": "^7.17.12",
-        "@babel/plugin-transform-typeof-symbol": "^7.17.12",
-        "@babel/plugin-transform-unicode-escapes": "^7.16.7",
-        "@babel/plugin-transform-unicode-regex": "^7.16.7",
+        "@babel/plugin-transform-arrow-functions": "^7.18.6",
+        "@babel/plugin-transform-async-to-generator": "^7.18.6",
+        "@babel/plugin-transform-block-scoped-functions": "^7.18.6",
+        "@babel/plugin-transform-block-scoping": "^7.20.2",
+        "@babel/plugin-transform-classes": "^7.20.2",
+        "@babel/plugin-transform-computed-properties": "^7.18.9",
+        "@babel/plugin-transform-destructuring": "^7.20.2",
+        "@babel/plugin-transform-dotall-regex": "^7.18.6",
+        "@babel/plugin-transform-duplicate-keys": "^7.18.9",
+        "@babel/plugin-transform-exponentiation-operator": "^7.18.6",
+        "@babel/plugin-transform-for-of": "^7.18.8",
+        "@babel/plugin-transform-function-name": "^7.18.9",
+        "@babel/plugin-transform-literals": "^7.18.9",
+        "@babel/plugin-transform-member-expression-literals": "^7.18.6",
+        "@babel/plugin-transform-modules-amd": "^7.19.6",
+        "@babel/plugin-transform-modules-commonjs": "^7.19.6",
+        "@babel/plugin-transform-modules-systemjs": "^7.19.6",
+        "@babel/plugin-transform-modules-umd": "^7.18.6",
+        "@babel/plugin-transform-named-capturing-groups-regex": "^7.19.1",
+        "@babel/plugin-transform-new-target": "^7.18.6",
+        "@babel/plugin-transform-object-super": "^7.18.6",
+        "@babel/plugin-transform-parameters": "^7.20.1",
+        "@babel/plugin-transform-property-literals": "^7.18.6",
+        "@babel/plugin-transform-regenerator": "^7.18.6",
+        "@babel/plugin-transform-reserved-words": "^7.18.6",
+        "@babel/plugin-transform-shorthand-properties": "^7.18.6",
+        "@babel/plugin-transform-spread": "^7.19.0",
+        "@babel/plugin-transform-sticky-regex": "^7.18.6",
+        "@babel/plugin-transform-template-literals": "^7.18.9",
+        "@babel/plugin-transform-typeof-symbol": "^7.18.9",
+        "@babel/plugin-transform-unicode-escapes": "^7.18.10",
+        "@babel/plugin-transform-unicode-regex": "^7.18.6",
         "@babel/preset-modules": "^0.1.5",
-        "@babel/types": "^7.17.12",
-        "babel-plugin-polyfill-corejs2": "^0.3.0",
-        "babel-plugin-polyfill-corejs3": "^0.5.0",
-        "babel-plugin-polyfill-regenerator": "^0.3.0",
-        "core-js-compat": "^3.22.1",
+        "@babel/types": "^7.20.2",
+        "babel-plugin-polyfill-corejs2": "^0.3.3",
+        "babel-plugin-polyfill-corejs3": "^0.6.0",
+        "babel-plugin-polyfill-regenerator": "^0.4.1",
+        "core-js-compat": "^3.25.1",
         "semver": "^6.3.0"
       }
     },
@@ -11093,9 +11673,9 @@
       }
     },
     "@babel/register": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.17.7.tgz",
-      "integrity": "sha512-fg56SwvXRifootQEDQAu1mKdjh5uthPzdO0N6t358FktfL4XjAVXuH58ULoiW8mesxiOgNIrxiImqEwv0+hRRA==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.18.9.tgz",
+      "integrity": "sha512-ZlbnXDcNYHMR25ITwwNKT88JiaukkdVj/nG7r3wnuXkOTHc60Uy05PwMCPre0hSkY68E6zK3xz+vUJSP2jWmcw==",
       "dev": true,
       "requires": {
         "clone-deep": "^4.0.1",
@@ -11106,76 +11686,71 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.17.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.9.tgz",
-      "integrity": "sha512-lSiBBvodq29uShpWGNbgFdKYNiFDo5/HIYsaCEY9ff4sb10x9jizo2+pRrSyF4jKZCXqgzuqBOQKbUm90gQwJg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.7.tgz",
+      "integrity": "sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       }
     },
     "@babel/template": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
-      "integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
+      "integrity": "sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==",
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/parser": "^7.16.7",
-        "@babel/types": "^7.16.7"
+        "@babel/code-frame": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7"
       }
     },
     "@babel/traverse": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.12.tgz",
-      "integrity": "sha512-zULPs+TbCvOkIFd4FrG53xrpxvCBwLIgo6tO0tJorY7YV2IWFxUfS/lXDJbGgfyYt9ery/Gxj2niwttNnB0gIw==",
+      "version": "7.20.12",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.20.12.tgz",
+      "integrity": "sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==",
       "requires": {
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.12",
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-function-name": "^7.17.9",
-        "@babel/helper-hoist-variables": "^7.16.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/parser": "^7.17.12",
-        "@babel/types": "^7.17.12",
+        "@babel/code-frame": "^7.18.6",
+        "@babel/generator": "^7.20.7",
+        "@babel/helper-environment-visitor": "^7.18.9",
+        "@babel/helper-function-name": "^7.19.0",
+        "@babel/helper-hoist-variables": "^7.18.6",
+        "@babel/helper-split-export-declaration": "^7.18.6",
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.17.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.12.tgz",
-      "integrity": "sha512-rH8i29wcZ6x9xjzI5ILHL/yZkbQnCERdHlogKuIb4PUr7do4iT8DPekrTbBLWTnRQm6U0GYABbTMSzijmEqlAg==",
+      "version": "7.20.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.20.7.tgz",
+      "integrity": "sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.16.7",
+        "@babel/helper-string-parser": "^7.19.4",
+        "@babel/helper-validator-identifier": "^7.19.1",
         "to-fast-properties": "^2.0.0"
       }
     },
     "@changesets/apply-release-plan": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.0.0.tgz",
-      "integrity": "sha512-gp6nIdVdfYdwKww2+f8whckKmvfE4JEm4jJgBhTmooi0uzHWhnxvk6JIzQi89qEAMINN0SeVNnXiAtbFY0Mj3w==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-6.1.3.tgz",
+      "integrity": "sha512-ECDNeoc3nfeAe1jqJb5aFQX7CqzQhD2klXRez2JDb/aVpGUbX673HgKrnrgJRuQR/9f2TtLoYIzrGB9qwD77mg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/config": "^2.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/config": "^2.3.0",
         "@changesets/get-version-range-type": "^0.3.2",
-        "@changesets/git": "^1.3.2",
-        "@changesets/types": "^5.0.0",
+        "@changesets/git": "^2.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
         "fs-extra": "^7.0.1",
         "lodash.startcase": "^4.4.0",
         "outdent": "^0.5.0",
-        "prettier": "^1.19.1",
+        "prettier": "^2.7.1",
         "resolve-from": "^5.0.0",
         "semver": "^5.4.1"
       },
       "dependencies": {
-        "prettier": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-          "dev": true
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -11185,15 +11760,15 @@
       }
     },
     "@changesets/assemble-release-plan": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.1.2.tgz",
-      "integrity": "sha512-nOFyDw4APSkY/vh5WNwGEtThPgEjVShp03PKVdId6wZTJALVcAALCSLmDRfeqjE2z9EsGJb7hZdDlziKlnqZgw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-5.2.3.tgz",
+      "integrity": "sha512-g7EVZCmnWz3zMBAdrcKhid4hkHT+Ft1n0mLussFMcB1dE2zCuwcvGoy9ec3yOgPGF4hoMtgHaMIk3T3TBdvU9g==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
-        "@changesets/types": "^5.0.0",
+        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "semver": "^5.4.1"
       },
@@ -11207,48 +11782,49 @@
       }
     },
     "@changesets/changelog-git": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.11.tgz",
-      "integrity": "sha512-sWJvAm+raRPeES9usNpZRkooeEB93lOpUN0Lmjz5vhVAb7XGIZrHEJ93155bpE1S0c4oJ5Di9ZWgzIwqhWP/Wg==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-git/-/changelog-git-0.1.14.tgz",
+      "integrity": "sha512-+vRfnKtXVWsDDxGctOfzJsPhaCdXRYoe+KyWYoq5X/GqoISREiat0l3L8B0a453B2B4dfHGcZaGyowHbp9BSaA==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.0.0"
+        "@changesets/types": "^5.2.1"
       }
     },
     "@changesets/changelog-github": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.4.tgz",
-      "integrity": "sha512-htSILqCkyYtTB5/LoVKwx7GCJQGxAiBcYbfUKWiz/QoDARuM01owYtMXhV6/iytJZq/Dqqz3PjMZUNB4MphpbQ==",
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@changesets/changelog-github/-/changelog-github-0.4.8.tgz",
+      "integrity": "sha512-jR1DHibkMAb5v/8ym77E4AMNWZKB5NPzw5a5Wtqm1JepAuIF+hrKp2u04NKM14oBZhHglkCfrla9uq8ORnK/dw==",
       "dev": true,
       "requires": {
-        "@changesets/get-github-info": "^0.5.0",
-        "@changesets/types": "^5.0.0",
+        "@changesets/get-github-info": "^0.5.2",
+        "@changesets/types": "^5.2.1",
         "dotenv": "^8.1.0"
       }
     },
     "@changesets/cli": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.22.0.tgz",
-      "integrity": "sha512-4bA3YoBkd5cm5WUxmrR2N9WYE7EeQcM+R3bVYMUj2NvffkQVpU3ckAI+z8UICoojq+HRl2OEwtz+S5UBmYY4zw==",
+      "version": "2.26.0",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.26.0.tgz",
+      "integrity": "sha512-0cbTiDms+ICTVtEwAFLNW0jBNex9f5+fFv3I771nBvdnV/mOjd1QJ4+f8KtVSOrwD9SJkk9xbDkWFb0oXd8d1Q==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/apply-release-plan": "^6.0.0",
-        "@changesets/assemble-release-plan": "^5.1.2",
-        "@changesets/changelog-git": "^0.1.11",
-        "@changesets/config": "^2.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/apply-release-plan": "^6.1.3",
+        "@changesets/assemble-release-plan": "^5.2.3",
+        "@changesets/changelog-git": "^0.1.14",
+        "@changesets/config": "^2.3.0",
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
-        "@changesets/get-release-plan": "^3.0.8",
-        "@changesets/git": "^1.3.2",
+        "@changesets/get-dependents-graph": "^1.3.5",
+        "@changesets/get-release-plan": "^3.0.16",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/pre": "^1.0.11",
-        "@changesets/read": "^0.5.5",
-        "@changesets/types": "^5.0.0",
-        "@changesets/write": "^0.1.8",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
+        "@changesets/write": "^0.2.3",
         "@manypkg/get-packages": "^1.1.3",
         "@types/is-ci": "^3.0.0",
         "@types/semver": "^6.0.0",
+        "ansi-colors": "^4.1.3",
         "chalk": "^2.1.0",
         "enquirer": "^2.3.0",
         "external-editor": "^3.1.0",
@@ -11263,7 +11839,7 @@
         "semver": "^5.4.1",
         "spawndamnit": "^2.0.0",
         "term-size": "^2.1.0",
-        "tty-table": "^2.8.10"
+        "tty-table": "^4.1.5"
       },
       "dependencies": {
         "semver": {
@@ -11275,15 +11851,15 @@
       }
     },
     "@changesets/config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.0.0.tgz",
-      "integrity": "sha512-r5bIFY6CN3K6SQ+HZbjyE3HXrBIopONR47mmX7zUbORlybQXtympq9rVAOzc0Oflbap8QeIexc+hikfZoREXDg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-2.3.0.tgz",
+      "integrity": "sha512-EgP/px6mhCx8QeaMAvWtRrgyxW08k/Bx2tpGT+M84jEdX37v3VKfh4Cz1BkwrYKuMV2HZKeHOh8sHvja/HcXfQ==",
       "dev": true,
       "requires": {
         "@changesets/errors": "^0.1.4",
-        "@changesets/get-dependents-graph": "^1.3.2",
+        "@changesets/get-dependents-graph": "^1.3.5",
         "@changesets/logger": "^0.0.5",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
         "micromatch": "^4.0.2"
@@ -11299,12 +11875,12 @@
       }
     },
     "@changesets/get-dependents-graph": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.2.tgz",
-      "integrity": "sha512-tsqA6qZRB86SQuApSoDvI8yEWdyIlo/WLI4NUEdhhxLMJ0dapdeT6rUZRgSZzK1X2nv5YwR0MxQBbDAiDibKrg==",
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-1.3.5.tgz",
+      "integrity": "sha512-w1eEvnWlbVDIY8mWXqWuYE9oKhvIaBhzqzo4ITSJY9hgoqQ3RoBqwlcAzg11qHxv/b8ReDWnMrpjpKrW6m1ZTA==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
@@ -11320,9 +11896,9 @@
       }
     },
     "@changesets/get-github-info": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.0.tgz",
-      "integrity": "sha512-vm5VgHwrxkMkUjFyn3UVNKLbDp9YMHd3vMf1IyJoa/7B+6VpqmtAaXyDS0zBLfN5bhzVCHrRnj4GcZXXcqrFTw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@changesets/get-github-info/-/get-github-info-0.5.2.tgz",
+      "integrity": "sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==",
       "dev": true,
       "requires": {
         "dataloader": "^1.4.0",
@@ -11330,17 +11906,17 @@
       }
     },
     "@changesets/get-release-plan": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.8.tgz",
-      "integrity": "sha512-TJYiWNuP0Lzu2dL/KHuk75w7TkiE5HqoYirrXF7SJIxkhlgH9toQf2C7IapiFTObtuF1qDN8HJAX1CuIOwXldg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-3.0.16.tgz",
+      "integrity": "sha512-OpP9QILpBp1bY2YNIKFzwigKh7Qe9KizRsZomzLe6pK8IUo8onkAAVUD8+JRKSr8R7d4+JRuQrfSSNlEwKyPYg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/assemble-release-plan": "^5.1.2",
-        "@changesets/config": "^2.0.0",
-        "@changesets/pre": "^1.0.11",
-        "@changesets/read": "^0.5.5",
-        "@changesets/types": "^5.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/assemble-release-plan": "^5.2.3",
+        "@changesets/config": "^2.3.0",
+        "@changesets/pre": "^1.0.14",
+        "@changesets/read": "^0.5.9",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3"
       }
     },
@@ -11351,16 +11927,17 @@
       "dev": true
     },
     "@changesets/git": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-1.3.2.tgz",
-      "integrity": "sha512-p5UL+urAg0Nnpt70DLiBe2iSsMcDubTo9fTOD/61krmcJ466MGh71OHwdAwu1xG5+NKzeysdy1joRTg8CXcEXA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-2.0.0.tgz",
+      "integrity": "sha512-enUVEWbiqUTxqSnmesyJGWfzd51PY4H7mH9yUw0hPVpZBJ6tQZFMU3F3mT/t9OJ/GjyiM4770i+sehAn6ymx6A==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
+        "micromatch": "^4.0.2",
         "spawndamnit": "^2.0.0"
       }
     },
@@ -11374,69 +11951,61 @@
       }
     },
     "@changesets/parse": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.13.tgz",
-      "integrity": "sha512-wh9Ifa0dungY6d2nMz6XxF6FZ/1I7j+mEgPAqrIyKS64nifTh1Ua82qKKMMK05CL7i4wiB2NYc3SfnnCX3RVeA==",
+      "version": "0.3.16",
+      "resolved": "https://registry.npmjs.org/@changesets/parse/-/parse-0.3.16.tgz",
+      "integrity": "sha512-127JKNd167ayAuBjUggZBkmDS5fIKsthnr9jr6bdnuUljroiERW7FBTDNnNVyJ4l69PzR57pk6mXQdtJyBCJKg==",
       "dev": true,
       "requires": {
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "js-yaml": "^3.13.1"
       }
     },
     "@changesets/pre": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.11.tgz",
-      "integrity": "sha512-CXZnt4SV9waaC9cPLm7818+SxvLKIDHUxaiTXnJYDp1c56xIexx1BNfC1yMuOdzO2a3rAIcZua5Odxr3dwSKfg==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-1.0.14.tgz",
+      "integrity": "sha512-dTsHmxQWEQekHYHbg+M1mDVYFvegDh9j/kySNuDKdylwfMEevTeDouR7IfHNyVodxZXu17sXoJuf2D0vi55FHQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.1.4",
-        "@changesets/types": "^5.0.0",
+        "@changesets/types": "^5.2.1",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1"
       }
     },
     "@changesets/read": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.5.tgz",
-      "integrity": "sha512-bzonrPWc29Tsjvgh+8CqJ0apQOwWim0zheeD4ZK44ApSa/GudnZJTODtA3yNOOuQzeZmL0NUebVoHIurtIkA7w==",
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.5.9.tgz",
+      "integrity": "sha512-T8BJ6JS6j1gfO1HFq50kU3qawYxa4NTbI/ASNVVCBTsKquy2HYwM9r7ZnzkiMe8IEObAJtUVGSrePCOxAK2haQ==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/git": "^1.3.2",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/git": "^2.0.0",
         "@changesets/logger": "^0.0.5",
-        "@changesets/parse": "^0.3.13",
-        "@changesets/types": "^5.0.0",
+        "@changesets/parse": "^0.3.16",
+        "@changesets/types": "^5.2.1",
         "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
         "p-filter": "^2.1.0"
       }
     },
     "@changesets/types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.0.0.tgz",
-      "integrity": "sha512-IT1kBLSbAgTS4WtpU6P5ko054hq12vk4tgeIFRVE7Vnm4a/wgbNvBalgiKP0MjEXbCkZbItiGQHkCGxYWR55sA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@changesets/types/-/types-5.2.1.tgz",
+      "integrity": "sha512-myLfHbVOqaq9UtUKqR/nZA/OY7xFjQMdfgfqeZIBK4d0hA6pgxArvdv8M+6NUzzBsjWLOtvApv8YHr4qM+Kpfg==",
       "dev": true
     },
     "@changesets/write": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.1.8.tgz",
-      "integrity": "sha512-oIHeFVMuP6jf0TPnKPpaFpvvAf3JBc+s2pmVChbeEgQTBTALoF51Z9kqxQfG4XONZPHZnqkmy564c7qohhhhTQ==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.2.3.tgz",
+      "integrity": "sha512-Dbamr7AIMvslKnNYsLFafaVORx4H0pvCA2MHqgtNCySMe1blImEyAEOzDmcgKAkgz4+uwoLz7demIrX+JBr/Xw==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.4",
-        "@changesets/types": "^5.0.0",
+        "@babel/runtime": "^7.20.1",
+        "@changesets/types": "^5.2.1",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
-        "prettier": "^1.19.1"
-      },
-      "dependencies": {
-        "prettier": {
-          "version": "1.19.1",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-          "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-          "dev": true
-        }
+        "prettier": "^2.7.1"
       }
     },
     "@ebay/browserslist-config": {
@@ -11463,9 +12032,9 @@
       },
       "dependencies": {
         "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "version": "13.19.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+          "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -11525,27 +12094,27 @@
       }
     },
     "@jridgewell/resolve-uri": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz",
-      "integrity": "sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/set-array": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.1.tgz",
-      "integrity": "sha512-Ct5MqZkLGEXTVmQYbGtx9SVqD2fqwvdubdps5D3djjAkgkKwT918VNOz65pEHFaYTeWcukmJmH5SwsA9Tn2ObQ=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
     },
     "@jridgewell/sourcemap-codec": {
-      "version": "1.4.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz",
-      "integrity": "sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w=="
+      "version": "1.4.14",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.13.tgz",
-      "integrity": "sha512-o1xbKhp9qnIAoHJSWd6KlCZfqslL4valSF81H8ImioOAxluWYWOpWkpyktY2vnt4tbrX9XYaxovq6cgowaJp2w==",
+      "version": "0.3.17",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
+      "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
       "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
+        "@jridgewell/resolve-uri": "3.1.0",
+        "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
     "@manypkg/find-root": {
@@ -11616,9 +12185,7 @@
       },
       "dependencies": {
         "jsesc": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
+          "version": "3.0.2"
         }
       }
     },
@@ -11651,18 +12218,13 @@
         "strip-json-comments": "^3.1.1"
       },
       "dependencies": {
-        "@babel/plugin-syntax-typescript": {
-          "version": "7.16.0",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.16.0.tgz",
-          "integrity": "sha512-Xv6mEXqVdaqCBfJFyeab0fH2DnUoMsDmhamxsSi4j8nLd4Vtw213WMJr55xxqipC/YVWyPY3K0blJncPYji+dQ==",
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.14.5"
-          }
-        },
         "jsesc": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
-          "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="
+          "version": "3.0.2"
+        },
+        "raptor-util": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+          "integrity": "sha512-uEDMMkBCJvjTqYMBnJNxn+neiS6a0rhybQNA9RaexGor1uvKjwyHA5VcbZMZEuqXhKUWbL+WNS7PhuZVZNB7pw=="
         }
       }
     },
@@ -11673,15 +12235,13 @@
         "@marko/babel-utils": "^5.21.3",
         "@marko/compiler": "^5.23.0",
         "escape-string-regexp": "^4.0.0",
-        "magic-string": "^0.25.7",
+        "magic-string": "^0.27.0",
         "marko": "^5.22.0",
         "self-closing-tags": "^1.0.1"
       },
       "dependencies": {
         "escape-string-regexp": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+          "version": "4.0.0"
         }
       }
     },
@@ -11725,9 +12285,9 @@
       "dev": true
     },
     "@types/babel__traverse": {
-      "version": "7.17.1",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.17.1.tgz",
-      "integrity": "sha512-kVzjari1s2YVi77D3w1yuvohV2idweYXMCDzqBiVNN63TcDWrIlTVOYpqVrvbbyOE/IyzBoTKF0fdnLPEORFxA==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.18.3.tgz",
+      "integrity": "sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -11749,9 +12309,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.20.52",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.52.tgz",
-      "integrity": "sha512-cfkwWw72849SNYp3Zx0IcIs25vABmFh73xicxhCkTcvtZQeIez15PpwQN8fY3RD7gv1Wrxlc9MEtfMORZDEsGw==",
+      "version": "12.20.55",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+      "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -11883,9 +12443,9 @@
       }
     },
     "anymatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
-      "integrity": "sha512-P43ePfOAIupkguHUycrc4qJ9kz8ZiuOUijaETwX7THt0Y/GNK7v0aa8rY816xWjZ7rJdA5XdMcpVFTKMq+RvWg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -11938,6 +12498,18 @@
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
       "dev": true
     },
+    "array.prototype.flat": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz",
+      "integrity": "sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4",
+        "es-shim-unscopables": "^1.0.0"
+      }
+    },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -11961,13 +12533,11 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
-    "babel-plugin-dynamic-import-node": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/babel-plugin-dynamic-import-node/-/babel-plugin-dynamic-import-node-2.3.3.tgz",
-      "integrity": "sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==",
-      "requires": {
-        "object.assign": "^4.1.0"
-      }
+    "available-typed-arrays": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
+      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
+      "dev": true
     },
     "babel-plugin-istanbul": {
       "version": "6.1.1",
@@ -11993,33 +12563,33 @@
       }
     },
     "babel-plugin-polyfill-corejs2": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.1.tgz",
-      "integrity": "sha512-v7/T6EQcNfVLfcN2X8Lulb7DjprieyLWJK/zOWH5DUYcAgex9sP3h25Q+DLsX9TloXe3y1O8l2q2Jv9q8UVB9w==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.3.tgz",
+      "integrity": "sha512-8hOdmFYFSZhqg2C/JgLUQ+t52o5nirNwaWM2B9LWteozwIvM14VSwdsCAUET10qT+kmySAlseadmfeeSWFCy+Q==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.11",
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
+        "@babel/compat-data": "^7.17.7",
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
         "semver": "^6.1.1"
       }
     },
     "babel-plugin-polyfill-corejs3": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.5.2.tgz",
-      "integrity": "sha512-G3uJih0XWiID451fpeFaYGVuxHEjzKTHtc9uGFEjR6hHrvNzeS/PX+LLLcetJcytsB5m4j+K3o/EpXJNb/5IEQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.6.0.tgz",
+      "integrity": "sha512-+eHqR6OPcBhJOGgsIar7xoAB1GcSwVUA3XjAd7HJNzOXT4wv6/H7KIdA/Nc60cvUlDbKApmqNvD1B1bzOt4nyA==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1",
-        "core-js-compat": "^3.21.0"
+        "@babel/helper-define-polyfill-provider": "^0.3.3",
+        "core-js-compat": "^3.25.1"
       }
     },
     "babel-plugin-polyfill-regenerator": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.1.tgz",
-      "integrity": "sha512-Y2B06tvgHYt1x0yz17jGkGeeMr5FeKUu+ASJ+N6nB5lQ8Dapfg42i0OVrf8PNGJ3zKL4A23snMi1IRwrqqND7A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.4.1.tgz",
+      "integrity": "sha512-NtQGmyQDXjQqQ+IzRkBVwEOz9lQ4zxAQZgoAYEtU9dJjnl1Oc98qnN7jcp+bE7O7aYzVpavXE3/VKXNzUbh7aw==",
       "dev": true,
       "requires": {
-        "@babel/helper-define-polyfill-provider": "^0.3.1"
+        "@babel/helper-define-polyfill-provider": "^0.3.3"
       }
     },
     "balanced-match": {
@@ -12049,9 +12619,9 @@
       "dev": true
     },
     "body-parser": {
-      "version": "1.20.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.0.tgz",
-      "integrity": "sha512-DfJ+q6EPcGKZD1QWUjSpqp+Q7bDQTsQIF4zfUAtZ6qk+H/3/QRhg9CEp39ss+/T2vw0+HaidC0ecJj/DRLIaKg==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.1.tgz",
+      "integrity": "sha512-jWi7abTbYwajOytWCQc37VulmWiRae5RyTpaCyDcS5/lMdtwSz5lOpDE67srw/HYe35f1z3fDQw+3txg7gNtWw==",
       "dev": true,
       "requires": {
         "bytes": "3.1.2",
@@ -12062,7 +12632,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "raw-body": "2.5.1",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -12080,7 +12650,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -12130,15 +12700,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.20.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.3.tgz",
-      "integrity": "sha512-NBhymBQl1zM0Y5dQT/O+xiLP9/rzOIQdKM/eMJBAq7yBgaB6krIYLGejrwVYnSHZdqjscB1SPuAjHwxjvN6Wdg==",
+      "version": "4.21.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
+      "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
       "requires": {
-        "caniuse-lite": "^1.0.30001332",
-        "electron-to-chromium": "^1.4.118",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.3",
-        "picocolors": "^1.0.0"
+        "caniuse-lite": "^1.0.30001400",
+        "electron-to-chromium": "^1.4.251",
+        "node-releases": "^2.0.6",
+        "update-browserslist-db": "^1.0.9"
       }
     },
     "buffer-from": {
@@ -12189,6 +12758,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
       "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "get-intrinsic": "^1.0.2"
@@ -12218,19 +12788,19 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001341",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001341.tgz",
-      "integrity": "sha512-2SodVrFFtvGENGCv0ChVJIDQ0KPaS1cg7/qtfMaICgeMolDdo/Z2OD32F0Aq9yl6F4YFwGPBS5AaPqNYiW4PoA=="
+      "version": "1.0.30001442",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001442.tgz",
+      "integrity": "sha512-239m03Pqy0hwxYPYR5JwOIxRJfLTWtle9FV8zosfV5pHg+/51uD4nxcUlM8+mWWGfwKtt8lJNHnD3cWw9VZ6ow=="
     },
     "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
+      "integrity": "sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==",
       "dev": true,
       "requires": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
+        "deep-eql": "^4.1.2",
         "get-func-name": "^2.0.0",
         "loupe": "^2.3.1",
         "pathval": "^1.1.1",
@@ -12277,9 +12847,9 @@
       }
     },
     "ci-info": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.1.tgz",
-      "integrity": "sha512-SXgeMX9VwDe7iFFaEWkA5AstuER9YKqy4EhHqr4DVqkwmD9rpVimkMKWHdjn30Ja45txyjhSn63lVX69eVCckg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
+      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
       "dev": true
     },
     "clean-stack": {
@@ -12321,7 +12891,7 @@
     "clone": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
       "dev": true
     },
     "clone-deep": {
@@ -12346,12 +12916,12 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "colorette": {
-      "version": "2.0.16",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
+      "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
       "dev": true
     },
     "combined-stream": {
@@ -12372,7 +12942,7 @@
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
     "compare-versions": {
@@ -12392,7 +12962,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "content-disposition": {
       "version": "0.5.4",
@@ -12401,14 +12971,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "5.2.1"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "content-type": {
@@ -12427,12 +12989,9 @@
       }
     },
     "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
     },
     "cookie": {
       "version": "0.5.0",
@@ -12443,31 +13002,22 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "core-js-compat": {
-      "version": "3.22.5",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.22.5.tgz",
-      "integrity": "sha512-rEF75n3QtInrYICvJjrAgV03HwKiYvtKHdPtaba1KucG+cNZ4NJnH9isqt979e67KZlhpbCOTwnsvnIr+CVeOg==",
+      "version": "3.27.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.27.1.tgz",
+      "integrity": "sha512-Dg91JFeCDA17FKnneN7oCMz4BkQ4TcffkgHP4OWwp9yx3pi7ubqMDXXSacfNak1PQqjc95skyt+YBLHQJnkJwA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.20.3",
-        "semver": "7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
-          "dev": true
-        }
+        "browserslist": "^4.21.4"
       }
     },
     "cosmiconfig": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
-      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -12590,13 +13140,13 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "dev": true
     },
     "decamelize-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
-      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
+      "integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
       "dev": true,
       "requires": {
         "decamelize": "^1.1.0",
@@ -12606,27 +13156,27 @@
         "map-obj": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-          "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
           "dev": true
         }
       }
     },
     "decimal.js": {
-      "version": "10.3.1",
-      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
-      "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ==",
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
       "dev": true
     },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
-      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "integrity": "sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==",
       "dev": true
     },
     "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
+      "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
       "dev": true,
       "requires": {
         "type-detect": "^4.0.0"
@@ -12639,18 +13189,18 @@
       "dev": true
     },
     "default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.1.tgz",
+      "integrity": "sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==",
       "dev": true,
       "requires": {
         "strip-bom": "^4.0.0"
       }
     },
     "defaults": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-      "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
       "dev": true,
       "requires": {
         "clone": "^1.0.2"
@@ -12660,6 +13210,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.4.tgz",
       "integrity": "sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==",
+      "dev": true,
       "requires": {
         "has-property-descriptors": "^1.0.0",
         "object-keys": "^1.1.1"
@@ -12668,7 +13219,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
     },
     "depd": {
@@ -12716,7 +13267,7 @@
     "docopt": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/docopt/-/docopt-0.6.2.tgz",
-      "integrity": "sha1-so6eIiDaXsSffqW7JKR3h0Be6xE=",
+      "integrity": "sha512-NqTbaYeE4gA/wU1hdKFdU+AFahpDOpgGLzHP42k6H6DKExJd0A55KEVWYhL9FEmHmgeLvEU2vuKXDuU+4yToOw==",
       "dev": true
     },
     "doctrine": {
@@ -12814,13 +13365,13 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.4.137",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.137.tgz",
-      "integrity": "sha512-0Rcpald12O11BUogJagX3HsCN3FE83DSqWjgXoHo5a72KUKMSfI39XBgJpgNNxS9fuGzytaFjE06kZkiVFy2qA=="
+      "version": "1.4.284",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
+      "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA=="
     },
     "emoji-regex": {
       "version": "8.0.0",
@@ -12831,7 +13382,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "end-of-stream": {
@@ -12868,11 +13419,82 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
-      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
+      "integrity": "sha512-Sk5V6wVazPhq5MhpO+AUxJn5x7XSXGl1R93Vn7i+zS15KDVxQijejNCrz8340/2bgLBjR9GtEG8ZVKONDjcqGQ==",
       "requires": {
-        "stackframe": "^1.1.1"
+        "stackframe": "^1.3.4"
+      }
+    },
+    "es-abstract": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.0.tgz",
+      "integrity": "sha512-GUGtW7eXQay0c+PRq0sGIKSdaBorfVqsCMhGHo4elP7YVqZu9nCZS4UkK4gv71gOWNMra/PaSKD3ao1oWExO0g==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.0",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "function.prototype.name": "^1.1.5",
+        "get-intrinsic": "^1.1.3",
+        "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
+        "gopd": "^1.0.1",
+        "has": "^1.0.3",
+        "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
+        "has-symbols": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.0",
+        "is-callable": "^1.2.7",
+        "is-negative-zero": "^2.0.2",
+        "is-regex": "^1.1.4",
+        "is-shared-array-buffer": "^1.0.2",
+        "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
+        "is-weakref": "^1.0.2",
+        "object-inspect": "^1.12.2",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.4",
+        "regexp.prototype.flags": "^1.4.3",
+        "safe-regex-test": "^1.0.0",
+        "string.prototype.trimend": "^1.0.6",
+        "string.prototype.trimstart": "^1.0.6",
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "es-shim-unscopables": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
+      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-error": {
@@ -12889,13 +13511,13 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
     },
     "escodegen": {
       "version": "2.0.0",
@@ -12919,7 +13541,7 @@
         "levn": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+          "integrity": "sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2",
@@ -12943,13 +13565,13 @@
         "prelude-ls": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-          "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+          "integrity": "sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==",
           "dev": true
         },
         "type-check": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-          "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+          "integrity": "sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==",
           "dev": true,
           "requires": {
             "prelude-ls": "~1.1.2"
@@ -13055,9 +13677,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.15.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.15.0.tgz",
-          "integrity": "sha512-bpzcOlgDhMG070Av0Vy5Owklpv1I6+j96GhUI7Rh7IzDCKLzboflLrrfqMu8NquDbiR4EOQk7XzJwqVJxicxog==",
+          "version": "13.19.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.19.0.tgz",
+          "integrity": "sha512-dkQ957uSRWHw7CFXLUtUHQI3g3aWApYhfNR2O6jn/907riyTYKVBmxYVROkBcY614FSSeSJh7Xm7SrUWCxvJMQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -13069,10 +13691,19 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
         "semver": {
-          "version": "7.3.7",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
@@ -13092,13 +13723,19 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
           "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
           "dev": true
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+          "dev": true
         }
       }
     },
     "eslint-config-prettier": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.5.0.tgz",
-      "integrity": "sha512-obmWKLUNCnhtQRKc+tmnYuQl0pFU1ibYJQ5BGhTVB08bHe9wC8qUeG7c08dj9XX+AuPj1YSGSQIHl1pnDHZR0Q==",
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz",
+      "integrity": "sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==",
       "dev": true,
       "requires": {}
     },
@@ -13209,13 +13846,13 @@
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "events-light": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/events-light/-/events-light-1.0.5.tgz",
-      "integrity": "sha1-lk5jRQugr0prAiqpVbF//vZXte4=",
+      "integrity": "sha512-jF51LJzg5W+tkJgfZbjlbFCLcyVFEtOjU+xMCBylrXG13X5XHvfp6lNGfyBLF9u1mRTpUsMVYqSDukvpZff1mQ==",
       "requires": {
         "chai": "^3.5.0"
       },
@@ -13233,7 +13870,7 @@
         "deep-eql": {
           "version": "0.1.3",
           "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+          "integrity": "sha512-6sEotTRGBFiNcqVoeHwnfopbSpi5NbH1VWJmYCVkmxMmaVTT0bUTrNaGyBwhgP4MZL012W/mkzIn3Da+iDYweg==",
           "requires": {
             "type-detect": "0.1.1"
           },
@@ -13241,14 +13878,14 @@
             "type-detect": {
               "version": "0.1.1",
               "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
-              "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI="
+              "integrity": "sha512-5rqszGVwYgBoDkIm2oUtvkfZMQ0vk29iDMU0W2qCa3rG0vPDNczCMT4hV/bLBgLg8k8ri6+u3Zbt+S/14eMzlA=="
             }
           }
         },
         "type-detect": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
-          "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI="
+          "integrity": "sha512-f9Uv6ezcpvCQjJU0Zqbg+65qdcszv3qUQsZfjdRbWiZ7AMenrX1u0lNk9EoWWX6e1F+NULyg27mtdeZ5WhpljA=="
         }
       }
     },
@@ -13270,14 +13907,14 @@
       }
     },
     "express": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.18.1.tgz",
-      "integrity": "sha512-zZBcOX9TfehHQhtupq57OF8lFZ3UZi08Y97dwFCkD8p9d/d2Y3M+ykKcwaMDEL+4qyUolgBDX6AblpR3fL212Q==",
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz",
+      "integrity": "sha512-5/PsL6iGPdfQ/lKM1UuielYgv3BUoJfz1aUwU9vHZ+J7gyvwdQXFEBIEIaxeGf0GIcreATNyBExtalisDbuMqQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.0",
+        "body-parser": "1.20.1",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.5.0",
@@ -13296,7 +13933,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "~2.0.7",
-        "qs": "6.10.3",
+        "qs": "6.11.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "0.18.0",
@@ -13320,13 +13957,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
-        },
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -13355,9 +13986,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
-      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
+      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -13376,13 +14007,13 @@
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
     "fastq": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -13433,7 +14064,7 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
       }
@@ -13506,10 +14137,19 @@
       }
     },
     "flatted": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
-      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
+      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "for-each": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.3"
+      }
     },
     "foreground-child": {
       "version": "2.0.0",
@@ -13541,7 +14181,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "fromentries": {
@@ -13570,7 +14210,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
     },
     "fsevents": {
@@ -13583,12 +14223,31 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "function.prototype.name": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.5.tgz",
+      "integrity": "sha512-uN7m/BzVKQnCUF/iW8jYea67v++2u7m5UgENbHRtdDVclOUP+FMPlCNdmk0h/ysGyo2tavMJEDqJAkJdRa1vMA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.19.0",
+        "functions-have-names": "^1.2.2"
+      }
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
-      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true
+    },
+    "functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
       "dev": true
     },
     "gensync": {
@@ -13605,17 +14264,18 @@
     "get-func-name": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
       "dev": true
     },
     "get-intrinsic": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
-      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
+      "integrity": "sha512-QJVz1Tj7MS099PevUG5jvnt9tSkXN8K14dxQlikJuPt4uD9hHAHjLyLBiLR5zELelBdD9QNRAXZzsJx0WaDL9A==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.3"
       }
     },
     "get-own-enumerable-property-symbols": {
@@ -13637,6 +14297,16 @@
       "dev": true,
       "requires": {
         "pump": "^3.0.0"
+      }
+    },
+    "get-symbol-description": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
+      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.1"
       }
     },
     "glob": {
@@ -13667,6 +14337,15 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
       "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -13682,9 +14361,9 @@
       },
       "dependencies": {
         "ignore": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-          "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+          "version": "5.2.4",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+          "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
           "dev": true
         },
         "slash": {
@@ -13693,6 +14372,15 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
           "dev": true
         }
+      }
+    },
+    "gopd": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
+      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3"
       }
     },
     "graceful-fs": {
@@ -13723,27 +14411,51 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
     },
+    "has-bigints": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
+      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
+      "dev": true
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
     },
     "has-property-descriptors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
     },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
+    },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
+    },
+    "has-tostringtag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
+      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "hasha": {
       "version": "5.2.2",
@@ -13790,9 +14502,9 @@
       "dev": true
     },
     "htmljs-parser": {
-      "version": "5.1.5",
-      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.1.5.tgz",
-      "integrity": "sha512-9ndiIymg6huRu6fIKhsUlbB7mij8MdVUOBvvh3tjq18JBhBPaoh5eSmkp24U8t5b+wWXGehX3lGkORJuJh1dVw=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/htmljs-parser/-/htmljs-parser-5.2.1.tgz",
+      "integrity": "sha512-nqhepseEMIjmESQRnqgMYTzdrrKtlj1WyvDE9NJ1tjTRLk5LnSTWlDOeHHvElEgbBCBSH1yT/Wfj5S4LHAop5Q=="
     },
     "htmlparser2": {
       "version": "3.10.1",
@@ -14017,7 +14729,7 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true
     },
     "indent-string": {
@@ -14029,7 +14741,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "dev": true,
       "requires": {
         "once": "^1.3.0",
@@ -14042,6 +14754,17 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "internal-slot": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.4.tgz",
+      "integrity": "sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "side-channel": "^1.0.4"
+      }
+    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -14051,7 +14774,7 @@
     "is-absolute": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/is-absolute/-/is-absolute-0.2.6.tgz",
-      "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
+      "integrity": "sha512-7Kr05z5LkcOpoMvxHN1PC11WbPabdNFmMYYo0eZvWu3BfVS0T03yoqYDczoCBx17xqk2x1XAZrcKiFVL88jxlQ==",
       "dev": true,
       "requires": {
         "is-relative": "^0.2.1",
@@ -14061,16 +14784,36 @@
         "is-windows": {
           "version": "0.2.0",
           "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-0.2.0.tgz",
-          "integrity": "sha1-3hqm1j6indJIc3tp8f+LgALSEIw=",
+          "integrity": "sha512-n67eJYmXbniZB7RF4I/FTjK1s6RPOCTxhYrVYLRaCt3lF0mpWZPKr3T2LSZAqyjQsxR2qMmGYXXzK0YWwcPM1Q==",
           "dev": true
         }
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-arrayish": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true
+    },
+    "is-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
+      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
+      "dev": true,
+      "requires": {
+        "has-bigints": "^1.0.1"
+      }
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -14080,6 +14823,22 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
+    },
+    "is-boolean-object": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
+      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true
     },
     "is-ci": {
       "version": "3.0.1",
@@ -14091,18 +14850,27 @@
       }
     },
     "is-core-module": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
-      "integrity": "sha512-+5FPy5PnwmO3lvfMb0AsoPaBG+5KHUI0wYFXOtYPnVVVspTFUuMZNfNaNVRt3FZadstu2c8x23vykRW/NBoU6A==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.11.0.tgz",
+      "integrity": "sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==",
       "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
     },
+    "is-date-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
+      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true
     },
     "is-fullwidth-code-point": {
@@ -14120,22 +14888,37 @@
         "is-extglob": "^2.1.1"
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
+      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
+      "dev": true
+    },
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true
     },
+    "is-number-object": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "dev": true
     },
     "is-plain-obj": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "dev": true
     },
     "is-plain-object": {
@@ -14153,19 +14936,38 @@
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
+      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-regexp": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
-      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
+      "integrity": "sha512-7zjFAPO4/gwyQAAgRRmqeEeyIICSdmCqa3tsVHMdBzaXXRiqopZL4Cyghg/XulGWrtABTpbnYYzzIRffLkP4oA==",
       "dev": true
     },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "integrity": "sha512-9AMzjRmLqcue629b4ezEVSK6kJsYJlUIhMcygmYORUgwUNJiavHcC3HkaGx0XYpyVKQSOqFbMEZmW42cY87sYw==",
       "dev": true,
       "requires": {
         "is-unc-path": "^0.1.1"
+      }
+    },
+    "is-shared-array-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
       }
     },
     "is-stream": {
@@ -14173,6 +14975,15 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "dev": true
+    },
+    "is-string": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
+      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
+      "dev": true,
+      "requires": {
+        "has-tostringtag": "^1.0.0"
+      }
     },
     "is-subdir": {
       "version": "1.2.0",
@@ -14183,16 +14994,38 @@
         "better-path-resolve": "1.0.0"
       }
     },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
+    },
+    "is-typed-array": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.10.tgz",
+      "integrity": "sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0"
+      }
+    },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
       "dev": true
     },
     "is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "integrity": "sha512-HhLc5VDMH4pu3oMtIuunz/DFQUIoR561kMME3U3Afhj8b7vH085vkIkemrz1kLXCEIuoMAmO3yVmafWdSbGW8w==",
       "dev": true,
       "requires": {
         "unc-path-regex": "^0.1.0"
@@ -14204,6 +15037,15 @@
       "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
       "dev": true
     },
+    "is-weakref": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
+      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -14213,13 +15055,13 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
       "dev": true
     },
     "istanbul-lib-coverage": {
@@ -14238,9 +15080,9 @@
       }
     },
     "istanbul-lib-instrument": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.0.tgz",
-      "integrity": "sha512-6Lthe1hqXHBNsqvgDzGO6l03XNeu3CrG4RqQ1KM9+l5+jNGpEJfIELx1NS3SEHmJQA8np/u+E4EPRKRiu6m19A==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.12.3",
@@ -14251,29 +15093,19 @@
       }
     },
     "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
+      "integrity": "sha512-NkwHbo3E00oybX6NGJi6ar0B29vxyvNwoC7eJ4G4Yq28UfY758Hgn/heV8VRFhevPED4LXfFz0DQ8z/0kw9zMg==",
       "dev": true,
       "requires": {
         "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
+        "cross-spawn": "^7.0.3",
+        "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       },
       "dependencies": {
-        "make-dir": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.0.0"
-          }
-        },
         "p-map": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
@@ -14334,9 +15166,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
+      "integrity": "sha512-nUsEMa9pBt/NOHqbcbeJEgqIlY/K7rVWUX6Lql2orY5e9roQOthbR3vtY4zzf2orPELg80fnxxk9zUyPlgwD1w==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
@@ -14404,17 +15236,17 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "8.7.1",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-          "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+          "version": "8.8.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
           "dev": true
         }
       }
     },
     "jsdom-context-require": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-4.0.4.tgz",
-      "integrity": "sha512-DlkAZsR0G6FfUiHKYahKAyDOJjBKW5h6x5z6iCft9cmXEJw6RhvwZ1JVFyH41on63cPEQrC/8N26ESxDAFHizw==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-4.0.6.tgz",
+      "integrity": "sha512-8J9izACVQv6amd6GlouJ5noGivQHOfJ6jeOKZr1MLtRtwshYUuW0elixrwmmyjmI0MIrntakAUO2T2rsE2f6yg==",
       "dev": true,
       "requires": {
         "context-require": "^1.1.0",
@@ -14441,18 +15273,18 @@
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "json5": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.1.tgz",
-      "integrity": "sha512-1hqLFMSrGHRHxav9q9gNjJ5EXznIxGVO09xQRrwplcS8qs28pZ8s8hupZAmqDwZUmVZ2Qb2jnyPOWcDH8m8dlA=="
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonfile": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-      "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
@@ -14464,10 +15296,16 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
+      "dev": true
+    },
     "lasso-caching-fs": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/lasso-caching-fs/-/lasso-caching-fs-1.0.2.tgz",
-      "integrity": "sha1-m+TrHwaqwSYDRMrq70LC8AhusQ0=",
+      "integrity": "sha512-mudop0s8U3tLm3Fn9lhiZsiELpLeJToEo6RlDLdph7vWRxL9Sz0o+9WUw1IwlpCYXv/P0CLsMYWFgPwIKWEYvg==",
       "requires": {
         "raptor-async": "^1.1.2"
       }
@@ -14475,7 +15313,7 @@
     "lasso-package-root": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lasso-package-root/-/lasso-package-root-1.0.1.tgz",
-      "integrity": "sha1-mX0OcfQdA8Xw+gmlvCmNeW+LLCM=",
+      "integrity": "sha512-j6LnauNCldqSDvOxoKpD6sTzudPGMiwcZQbySoF9KvJ0lD9Dp2t6QZF8kC0jbUDHuQPiAo5RuQ/mC3AGXscUYA==",
       "requires": {
         "lasso-caching-fs": "^1.0.0"
       }
@@ -14483,7 +15321,7 @@
     "lasso-resolve-from": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/lasso-resolve-from/-/lasso-resolve-from-1.2.0.tgz",
-      "integrity": "sha1-v7I0Rnr7abUwn1aLpFnMgyBiHG4=",
+      "integrity": "sha512-WPDAQi5uYRDous353yxouFjD8g3GL07v0RTq/RUgAv2KVcNST9rts33pLAN0VS6FFs4FIBU1g8wUsBHQMWp1IA==",
       "dev": true,
       "requires": {
         "is-absolute": "^0.2.3",
@@ -14492,16 +15330,10 @@
         "resolve-from": "^2.0.0"
       },
       "dependencies": {
-        "raptor-util": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
-          "integrity": "sha1-8u6AdqmuPq4uZWcuRqIgB0+i3/M=",
-          "dev": true
-        },
         "resolve-from": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+          "integrity": "sha512-qpFcKaXsq8+oRoLilkwyc7zHGF5i9Q2/25NIgLQQ/+VVv9rU4qvr6nXVAw1DsnXJyQkZsR4Ytfbtg5ehfcUssQ==",
           "dev": true
         }
       }
@@ -14605,7 +15437,7 @@
     "listener-tracker": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/listener-tracker/-/listener-tracker-2.0.0.tgz",
-      "integrity": "sha1-OWCLQ1wJAfpVECF8FFJyjWvBm18="
+      "integrity": "sha512-U6NLzBRyrAsJs9AAjuBYifXtNYnAIDPIp81rNpxNoypXBR7qi/LhsuUWX5399zuTg1sBEQyOnWDYFrBQ28vk/w=="
     },
     "listr2": {
       "version": "3.14.0",
@@ -14638,7 +15470,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }
@@ -14655,13 +15487,13 @@
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
       "dev": true
     },
     "lodash.merge": {
@@ -14673,13 +15505,13 @@
     "lodash.startcase": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
-      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg=",
+      "integrity": "sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==",
       "dev": true
     },
     "lodash.truncate": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
-      "integrity": "sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
       "dev": true
     },
     "log-symbols": {
@@ -14804,29 +15636,28 @@
       }
     },
     "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.6.tgz",
+      "integrity": "sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==",
       "dev": true,
       "requires": {
         "get-func-name": "^2.0.0"
       }
     },
     "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "requires": {
-        "yallist": "^4.0.0"
+        "yallist": "^3.0.2"
       }
     },
     "magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
       "requires": {
-        "sourcemap-codec": "^1.4.8"
+        "@jridgewell/sourcemap-codec": "^1.4.13"
       }
     },
     "make-dir": {
@@ -14869,12 +15700,19 @@
         "resolve-from": "^5.0.0",
         "self-closing-tags": "^1.0.1",
         "warp10": "^2.0.1"
+      },
+      "dependencies": {
+        "raptor-util": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
+          "integrity": "sha512-uEDMMkBCJvjTqYMBnJNxn+neiS6a0rhybQNA9RaexGor1uvKjwyHA5VcbZMZEuqXhKUWbL+WNS7PhuZVZNB7pw=="
+        }
       }
     },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "meow": {
@@ -14907,7 +15745,7 @@
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "merge-stream": {
@@ -14925,7 +15763,7 @@
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "micromatch": {
@@ -15272,7 +16110,7 @@
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "negotiator": {
@@ -15293,19 +16131,19 @@
         "tr46": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
           "dev": true
         },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
           "dev": true
         },
         "whatwg-url": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
           "dev": true,
           "requires": {
             "tr46": "~0.0.3",
@@ -15324,9 +16162,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.4.tgz",
-      "integrity": "sha512-gbMzqQtTtDz/00jQzZ21PQzdI9PyLYqUSvD0p3naOhX4odFji0ZxYdnVwPTxmSwkmxhcFImpozceidSG+AgoPQ=="
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
+      "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -15364,9 +16202,9 @@
       }
     },
     "nwsapi": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.0.tgz",
-      "integrity": "sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.2.tgz",
+      "integrity": "sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==",
       "dev": true
     },
     "nyc": {
@@ -15528,24 +16366,26 @@
       }
     },
     "object-inspect": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.0.tgz",
-      "integrity": "sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
       "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
     },
     "object.assign": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
-      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
+      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+      "dev": true,
       "requires": {
-        "call-bind": "^1.0.0",
-        "define-properties": "^1.1.3",
-        "has-symbols": "^1.0.1",
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "has-symbols": "^1.0.3",
         "object-keys": "^1.1.1"
       }
     },
@@ -15561,7 +16401,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "requires": {
         "wrappy": "1"
@@ -15599,7 +16439,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
       "dev": true
     },
     "outdent": {
@@ -15712,7 +16552,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
       "dev": true
     },
     "path-key": {
@@ -15730,7 +16570,7 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "path-type": {
@@ -15808,7 +16648,7 @@
         "path-exists": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
           "dev": true
         }
       }
@@ -15880,9 +16720,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.6.2.tgz",
-      "integrity": "sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
+      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
       "dev": true
     },
     "process-on-spawn": {
@@ -15903,7 +16743,7 @@
     "property-handlers": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/property-handlers/-/property-handlers-1.1.1.tgz",
-      "integrity": "sha1-yyDTIqq32U//rCj0bJGGvVlHtLQ="
+      "integrity": "sha512-bPlermJL6CETDwI6SxODyMzr1a0aXzbXpNGCW9SnsnetEMJdjon1mdgLbidSN7o47B2oqLOwXYzGyyIQHsQrmw=="
     },
     "proxy-addr": {
       "version": "2.0.7",
@@ -15918,13 +16758,13 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
       "dev": true
     },
     "psl": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "pump": {
@@ -15944,13 +16784,19 @@
       "dev": true
     },
     "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
       "dev": true,
       "requires": {
         "side-channel": "^1.0.4"
       }
+    },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -15982,17 +16828,18 @@
     "raptor-async": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/raptor-async/-/raptor-async-1.1.3.tgz",
-      "integrity": "sha1-uDw8m2A9yYXCw6n3jStAc+b2Akw="
+      "integrity": "sha512-VZCxygWMjW9lKqnApK9D2QbfyzRn7ehiTqnXWwMCLBXANSy+xbnYfbX/5f8YX3bZXu+g+JESmqWPchIQrZj2ig=="
     },
     "raptor-regexp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/raptor-regexp/-/raptor-regexp-1.0.1.tgz",
-      "integrity": "sha1-7PD2bGZxwM2fXkjDcFAmxVCZlcA="
+      "integrity": "sha512-DqC7ViHJUs3jLIxJI1/HVvCu3yPJaP8CM7PGsHvjimg7yJ3lLOdCBxlPE0G2Q8OJgUA8Pe7nvhm6lcQ3hZepow=="
     },
     "raptor-util": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-3.2.0.tgz",
-      "integrity": "sha1-I7DIA8jxrIocrmfZpjiLSRYcl1g="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/raptor-util/-/raptor-util-1.1.2.tgz",
+      "integrity": "sha512-y3aISuv1oFMzEscN0U8kd5J/lrW4pTiJuBU6v4uksXBecfshYNrZ8h5ODg9J+CfRyuujZ84UEbuu3KnvswjnEA==",
+      "dev": true
     },
     "raw-body": {
       "version": "2.5.1",
@@ -16060,7 +16907,7 @@
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
           "dev": true
         }
       }
@@ -16103,26 +16950,37 @@
       "dev": true
     },
     "regenerate-unicode-properties": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.0.1.tgz",
-      "integrity": "sha512-vn5DU6yg6h8hP/2OkQo3K7uVILvY4iu0oI4t3HFa81UPkhGJwkRwM10JEc3upjdhHjs/k8GJY1sRBhk5sr69Bw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.0.tgz",
+      "integrity": "sha512-d1VudCLoIGitcU/hEg2QqvyGZQmdC0Lf8BqdOMXGFSvJP4bNV1+XqbPQeHHLD51Jh4QJJ225dlIFvY4Ly6MXmQ==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.2"
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.9",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-      "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "regenerator-transform": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.0.tgz",
-      "integrity": "sha512-LsrGtPmbYg19bcPHwdtmXwbW+TqNvtY4riE3P83foeHRroMbH6/2ddFBfab3t7kbzc7v7p4wbkIecHImqt0QNg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.15.1.tgz",
+      "integrity": "sha512-knzmNAcuyxV+gQCufkYcvOqX/qIIfHLv0u5x79kRxuGojfYVky1f15TzZEu2Avte8QGepvUNTnLskf8E6X6Vyg==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.8.4"
+      }
+    },
+    "regexp.prototype.flags": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.3.tgz",
+      "integrity": "sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "functions-have-names": "^1.2.2"
       }
     },
     "regexpp": {
@@ -16132,29 +16990,29 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.0.1.tgz",
-      "integrity": "sha512-CriEZlrKK9VJw/xQGJpQM5rY88BtuL8DM+AEwvcThHilbxiTAy8vq4iJnd2tqq8wLmjbGZzP7ZcKFjbGkmEFrw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-5.2.2.tgz",
+      "integrity": "sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==",
       "dev": true,
       "requires": {
         "regenerate": "^1.4.2",
-        "regenerate-unicode-properties": "^10.0.1",
-        "regjsgen": "^0.6.0",
-        "regjsparser": "^0.8.2",
+        "regenerate-unicode-properties": "^10.1.0",
+        "regjsgen": "^0.7.1",
+        "regjsparser": "^0.9.1",
         "unicode-match-property-ecmascript": "^2.0.0",
-        "unicode-match-property-value-ecmascript": "^2.0.0"
+        "unicode-match-property-value-ecmascript": "^2.1.0"
       }
     },
     "regjsgen": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.6.0.tgz",
-      "integrity": "sha512-ozE883Uigtqj3bx7OhL1KNbCzGyW2NQZPl6Hs09WTvCuZD5sTI4JY58bkbQWa/Y9hxIsvJ3M8Nbf7j54IqeZbA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.7.1.tgz",
+      "integrity": "sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==",
       "dev": true
     },
     "regjsparser": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.8.4.tgz",
-      "integrity": "sha512-J3LABycON/VNEu3abOviqGHuB/LOtOQj8SKmfP9anY5GfAVw/SPjwzSjxGjbZXIxbGfqTHtJw58C2Li/WkStmA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.9.1.tgz",
+      "integrity": "sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==",
       "dev": true,
       "requires": {
         "jsesc": "~0.5.0"
@@ -16163,7 +17021,7 @@
         "jsesc": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+          "integrity": "sha512-uZz5UnB7u4T9LvwmFqXii7pZSouaRPorGs5who1Ip7VO0wxanFvBL7GkM6dTHlgX+jhBApRetaWpnDabOeTcnA==",
           "dev": true
         }
       }
@@ -16176,7 +17034,7 @@
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
+      "integrity": "sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==",
       "dev": true,
       "requires": {
         "es6-error": "^4.0.1"
@@ -16185,7 +17043,7 @@
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "dev": true
     },
     "require-from-string": {
@@ -16200,13 +17058,19 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "resolve": {
-      "version": "1.22.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
-      "integrity": "sha512-Hhtrw0nLeSrFQ7phPp4OOcVjLPIeMnRlr5mcnVuMe7M/7eBn98A3hmFRLoFo3DLZkivSYwhRUJTyPyWAk56WLw==",
+      "version": "1.22.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
+      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.8.1",
+        "is-core-module": "^2.9.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
@@ -16257,18 +17121,30 @@
       }
     },
     "rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
+      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
+    },
+    "safe-regex-test": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
+      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-regex": "^1.1.4"
+      }
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -16298,7 +17174,7 @@
     "semver-compare": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
-      "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w=",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
       "dev": true
     },
     "semver-regex": {
@@ -16340,7 +17216,7 @@
             "ms": {
               "version": "2.0.0",
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+              "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
               "dev": true
             }
           }
@@ -16377,7 +17253,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
       "dev": true
     },
     "setprototypeof": {
@@ -16411,9 +17287,9 @@
       "dev": true
     },
     "shell-quote": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz",
-      "integrity": "sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
+      "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
       "dev": true
     },
     "side-channel": {
@@ -16477,11 +17353,12 @@
       }
     },
     "smartwrap": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-1.2.5.tgz",
-      "integrity": "sha512-bzWRwHwu0RnWjwU7dFy7tF68pDAx/zMSu3g7xr9Nx5J0iSImYInglwEVExyHLxXljy6PWMjkSAbwF7t2mPnRmg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/smartwrap/-/smartwrap-2.0.2.tgz",
+      "integrity": "sha512-vCsKNQxb7PnCNd2wY1WClWifAc2lwqsG8OaswpJkVJsvMGcnEntdTCDajZCkk93Ay1U3t/9puJmb525Rg5MZBA==",
       "dev": true,
       "requires": {
+        "array.prototype.flat": "^1.2.3",
         "breakword": "^1.0.5",
         "grapheme-splitter": "^1.0.4",
         "strip-ansi": "^6.0.0",
@@ -16578,11 +17455,6 @@
         "source-map": "^0.6.0"
       }
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "spawn-wrap": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
@@ -16621,7 +17493,7 @@
         "cross-spawn": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
           "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
@@ -16642,7 +17514,7 @@
         "shebang-command": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+          "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
           "dev": true,
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -16651,7 +17523,7 @@
         "shebang-regex": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+          "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
           "dev": true
         },
         "which": {
@@ -16666,7 +17538,7 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+          "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
           "dev": true
         }
       }
@@ -16698,21 +17570,21 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.11",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.12.tgz",
+      "integrity": "sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==",
       "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
     "stackframe": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
-      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
+      "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw=="
     },
     "statuses": {
       "version": "2.0.1",
@@ -16736,14 +17608,6 @@
       "dev": true,
       "requires": {
         "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-          "dev": true
-        }
       }
     },
     "string-argv": {
@@ -16761,6 +17625,28 @@
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.1"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.6.tgz",
+      "integrity": "sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.6.tgz",
+      "integrity": "sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.4",
+        "es-abstract": "^1.20.4"
       }
     },
     "stringify-object": {
@@ -16829,9 +17715,9 @@
       "dev": true
     },
     "table": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
-      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.1.tgz",
+      "integrity": "sha512-Y4X9zqrCftUhMeH2EptSSERdVKt/nEdijTOacGD/97EKjhQ/Qs8RTlEGABSJNNN8lac9kheH+af7yAkEWlgneA==",
       "dev": true,
       "requires": {
         "ajv": "^8.0.1",
@@ -16842,9 +17728,9 @@
       },
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "version": "8.12.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
+          "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
           "dev": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
@@ -16916,13 +17802,13 @@
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
     },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
       "dev": true
     },
     "through2": {
@@ -16946,7 +17832,7 @@
     "to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog=="
     },
     "to-regex-range": {
       "version": "5.0.1",
@@ -16964,14 +17850,23 @@
       "dev": true
     },
     "tough-cookie": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
       "dev": true,
       "requires": {
         "psl": "^1.1.33",
         "punycode": "^2.1.1",
-        "universalify": "^0.1.2"
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "universalify": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+          "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+          "dev": true
+        }
       }
     },
     "tr46": {
@@ -16990,23 +17885,24 @@
       "dev": true
     },
     "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
+      "integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
       "dev": true
     },
     "tty-table": {
-      "version": "2.8.13",
-      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-2.8.13.tgz",
-      "integrity": "sha512-eVV/+kB6fIIdx+iUImhXrO22gl7f6VmmYh0Zbu6C196fe1elcHXd7U6LcLXu0YoVPc2kNesWiukYcdK8ZmJ6aQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/tty-table/-/tty-table-4.1.6.tgz",
+      "integrity": "sha512-kRj5CBzOrakV4VRRY5kUWbNYvo/FpOsz65DzI5op9P+cHov3+IqPbo1JE1ZnQGkHdZgNFDsrEjrfqqy/Ply9fw==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "csv": "^5.3.1",
-        "smartwrap": "^1.2.3",
+        "chalk": "^4.1.2",
+        "csv": "^5.5.0",
+        "kleur": "^4.1.4",
+        "smartwrap": "^2.0.2",
         "strip-ansi": "^6.0.0",
         "wcwidth": "^1.0.1",
-        "yargs": "^15.1.0"
+        "yargs": "^17.1.1"
       },
       "dependencies": {
         "ansi-styles": {
@@ -17019,9 +17915,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -17029,14 +17925,14 @@
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
           "dev": true,
           "requires": {
             "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
@@ -17069,41 +17965,26 @@
             "has-flag": "^4.0.0"
           }
         },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "dev": true
-        },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "17.6.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
+          "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
           "dev": true,
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
           }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
         }
       }
     },
@@ -17138,6 +18019,17 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "typedarray-to-buffer": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
@@ -17147,22 +18039,34 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "unbox-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
+      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.0.3",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
     "unc-path-regex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
-      "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo=",
+      "integrity": "sha512-eXL4nmJT7oCpkZsHZUOJo8hcX3GbsiDOa0Qu9F646fi8dT3XuSVopVqAcEiVzSKKH7UoDti23wNX3qGFxcW5Qg==",
       "dev": true
     },
     "underscore": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-      "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
+      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==",
       "dev": true
     },
     "underscore-keypath": {
       "version": "0.0.22",
       "resolved": "https://registry.npmjs.org/underscore-keypath/-/underscore-keypath-0.0.22.tgz",
-      "integrity": "sha1-SKUoOSu278QkvhyqVtpLX6zPJk0=",
+      "integrity": "sha512-fU7aYj1J2LQd+jqdQ67AlCOZKK3Pl+VErS8fGYcgZG75XB9/bY+RLM+F2xEcKHhHNtLvqqFyXAoZQlLYfec3Xg==",
       "dev": true,
       "requires": {
         "underscore": "*"
@@ -17185,15 +18089,15 @@
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-7Yhkc0Ye+t4PNYzOGKedDhXbYIBe1XEQYQxOPyhcXNMJ0WCABqqj6ckydd6pWRZTHV4GuCPKdBAUiMc60tsKVw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
       "dev": true
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-5Zfuy9q/DFr4tfO7ZPeVXb1aPoeQSdeFMLpYuFebehDAhbuevLs5yxSZmIFN1tP5F9Wl4IpJrYojg85/zgyZHQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz",
+      "integrity": "sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==",
       "dev": true
     },
     "universalify": {
@@ -17205,8 +18109,17 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
+    },
+    "update-browserslist-db": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
+      "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+      "requires": {
+        "escalade": "^3.1.1",
+        "picocolors": "^1.0.0"
+      }
     },
     "uri-js": {
       "version": "4.4.1",
@@ -17217,22 +18130,32 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true
     },
     "v8-compile-cache": {
@@ -17254,7 +18177,7 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "w3c-hr-time": {
@@ -17283,7 +18206,7 @@
     "wcwidth": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
-      "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
       "dev": true,
       "requires": {
         "defaults": "^1.0.3"
@@ -17340,10 +18263,23 @@
         "isexe": "^2.0.0"
       }
     },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "dev": true,
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
+      }
+    },
     "which-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "integrity": "sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==",
       "dev": true
     },
     "which-pm": {
@@ -17361,6 +18297,20 @@
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
       "integrity": "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==",
       "dev": true
+    },
+    "which-typed-array": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.9.tgz",
+      "integrity": "sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==",
+      "dev": true,
+      "requires": {
+        "available-typed-arrays": "^1.0.5",
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "gopd": "^1.0.1",
+        "has-tostringtag": "^1.0.0",
+        "is-typed-array": "^1.1.10"
+      }
     },
     "wide-align": {
       "version": "1.1.3",
@@ -17380,7 +18330,7 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "integrity": "sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==",
           "dev": true
         },
         "string-width": {
@@ -17396,7 +18346,7 @@
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "integrity": "sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==",
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
@@ -17456,7 +18406,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
     "write-file-atomic": {
@@ -17472,9 +18422,9 @@
       }
     },
     "ws": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.6.0.tgz",
-      "integrity": "sha512-AzmM3aH3gk0aX7/rZLYvjdvZooofDu3fFOzGqcSnQ1tOcTWwhM/o+q++E8mAyVVIyUdajrkzWUGftaVSDLn1bw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.12.0.tgz",
+      "integrity": "sha512-kU62emKIdKVeEIOIKVegvqpXMSTAMLJozpHZaJNDYqBjzlSYXQGviYwN1osDLJ9av68qHd4a2oSjd7yD4pacig==",
       "dev": true,
       "requires": {}
     },
@@ -17497,10 +18447,9 @@
       "dev": true
     },
     "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/packages/marko/test/marko-debug-babel-plugin/fixtures/compiles/expected.js
+++ b/packages/marko/test/marko-debug-babel-plugin/fixtures/compiles/expected.js
@@ -4,22 +4,18 @@ var NegateOr;
 var NegateAnd = 'negate and';
 'else';
 'else';
-
 if (true) {
   'else if';
 } else {
   'else';
 }
-
 'negated if';
 'negated if';
 'negated if';
-
 if (true) {
   'negated if';
 } else {
   'negated else if';
 }
-
 'alternate';
 'negated consequent';

--- a/packages/marko/test/marko-debug-babel-plugin/fixtures/compiles/test.js
+++ b/packages/marko/test/marko-debug-babel-plugin/fixtures/compiles/test.js
@@ -7,15 +7,21 @@ const pluginPath = require.resolve(
 
 exports.check = function (expect, helpers, done) {
   const input = fs.readFileSync(path.join(__dirname, "input.js"), "utf-8");
-  const expected = fs
-    .readFileSync(path.join(__dirname, "expected.js"), "utf-8")
-    .trim();
   const actual = babel.transform(input, {
     plugins: [pluginPath],
     babelrc: false,
     configFile: false
   }).code;
 
-  expect(expected).to.equal(actual);
+  if (process.env.UPDATE_EXPECTATIONS) {
+    fs.writeFileSync(path.join(__dirname, "expected.js"), actual);
+  } else {
+    const expected = fs
+      .readFileSync(path.join(__dirname, "expected.js"), "utf-8")
+      .trim();
+
+    expect(expected).to.equal(actual);
+  }
+
   done();
 };

--- a/packages/translator-default/package.json
+++ b/packages/translator-default/package.json
@@ -8,7 +8,7 @@
     "@babel/runtime": "^7.16.0",
     "@marko/babel-utils": "^5.21.3",
     "escape-string-regexp": "^4.0.0",
-    "magic-string": "^0.25.7",
+    "magic-string": "^0.27.0",
     "self-closing-tags": "^1.0.1"
   },
   "devDependencies": {

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/cjs-expected.js
@@ -2,26 +2,18 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/custom-tag/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tag-inside-if-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   let _thing = null;
-
   if (x) {
     _thing = {
       "x": 1,
@@ -30,7 +22,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       }
     };
   }
-
   (0, _renderTag.default)(_index2.default, {
     "thing": _thing
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tag-inside-if-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -10,7 +8,6 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _thing = null;
-
   if (x) {
     _thing = {
       "x": 1,
@@ -19,7 +16,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_customTag, {
     "thing": _thing
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "cY5vQoUJ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -10,7 +8,6 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _thing = null;
-
   if (x) {
     _thing = {
       "x": 1,
@@ -19,7 +16,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_customTag, {
     "thing": _thing
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdom-expected.js
@@ -1,20 +1,15 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tag-inside-if-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _thing = null;
-
   if (x) {
     _thing = {
       "x": 1,
@@ -23,7 +18,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_customTag, {
     "thing": _thing
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdomProduction-expected.js
@@ -1,20 +1,15 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "cY5vQoUJ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _thing = null;
-
   if (x) {
     _thing = {
       "x": 1,
@@ -23,7 +18,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_customTag, {
     "thing": _thing
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/cjs-expected.js
@@ -2,30 +2,21 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-and-static/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   const _items = [];
-
   for (const a in b) {
     _items.push(null);
   }
-
   (0, _renderTag.default)(_index2.default, {
     "items": _items,
     "other": {}

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-and-static/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -10,11 +8,9 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _items = [];
-
   for (const a in b) {
     _items.push(null);
   }
-
   _marko_tag(_hello, {
     "items": _items,
     "other": {}

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "EC7Wpjet",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -10,11 +8,9 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _items = [];
-
   for (const a in b) {
     _items.push(null);
   }
-
   _marko_tag(_hello, {
     "items": _items,
     "other": {}

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdom-expected.js
@@ -1,24 +1,18 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-and-static/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _items = [];
-
   for (const a in b) {
     _items.push(null);
   }
-
   _marko_tag(_hello, {
     "items": _items,
     "other": {}

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdomProduction-expected.js
@@ -1,24 +1,18 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "EC7Wpjet",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _items = [];
-
   for (const a in b) {
     _items.push(null);
   }
-
   _marko_tag(_hello, {
     "items": _items,
     "other": {}

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "V8pzyNwe",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input.x, () => ({

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "V8pzyNwe",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input.x, () => ({

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/cjs-expected.js
@@ -2,28 +2,19 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-with-params/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   let _item = null;
-
   if (input.x) {
     _item = {
       "renderBody": (out, y) => {
@@ -31,7 +22,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       }
     };
   }
-
   (0, _renderTag.default)(_index2.default, {
     "item": _item
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-with-params/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
@@ -11,7 +9,6 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _item = null;
-
   if (input.x) {
     _item = {
       "renderBody": (out, y) => {
@@ -19,7 +16,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_hello, {
     "item": _item
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "OLo+Dwkn",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
@@ -11,7 +9,6 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _item = null;
-
   if (input.x) {
     _item = {
       "renderBody": (out, y) => {
@@ -19,7 +16,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_hello, {
     "item": _item
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdom-expected.js
@@ -1,20 +1,15 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic-with-params/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _item = null;
-
   if (input.x) {
     _item = {
       "renderBody": (out, y) => {
@@ -22,7 +17,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_hello, {
     "item": _item
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
@@ -1,20 +1,15 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "OLo+Dwkn",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _item = null;
-
   if (input.x) {
     _item = {
       "renderBody": (out, y) => {
@@ -22,7 +17,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     };
   }
-
   _marko_tag(_hello, {
     "item": _item
   }, out, _componentDef, "0");

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
@@ -2,29 +2,20 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   const _cols = [];
   const _items = [];
-
   for (const color of input.colors) {
     if (x) {
       _items.push({
@@ -55,9 +46,7 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       });
     }
   }
-
   let i = 10;
-
   while (i--) {
     _items.push({
       "renderBody": out => {
@@ -65,10 +54,8 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       }
     });
   }
-
   for (const col of input.table) {
     const _rows = [];
-
     for (const row of col) {
       _rows.push({
         "row": row,
@@ -77,27 +64,22 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
         }
       });
     }
-
     _cols.push({
       "x": y,
       "rows": _rows
     });
   }
-
   const _rows2 = [];
-
   _rows2.push({
     "row": -1,
     "renderBody": out => {
       out.w("Outside");
     }
   });
-
   _cols.push({
     "outside": true,
     "rows": _rows2
   });
-
   (0, _renderTag.default)(_index2.default, {
     "list": {
       "items": _items

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
@@ -12,7 +10,6 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _cols = [];
   const _items = [];
-
   for (const color of input.colors) {
     if (x) {
       _items.push({
@@ -43,9 +40,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       });
     }
   }
-
   let i = 10;
-
   while (i--) {
     _items.push({
       "renderBody": out => {
@@ -53,10 +48,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     });
   }
-
   for (const col of input.table) {
     const _rows = [];
-
     for (const row of col) {
       _rows.push({
         "row": row,
@@ -65,27 +58,22 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         }
       });
     }
-
     _cols.push({
       "x": y,
       "rows": _rows
     });
   }
-
   const _rows2 = [];
-
   _rows2.push({
     "row": -1,
     "renderBody": out => {
       out.w("Outside");
     }
   });
-
   _cols.push({
     "outside": true,
     "rows": _rows2
   });
-
   _marko_tag(_hello, {
     "list": {
       "items": _items

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "GuHig6zQ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
@@ -12,7 +10,6 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _cols = [];
   const _items = [];
-
   for (const color of input.colors) {
     if (x) {
       _items.push({
@@ -43,9 +40,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       });
     }
   }
-
   let i = 10;
-
   while (i--) {
     _items.push({
       "renderBody": out => {
@@ -53,10 +48,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     });
   }
-
   for (const col of input.table) {
     const _rows = [];
-
     for (const row of col) {
       _rows.push({
         "row": row,
@@ -65,27 +58,22 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         }
       });
     }
-
     _cols.push({
       "x": y,
       "rows": _rows
     });
   }
-
   const _rows2 = [];
-
   _rows2.push({
     "row": -1,
     "renderBody": out => {
       out.w("Outside");
     }
   });
-
   _cols.push({
     "outside": true,
     "rows": _rows2
   });
-
   _marko_tag(_hello, {
     "list": {
       "items": _items

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
@@ -1,21 +1,16 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-dynamic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _cols = [];
   const _items = [];
-
   for (const color of input.colors) {
     if (x) {
       _items.push({
@@ -46,9 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       });
     }
   }
-
   let i = 10;
-
   while (i--) {
     _items.push({
       "renderBody": out => {
@@ -56,10 +49,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     });
   }
-
   for (const col of input.table) {
     const _rows = [];
-
     for (const row of col) {
       _rows.push({
         "row": row,
@@ -68,27 +59,22 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         }
       });
     }
-
     _cols.push({
       "x": y,
       "rows": _rows
     });
   }
-
   const _rows2 = [];
-
   _rows2.push({
     "row": -1,
     "renderBody": out => {
       out.t("Outside", _component);
     }
   });
-
   _cols.push({
     "outside": true,
     "rows": _rows2
   });
-
   _marko_tag(_hello, {
     "list": {
       "items": _items

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
@@ -1,21 +1,16 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "GuHig6zQ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _cols = [];
   const _items = [];
-
   for (const color of input.colors) {
     if (x) {
       _items.push({
@@ -46,9 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       });
     }
   }
-
   let i = 10;
-
   while (i--) {
     _items.push({
       "renderBody": out => {
@@ -56,10 +49,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       }
     });
   }
-
   for (const col of input.table) {
     const _rows = [];
-
     for (const row of col) {
       _rows.push({
         "row": row,
@@ -68,27 +59,22 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         }
       });
     }
-
     _cols.push({
       "x": y,
       "rows": _rows
     });
   }
-
   const _rows2 = [];
-
   _rows2.push({
     "row": -1,
     "renderBody": out => {
       out.t("Outside", _component);
     }
   });
-
   _cols.push({
     "outside": true,
     "rows": _rows2
   });
-
   _marko_tag(_hello, {
     "list": {
       "items": _items

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-with-key/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-with-key/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "9N4Yuzi+",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-with-key/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "9N4Yuzi+",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "hNiObgtw",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/at-tags/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "hNiObgtw",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-boolean/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-boolean/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "CtqnD7TI",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-boolean/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("input", {

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdomProduction-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "CtqnD7TI",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("input", {
   "checked": ""
 }, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/cjs-expected.js
@@ -2,26 +2,16 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _classValue = _interopRequireDefault(require("marko/src/runtime/helpers/class-value.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _customTag2 = _interopRequireDefault(require("./components/custom-tag.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-class/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-class/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
@@ -18,18 +16,15 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }]))}></div>`);
   out.w("<div class=\"a b\"></div>");
   out.w("<div class=\"a b c\"></div>");
-
   _marko_tag(_customTag, {
     "class": ["a", {
       b: c,
       d
     }]
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "class": ["a", false, "b"]
   }, out, _componentDef, "4");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "class": ["a", {
       b: c,

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "TKoJdMQb",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
@@ -16,18 +14,15 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     b: c,
     d
   }]))}></div><div class="a b"></div><div class="a b c"></div>`);
-
   _marko_tag(_customTag, {
     "class": ["a", {
       b: c,
       d
     }]
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "class": ["a", false, "b"]
   }, out, _componentDef, "4");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "class": ["a", {
       b: c,

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/vdom-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-class/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _customTag from "./components/custom-tag.marko";
@@ -10,9 +8,7 @@ import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {
@@ -27,18 +23,15 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("div", {
     "class": "a b c"
   }, "2", _component, 0, 1);
-
   _marko_tag(_customTag, {
     "class": ["a", {
       b: c,
       d
     }]
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "class": ["a", false, "b"]
   }, out, _componentDef, "4");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "class": ["a", {
       b: c,

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/vdomProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "TKoJdMQb",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _customTag from "./components/custom-tag.marko";
@@ -10,9 +8,7 @@ import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {
@@ -27,18 +23,15 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("div", {
     "class": "a b c"
   }, "2", _component, 0, 1);
-
   _marko_tag(_customTag, {
     "class": ["a", {
       b: c,
       d
     }]
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "class": ["a", false, "b"]
   }, out, _componentDef, "4");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "class": ["a", {
       b: c,

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _classValue = _interopRequireDefault(require("marko/src/runtime/helpers/class-value.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-escape/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-escape/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "SA1M0lYk",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-escape/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "SA1M0lYk",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-falsey/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-falsey/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "9WNpCPpT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-falsey/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdomProduction-expected.js
@@ -1,21 +1,15 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "9WNpCPpT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", {
   "d": "0",
   "y": "1"
 }, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _customTag2 = _interopRequireDefault(require("./components/custom-tag.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-shorthand/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-shorthand/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -14,7 +12,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       console.log("hello");
     }
   }, out, _componentDef, "0");
-
   _marko_tag(_customTag, {
     "value": function () {
       console.log("again");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "8v5gGoOT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -14,7 +12,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       console.log("hello");
     }
   }, out, _componentDef, "0");
-
   _marko_tag(_customTag, {
     "value": function () {
       console.log("again");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-shorthand/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {
@@ -18,7 +14,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       console.log("hello");
     }
   }, out, _componentDef, "0");
-
   _marko_tag(_customTag, {
     "value": function () {
       console.log("again");

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "8v5gGoOT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {
@@ -18,7 +14,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       console.log("hello");
     }
   }, out, _componentDef, "0");
-
   _marko_tag(_customTag, {
     "value": function () {
       console.log("again");

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _test2 = _interopRequireDefault(require("./components/test.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "+mnrnsox",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-method-with-return/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_test, {

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "+mnrnsox",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_test, {

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-scoped/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-scoped/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "m2haKSSA",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-scoped/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "m2haKSSA",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/cjs-expected.js
@@ -2,26 +2,16 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _styleValue = _interopRequireDefault(require("marko/src/runtime/helpers/style-value.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _customTag2 = _interopRequireDefault(require("./components/custom-tag.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-style/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-style/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/src/runtime/helpers/style-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
@@ -17,23 +15,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }))}></div>`);
   out.w("<div style=width:100px;></div>");
   out.w("<div style=\"color: green\"></div>");
-
   _marko_tag(_customTag, {
     "style": {
       color: input.color
     }
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "style": {
       width: 100
     }
   }, out, _componentDef, "4");
-
   _marko_tag(_customTag, {
     "style": "color: green"
   }, out, _componentDef, "5");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "style": {
       color: "green"

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "Up7A+MWi",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/dist/runtime/helpers/style-value.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
@@ -15,23 +13,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w(`<div${_marko_attr("style", _marko_style_merge({
     color: input.color
   }))}></div><div style=width:100px;></div><div style="color: green"></div>`);
-
   _marko_tag(_customTag, {
     "style": {
       color: input.color
     }
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "style": {
       width: 100
     }
   }, out, _componentDef, "4");
-
   _marko_tag(_customTag, {
     "style": "color: green"
   }, out, _componentDef, "5");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "style": {
       color: "green"

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/vdom-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-style/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/src/runtime/helpers/style-value.js";
 import _customTag from "./components/custom-tag.marko";
@@ -10,9 +8,7 @@ import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {
@@ -26,23 +22,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("div", {
     "style": "color: green"
   }, "2", _component, 0, 1);
-
   _marko_tag(_customTag, {
     "style": {
       color: input.color
     }
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "style": {
       width: 100
     }
   }, out, _componentDef, "4");
-
   _marko_tag(_customTag, {
     "style": "color: green"
   }, out, _componentDef, "5");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "style": {
       color: "green"

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/vdomProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "Up7A+MWi",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/dist/runtime/helpers/style-value.js";
 import _customTag from "./components/custom-tag.marko";
@@ -10,9 +8,7 @@ import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {
@@ -26,23 +22,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("div", {
     "style": "color: green"
   }, "2", _component, 0, 1);
-
   _marko_tag(_customTag, {
     "style": {
       color: input.color
     }
   }, out, _componentDef, "3");
-
   _marko_tag(_customTag, {
     "style": {
       width: 100
     }
   }, out, _componentDef, "4");
-
   _marko_tag(_customTag, {
     "style": "color: green"
   }, out, _componentDef, "5");
-
   _marko_dynamic_tag(out, input.test, () => ({
     "style": {
       color: "green"

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-template-literal-escape/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-template-literal-escape/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "vJZypcf5",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/attr-template-literal-escape/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "vJZypcf5",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/cjs-expected.js
@@ -2,22 +2,14 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/core-tags/core/await/renderer.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer2 = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/await-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/await-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _await from "marko/src/core-tags/core/await/renderer.js";

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "8BXCo81d",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _await from "marko/dist/core-tags/core/await/renderer.js";

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/await-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _await from "marko/src/core-tags/core/await/renderer.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_await, {

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "8BXCo81d",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _await from "marko/dist/core-tags/core/await/renderer.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_await, {

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/custom-tag/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/camel-case-attr-name-override/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/camel-case-attr-name-override/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "MoYb8VAR",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/camel-case-attr-name-override/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "MoYb8VAR",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {

--- a/packages/translator-default/test/fixtures/cdata/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/cdata/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/cdata/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/cdata/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/cdata/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "EazLsc5m",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/cdata/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/cdata/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/cdata/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "EazLsc5m",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _component2 = _interopRequireDefault(require("./component.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component-index/index.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component2 = _component2.default;

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component-index/index.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "ErZDLFTk",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component-index/index.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdomProduction-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "ErZDLFTk",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_component from "./component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _templateComponent = _interopRequireDefault(require("./template.component.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component2 = _templateComponent.default;

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "cQ4BiZgz",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-external-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/vdomProduction-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "cQ4BiZgz",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {
@@ -19,7 +14,6 @@ const _marko_component = {
     this.x = 1
     this.y = 2
   }
-
 };
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {
@@ -10,7 +8,6 @@ const _marko_component = {
     this.x = 1
     this.y = 2
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "rmgp0gbX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {
@@ -10,7 +8,6 @@ const _marko_component = {
     this.x = 1
     this.y = 2
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdom-expected.js
@@ -1,20 +1,15 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.x = 1
     this.y = 2
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdomProduction-expected.js
@@ -1,24 +1,17 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "rmgp0gbX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.x = 1
     this.y = 2
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {
@@ -20,7 +15,6 @@ const _marko_component = {
     this.y = 2
     this.stuff();
   }
-
 };
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/generated-expected.marko
@@ -1,10 +1,8 @@
 class {
   x = 1;
   y = 2;
-
   onCreate() {
     this.stuff();
   }
-
 }
 <div/>

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {
@@ -11,7 +9,6 @@ const _marko_component = {
     this.y = 2
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "F7GLatBK",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {
@@ -11,7 +9,6 @@ const _marko_component = {
     this.y = 2
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div></div>");

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/vdom-expected.js
@@ -1,21 +1,16 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/class-inline/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.x = 1
     this.y = 2
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/vdomProduction-expected.js
@@ -1,25 +1,18 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "F7GLatBK",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.x = 1
     this.y = 2
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/comments/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/comments/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/comments/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/comments/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/comments/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "7oQXz9rS",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/comments/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/comments/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "7oQXz9rS",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-element-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-element-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "O83mlmop",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-element-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("hello", null, "0", _component, 0, 2);

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "O83mlmop",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("hello", null, "0", null, 0, 2);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-child-analyze/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-child-analyze/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "aA/l93YC",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-child-analyze/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello Frank", _component);

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "aA/l93YC",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello Frank", _component);

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _customTagDataTag = _interopRequireDefault(require("./custom-tag-data-tag.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-data/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-data/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "ZqQwXW7R",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-data/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTagData, {

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "ZqQwXW7R",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTagData, {

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _new2 = _interopRequireDefault(require("./new.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-migration/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "hPPGxVRm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_new, {

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "hPPGxVRm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_new, {

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/cjs-expected.js
@@ -2,22 +2,14 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _customTag2 = _interopRequireDefault(require("./components/custom-tag.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-parameters/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-parameters/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "D4iHvcrp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-parameters/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "D4iHvcrp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_customTag, {

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("./tags/test-body-function/renderer.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer2 = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-render-body/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-render-body/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "c9tNjqrV",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-render-body/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_testBodyFunction, {

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "c9tNjqrV",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_testBodyFunction, {

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _templateComponent = _interopRequireDefault(require("./template.component.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-separate-assets/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component2 = _templateComponent.default;

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-separate-assets/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "WET+Vfy4",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-separate-assets/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdomProduction-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "WET+Vfy4",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _hello2 = _interopRequireDefault(require("./hello.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-template/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-template/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "s2zGW8TX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-template/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "s2zGW8TX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_hello, {

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-transform/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-transform/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "5fhDZgMT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag-transform/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("span", {

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "5fhDZgMT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("span", {

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("./tags/test-hello/renderer.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer2 = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "gHRccTPG",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/custom-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_testHello, {

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "gHRccTPG",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_testHello, {

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-marko-implicit-component/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-marko-implicit-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "qc7Y7xBI",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-marko-implicit-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/src/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", {

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "qc7Y7xBI",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/dist/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", {

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/cjs-expected.js
@@ -2,22 +2,14 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _test2 = _interopRequireDefault(require("./test.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-migration/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
@@ -33,23 +25,19 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w("Hello ");
   out.w((0, _escapeXml.x)(input.name));
   out.w("<span>");
-
   () => {
     data;
     const data = "foo";
     console.log(data);
   };
-
   out.w("Hello ");
   out.w((0, _escapeXml.x)(input));
   out.w("</span>");
-
   if (true) {
     const data = "bar";
     out.w("Hello ");
     out.w("bar");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _test from "./test.marko";
@@ -17,28 +15,23 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w(_marko_escapeXml(data.name));
     }
   }, out, _componentDef, "0");
-
   out.w("<div>");
   out.w("Hello ");
   out.w(_marko_escapeXml(input.name));
   out.w("<span>");
-
   () => {
     data;
     const data = "foo";
     console.log(data);
   };
-
   out.w("Hello ");
   out.w(_marko_escapeXml(input));
   out.w("</span>");
-
   if (true) {
     const data = "bar";
     out.w("Hello ");
     out.w("bar");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "Pet223we",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _test from "./test.marko";
@@ -16,22 +14,17 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w(`Hello ${_marko_escapeXml(data.name)}`);
     }
   }, out, _componentDef, "0");
-
   out.w(`<div>Hello ${_marko_escapeXml(input.name)}<span>`);
-
   () => {
     data;
     const data = "foo";
     console.log(data);
   };
-
   out.w(`Hello ${_marko_escapeXml(input)}</span>`);
-
   if (true) {
     const data = "bar";
     out.w("Hello bar");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/data-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./test.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_test, {
@@ -20,28 +16,23 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.t(data.name, _component);
     }
   }, out, _componentDef, "0");
-
   out.be("div", null, "1", _component, null, 0);
   out.t("Hello ", _component);
   out.t(input.name, _component);
   out.be("span", null, "2", _component, null, 0);
-
   () => {
     data;
     const data = "foo";
     console.log(data);
   };
-
   out.t("Hello ", _component);
   out.t(input, _component);
   out.ee();
-
   if (true) {
     const data = "bar";
     out.t("Hello ", _component);
     out.t(data, _component);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "Pet223we",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./test.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_test, {
@@ -20,28 +16,23 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.t(data.name, _component);
     }
   }, out, _componentDef, "0");
-
   out.be("div", null, "1", _component, null, 0);
   out.t("Hello ", _component);
   out.t(input.name, _component);
   out.be("span", null, "2", _component, null, 0);
-
   () => {
     data;
     const data = "foo";
     console.log(data);
   };
-
   out.t("Hello ", _component);
   out.t(input, _component);
   out.ee();
-
   if (true) {
     const data = "bar";
     out.t("Hello ", _component);
     out.t(data, _component);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/declaration/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/declaration/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/declaration/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/declaration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/declaration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "p0+/pj8a",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/declaration/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/declaration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("contact-info", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/declaration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "p0+/pj8a",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("contact-info", null, "0", null, 1, 0).e("name", null, "1", null, 1, 0).t("Hello World");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/doctype/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/cjs-expected.js
@@ -2,24 +2,15 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _initComponentsTag = _interopRequireDefault(require("marko/src/core-tags/components/init-components-tag.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _reordererRenderer = _interopRequireDefault(require("marko/src/core-tags/core/await/reorderer-renderer.js"));
-
 var _preferredScriptLocationTag = _interopRequireDefault(require("marko/src/core-tags/components/preferred-script-location-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/doctype/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/doctype/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/doctype/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _initComponents from "marko/src/core-tags/components/init-components-tag.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -20,13 +18,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w("</head>");
   out.w("<body>");
   out.w("The content of the document......");
-
   _marko_tag(_initComponents, {}, out, _componentDef, "4");
-
   _marko_tag(_awaitReorderer, {}, out, _componentDef, "5");
-
   _marko_tag(_preferredScriptLocation, {}, out, _componentDef, "6");
-
   out.w("</body>");
   out.w("</html>");
 }, {

--- a/packages/translator-default/test/fixtures/doctype/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "VJrYycFN",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _initComponents from "marko/dist/core-tags/components/init-components-tag.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -12,13 +10,9 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<!DOCTYPE html><html><head><title>Title of the document</title></head><body>The content of the document......");
-
   _marko_tag(_initComponents, {}, out, _componentDef, "4");
-
   _marko_tag(_awaitReorderer, {}, out, _componentDef, "5");
-
   _marko_tag(_preferredScriptLocation, {}, out, _componentDef, "6");
-
   out.w("</body></html>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/doctype/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/doctype/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("html", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "VJrYycFN",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("head", null, "1", null, 1, 0).e("title", null, "2", null, 1, 0).t("Title of the document");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("html", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/cjs-expected.js
@@ -2,26 +2,16 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/tag-a/index.marko"));
-
 var _index3 = _interopRequireDefault(require("./components/tag-b/index.marko"));
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-name/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
@@ -34,41 +24,28 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "1");
-
   const _tagName = input.show ? "div" : null;
-
   if (_tagName) out.w(`<${_tagName} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName}>`);else out.bf("f_2", _component, 1);
-
   const _tagName2 = input.show && "div";
-
   if (_tagName2) out.w(`<${_tagName2} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName2}>`);else out.bf("f_3", _component, 1);
-
   const _tagName3 = input.large ? "h1" : "h2";
-
   out.w(`<${_tagName3} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName3}>`);
-
   const _tagName4 = input.showTagA ? _index2.default : _index3.default;
-
   (0, _renderTag.default)(_tagName4, {
     "class": ["a", "b"],
     "other": input.other,
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "5");
-
   const _tagName5 = input.showTagA && _index2.default;
-
   if (_tagName5) (0, _renderTag.default)(_tagName5, {
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "6");
-
   const _tagName6 = input.showTagA && _index2.default;
-
   const _renderBody = out => {
     out.w("Body content");
   };
-
   if (_tagName6) (0, _renderTag.default)(_tagName6, {
     "class": ["a", "b"],
     "other": input.other,
@@ -79,17 +56,11 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     "other": input.other
   }), null, null, null, _componentDef, "8");
   const largeHeading = input.isLarge && "h1";
-
   const _tagName7 = largeHeading || "h2";
-
   if (_tagName7) out.w(`<${_tagName7} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName7}>`);else out.bf("f_9", _component, 1);
-
   const _tagName8 = global.x = "a" + "b";
-
   out.w(`<${_tagName8} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName8}>`);
-
   const _tagName9 = "h" + input.level;
-
   out.w(`<${_tagName9} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName9}>`);
   const _tagName10 = `h${input.level}`;
   out.w(`<${_tagName10} class="a b"${(0, _attr.default)("other", input.other)}></${_tagName10}>`);

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-name/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";
 import tagB from "./components/tag-b/index.marko";
@@ -16,69 +14,47 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "0");
-
   _marko_dynamic_tag(out, input.x, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "1");
-
   const _tagName = input.show ? "div" : null;
-
   if (_tagName) out.w(`<${_tagName} class="a b"${_marko_attr("other", input.other)}></${_tagName}>`);else out.bf("f_2", _component, 1);
-
   const _tagName2 = input.show && "div";
-
   if (_tagName2) out.w(`<${_tagName2} class="a b"${_marko_attr("other", input.other)}></${_tagName2}>`);else out.bf("f_3", _component, 1);
-
   const _tagName3 = input.large ? "h1" : "h2";
-
   out.w(`<${_tagName3} class="a b"${_marko_attr("other", input.other)}></${_tagName3}>`);
-
   const _tagName4 = input.showTagA ? tagA : tagB;
-
   _marko_tag(_tagName4, {
     "class": ["a", "b"],
     "other": input.other,
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "5");
-
   const _tagName5 = input.showTagA && tagA;
-
   if (_tagName5) _marko_tag(_tagName5, {
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "6");
-
   const _tagName6 = input.showTagA && tagA;
-
   const _renderBody = out => {
     out.w("Body content");
   };
-
   if (_tagName6) _marko_tag(_tagName6, {
     "class": ["a", "b"],
     "other": input.other,
     "renderBody": _renderBody
   }, out, _componentDef, "7");else _renderBody(out);
-
   _marko_dynamic_tag(out, input.tag || tagA, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "8");
-
   const largeHeading = input.isLarge && "h1";
-
   const _tagName7 = largeHeading || "h2";
-
   if (_tagName7) out.w(`<${_tagName7} class="a b"${_marko_attr("other", input.other)}></${_tagName7}>`);else out.bf("f_9", _component, 1);
-
   const _tagName8 = global.x = "a" + "b";
-
   out.w(`<${_tagName8} class="a b"${_marko_attr("other", input.other)}></${_tagName8}>`);
-
   const _tagName9 = "h" + input.level;
-
   out.w(`<${_tagName9} class="a b"${_marko_attr("other", input.other)}></${_tagName9}>`);
   const _tagName10 = `h${input.level}`;
   out.w(`<${_tagName10} class="a b"${_marko_attr("other", input.other)}></${_tagName10}>`);

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "FiPq+pCl",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";
 import tagB from "./components/tag-b/index.marko";
@@ -16,69 +14,47 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "0");
-
   _marko_dynamic_tag(out, input.x, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "1");
-
   const _tagName = input.show ? "div" : null;
-
   if (_tagName) out.w(`<${_tagName} class="a b"${_marko_attr("other", input.other)}></${_tagName}>`);else out.bf("f_2", _component, 1);
-
   const _tagName2 = input.show && "div";
-
   if (_tagName2) out.w(`<${_tagName2} class="a b"${_marko_attr("other", input.other)}></${_tagName2}>`);else out.bf("f_3", _component, 1);
-
   const _tagName3 = input.large ? "h1" : "h2";
-
   out.w(`<${_tagName3} class="a b"${_marko_attr("other", input.other)}></${_tagName3}>`);
-
   const _tagName4 = input.showTagA ? tagA : tagB;
-
   _marko_tag(_tagName4, {
     "class": ["a", "b"],
     "other": input.other,
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "5");
-
   const _tagName5 = input.showTagA && tagA;
-
   if (_tagName5) _marko_tag(_tagName5, {
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "6");
-
   const _tagName6 = input.showTagA && tagA;
-
   const _renderBody = out => {
     out.w("Body content");
   };
-
   if (_tagName6) _marko_tag(_tagName6, {
     "class": ["a", "b"],
     "other": input.other,
     "renderBody": _renderBody
   }, out, _componentDef, "7");else _renderBody(out);
-
   _marko_dynamic_tag(out, input.tag || tagA, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "8");
-
   const largeHeading = input.isLarge && "h1";
-
   const _tagName7 = largeHeading || "h2";
-
   if (_tagName7) out.w(`<${_tagName7} class="a b"${_marko_attr("other", input.other)}></${_tagName7}>`);else out.bf("f_9", _component, 1);
-
   const _tagName8 = global.x = "a" + "b";
-
   out.w(`<${_tagName8} class="a b"${_marko_attr("other", input.other)}></${_tagName8}>`);
-
   const _tagName9 = "h" + input.level;
-
   out.w(`<${_tagName9} class="a b"${_marko_attr("other", input.other)}></${_tagName9}>`);
   const _tagName10 = `h${input.level}`;
   out.w(`<${_tagName10} class="a b"${_marko_attr("other", input.other)}></${_tagName10}>`);

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdom-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-name/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";
 import tagB from "./components/tag-b/index.marko";
@@ -10,93 +8,69 @@ import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "0");
-
   _marko_dynamic_tag(out, input.x, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "1");
-
   const _tagName = input.show ? "div" : null;
-
   if (_tagName) out.e(_tagName, {
     "class": "a b",
     "other": input.other
   }, "2", _component, 0, 0);else out.bf("f_2", _component);
-
   const _tagName2 = input.show && "div";
-
   if (_tagName2) out.e(_tagName2, {
     "class": "a b",
     "other": input.other
   }, "3", _component, 0, 0);else out.bf("f_3", _component);
-
   const _tagName3 = input.large ? "h1" : "h2";
-
   out.e(_tagName3, {
     "class": "a b",
     "other": input.other
   }, "4", _component, 0, 0);
-
   const _tagName4 = input.showTagA ? tagA : tagB;
-
   _marko_tag(_tagName4, {
     "class": ["a", "b"],
     "other": input.other,
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "5");
-
   const _tagName5 = input.showTagA && tagA;
-
   if (_tagName5) _marko_tag(_tagName5, {
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "6");
-
   const _tagName6 = input.showTagA && tagA;
-
   const _renderBody = out => {
     out.t("Body content", _component);
   };
-
   if (_tagName6) _marko_tag(_tagName6, {
     "class": ["a", "b"],
     "other": input.other,
     "renderBody": _renderBody
   }, out, _componentDef, "7");else _renderBody(out);
-
   _marko_dynamic_tag(out, input.tag || tagA, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "8");
-
   const largeHeading = input.isLarge && "h1";
-
   const _tagName7 = largeHeading || "h2";
-
   if (_tagName7) out.e(_tagName7, {
     "class": "a b",
     "other": input.other
   }, "9", _component, 0, 0);else out.bf("f_9", _component);
-
   const _tagName8 = global.x = "a" + "b";
-
   out.e(_tagName8, {
     "class": "a b",
     "other": input.other
   }, "10", _component, 0, 0);
-
   const _tagName9 = "h" + input.level;
-
   out.e(_tagName9, {
     "class": "a b",
     "other": input.other

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdomProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "FiPq+pCl",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";
 import tagB from "./components/tag-b/index.marko";
@@ -10,93 +8,69 @@ import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "0");
-
   _marko_dynamic_tag(out, input.x, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "1");
-
   const _tagName = input.show ? "div" : null;
-
   if (_tagName) out.e(_tagName, {
     "class": "a b",
     "other": input.other
   }, "2", _component, 0, 0);else out.bf("f_2", _component);
-
   const _tagName2 = input.show && "div";
-
   if (_tagName2) out.e(_tagName2, {
     "class": "a b",
     "other": input.other
   }, "3", _component, 0, 0);else out.bf("f_3", _component);
-
   const _tagName3 = input.large ? "h1" : "h2";
-
   out.e(_tagName3, {
     "class": "a b",
     "other": input.other
   }, "4", _component, 0, 0);
-
   const _tagName4 = input.showTagA ? tagA : tagB;
-
   _marko_tag(_tagName4, {
     "class": ["a", "b"],
     "other": input.other,
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "5");
-
   const _tagName5 = input.showTagA && tagA;
-
   if (_tagName5) _marko_tag(_tagName5, {
     "class": ["a", "b"],
     "other": input.other
   }, out, _componentDef, "6");
-
   const _tagName6 = input.showTagA && tagA;
-
   const _renderBody = out => {
     out.t("Body content", _component);
   };
-
   if (_tagName6) _marko_tag(_tagName6, {
     "class": ["a", "b"],
     "other": input.other,
     "renderBody": _renderBody
   }, out, _componentDef, "7");else _renderBody(out);
-
   _marko_dynamic_tag(out, input.tag || tagA, () => ({
     "class": ["a", "b"],
     "other": input.other
   }), null, null, null, _componentDef, "8");
-
   const largeHeading = input.isLarge && "h1";
-
   const _tagName7 = largeHeading || "h2";
-
   if (_tagName7) out.e(_tagName7, {
     "class": "a b",
     "other": input.other
   }, "9", _component, 0, 0);else out.bf("f_9", _component);
-
   const _tagName8 = global.x = "a" + "b";
-
   out.e(_tagName8, {
     "class": "a b",
     "other": input.other
   }, "10", _component, 0, 0);
-
   const _tagName9 = "h" + input.level;
-
   out.e(_tagName9, {
     "class": "a b",
     "other": input.other

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-string-literal/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-string-literal/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "W5oFh28/",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/dynamic-tag-string-literal/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _tagName = `some-wacky-tag-name`;

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "W5oFh28/",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const _tagName = `some-wacky-tag-name`;

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "GzjO/FF7",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   if (x) {} else if (y) {} else {}

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "GzjO/FF7",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   if (x) {} else if (y) {} else {}

--- a/packages/translator-default/test/fixtures/entities/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/entities/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/entities/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/entities/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/entities/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "Q2oCYb3A",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/entities/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/entities/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello John & Suzy Invalid Entity: &b ; Valid Numeric Entity: \" Valid Hexadecimal Entity: \xA2", _component);

--- a/packages/translator-default/test/fixtures/entities/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "Q2oCYb3A",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello John & Suzy Invalid Entity: &b ; Valid Numeric Entity: \" Valid Hexadecimal Entity: \xA2", _component);

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-body-only-if-no-condition/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-body-only-if-no-condition/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "QPcOe9nt",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-body-only-if-no-condition/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdomProduction-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "QPcOe9nt",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", {
   "body-only-if": ""
 }, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "vPxaLPFT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input.x, null, out => {

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "vPxaLPFT",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_dynamic_tag(out, input.x, null, out => {

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/cjs-expected.js
@@ -2,22 +2,14 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _customTag2 = _interopRequireDefault(require("./components/custom-tag.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/event-handlers/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/event-handlers/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
 import _customTag from "./components/custom-tag.marko";
@@ -19,11 +17,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w(`<div${_marko_props(out, _componentDef, {
     "oncamelcasedevent": _componentDef.d("camelcasedevent", "handle", false)
   })} onmouseout=someStringHandler></div>`);
-
   _marko_tag(_customTag, {}, out, _componentDef, "3", [["thing", "handleThing", false, [a, b, ...d]]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "4", [["Dashed-cased-Event", "handle", false]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "7zxvsBE8",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
 import _customTag from "./components/custom-tag.marko";
@@ -17,11 +15,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   })}></div><div${_marko_props(out, _componentDef, {
     "oncamelcasedevent": _componentDef.d("camelcasedevent", "handle", false)
   })} onmouseout=someStringHandler></div>`);
-
   _marko_tag(_customTag, {}, out, _componentDef, "3", [["thing", "handleThing", false, [a, b, ...d]]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "4", [["Dashed-cased-Event", "handle", false]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/event-handlers/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0, {
@@ -24,11 +20,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, "2", _component, 0, 0, {
     "oncamelcasedevent": _componentDef.d("camelcasedevent", "handle", false)
   });
-
   _marko_tag(_customTag, {}, out, _componentDef, "3", [["thing", "handleThing", false, [a, b, ...d]]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "4", [["Dashed-cased-Event", "handle", false]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "7zxvsBE8",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0, {
@@ -24,11 +20,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   }, "2", _component, 0, 0, {
     "oncamelcasedevent": _componentDef.d("camelcasedevent", "handle", false)
   });
-
   _marko_tag(_customTag, {}, out, _componentDef, "3", [["thing", "handleThing", false, [a, b, ...d]]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "4", [["Dashed-cased-Event", "handle", false]]);
-
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/cjs-expected.js
@@ -2,26 +2,18 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/for-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   let _i = 0;
-
   for (const val of arr) {
     let i = _i++;
     const _keyScope = `[${i}]`;
@@ -33,7 +25,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;
@@ -45,7 +36,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope3 = `[${i}]`;
@@ -55,13 +45,11 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   let _i2 = 0;
-
   for (const val of arr) {
     let i = _i2++;
     const _keyValue = `@${i}`,
-          _keyScope4 = `[${_keyValue}]`;
+      _keyScope4 = `[${_keyValue}]`;
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, _keyValue, _componentDef)}>`);
     out.w((0, _escapeXml.x)(i));
     out.w(": ");
@@ -70,10 +58,8 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   let _i3 = 0;
   const list = arr;
-
   for (const val of list) {
     let i = _i3++;
     const _keyValue2 = `@${i}`;
@@ -83,11 +69,10 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w((0, _escapeXml.x)(val));
     out.w("</div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyValue3 = `@${key}`,
-          _keyScope5 = `[${_keyValue3}]`;
+      _keyScope5 = `[${_keyValue3}]`;
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, _keyValue3, _componentDef)}>`);
     out.w((0, _escapeXml.x)(key));
     out.w(": ");
@@ -96,21 +81,19 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, `@other-${key}`, _componentDef)}></div>`);
   }
-
   for (let _steps3 = (10 - 0) / 2, _step3 = 0; _step3 <= _steps3; _step3++) {
     const i = 0 + _step3 * 2;
     const _keyValue4 = `@${i}`,
-          _keyScope6 = `[${_keyValue4}]`;
+      _keyScope6 = `[${_keyValue4}]`;
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, _keyValue4, _componentDef)}>`);
     out.w((0, _escapeXml.x)(i));
     out.w("</div>");
     out.w("<div></div>");
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
-
     for (let _steps2 = (10 - 0) / 2, _step2 = 0; _step2 <= _steps2; _step2++) {
       const i = 0 + _step2 * 2;
       const _keyValue5 = `@${i}`,
-            _keyScope7 = `[${_keyValue5}]`;
+        _keyScope7 = `[${_keyValue5}]`;
       out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, _keyValue5, _componentDef)}>`);
       out.w((0, _escapeXml.x)(i));
       out.w("</div>");
@@ -118,22 +101,19 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
     }
   }
-
   for (let _steps4 = (0 - 10) / -2, _step4 = 0; _step4 <= _steps4; _step4++) {
     const i = 10 + _step4 * -2;
     const _keyValue6 = `@${i}`,
-          _keyScope8 = `[${_keyValue6}]`;
+      _keyScope8 = `[${_keyValue6}]`;
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, _keyValue6, _componentDef)}>`);
     out.w((0, _escapeXml.x)(i));
     out.w("</div>");
     out.w("<div></div>");
     out.w(`<div${(0, _dataMarko.default)(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   for (let _steps5 = (10 - 0) / 1, _step5 = 0; _step5 <= _steps5; _step5++) {
     out.w("Hello");
   }
-
   for (let _steps6 = (10 - 0) / 1, _step6 = 0; _step6 <= _steps6; _step6++) {
     out.w("Hello");
   }

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/for-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
@@ -10,7 +8,6 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _i = 0;
-
   for (const val of arr) {
     let i = _i++;
     const _keyScope = `[${i}]`;
@@ -22,7 +19,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;
@@ -34,7 +30,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope3 = `[${i}]`;
@@ -44,13 +39,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
     out.w("<div></div>");
   }
-
   let _i2 = 0;
-
   for (const val of arr) {
     let i = _i2++;
     const _keyValue = `@${i}`,
-          _keyScope4 = `[${_keyValue}]`;
+      _keyScope4 = `[${_keyValue}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue, _componentDef)}>`);
     out.w(_marko_escapeXml(i));
     out.w(": ");
@@ -59,10 +52,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
     out.w(`<div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   let _i3 = 0;
   const list = arr;
-
   for (const val of list) {
     let i = _i3++;
     const _keyValue2 = `@${i}`;
@@ -72,11 +63,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w(_marko_escapeXml(val));
     out.w("</div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyValue3 = `@${key}`,
-          _keyScope5 = `[${_keyValue3}]`;
+      _keyScope5 = `[${_keyValue3}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue3, _componentDef)}>`);
     out.w(_marko_escapeXml(key));
     out.w(": ");
@@ -85,21 +75,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
     out.w(`<div${_marko_props(out, _componentDef, 0, `@other-${key}`, _componentDef)}></div>`);
   }
-
   for (let _steps3 = (10 - 0) / 2, _step3 = 0; _step3 <= _steps3; _step3++) {
     const i = 0 + _step3 * 2;
     const _keyValue4 = `@${i}`,
-          _keyScope6 = `[${_keyValue4}]`;
+      _keyScope6 = `[${_keyValue4}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue4, _componentDef)}>`);
     out.w(_marko_escapeXml(i));
     out.w("</div>");
     out.w("<div></div>");
     out.w(`<div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
-
     for (let _steps2 = (10 - 0) / 2, _step2 = 0; _step2 <= _steps2; _step2++) {
       const i = 0 + _step2 * 2;
       const _keyValue5 = `@${i}`,
-            _keyScope7 = `[${_keyValue5}]`;
+        _keyScope7 = `[${_keyValue5}]`;
       out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue5, _componentDef)}>`);
       out.w(_marko_escapeXml(i));
       out.w("</div>");
@@ -107,22 +95,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w(`<div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
     }
   }
-
   for (let _steps4 = (0 - 10) / -2, _step4 = 0; _step4 <= _steps4; _step4++) {
     const i = 10 + _step4 * -2;
     const _keyValue6 = `@${i}`,
-          _keyScope8 = `[${_keyValue6}]`;
+      _keyScope8 = `[${_keyValue6}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue6, _componentDef)}>`);
     out.w(_marko_escapeXml(i));
     out.w("</div>");
     out.w("<div></div>");
     out.w(`<div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   for (let _steps5 = (10 - 0) / 1, _step5 = 0; _step5 <= _steps5; _step5++) {
     out.w("Hello");
   }
-
   for (let _steps6 = (10 - 0) / 1, _step6 = 0; _step6 <= _steps6; _step6++) {
     out.w("Hello");
   }

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "avg1eu47",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
@@ -10,75 +8,62 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _i = 0;
-
   for (const val of arr) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;
     out.w(`<div>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope3 = `[${i}]`;
     out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
   }
-
   let _i2 = 0;
-
   for (const val of arr) {
     let i = _i2++;
     const _keyValue = `@${i}`,
-          _keyScope4 = `[${_keyValue}]`;
+      _keyScope4 = `[${_keyValue}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue, _componentDef)}>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   let _i3 = 0;
   const list = arr;
-
   for (const val of list) {
     let i = _i3++;
     const _keyValue2 = `@${i}`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue2, _componentDef)}>${_marko_escapeXml(list.length)}: ${_marko_escapeXml(val)}</div>`);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyValue3 = `@${key}`,
-          _keyScope5 = `[${_keyValue3}]`;
+      _keyScope5 = `[${_keyValue3}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue3, _componentDef)}>${_marko_escapeXml(key)}: ${_marko_escapeXml(val)}</div><div></div><div${_marko_props(out, _componentDef, 0, `@other-${key}`, _componentDef)}></div>`);
   }
-
   for (let _steps3 = (10 - 0) / 2, _step3 = 0; _step3 <= _steps3; _step3++) {
     const i = 0 + _step3 * 2;
     const _keyValue4 = `@${i}`,
-          _keyScope6 = `[${_keyValue4}]`;
+      _keyScope6 = `[${_keyValue4}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue4, _componentDef)}>${_marko_escapeXml(i)}</div><div></div><div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
-
     for (let _steps2 = (10 - 0) / 2, _step2 = 0; _step2 <= _steps2; _step2++) {
       const i = 0 + _step2 * 2;
       const _keyValue5 = `@${i}`,
-            _keyScope7 = `[${_keyValue5}]`;
+        _keyScope7 = `[${_keyValue5}]`;
       out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue5, _componentDef)}>${_marko_escapeXml(i)}</div><div></div><div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
     }
   }
-
   for (let _steps4 = (0 - 10) / -2, _step4 = 0; _step4 <= _steps4; _step4++) {
     const i = 10 + _step4 * -2;
     const _keyValue6 = `@${i}`,
-          _keyScope8 = `[${_keyValue6}]`;
+      _keyScope8 = `[${_keyValue6}]`;
     out.w(`<div${_marko_props(out, _componentDef, 0, _keyValue6, _componentDef)}>${_marko_escapeXml(i)}</div><div></div><div${_marko_props(out, _componentDef, 0, `@other-${i}`, _componentDef)}></div>`);
   }
-
   for (let _steps5 = (10 - 0) / 1, _step5 = 0; _step5 <= _steps5; _step5++) {
     out.w("Hello");
   }
-
   for (let _steps6 = (10 - 0) / 1, _step6 = 0; _step6 <= _steps6; _step6++) {
     out.w("Hello");
   }

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/vdom-expected.js
@@ -1,18 +1,13 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/for-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _i = 0;
-
   for (const val of arr) {
     let i = _i++;
     const _keyScope = `[${i}]`;
@@ -24,7 +19,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "1" + _keyScope, _component, 0, 0);
     out.e("div", null, "2" + _keyScope, _component, 0, 0);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;
@@ -36,7 +30,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "4" + _keyScope2, _component, 0, 0);
     out.e("div", null, "5" + _keyScope2, _component, 0, 0);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope3 = `[${i}]`;
@@ -46,13 +39,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "7" + _keyScope3, _component, 0, 0);
     out.e("div", null, "8" + _keyScope3, _component, 0, 0);
   }
-
   let _i2 = 0;
-
   for (const val of arr) {
     let i = _i2++;
     const _keyValue = `@${i}`,
-          _keyScope4 = `[${_keyValue}]`;
+      _keyScope4 = `[${_keyValue}]`;
     out.be("div", null, _keyValue, _component, null, 0);
     out.t(i, _component);
     out.t(": ", _component);
@@ -61,10 +52,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "9" + _keyScope4, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
   }
-
   let _i3 = 0;
   const list = arr;
-
   for (const val of list) {
     let i = _i3++;
     const _keyValue2 = `@${i}`;
@@ -74,11 +63,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.t(val, _component);
     out.ee();
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyValue3 = `@${key}`,
-          _keyScope5 = `[${_keyValue3}]`;
+      _keyScope5 = `[${_keyValue3}]`;
     out.be("div", null, _keyValue3, _component, null, 0);
     out.t(key, _component);
     out.t(": ", _component);
@@ -87,21 +75,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "10" + _keyScope5, _component, 0, 0);
     out.e("div", null, `@other-${key}`, _component, 0, 0);
   }
-
   for (let _steps3 = (10 - 0) / 2, _step3 = 0; _step3 <= _steps3; _step3++) {
     const i = 0 + _step3 * 2;
     const _keyValue4 = `@${i}`,
-          _keyScope6 = `[${_keyValue4}]`;
+      _keyScope6 = `[${_keyValue4}]`;
     out.be("div", null, _keyValue4, _component, null, 0);
     out.t(i, _component);
     out.ee();
     out.e("div", null, "11" + _keyScope6, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
-
     for (let _steps2 = (10 - 0) / 2, _step2 = 0; _step2 <= _steps2; _step2++) {
       const i = 0 + _step2 * 2;
       const _keyValue5 = `@${i}`,
-            _keyScope7 = `[${_keyValue5}]`;
+        _keyScope7 = `[${_keyValue5}]`;
       out.be("div", null, _keyValue5, _component, null, 0);
       out.t(i, _component);
       out.ee();
@@ -109,22 +95,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.e("div", null, `@other-${i}`, _component, 0, 0);
     }
   }
-
   for (let _steps4 = (0 - 10) / -2, _step4 = 0; _step4 <= _steps4; _step4++) {
     const i = 10 + _step4 * -2;
     const _keyValue6 = `@${i}`,
-          _keyScope8 = `[${_keyValue6}]`;
+      _keyScope8 = `[${_keyValue6}]`;
     out.be("div", null, _keyValue6, _component, null, 0);
     out.t(i, _component);
     out.ee();
     out.e("div", null, "13" + _keyScope8, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
   }
-
   for (let _steps5 = (10 - 0) / 1, _step5 = 0; _step5 <= _steps5; _step5++) {
     out.t("Hello", _component);
   }
-
   for (let _steps6 = (10 - 0) / 1, _step6 = 0; _step6 <= _steps6; _step6++) {
     out.t("Hello", _component);
   }

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
@@ -1,18 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "avg1eu47",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let _i = 0;
-
   for (const val of arr) {
     let i = _i++;
     const _keyScope = `[${i}]`;
@@ -24,7 +19,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "1" + _keyScope, _component, 0, 0);
     out.e("div", null, "2" + _keyScope, _component, 0, 0);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;
@@ -36,7 +30,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "4" + _keyScope2, _component, 0, 0);
     out.e("div", null, "5" + _keyScope2, _component, 0, 0);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope3 = `[${i}]`;
@@ -46,13 +39,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "7" + _keyScope3, _component, 0, 0);
     out.e("div", null, "8" + _keyScope3, _component, 0, 0);
   }
-
   let _i2 = 0;
-
   for (const val of arr) {
     let i = _i2++;
     const _keyValue = `@${i}`,
-          _keyScope4 = `[${_keyValue}]`;
+      _keyScope4 = `[${_keyValue}]`;
     out.be("div", null, _keyValue, _component, null, 0);
     out.t(i, _component);
     out.t(": ", _component);
@@ -61,10 +52,8 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "9" + _keyScope4, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
   }
-
   let _i3 = 0;
   const list = arr;
-
   for (const val of list) {
     let i = _i3++;
     const _keyValue2 = `@${i}`;
@@ -74,11 +63,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.t(val, _component);
     out.ee();
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyValue3 = `@${key}`,
-          _keyScope5 = `[${_keyValue3}]`;
+      _keyScope5 = `[${_keyValue3}]`;
     out.be("div", null, _keyValue3, _component, null, 0);
     out.t(key, _component);
     out.t(": ", _component);
@@ -87,21 +75,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "10" + _keyScope5, _component, 0, 0);
     out.e("div", null, `@other-${key}`, _component, 0, 0);
   }
-
   for (let _steps3 = (10 - 0) / 2, _step3 = 0; _step3 <= _steps3; _step3++) {
     const i = 0 + _step3 * 2;
     const _keyValue4 = `@${i}`,
-          _keyScope6 = `[${_keyValue4}]`;
+      _keyScope6 = `[${_keyValue4}]`;
     out.be("div", null, _keyValue4, _component, null, 0);
     out.t(i, _component);
     out.ee();
     out.e("div", null, "11" + _keyScope6, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
-
     for (let _steps2 = (10 - 0) / 2, _step2 = 0; _step2 <= _steps2; _step2++) {
       const i = 0 + _step2 * 2;
       const _keyValue5 = `@${i}`,
-            _keyScope7 = `[${_keyValue5}]`;
+        _keyScope7 = `[${_keyValue5}]`;
       out.be("div", null, _keyValue5, _component, null, 0);
       out.t(i, _component);
       out.ee();
@@ -109,22 +95,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.e("div", null, `@other-${i}`, _component, 0, 0);
     }
   }
-
   for (let _steps4 = (0 - 10) / -2, _step4 = 0; _step4 <= _steps4; _step4++) {
     const i = 10 + _step4 * -2;
     const _keyValue6 = `@${i}`,
-          _keyScope8 = `[${_keyValue6}]`;
+      _keyScope8 = `[${_keyValue6}]`;
     out.be("div", null, _keyValue6, _component, null, 0);
     out.t(i, _component);
     out.ee();
     out.e("div", null, "13" + _keyScope8, _component, 0, 0);
     out.e("div", null, `@other-${i}`, _component, 0, 0);
   }
-
   for (let _steps5 = (10 - 0) / 1, _step5 = 0; _step5 <= _steps5; _step5++) {
     out.t("Hello", _component);
   }
-
   for (let _steps6 = (10 - 0) / 1, _step6 = 0; _step6 <= _steps6; _step6++) {
     out.t("Hello", _component);
   }

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _toString = _interopRequireDefault(require("marko/src/runtime/helpers/to-string.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/hello-dynamic/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/hello-dynamic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_to_string from "marko/src/runtime/helpers/to-string.js";

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "kCnjd+Lm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_to_string from "marko/dist/runtime/helpers/to-string.js";

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/hello-dynamic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello ", _component);

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "kCnjd+Lm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello ", _component);

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-comment/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-comment/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "3DMKav/3",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-comment/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "3DMKav/3",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-entity/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-entity/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "PF20NQ88",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/html-entity/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "PF20NQ88",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 1, 0).t("<div>");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/if-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
@@ -19,13 +14,10 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   if (a + b) {
     out.w("Hello");
   }
-
   if (a, b) {
     out.w("World");
   }
-
   out.w("<div>");
-
   if (x) {
     out.w("A");
   } else if (y) {
@@ -33,7 +25,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   } else {
     out.w("C");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/if-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
@@ -10,13 +8,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   if (a + b) {
     out.w("Hello");
   }
-
   if (a, b) {
     out.w("World");
   }
-
   out.w("<div>");
-
   if (x) {
     out.w("A");
   } else if (y) {
@@ -24,7 +19,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.w("C");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "y0rlhGQ3",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
@@ -10,13 +8,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   if (a + b) {
     out.w("Hello");
   }
-
   if (a, b) {
     out.w("World");
   }
-
   out.w("<div>");
-
   if (x) {
     out.w("A");
   } else if (y) {
@@ -24,7 +19,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.w("C");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/vdom-expected.js
@@ -1,26 +1,19 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/if-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   if (a + b) {
     out.t("Hello", _component);
   }
-
   if (a, b) {
     out.t("World", _component);
   }
-
   out.be("div", null, "0", _component, null, 0);
-
   if (x) {
     out.t("A", _component);
   } else if (y) {
@@ -28,7 +21,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.t("C", _component);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/vdomProduction-expected.js
@@ -1,26 +1,19 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "y0rlhGQ3",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   if (a + b) {
     out.t("Hello", _component);
   }
-
   if (a, b) {
     out.t("World", _component);
   }
-
   out.be("div", null, "0", _component, null, 0);
-
   if (x) {
     out.t("A", _component);
   } else if (y) {
@@ -28,7 +21,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.t("C", _component);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/cjs-expected.js
@@ -2,24 +2,15 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _bar = _interopRequireWildcard(require("./bar"));
-
 require("./foo.css");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
-
 function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-hydrate-include/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-hydrate-include/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo.css";

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "9FdWS4tF",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo.css";

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-hydrate-include/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo.css";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "9FdWS4tF",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo.css";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _asset = require("./test1/asset");
-
 var _asset2 = require("./test2/asset");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag-conflict/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag-conflict/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "xrPYS1qL",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag-conflict/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdomProduction-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "xrPYS1qL",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";
 import { asset } from "./test2/asset";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/cjs-expected.js
@@ -2,26 +2,16 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _bar = _interopRequireWildcard(require("./bar"));
-
 require("./foo");
-
 var _baz = _interopRequireDefault(require("./components/baz.marko"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 function _getRequireWildcardCache(nodeInterop) { if (typeof WeakMap !== "function") return null; var cacheBabelInterop = new WeakMap(); var cacheNodeInterop = new WeakMap(); return (_getRequireWildcardCache = function (nodeInterop) { return nodeInterop ? cacheNodeInterop : cacheBabelInterop; })(nodeInterop); }
-
 function _interopRequireWildcard(obj, nodeInterop) { if (!nodeInterop && obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(nodeInterop); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (key !== "default" && Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo";

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "aVPzDB9L",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo";

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/vdom-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/import-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo";
 import baz from "./components/baz.marko";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/vdomProduction-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "aVPzDB9L",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";
 import "./foo";
 import baz from "./components/baz.marko";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/cjs-expected.js
@@ -2,26 +2,19 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macro-non-root/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   out.w("<div>");
-
   function _stuff(out, x) {
     out.w("<div></div>");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/html-expected.js
@@ -1,18 +1,14 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macro-non-root/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div>");
-
   function _stuff(out, x) {
     out.w("<div></div>");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/htmlProduction-expected.js
@@ -1,18 +1,14 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "R6eF4gGA",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<div>");
-
   function _stuff(out, x) {
     out.w("<div></div>");
   }
-
   out.w("</div>");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdom-expected.js
@@ -1,22 +1,16 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macro-non-root/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);
-
   function _stuff(out, x) {
     out.e("div", null, "2", _component, 0, 0);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdomProduction-expected.js
@@ -1,26 +1,18 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "R6eF4gGA",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "2", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);
-
   function _stuff(out, x) {
     out.n(_marko_node, _component);
   }
-
   out.ee();
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macros/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macros/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
@@ -24,12 +17,10 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("Name: ");
     out.w((0, _escapeXml.x)(node.name));
     out.w(" Children: ");
-
     if (node.children) {
       out.w("<ul>");
       {
         let _keyValue = 0;
-
         for (const child of node.children) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
@@ -40,7 +31,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       out.w("</ul>");
     }
   }
-
   (0, _dynamicTag.default)(out, _renderTree, () => input.node, null, null, null, _componentDef, "4");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macros/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macros/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
@@ -13,25 +11,20 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("Name: ");
     out.w(_marko_escapeXml(node.name));
     out.w(" Children: ");
-
     if (node.children) {
       out.w("<ul>");
       {
         let _keyValue = 0;
-
         for (const child of node.children) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
-
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);
-
           out.w("</li>");
         }
       }
       out.w("</ul>");
     }
   }
-
   _marko_dynamic_tag(out, _renderTree, () => input.node, null, null, null, _componentDef, "4");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "pLQ9rpQM",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
@@ -11,25 +9,20 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   function _renderTree(out, node) {
     out.w(`Name: ${_marko_escapeXml(node.name)} Children: `);
-
     if (node.children) {
       out.w("<ul>");
       {
         let _keyValue = 0;
-
         for (const child of node.children) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
-
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);
-
           out.w("</li>");
         }
       }
       out.w("</ul>");
     }
   }
-
   _marko_dynamic_tag(out, _renderTree, () => input.node, null, null, null, _componentDef, "4");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macros/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/vdom-expected.js
@@ -1,40 +1,31 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/macros/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   function _renderTree(out, node) {
     out.t("Name: ", _component);
     out.t(node.name, _component);
     out.t(" Children: ", _component);
-
     if (node.children) {
       out.be("ul", null, "1", _component, null, 0);
       {
         let _keyValue = 0;
-
         for (const child of node.children) {
           const _keyScope = `[${_keyValue++}]`;
           out.be("li", null, "2" + _keyScope, _component, null, 0);
-
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);
-
           out.ee();
         }
       }
       out.ee();
     }
   }
-
   _marko_dynamic_tag(out, _renderTree, () => input.node, null, null, null, _componentDef, "4");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
@@ -1,40 +1,31 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "pLQ9rpQM",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   function _renderTree(out, node) {
     out.t("Name: ", _component);
     out.t(node.name, _component);
     out.t(" Children: ", _component);
-
     if (node.children) {
       out.be("ul", null, "1", _component, null, 0);
       {
         let _keyValue = 0;
-
         for (const child of node.children) {
           const _keyScope = `[${_keyValue++}]`;
           out.be("li", null, "2" + _keyScope, _component, null, 0);
-
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);
-
           out.ee();
         }
       }
       out.ee();
     }
   }
-
   _marko_dynamic_tag(out, _renderTree, () => input.node, null, null, null, _componentDef, "4");
 }, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attrs = _interopRequireDefault(require("marko/src/runtime/html/helpers/attrs.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/native-tag-spread-attrs/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/native-tag-spread-attrs/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attrs from "marko/src/runtime/html/helpers/attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "+Vkh85NW",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attrs from "marko/dist/runtime/html/helpers/attrs.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/native-tag-spread-attrs/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "+Vkh85NW",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/cjs-expected.js
@@ -2,22 +2,14 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _preserveTag = _interopRequireDefault(require("marko/src/core-tags/components/preserve-tag"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-directives/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-directives/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -15,13 +13,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "1");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "0");
     }
   }, out, _componentDef, "p_0");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -33,25 +29,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "4");
             }
           }, out, _componentDef, "p_4");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "3");
     }
   }, out, _componentDef, "p_3");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "7");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_6");
     }
   }, out, _componentDef, "6");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -67,25 +59,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_10");
             }
           }, out, _componentDef, "10");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_9");
     }
   }, out, _componentDef, "9");
-
   _marko_tag(_preserve, {
     "renderBody": out => {
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "12");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "@a");
     }
   }, out, _componentDef, "p_@a");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -97,25 +85,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "@c");
             }
           }, out, _componentDef, "p_@c");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "@b");
     }
   }, out, _componentDef, "p_@b");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "15");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_@d");
     }
   }, out, _componentDef, "@d");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -131,13 +115,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_@f");
             }
           }, out, _componentDef, "@f");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_@e");
     }
   }, out, _componentDef, "@e");
-
   _marko_tag(_preserve, {
     "n": true,
     "renderBody": out => {

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "qUg9ApxN",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -15,13 +13,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "1");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "0");
     }
   }, out, _componentDef, "p_0");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -33,25 +29,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "4");
             }
           }, out, _componentDef, "p_4");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "3");
     }
   }, out, _componentDef, "p_3");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "7");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_6");
     }
   }, out, _componentDef, "6");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -67,25 +59,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_10");
             }
           }, out, _componentDef, "10");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_9");
     }
   }, out, _componentDef, "9");
-
   _marko_tag(_preserve, {
     "renderBody": out => {
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "12");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "@a");
     }
   }, out, _componentDef, "p_@a");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -97,25 +85,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "@c");
             }
           }, out, _componentDef, "p_@c");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "@b");
     }
   }, out, _componentDef, "p_@b");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "15");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_@d");
     }
   }, out, _componentDef, "@d");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -131,13 +115,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_@f");
             }
           }, out, _componentDef, "@f");
-
           out.w("<div></div>");
         }
       }, out, _componentDef, "p_@e");
     }
   }, out, _componentDef, "@e");
-
   _marko_tag(_preserve, {
     "n": true,
     "renderBody": out => {

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdom-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-directives/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _preserve from "marko/src/core-tags/components/preserve-tag";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_preserve, {
@@ -19,13 +15,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "1");
-
           out.e("div", null, "2", _component, 0, 0);
         }
       }, out, _componentDef, "0");
     }
   }, out, _componentDef, "p_0");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -37,25 +31,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "4");
             }
           }, out, _componentDef, "p_4");
-
           out.e("div", null, "5", _component, 0, 0);
         }
       }, out, _componentDef, "3");
     }
   }, out, _componentDef, "p_3");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "7");
-
           out.e("div", null, "8", _component, 0, 0);
         }
       }, out, _componentDef, "p_6");
     }
   }, out, _componentDef, "6");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -71,25 +61,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_10");
             }
           }, out, _componentDef, "10");
-
           out.e("div", null, "11", _component, 0, 0);
         }
       }, out, _componentDef, "p_9");
     }
   }, out, _componentDef, "9");
-
   _marko_tag(_preserve, {
     "renderBody": out => {
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "12");
-
           out.e("div", null, "13", _component, 0, 0);
         }
       }, out, _componentDef, "@a");
     }
   }, out, _componentDef, "p_@a");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -101,25 +87,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "@c");
             }
           }, out, _componentDef, "p_@c");
-
           out.e("div", null, "14", _component, 0, 0);
         }
       }, out, _componentDef, "@b");
     }
   }, out, _componentDef, "p_@b");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "15");
-
           out.e("div", null, "16", _component, 0, 0);
         }
       }, out, _componentDef, "p_@d");
     }
   }, out, _componentDef, "@d");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -135,13 +117,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_@f");
             }
           }, out, _componentDef, "@f");
-
           out.e("div", null, "17", _component, 0, 0);
         }
       }, out, _componentDef, "p_@e");
     }
   }, out, _componentDef, "@e");
-
   _marko_tag(_preserve, {
     "n": true,
     "renderBody": out => {

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdomProduction-expected.js
@@ -1,36 +1,22 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "qUg9ApxN",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "2", null, 0, 0);
-
 import _preserve from "marko/dist/core-tags/components/preserve-tag";
-
 const _marko_node2 = _marko_createElement("div", null, "5", null, 0, 0);
-
 const _marko_node3 = _marko_createElement("div", null, "8", null, 0, 0);
-
 const _marko_node4 = _marko_createElement("div", null, "11", null, 0, 0);
-
 const _marko_node5 = _marko_createElement("div", null, "13", null, 0, 0);
-
 const _marko_node6 = _marko_createElement("div", null, "14", null, 0, 0);
-
 const _marko_node7 = _marko_createElement("div", null, "16", null, 0, 0);
-
 const _marko_node8 = _marko_createElement("div", null, "17", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   _marko_tag(_preserve, {
@@ -38,13 +24,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "1");
-
           out.n(_marko_node, _component);
         }
       }, out, _componentDef, "0");
     }
   }, out, _componentDef, "p_0");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -56,25 +40,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "4");
             }
           }, out, _componentDef, "p_4");
-
           out.n(_marko_node2, _component);
         }
       }, out, _componentDef, "3");
     }
   }, out, _componentDef, "p_3");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "7");
-
           out.n(_marko_node3, _component);
         }
       }, out, _componentDef, "p_6");
     }
   }, out, _componentDef, "6");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -90,25 +70,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_10");
             }
           }, out, _componentDef, "10");
-
           out.n(_marko_node4, _component);
         }
       }, out, _componentDef, "p_9");
     }
   }, out, _componentDef, "9");
-
   _marko_tag(_preserve, {
     "renderBody": out => {
       _marko_tag(_hello, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "12");
-
           out.n(_marko_node5, _component);
         }
       }, out, _componentDef, "@a");
     }
   }, out, _componentDef, "p_@a");
-
   _marko_tag(_preserve, {
     "i": x,
     "renderBody": out => {
@@ -120,25 +96,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               _marko_tag(_hello, {}, out, _componentDef, "@c");
             }
           }, out, _componentDef, "p_@c");
-
           out.n(_marko_node6, _component);
         }
       }, out, _componentDef, "@b");
     }
   }, out, _componentDef, "p_@b");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
         "renderBody": out => {
           _marko_tag(_hello, {}, out, _componentDef, "15");
-
           out.n(_marko_node7, _component);
         }
       }, out, _componentDef, "p_@d");
     }
   }, out, _componentDef, "@d");
-
   _marko_tag(_hello, {
     "renderBody": out => {
       _marko_tag(_preserve, {
@@ -154,13 +126,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
               }, out, _componentDef, "p_@f");
             }
           }, out, _componentDef, "@f");
-
           out.n(_marko_node8, _component);
         }
       }, out, _componentDef, "p_@e");
     }
   }, out, _componentDef, "@e");
-
   _marko_tag(_preserve, {
     "n": true,
     "renderBody": out => {

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier-multiple/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier-multiple/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "r46whWwu",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier-multiple/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/src/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "r46whWwu",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/dist/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "az9GXCCR",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/no-update-modifier/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/src/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("input", {

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "az9GXCCR",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/dist/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("input", {

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _toString = _interopRequireDefault(require("marko/src/runtime/helpers/to-string.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/placeholders/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/placeholders/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_to_string from "marko/src/runtime/helpers/to-string.js";

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "jxXJawbJ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_to_string from "marko/dist/runtime/helpers/to-string.js";

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/placeholders/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/vdomProduction-expected.js
@@ -1,20 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "jxXJawbJ",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("script", null, "1", null, 3, 0).t("\n    ").t("Hello <b> </script>").t("\n  ");
-
 const _marko_node2 = _marko_createElement("style", null, "2", null, 3, 0).t("\n    ").t("Hello <b> </style>").t("\n  ");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/prevent-override-component-def/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/prevent-override-component-def/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "AWlOZ9B/",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/prevent-override-component-def/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component2, state) {
   const _component = "test";

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "AWlOZ9B/",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component2, state) {
   const _component = "test";

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-migration/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "iJY8a2Ko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-migration/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "iJY8a2Ko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-transform/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-transform/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "dqltXdhn",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/root-transform/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "dqltXdhn",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/cjs-expected.js
@@ -2,50 +2,32 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _b = _interopRequireDefault(require("b"));
-
 var _escapeStylePlaceholder = _interopRequireDefault(require("marko/src/runtime/html/helpers/escape-style-placeholder.js"));
-
 var _escapeScriptPlaceholder = _interopRequireDefault(require("marko/src/runtime/html/helpers/escape-script-placeholder.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _classValue = _interopRequireDefault(require("marko/src/runtime/helpers/class-value.js"));
-
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
-
 var _index2 = _interopRequireDefault(require("./components/other/index.marko"));
-
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _attrs = _interopRequireDefault(require("marko/src/runtime/html/helpers/attrs.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/sanity-check/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 doThings();
 andStuff();
-
 function more() {
   abc();
 }
-
 const _marko_component = {
   onCreate() {
     this.stuff();
   }
-
 };
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   out.w("<style id=css>");
@@ -58,11 +40,9 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w((0, _escapeScriptPlaceholder.default)(x));
   out.w(";\n");
   out.w("</script>");
-
   function _thing(out, stuff) {
     out.w(`<div${(0, _attr.default)("x", stuff.x)}></div>`);
   }
-
   var b = thing;
   let c = thing;
   out.w(`<div${(0, _attr.default)("b", b)}${(0, _attr.default)("c", c)}>`);
@@ -129,7 +109,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w("-->");
   out.w("<div c=1></div>");
   out.w("<div d=1></div>");
-
   if (x === _b.default) {
     out.w("a ");
     out.w((0, _escapeXml.x)(b));
@@ -138,25 +117,21 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   } else {
     out.w("c");
   }
-
   out.w("</div>");
   out.w("<div b=1></div>");
   out.w("<div>");
   out.w("123 abc 123");
   out.w("</div>");
   out.w(`<span${(0, _attrs.default)(abc)}></span>`);
-
   if (cond) {
     out.w("Hello ");
     out.w((0, _escapeXml.x)(planet));
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope = `[${i}]`;
     out.w("<div c=1></div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/generated-expected.marko
@@ -10,27 +10,22 @@ style {
   div {
     color: ${x};
   }
-
 </style>
 <script>
 
   var y = ${x};
-
 </script>
 static {
   doThings();
   andStuff();
-
   function more() {
     abc();
   }
-
 }
 class {
   onCreate() {
     this.stuff();
   }
-
 }
 <macro|stuff| name="thing">
   <div x=stuff.x/>

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/html-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/sanity-check/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";
 doThings();
 andStuff();
-
 function more() {
   abc();
 }
-
 import _marko_escapeStyle from "marko/src/runtime/html/helpers/escape-style-placeholder.js";
 import _marko_escapeScript from "marko/src/runtime/html/helpers/escape-script-placeholder.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
@@ -26,7 +22,6 @@ const _marko_component = {
   onCreate() {
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w("<style id=css>");
@@ -39,11 +34,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w(_marko_escapeScript(x));
   out.w(";\n");
   out.w("</script>");
-
   function _thing(out, stuff) {
     out.w(`<div${_marko_attr("x", stuff.x)}></div>`);
   }
-
   var b = thing;
   let c = thing;
   out.w(`<div${_marko_attr("b", b)}${_marko_attr("c", c)}>`);
@@ -60,21 +53,17 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     d
   }]))} style=a:b;></div>`);
   out.w("<input type=text>");
-
   _marko_dynamic_tag(out, a, null, out => {
     out.w("<div></div>");
   }, null, null, _componentDef, "@x");
-
   _marko_dynamic_tag(out, _thing, () => ({
     "x": 1
   }), null, null, null, _componentDef, "11");
-
   _marko_tag(_other, {
     "renderBody": (out, a) => {
       out.w("<div></div>");
     }
   }, out, _componentDef, "12", [["click", "handleClick", false, [a, b, ...d]]]);
-
   _marko_tag(_other, {
     "x": 1,
     ...thing,
@@ -98,7 +87,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w("<div></div>");
     }
   }, out, _componentDef, "14");
-
   out.w(`<div${_marko_attrs({
     "class": "b c",
     "a": {
@@ -115,7 +103,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w("-->");
   out.w("<div c=1></div>");
   out.w("<div d=1></div>");
-
   if (x === a) {
     out.w("a ");
     out.w(_marko_escapeXml(b));
@@ -124,25 +111,21 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.w("c");
   }
-
   out.w("</div>");
   out.w("<div b=1></div>");
   out.w("<div>");
   out.w("123 abc 123");
   out.w("</div>");
   out.w(`<span${_marko_attrs(abc)}></span>`);
-
   if (cond) {
     out.w("Hello ");
     out.w(_marko_escapeXml(planet));
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope = `[${i}]`;
     out.w("<div c=1></div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/htmlProduction-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "OLFRWJ/R",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";
 doThings();
 andStuff();
-
 function more() {
   abc();
 }
-
 import _marko_escapeStyle from "marko/dist/runtime/html/helpers/escape-style-placeholder.js";
 import _marko_escapeScript from "marko/dist/runtime/html/helpers/escape-script-placeholder.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
@@ -26,15 +22,12 @@ const _marko_component = {
   onCreate() {
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w(`<style id=css>\n  div {\n    color: ${_marko_escapeStyle(x)};\n  }\n</style><script>\n  var y = ${_marko_escapeScript(x)};\n</script>`);
-
   function _thing(out, stuff) {
     out.w(`<div${_marko_attr("x", stuff.x)}></div>`);
   }
-
   var b = thing;
   let c = thing;
   out.w(`<div${_marko_attr("b", b)}${_marko_attr("c", c)}>`);
@@ -47,21 +40,17 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     b: c,
     d
   }]))} style=a:b;></div><input type=text>`);
-
   _marko_dynamic_tag(out, a, null, out => {
     out.w("<div></div>");
   }, null, null, _componentDef, "@x");
-
   _marko_dynamic_tag(out, _thing, () => ({
     "x": 1
   }), null, null, null, _componentDef, "11");
-
   _marko_tag(_other, {
     "renderBody": (out, a) => {
       out.w("<div></div>");
     }
   }, out, _componentDef, "12", [["click", "handleClick", false, [a, b, ...d]]]);
-
   _marko_tag(_other, {
     "x": 1,
     ...thing,
@@ -85,7 +74,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w("<div></div>");
     }
   }, out, _componentDef, "14");
-
   out.w(`<div${_marko_attrs({
     "class": "b c",
     "a": {
@@ -96,7 +84,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     ...f(),
     "id": "a"
   })}>${_marko_escapeXml(a)}<!--abc--><div c=1></div><div d=1></div>`);
-
   if (x === a) {
     out.w(`a ${_marko_escapeXml(b)}`);
   } else if (x === 2) {
@@ -104,19 +91,15 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.w("c");
   }
-
   out.w(`</div><div b=1></div><div>123 abc 123</div><span${_marko_attrs(abc)}></span>`);
-
   if (cond) {
     out.w(`Hello ${_marko_escapeXml(planet)}`);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope = `[${i}]`;
     out.w("<div c=1></div>");
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/sanity-check/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";
 doThings();
 andStuff();
-
 function more() {
   abc();
 }
-
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
 import _other from "./components/other/index.marko";
@@ -19,14 +15,11 @@ import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_attrs from "marko/src/runtime/vdom/helpers/attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("style", {
@@ -41,13 +34,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t(x, _component);
   out.t(";\n", _component);
   out.ee();
-
   function _thing(out, stuff) {
     out.e("div", {
       "x": stuff.x
     }, "3", _component, 0, 0);
   }
-
   var b = thing;
   let c = thing;
   out.be("div", {
@@ -79,21 +70,17 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("input", {
     "type": "text"
   }, "9", _component, 0, 0);
-
   _marko_dynamic_tag(out, a, null, out => {
     out.e("div", null, "10", _component, 0, 0);
   }, null, null, _componentDef, "@x");
-
   _marko_dynamic_tag(out, _thing, () => ({
     "x": 1
   }), null, null, null, _componentDef, "11");
-
   _marko_tag(_other, {
     "renderBody": (out, a) => {
       out.e("div", null, "13", _component, 0, 0);
     }
   }, out, _componentDef, "12", [["click", "handleClick", false, [a, b, ...d]]]);
-
   _marko_tag(_other, {
     "x": 1,
     ...thing,
@@ -117,7 +104,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.e("div", null, "15", _component, 0, 0);
     }
   }, out, _componentDef, "14");
-
   out.be("div", _marko_attrs({
     "class": "b c",
     "a": "[object Object]",
@@ -133,7 +119,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.e("div", {
     "d": "1"
   }, "20", _component, 0, 0);
-
   if (x === a) {
     out.t("a ", _component);
     out.t(b, _component);
@@ -142,7 +127,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.t("c", _component);
   }
-
   out.ee();
   out.e("div", {
     "b": "1"
@@ -151,12 +135,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t("123 abc 123", _component);
   out.ee();
   out.e("span", _marko_attrs(abc), "23", _component, 0, 4);
-
   if (cond) {
     out.t("Hello ", _component);
     out.t(planet, _component);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope = `[${i}]`;
@@ -164,7 +146,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       "c": "1"
     }, "24" + _keyScope, _component, 0, 0);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
@@ -1,65 +1,44 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "OLFRWJ/R",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";
 doThings();
 andStuff();
-
 function more() {
   abc();
 }
-
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("input", {
   "type": "text"
 }, "9", null, 0, 0);
-
 const _marko_node2 = _marko_createElement("div", null, "10", null, 0, 0);
-
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
-
 const _marko_node3 = _marko_createElement("div", null, "13", null, 0, 0);
-
 import _other from "./components/other/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
-
 const _marko_node4 = _marko_createElement("div", null, "15", null, 0, 0);
-
 const _marko_node5 = _marko_createElement("div", null, "16", null, 0, 0);
-
 const _marko_node6 = _marko_createElement("div", null, "17", null, 0, 0);
-
 const _marko_node7 = _marko_createElement("div", {
   "c": "1"
 }, "19", null, 0, 0);
-
 const _marko_node8 = _marko_createElement("div", {
   "d": "1"
 }, "20", null, 0, 0);
-
 import _marko_attrs from "marko/dist/runtime/vdom/helpers/attrs.js";
-
 const _marko_node9 = _marko_createElement("div", {
   "b": "1"
 }, "21", null, 0, 0);
-
 const _marko_node10 = _marko_createElement("div", null, "22", null, 1, 0).t("123 abc 123");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {
   onCreate() {
     this.stuff();
   }
-
 };
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("style", {
@@ -74,13 +53,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t(x, _component);
   out.t(";\n", _component);
   out.ee();
-
   function _thing(out, stuff) {
     out.e("div", {
       "x": stuff.x
     }, "3", _component, 0, 0);
   }
-
   var b = thing;
   let c = thing;
   out.be("div", {
@@ -110,21 +87,17 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     "style": "a:b;"
   }, "8", _component, 0, 1);
   out.n(_marko_node, _component);
-
   _marko_dynamic_tag(out, a, null, out => {
     out.n(_marko_node2, _component);
   }, null, null, _componentDef, "@x");
-
   _marko_dynamic_tag(out, _thing, () => ({
     "x": 1
   }), null, null, null, _componentDef, "11");
-
   _marko_tag(_other, {
     "renderBody": (out, a) => {
       out.n(_marko_node3, _component);
     }
   }, out, _componentDef, "12", [["click", "handleClick", false, [a, b, ...d]]]);
-
   _marko_tag(_other, {
     "x": 1,
     ...thing,
@@ -148,7 +121,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.n(_marko_node4, _component);
     }
   }, out, _componentDef, "14");
-
   out.be("div", _marko_attrs({
     "class": "b c",
     "a": "[object Object]",
@@ -160,7 +132,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t(a, _component);
   out.n(_marko_node7, _component);
   out.n(_marko_node8, _component);
-
   if (x === a) {
     out.t("a ", _component);
     out.t(b, _component);
@@ -169,17 +140,14 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   } else {
     out.t("c", _component);
   }
-
   out.ee();
   out.n(_marko_node9, _component);
   out.n(_marko_node10, _component);
   out.e("span", _marko_attrs(abc), "23", _component, 0, 4);
-
   if (cond) {
     out.t("Hello ", _component);
     out.t(planet, _component);
   }
-
   for (let _steps = (10 - 0) / 2, _step = 0; _step <= _steps; _step++) {
     const i = 0 + _step * 2;
     const _keyScope = `[${i}]`;
@@ -187,7 +155,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       "c": "1"
     }, "24" + _keyScope, _component, 0, 0);
   }
-
   for (const key in obj) {
     const val = obj[key];
     const _keyScope2 = `[${key}]`;

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/cjs-expected.js
@@ -2,26 +2,18 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/scriptlet-line-block/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   var foo = 123;
-
   function bar() {}
-
   var baz = 456;
   out.w("<div>");
   console.log('foo');

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/generated-expected.marko
@@ -1,7 +1,6 @@
 $ var foo = 123;
 $ {
   function bar() {}
-
   var baz = 456;
 }
 <div>

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/html-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/scriptlet-line-block/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var foo = 123;
-
   function bar() {}
-
   var baz = 456;
   out.w("<div>");
   console.log('foo');

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/htmlProduction-expected.js
@@ -1,17 +1,13 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "g3aimRge",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var foo = 123;
-
   function bar() {}
-
   var baz = 456;
   out.w("<div>");
   console.log('foo');

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdom-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/scriptlet-line-block/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var foo = 123;
-
   function bar() {}
-
   var baz = 456;
   out.be("div", null, "0", _component, null, 0);
   console.log('foo');

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdomProduction-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "g3aimRge",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var foo = 123;
-
   function bar() {}
-
   var baz = 456;
   out.be("div", null, "0", _component, null, 0);
   console.log('foo');

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _classValue = _interopRequireDefault(require("marko/src/runtime/helpers/class-value.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-classname/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-classname/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "WqUsRyBC",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-classname/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "WqUsRyBC",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-id/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-id/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "wUxkdMJU",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/shorthand-id/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdomProduction-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "wUxkdMJU",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", {
   "id": "shorthand"
 }, "0", null, 0, 1);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple-attrs-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple-attrs-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "YUZPhHIa",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple-attrs-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/src/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "YUZPhHIa",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import "marko/dist/runtime/vdom/preserve-attrs.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/simple/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
@@ -21,12 +15,10 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w("Hello ");
   out.w((0, _escapeXml.x)(input.name));
   out.w("! ");
-
   if (input.colors.length) {
     out.w("<ul>");
     {
       let _keyValue = 0;
-
       for (const color of input.colors) {
         const _keyScope = `[${_keyValue++}]`;
         out.w("<li>");

--- a/packages/translator-default/test/fixtures/simple/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
@@ -11,12 +9,10 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w("Hello ");
   out.w(_marko_escapeXml(input.name));
   out.w("! ");
-
   if (input.colors.length) {
     out.w("<ul>");
     {
       let _keyValue = 0;
-
       for (const color of input.colors) {
         const _keyScope = `[${_keyValue++}]`;
         out.w("<li>");

--- a/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
@@ -1,20 +1,16 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "NRekT+g6",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.w(`Hello ${_marko_escapeXml(input.name)}! `);
-
   if (input.colors.length) {
     out.w("<ul>");
     {
       let _keyValue = 0;
-
       for (const color of input.colors) {
         const _keyScope = `[${_keyValue++}]`;
         out.w(`<li>${_marko_escapeXml(color)}</li>`);

--- a/packages/translator-default/test/fixtures/simple/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/vdom-expected.js
@@ -1,25 +1,19 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/simple/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello ", _component);
   out.t(input.name, _component);
   out.t("! ", _component);
-
   if (input.colors.length) {
     out.be("ul", null, "0", _component, null, 0);
     {
       let _keyValue = 0;
-
       for (const color of input.colors) {
         const _keyScope = `[${_keyValue++}]`;
         out.be("li", null, "1" + _keyScope, _component, null, 0);

--- a/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
@@ -1,29 +1,21 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "NRekT+g6",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "2", null, 1, 0).t("No colors!");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello ", _component);
   out.t(input.name, _component);
   out.t("! ", _component);
-
   if (input.colors.length) {
     out.be("ul", null, "0", _component, null, 0);
     {
       let _keyValue = 0;
-
       for (const color of input.colors) {
         const _keyScope = `[${_keyValue++}]`;
         out.be("li", null, "1" + _keyScope, _component, null, 0);

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _templateComponent = _interopRequireDefault(require("./template.component.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component-with-component/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component2 = _templateComponent.default;

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component-with-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "Wgq3cfjm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdom-expected.js
@@ -1,16 +1,12 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component-with-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
 import _marko_split_component from "./template.component-browser.js";
-
 _marko_registerComponent(_marko_componentType, () => _marko_split_component);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdomProduction-expected.js
@@ -1,20 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "Wgq3cfjm",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_component from "./template.component.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
 import _marko_split_component from "./template.component-browser.js";
-
 _marko_registerComponent(_marko_componentType, () => _marko_split_component);
-
 const _marko_component2 = _marko_component;
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/split-component/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/split-component/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/split-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "tgVjO8nX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/split-component/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/split-component/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
 import _marko_split_component from "./template.component-browser.js";
-
 _marko_registerComponent(_marko_componentType, () => _marko_split_component);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", null, "0", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/split-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/vdomProduction-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "tgVjO8nX",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
 import _marko_split_component from "./template.component-browser.js";
-
 _marko_registerComponent(_marko_componentType, () => _marko_split_component);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/cjs-expected.js
@@ -2,22 +2,15 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/static-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 var foo = 123;
-
 function bar() {}
-
 var baz = 456;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {}, {

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/generated-expected.marko
@@ -1,6 +1,5 @@
 static var foo = 123;
 static {
   function bar() {}
-
   var baz = 456;
 }

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/html-expected.js
@@ -1,13 +1,9 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/static-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;
-
 function bar() {}
-
 var baz = 456;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/htmlProduction-expected.js
@@ -1,13 +1,9 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "zKxreLgp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;
-
 function bar() {}
-
 var baz = 456;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/vdom-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/static-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;
-
 function bar() {}
-
 var baz = 456;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/vdomProduction-expected.js
@@ -1,19 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "zKxreLgp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;
-
 function bar() {}
-
 var baz = 456;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {}, {
   t: _marko_componentType,

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-empty/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-empty/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "iTWeM9Hv",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-empty/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "iTWeM9Hv",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-with-styles/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-with-styles/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "ZsW3uNOB",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/style-block-with-styles/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "ZsW3uNOB",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/svg-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/svg-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "LOy6P2CY",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/svg-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("svg", {

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/vdomProduction-expected.js
@@ -1,11 +1,8 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "LOy6P2CY",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("circle", {
   "cx": "50",
   "cy": "50",
@@ -14,27 +11,18 @@ const _marko_node = _marko_createElement("circle", {
   "stroke-width": "3",
   "fill": "red"
 }, "1", null, 0, 0);
-
 const _marko_node2 = _marko_createElement("a", null, "2", null, 0, 0);
-
 const _marko_node3 = _marko_createElement("style", null, "3", null, 1, 0).t("div { color: green }");
-
 const _marko_node4 = _marko_createElement("script", null, "4", null, 1, 0).t("alert(\"Hello\");");
-
 const _marko_node5 = _marko_createElement("title", null, "5", null, 1, 0).t("Test");
-
 const _marko_node6 = _marko_createElement("text", {
   "x": "10",
   "y": "25"
 }, "7", null, 1, 0).t("MDN Web Docs");
-
 const _marko_node7 = _marko_createElement("a", null, "8", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("svg", {

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-block-scoping/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-block-scoping/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "s8GmyX5C",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-block-scoping/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var b = thing;

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "s8GmyX5C",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   var b = thing;

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-with-default-attr/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-with-default-attr/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "d4MwwGDt",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/tag-with-default-attr/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.e("div", {

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
@@ -1,22 +1,15 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "d4MwwGDt",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", {
   "value": ""
 }, "0", null, 0, 0);
-
 const _marko_node2 = _marko_createElement("div", null, "1", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/textarea-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/generated-expected.marko
@@ -1,5 +1,4 @@
 <textarea>
 
   hello world
-
 </textarea>

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/textarea-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "or1T1BHP",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/textarea-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("textarea", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdomProduction-expected.js
@@ -1,18 +1,12 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "or1T1BHP",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("textarea", null, "0", null, 1, 0).t("\n  hello world\n");
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/cjs-expected.js
@@ -2,16 +2,11 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/top-level-text/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/top-level-text/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "L6x2qKS4",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/top-level-text/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello John", _component);

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/vdomProduction-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "L6x2qKS4",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.t("Hello John", _component);

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/cjs-expected.js
@@ -2,20 +2,13 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _classValue = _interopRequireDefault(require("marko/src/runtime/helpers/class-value.js"));
-
 var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/typescript-basic/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/typescript-basic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_attr from "marko/src/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "vnqwugCu",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdom-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/typescript-basic/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/src/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const x = "hello!";

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
@@ -1,15 +1,11 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "vnqwugCu",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   const x = "hello!";

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/cjs-expected.js
@@ -2,23 +2,17 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/while-tag/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state) {
   let i = 0;
   let _keyValue = 0;
-
   while (i < 10) {
     const _keyScope = `[${_keyValue++}]`;
     i++;

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/html-expected.js
@@ -1,15 +1,12 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/while-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let i = 0;
   let _keyValue = 0;
-
   while (i < 10) {
     const _keyScope = `[${_keyValue++}]`;
     i++;

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/htmlProduction-expected.js
@@ -1,15 +1,12 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "R2kcOR51",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let i = 0;
   let _keyValue = 0;
-
   while (i < 10) {
     const _keyScope = `[${_keyValue++}]`;
     i++;

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/vdom-expected.js
@@ -1,19 +1,14 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/while-tag/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let i = 0;
   let _keyValue = 0;
-
   while (i < 10) {
     const _keyScope = `[${_keyValue++}]`;
     i++;

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/vdomProduction-expected.js
@@ -1,19 +1,14 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "R2kcOR51",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   let i = 0;
   let _keyValue = 0;
-
   while (i < 10) {
     const _keyScope = `[${_keyValue++}]`;
     i++;

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/cjs-expected.js
@@ -2,18 +2,12 @@
 
 exports.__esModule = true;
 exports.default = void 0;
-
 var _index = require("marko/src/runtime/html/index.js");
-
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
-
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
-
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
-
 const _marko_componentType = "packages/translator-default/test/fixtures/white-space-test/template.marko",
-      _marko_template = (0, _index.t)(_marko_componentType);
-
+  _marko_template = (0, _index.t)(_marko_componentType);
 var _default = _marko_template;
 exports.default = _default;
 const _marko_component = {};

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/html-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/src/runtime/html/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/white-space-test/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/htmlProduction-expected.js
@@ -1,8 +1,6 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-
 const _marko_componentType = "TRrwGTtp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/vdom-expected.js
@@ -1,14 +1,10 @@
 import { t as _t } from "marko/src/runtime/vdom/index.js";
-
 const _marko_componentType = "packages/translator-default/test/fixtures/white-space-test/template.marko",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.be("div", null, "0", _component, null, 0);

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
@@ -1,20 +1,13 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-
 const _marko_componentType = "TRrwGTtp",
-      _marko_template = _t(_marko_componentType);
-
+  _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_createElement from "marko/dist/runtime/vdom/helpers/v-element.js";
-
 const _marko_node = _marko_createElement("div", null, "0", null, 4, 0).e("div", null, "1", null, 3, 0).t("Hello ").e("div", null, "2", null, 1, 0).t(" ").t(" World").e("div", null, "3", null, 1, 0).t(" Hello").e("pre", null, "4", null, 1, 0).t("\n    This should  \n      be preserved\n  ").e("div", null, "5", null, 1, 0).e("div", null, "6", null, 1, 0).t("Hello ");
-
 const _marko_node2 = _marko_createElement("div", null, "8", null, 0, 0);
-
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
-
 _marko_registerComponent(_marko_componentType, () => _marko_template);
-
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state) {
   out.n(_marko_node, _component);


### PR DESCRIPTION
## Description

* Upgrades lock file (this causes a bunch of snapshots to change slightly because of babel whitespace changes in output).
* Upgrades `magic-string` used by translator-default for css source maps. This removes a deprecation warning when installing the default translator.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
