### PR TITLE
fix(input): make type optional

### DIFF
--- a/.changeset/thin-goats-happen.md
+++ b/.changeset/thin-goats-happen.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Accuracy of types for Marko.Input<"input"> has been improved

--- a/packages/marko/tags-html.d.ts
+++ b/packages/marko/tags-html.d.ts
@@ -1237,7 +1237,7 @@ declare global {
          * Controls the data type (and associated control) of the element.
          * @see https://html.spec.whatwg.org/multipage/input.html#attr-input-type
          */
-        type:
+        type?:
           | AttrMissing
           | "button"
           | "checkbox"


### PR DESCRIPTION
## Description

`Marko.Input<"input">` had a required `type` attribute, which meant that `<input>` tags without `type` were receiving errors.