### PR TITLE
Add note that dynamic tag doesn't work for macro

### DIFF
--- a/packages/marko/docs/syntax.md
+++ b/packages/marko/docs/syntax.md
@@ -419,7 +419,7 @@ import componentB from "<component-b>";
 > </>
 > ```
 
-> **Note:** You cannot reference a Marko custom tag using a name string:
+> **Note:** You **cannot** reference a Marko custom tag or macro using a name string:
 >
 > _Marko Source:_
 >


### PR DESCRIPTION
I've noticed that dynamic tag doesn't work also for macros, so it is good to mention in the docs

Example what is not working
```
<macro|{ renderBody, color }| name="greeting">
    <div
        class="greeting"
        style={
            backgroundColor: color
        }>
        Hello <${renderBody}/>}!
    </div>
</macro>
<!-- Macros can be used like any other tag -->
<${true ? "greeting": "h1" } color="green">
World
</>
```

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
