### PR TITLE
fix: avoid using eval in dev mode

### DIFF
--- a/.changeset/sixty-bottles-call.md
+++ b/.changeset/sixty-bottles-call.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Avoid using eval (in dev mode) for providing a better class name on component constructors.

--- a/packages/marko/src/runtime/components/registry/index-browser.js
+++ b/packages/marko/src/runtime/components/registry/index-browser.js
@@ -124,18 +124,13 @@ function getComponentClass(typeName) {
       .replace(/^[^a-z$_]/i, "_$&")
       .replace(/[^0-9a-z$_]+/gi, "_");
     className = className[0].toUpperCase() + className.slice(1);
-    // eslint-disable-next-line no-unused-vars
-    try {
-      var OldComponentClass = ComponentClass;
-      eval(
-        "ComponentClass = function " +
-          className +
-          "(id, doc) { OldComponentClass.call(this, id, doc); }"
-      );
-      ComponentClass.prototype = OldComponentClass.prototype;
-    } catch (e) {
-      /** ignore error */
-    }
+    var OldComponentClass = ComponentClass;
+    ComponentClass = {
+      [className]: function (id, doc) {
+        OldComponentClass.call(this, id, doc);
+      }
+    }[className];
+    ComponentClass.prototype = OldComponentClass.prototype;
   }
 
   componentTypes[typeName] = ComponentClass;


### PR DESCRIPTION
## Description
Avoid using eval (in dev mode) for providing a better class name on component constructors.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
