### PR TITLE
fix: ensure delimiter added when scripts merged across async writers

### DIFF
--- a/.changeset/purple-cameras-sit.md
+++ b/.changeset/purple-cameras-sit.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/compiler": patch
+"@marko/translator-default": patch
+---
+
+Fix an issue where merging scripts (via the out.script api) was not properly inserting delimeters when scripts are added in different async writers.

--- a/packages/marko/src/runtime/html/StringWriter.js
+++ b/packages/marko/src/runtime/html/StringWriter.js
@@ -27,7 +27,13 @@ StringWriter.prototype = {
 
   merge: function (otherWriter) {
     this._content += otherWriter._content;
-    this._scripts += otherWriter._scripts;
+
+    if (otherWriter._scripts) {
+      this._scripts = this._scripts
+        ? this._scripts + ";" + otherWriter._scripts
+        : otherWriter._scripts;
+    }
+
     if (otherWriter._data) {
       if (this._data) {
         for (const key in otherWriter._data) {

--- a/packages/marko/test/components-server/fixtures/scriptConcat/template.marko
+++ b/packages/marko/test/components-server/fixtures/scriptConcat/template.marko
@@ -1,0 +1,17 @@
+import { setImmediate } from "timers";
+static function tick() {
+	return new Promise(resolve => setImmediate(() => setImmediate(resolve)));
+}
+
+<!-- Should merge scripts in the same writer.-->
+$ out.script("console.log('hello')");
+$ out.script("console.log('world')");
+
+<!-- Should merge scripts in different writers.-->
+<await(tick())>
+	<@then>
+		$ out.script("console.log('again')");
+	</>
+</await>
+
+$ out.script("console.log('and again')");

--- a/packages/marko/test/components-server/fixtures/scriptConcat/test.js
+++ b/packages/marko/test/components-server/fixtures/scriptConcat/test.js
@@ -1,0 +1,12 @@
+var expect = require("chai").expect;
+
+module.exports = function (helpers, done) {
+  var template = require("./template.marko").default;
+
+  template.render({}, function (err, html) {
+    expect(html.toString()).to.include(
+      "console.log('hello');console.log('world');console.log('again');console.log('and again')"
+    );
+    done();
+  });
+};


### PR DESCRIPTION
## Description
Fix an issue where merging scripts (via the out.script api) was not properly inserting delimiters when scripts are added in different async writers.

Specifically these scripts should be joined by `;`.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
