### PR TITLE
fix: allow empty class member

### DIFF
--- a/.changeset/clever-kids-smile.md
+++ b/.changeset/clever-kids-smile.md
@@ -1,0 +1,5 @@
+---
+"@marko/translator-default": patch
+---
+
+Allow empty class members

--- a/packages/translator-default/src/class.js
+++ b/packages/translator-default/src/class.js
@@ -29,7 +29,7 @@ export default function (path) {
           t.assignmentExpression(
             "=",
             t.memberExpression(t.thisExpression(), prop.key, prop.computed),
-            prop.value
+            prop.value || t.unaryExpression("void", t.numericLiteral(0))
           )
         );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

An error was surfaced when a class component had empty members:
```
class {
  state;
}
```
This is especially important for TypeScript:
```
class {
  state: { count: number };
}
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
