### PR TITLE
Mention TLS record sizes & MIME sniffing

### DIFF
--- a/packages/marko/docs/troubleshooting-streaming.md
+++ b/packages/marko/docs/troubleshooting-streaming.md
@@ -10,9 +10,15 @@
 
 - Some software doesn’t support HTTP/2 or higher “upstream” connections at all or very well — if your Node server uses HTTP/2, you may need to downgrade.
 
-- Automatic gzip/brotli compression may have their buffer sizes set too high; you can tune their buffers to be smaller for faster streaming in exchange for slightly worse compression.
-
 - Check if “upstream” connections are `keep-alive`: overhead from closing and reopening connections may delay responses.
+
+- For typical modern webpage filesizes, the following bullet points probably won’t matter. But if you want to stream **small chunks of data with the lowest latency**, investigate these sources of buffering:
+
+  - Automatic gzip/brotli compression may have their buffer sizes set too high; you can tune their buffers to be smaller for faster streaming in exchange for slightly worse compression.
+
+  - You can [tune HTTPS record sizes for lower latency, as described in High Performance Browser Networking](https://hpbn.co/transport-layer-security-tls/#optimize-tls-record-size).
+
+  - Turning off MIME sniffing with [the `X-Content-Type-Options`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options) header eliminates browser buffering at the very beginning of HTTP responses
 
 ### NGiNX
 


### PR DESCRIPTION
## Description

Smaller record sizes can have massive TTFB improvements for clients, and `X-CTO: nosniff` is something sites should really be doing anyway for security reasons.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- ~~[n/a] I have added tests to cover my changes.~~
