### PR TITLE
docs: Fix a few typos

### DIFF
--- a/packages/marko/docs/marko-json.md
+++ b/packages/marko/docs/marko-json.md
@@ -134,7 +134,7 @@ Similar to [`marko-tag.json`](#single-component-definition), this file is discov
   "tags-dir": "./ui-modules", // What directory to crawl to autodiscover components. Default:`./components/`
   "taglib-imports": ["./some-folder/marko.json", "./other-folder/marko.json"], // Creates a _combined_ tag library by referencing others.
 
-  "tags": { // Definitions for individial tags.
+  "tags": { // Definitions for individual tags.
     "my-tag": {
       // Same options as “marko-tag.json”.
     }

--- a/packages/marko/docs/state.md
+++ b/packages/marko/docs/state.md
@@ -50,7 +50,7 @@ When a property on `state` is set, the component will be scheduled for an update
 
 > **ProTip:** If you need to know when the update has been applied, you can use `this.once('update', fn)` within a component method.
 
-> **Note:** The state object only watches its properties one level deep. This means updates to nested properites on the state (e.g. `this.state.object.something = newValue`) will not be detected.
+> **Note:** The state object only watches its properties one level deep. This means updates to nested properties on the state (e.g. `this.state.object.something = newValue`) will not be detected.
 >
 > Using [immutable](https://wecodetheweb.com/2016/02/12/immutable-javascript-using-es6-and-beyond/) data structures is recommended, but if you want to mutate a state property (perhaps push a new item into an array) you can let Marko know it changed using `setStateDirty`.
 >

--- a/packages/marko/docs/vite.md
+++ b/packages/marko/docs/vite.md
@@ -48,7 +48,7 @@ if (process.env.NODE_ENV === "production") {
 
 app.get("/", async (req, res) => {
   const template = (await loadTemplate()).default;
-  // When the template is loaded, it will automaticall have `vite` assets inlined.
+  // When the template is loaded, it will automatically have `vite` assets inlined.
   template.render({ hello: "world" }, res);
 );
 


### PR DESCRIPTION
There are small typos in:
- packages/marko/docs/marko-json.md
- packages/marko/docs/state.md
- packages/marko/docs/vite.md

Fixes:
- Should read `properties` rather than `properites`.
- Should read `individual` rather than `individial`.
- Should read `automatically` rather than `automaticall`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md