### PR TITLE
fix: arc support

### DIFF
--- a/.changeset/stupid-jeans-lick.md
+++ b/.changeset/stupid-jeans-lick.md
@@ -1,0 +1,6 @@
+---
+"@marko/translator-default": patch
+"marko": patch
+---
+
+Fixes support for usage with [arc](https://github.com/eBay/arc) and adaptive `.marko` files.


### PR DESCRIPTION
## Description

Marko@4 supported adaptive `.marko` files importing their supporting files (`component.js`, `style.css`, etc) when using [arc](https://github.com/eBay/arc).

In Marko 5 this handling was removed (seemingly accidentally).

This PR brings back support for that.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
