### PR TITLE
fix: loosen babel parse errors

### DIFF
--- a/.changeset/small-donuts-sip.md
+++ b/.changeset/small-donuts-sip.md
@@ -1,0 +1,15 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Reduce script parsing restrictions added by Babel.
+This was causing Babel to error when parsing partion scripts.
+
+```marko
+static const x = 1;
+export { x };
+```
+
+Before this change in the above code Babel would error when parsing `export { x }` saying `x` was not previously defined. This is because Marko parses these statements in isolation.

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -46,6 +46,14 @@ export default (api, markoOpts) => {
   return {
     name: "marko",
     manipulateOptions(opts) {
+      // We need to allow these for now since we are not parsing the entire file
+      // These types of syntax errors will be picked up by the bundler / runtime anyways.
+      opts.parserOpts.allowAwaitOutsideFunction =
+        opts.parserOpts.allowImportExportEverywhere =
+        opts.parserOpts.allowReturnOutsideFunction =
+        opts.parserOpts.allowSuperOutsideMethod =
+        opts.parserOpts.allowUndeclaredExports =
+          true;
       curOpts = opts;
     },
     parserOverride(code) {

--- a/packages/translator-default/test/fixtures/exports/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/cjs-expected.js
@@ -1,0 +1,23 @@
+"use strict";
+
+exports.__esModule = true;
+exports.y = exports.x = exports.default = void 0;
+exports.z = z;
+var _index = require("marko/src/runtime/html/index.js");
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+const _marko_componentType = "packages/translator-default/test/fixtures/exports/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = _marko_template;
+exports.default = _default;
+const x = 1;
+exports.x = x;
+const y = 2;
+exports.y = y;
+function z() {}
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/exports/snapshots/generated-expected.marko
+++ b/packages/translator-default/test/fixtures/exports/snapshots/generated-expected.marko
@@ -1,0 +1,4 @@
+export const x = 1;
+static const y = 2;
+export { y };
+export function z() {}

--- a/packages/translator-default/test/fixtures/exports/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/html-expected.js
@@ -1,0 +1,15 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "packages/translator-default/test/fixtures/exports/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+export const x = 1;
+const y = 2;
+export { y };
+export function z() {}
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/exports/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/htmlProduction-expected.js
@@ -1,0 +1,14 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "NPJMtzPP",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+export const x = 1;
+const y = 2;
+export { y };
+export function z() {}
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/translator-default/test/fixtures/exports/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/vdom-expected.js
@@ -1,0 +1,19 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "packages/translator-default/test/fixtures/exports/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+export const x = 1;
+const y = 2;
+export { y };
+export function z() {}
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/exports/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/vdomProduction-expected.js
@@ -1,0 +1,18 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "NPJMtzPP",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+export const x = 1;
+const y = 2;
+export { y };
+export function z() {}
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-default/test/fixtures/exports/template.marko
+++ b/packages/translator-default/test/fixtures/exports/template.marko
@@ -1,0 +1,8 @@
+export const x = 1;
+
+static const y = 2;
+export { y };
+
+export function z() {
+
+}


### PR DESCRIPTION
## Description

Reduce script parsing restrictions added by Babel.
This was causing Babel to error when parsing partion scripts.

```marko
static const x = 1;
export { x };
```

Before this change in the above code Babel would error when parsing `export { x }` saying `x` was not previously defined. This is because Marko parses these statements in isolation.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
