### PR TITLE
fix: issue with Marko.Component registered too late

### DIFF
--- a/.changeset/eleven-lobsters-pretend.md
+++ b/.changeset/eleven-lobsters-pretend.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix issue where Marko.Component global was potentially not registered before the component file was loaded.

--- a/packages/marko/src/runtime/components/entry/index-browser.js
+++ b/packages/marko/src/runtime/components/entry/index-browser.js
@@ -11,7 +11,3 @@ exports.register = function (id, component) {
     return component;
   });
 };
-
-window.Marko = {
-  Component: function () {}
-};

--- a/packages/marko/src/runtime/components/entry/index.js
+++ b/packages/marko/src/runtime/components/entry/index.js
@@ -271,7 +271,3 @@ exports.writeInitComponentsCode = writeInitComponentsCode;
 exports.getRenderedComponents = function (out) {
   return warp10.stringifyPrepare(getInitComponentsDataFromOut(out));
 };
-
-globalThis.Marko = {
-  Component: function () {}
-};

--- a/packages/marko/src/runtime/html/index.js
+++ b/packages/marko/src/runtime/html/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+globalThis.Marko = {
+  Component: function () {}
+};
+
 /**
  * Method is for internal usage only. This method
  * is invoked by code in a compiled Marko template and

--- a/packages/marko/src/runtime/vdom/index.js
+++ b/packages/marko/src/runtime/vdom/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+window.Marko = {
+  Component: function () {}
+};
+
 /**
  * Method is for internal usage only. This method
  * is invoked by code in a compiled Marko template and


### PR DESCRIPTION
## Description
Depending on execution order it was possible that the `Marko.Component` global (used for typescript classes) was not defined before a `component.*` file was loaded.

This PR ensures that the global is set right away.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
