### PR TITLE
fix: remove class lifecycle types

### DIFF
--- a/.changeset/hungry-games-flash.md
+++ b/.changeset/hungry-games-flash.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/compiler": patch
+"@marko/translator-default": patch
+---
+
+Remove class lifecycle types to avoid the need to `override` them.

--- a/packages/marko/index.d.ts
+++ b/packages/marko/index.d.ts
@@ -203,18 +203,18 @@ declare namespace Marko {
     replace(target: ChildNode): this;
     /** Replaces the children of an existing DOM element with the dom for the current instance. */
     replaceChildrenOf(target: ParentNode): this;
-    /** Called when the component is firsted created. */
-    onCreate?(input: this["input"], out: Marko.Out): void;
-    /** Called every time the component receives input from it's parent. */
-    onInput?(input: this["input"], out: Marko.Out): void | this["input"];
-    /** Called after a component has successfully rendered, but before it's update has been applied to the dom. */
-    onRender?(out: Marko.Out): void;
-    /** Called after the first time the component renders and is attached to the dom. */
-    onMount?(): void;
-    /** Called when a components render has been applied to the DOM (excluding when it is initially mounted). */
-    onUpdate?(): void;
-    /** Called when a component is destroyed and removed from the dom. */
-    onDestroy?(): void;
+    // /** Called when the component is firsted created. */
+    // onCreate?(input: this["input"], out: Marko.Out): void;
+    // /** Called every time the component receives input from it's parent. */
+    // onInput?(input: this["input"], out: Marko.Out): void | this["input"];
+    // /** Called after a component has successfully rendered, but before it's update has been applied to the dom. */
+    // onRender?(out: Marko.Out): void;
+    // /** Called after the first time the component renders and is attached to the dom. */
+    // onMount?(): void;
+    // /** Called when a components render has been applied to the DOM (excluding when it is initially mounted). */
+    // onUpdate?(): void;
+    // /** Called when a component is destroyed and removed from the dom. */
+    // onDestroy?(): void;
   }
 
   /** The top level api for a Marko Template. */


### PR DESCRIPTION
## Description

Remove class lifecycle types to avoid the need to `override` them.
This provides slightly worse intenseness, but typing class methods based on super class is tricky in typescript. This may be revisited in the future.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
