### PR TITLE
Additional Compiler Diagnostics

### DIFF
--- a/.changeset/forty-eyes-trade.md
+++ b/.changeset/forty-eyes-trade.md
@@ -1,0 +1,8 @@
+---
+"@marko/translator-default": minor
+"@marko/babel-utils": minor
+"@marko/compiler": minor
+"marko": minor
+---
+
+Add support for additional diagnostics emitted from the compiler.

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,9 @@
       "jsx": false
     }
   },
+  "globals": {
+    "AggregateError": true
+  },
   "env": {
     "node": true,
     "mocha": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -6235,7 +6235,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -10499,6 +10498,7 @@
         "he": "^1.2.0",
         "htmljs-parser": "^5.4.3",
         "jsesc": "^3.0.2",
+        "kleur": "^4.1.5",
         "lasso-package-root": "^1.0.1",
         "raptor-regexp": "^1.0.1",
         "raptor-util": "^3.2.0",
@@ -12206,6 +12206,7 @@
         "he": "^1.2.0",
         "htmljs-parser": "^5.4.3",
         "jsesc": "^3.0.2",
+        "kleur": "^4.1.5",
         "lasso-package-root": "^1.0.1",
         "raptor-regexp": "^1.0.1",
         "raptor-util": "^3.2.0",
@@ -15301,8 +15302,7 @@
     "kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
-      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="
     },
     "lasso-caching-fs": {
       "version": "1.0.2",

--- a/packages/babel-utils/index.d.ts
+++ b/packages/babel-utils/index.d.ts
@@ -257,3 +257,64 @@ export function resolveTagImport(
   path: t.NodePath<any>,
   request: string
 ): string | undefined;
+
+export enum DiagnosticType {
+  Error = "error",
+  Warning = "warning",
+  Deprecation = "deprecation",
+  Suggestion = "suggestion"
+}
+
+export interface Diagnostic {
+  type: DiagnosticType;
+  label: string;
+  loc: undefined | false | LocRange;
+  fix: boolean | ConfirmFix | SelectFix;
+}
+
+export interface DiagnosticOptions {
+  label: string;
+  loc?: undefined | false | LocRange;
+  fix?:
+    | undefined
+    | (() => void)
+    | (ConfirmFix & {
+        apply(confirmed: boolean | undefined): void;
+      })
+    | (SelectFix & {
+        apply(selected: string | undefined): void;
+      });
+}
+
+export function diagnosticError(
+  path: t.NodePath<any>,
+  options: DiagnosticOptions
+): void;
+export function diagnosticWarn(
+  path: t.NodePath<any>,
+  options: DiagnosticOptions
+): void;
+export function diagnosticDeprecate(
+  path: t.NodePath<any>,
+  options: DiagnosticOptions
+): void;
+export function diagnosticSuggest(
+  path: t.NodePath<any>,
+  options: DiagnosticOptions
+): void;
+
+interface ConfirmFix {
+  type: "confirm";
+  message: string;
+  initialValue?: boolean;
+}
+
+interface SelectFix {
+  type: "select";
+  message: string;
+  options: {
+    value: string;
+    label?: string;
+  }[];
+  initialValue?: string;
+}

--- a/packages/babel-utils/src/diagnostics.js
+++ b/packages/babel-utils/src/diagnostics.js
@@ -1,0 +1,35 @@
+export const DiagnosticType = {
+  Error: "error",
+  Warning: "warning",
+  Deprecation: "deprecation",
+  Suggestion: "suggestion"
+};
+
+export function diagnosticError(path, options) {
+  add(DiagnosticType.Error, path, options);
+}
+
+export function diagnosticWarn(path, options) {
+  add(DiagnosticType.Warning, path, options);
+}
+
+export function diagnosticDeprecate(path, options) {
+  add(DiagnosticType.Deprecation, path, options);
+}
+
+export function diagnosticSuggest(path, options) {
+  add(DiagnosticType.Suggestion, path, options);
+}
+
+function add(type, path, options) {
+  const { file } = path.hub;
+  const { diagnostics } = file.metadata.marko;
+  const { label, fix, loc = path.node.loc } = options;
+  diagnostics.push({ type, label, loc, fix });
+
+  if (fix && file.___compileStage !== "migrate") {
+    throw new Error(
+      "Diagnostic fixes can only be registered during the migrate stage."
+    );
+  }
+}

--- a/packages/babel-utils/src/index.js
+++ b/packages/babel-utils/src/index.js
@@ -34,6 +34,14 @@ export { resolveRelativePath, importDefault, importNamed } from "./imports";
 
 export { getTaglibLookup, getTagDefForTagName } from "./taglib";
 
+export {
+  DiagnosticType,
+  diagnosticError,
+  diagnosticDeprecate,
+  diagnosticWarn,
+  diagnosticSuggest
+} from "./diagnostics";
+
 export function defineTag(tag) {
   return tag;
 } // just used for adding types for compiler plugins.

--- a/packages/compiler/config.d.ts
+++ b/packages/compiler/config.d.ts
@@ -1,5 +1,7 @@
 declare const Config: {
   output?: "html" | "dom" | "hydrate" | "migrate" | "source";
+  errorRecovery?: boolean;
+  applyFixes?: Map<number, unknown>;
   stripTypes?: boolean;
   runtimeId?: string | null;
   ast?: boolean;

--- a/packages/compiler/index.d.ts
+++ b/packages/compiler/index.d.ts
@@ -1,5 +1,5 @@
 import { SourceMap } from "magic-string";
-import { TaglibLookup } from "@marko/babel-utils";
+import { TaglibLookup, Diagnostic } from "@marko/babel-utils";
 import * as types from "./babel-types";
 export { types };
 
@@ -22,6 +22,7 @@ export type MarkoMeta = {
   watchFiles: string[];
   tags?: string[];
   deps: Array<string | Dep>;
+  diagnostics: Diagnostic[];
 };
 
 export type CompileResult = {

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -20,6 +20,7 @@
     "he": "^1.2.0",
     "htmljs-parser": "^5.4.3",
     "jsesc": "^3.0.2",
+    "kleur": "^4.1.5",
     "lasso-package-root": "^1.0.1",
     "raptor-regexp": "^1.0.1",
     "raptor-util": "^3.2.0",

--- a/packages/compiler/src/babel-plugin/file.js
+++ b/packages/compiler/src/babel-plugin/file.js
@@ -1,48 +1,18 @@
-import path from "path";
 import { File } from "@babel/core";
-import { codeFrameColumns } from "@babel/code-frame";
-const CWD = process.cwd();
+import { buildCodeFrameError } from "../util/build-code-frame";
 
 export class MarkoFile extends File {
   addHelper() {
     throw new Error("addHelper is not supported during a Marko transform");
   }
 
-  buildCodeFrameError(node, msg, Error = SyntaxError) {
-    const { loc } = node;
-    const frame =
-      loc &&
-      codeFrameColumns(
-        this.code,
-        {
-          start: {
-            line: loc.start.line,
-            column: loc.start.column + 1
-          },
-          end:
-            loc.end && loc.start.line === loc.end.line
-              ? {
-                  line: loc.end.line,
-                  column: loc.end.column + 1
-                }
-              : undefined
-        },
-        { highlightCode: true }
-      );
-
-    const finalMsg = `${path.relative(CWD, this.opts.filename)}${
-      loc ? `(${loc.start.line},${loc.start.column + 1})` : ""
-    }: ${msg}\n${frame || ""}`;
-
-    const err = new Error();
-
-    // Prevent babel from changing our error message.
-    Object.defineProperty(err, "message", {
-      get() {
-        return finalMsg;
-      },
-      set() {}
-    });
-    return err;
+  buildCodeFrameError(node, msg, Error) {
+    return buildCodeFrameError(
+      this.opts.filename,
+      this.code,
+      node.loc,
+      msg,
+      Error
+    );
   }
 }

--- a/packages/compiler/src/config.js
+++ b/packages/compiler/src/config.js
@@ -139,7 +139,20 @@ const config = {
   /**
    * Set to true in order to bring in the hot module replacement runtime.
    */
-  hot: false
+  hot: false,
+
+  /**
+   * Wether error diagnostics should be thrown as errors
+   * before the compile result is returned.
+   *
+   * Note that the compiler can still throw errors even when true.
+   * When the errorRecovery is true, any recoverable errors will be
+   * returned in the `meta.diagnostics` property of the compile result.
+   */
+  errorRecovery: false,
+
+  // When supplied, any diagnostics which have a fix specified in the lookup will be applied to the source code.
+  applyFixes: undefined
 };
 
 if (process.env.MARKO_CONFIG) {

--- a/packages/compiler/src/util/build-code-frame.js
+++ b/packages/compiler/src/util/build-code-frame.js
@@ -1,11 +1,14 @@
 import path from "path";
+import color from "kleur";
 import { codeFrameColumns } from "@babel/code-frame";
 const CWD = process.cwd();
 
 export function buildCodeFrame(filename, code, loc, message) {
-  return `${path.relative(CWD, filename)}${
-    loc ? `(${loc.start.line},${loc.start.column + 1})` : ""
-  }: ${message}\n${
+  return `${color.cyan(path.relative(CWD, filename))}${
+    loc
+      ? `:${color.yellow(loc.start.line)}:${color.yellow(loc.start.column + 1)}`
+      : ""
+  }\n\n${
     loc
       ? codeFrameColumns(
           code,
@@ -22,7 +25,7 @@ export function buildCodeFrame(filename, code, loc, message) {
                   }
                 : undefined
           },
-          { highlightCode: true }
+          { highlightCode: true, message }
         )
       : ""
   }`;

--- a/packages/compiler/src/util/build-code-frame.js
+++ b/packages/compiler/src/util/build-code-frame.js
@@ -1,0 +1,53 @@
+import path from "path";
+import { codeFrameColumns } from "@babel/code-frame";
+const CWD = process.cwd();
+
+export function buildCodeFrame(filename, code, loc, message) {
+  return `${path.relative(CWD, filename)}${
+    loc ? `(${loc.start.line},${loc.start.column + 1})` : ""
+  }: ${message}\n${
+    loc
+      ? codeFrameColumns(
+          code,
+          {
+            start: {
+              line: loc.start.line,
+              column: loc.start.column + 1
+            },
+            end:
+              loc.end && loc.start.line === loc.end.line
+                ? {
+                    line: loc.end.line,
+                    column: loc.end.column + 1
+                  }
+                : undefined
+          },
+          { highlightCode: true }
+        )
+      : ""
+  }`;
+}
+
+export function buildCodeFrameError(
+  filename,
+  code,
+  loc,
+  message,
+  Error = SyntaxError
+) {
+  const err = new Error();
+  const codeFrame = buildCodeFrame(filename, code, loc, message);
+
+  // Avoid showing the stack trace for this error.
+  err.stack = "";
+
+  // Prevent babel from changing our error message.
+  Object.defineProperty(err, "message", {
+    get() {
+      return codeFrame;
+    },
+    set() {}
+  });
+
+  return err;
+}

--- a/packages/marko/test/render/fixtures/tags-dir-null/test.js
+++ b/packages/marko/test/render/fixtures/tags-dir-null/test.js
@@ -1,11 +1,13 @@
 var expect = require("chai").expect;
+var stripAnsi = require("strip-ansi");
 
 exports.templateData = {};
 
 exports.checkError = function (e) {
+  var message = stripAnsi(e.message);
   //includes the tag it broke on
-  expect(e.message).to.contain("test-hello");
+  expect(message).to.contain("test-hello");
 
   //includes the line number of the template
-  expect(e.message).to.contain("template.marko(1,2)");
+  expect(message).to.contain("template.marko:1:2");
 };

--- a/packages/translator-default/src/taglib/migrate/all-templates.js
+++ b/packages/translator-default/src/taglib/migrate/all-templates.js
@@ -1,10 +1,18 @@
 import { types as t } from "@marko/compiler";
 import withPreviousLocation from "../../util/with-previous-location";
+import { diagnosticDeprecate } from "@marko/babel-utils";
 
 export default {
   ReferencedIdentifier(path) {
     if (path.node.name === "data" && !path.scope.hasBinding("data")) {
-      path.replaceWith(withPreviousLocation(t.identifier("input"), path.node));
+      diagnosticDeprecate(path, {
+        label: "The 'data' variable is deprecated. Use 'input' instead.",
+        fix() {
+          path.replaceWith(
+            withPreviousLocation(t.identifier("input"), path.node)
+          );
+        }
+      });
     }
   }
 };

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko(1,6): Unsupported arguments on the "hello" attribute.
+packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
+
 > 1 | <div hello('a')/>
-    |      ^^^^^^^^^^
+    |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko(1,6): Unsupported arguments on the "hello" attribute.
+packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
+
 > 1 | <div hello('a')/>
-    |      ^^^^^^^^^^
+    |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko(1,6): Unsupported arguments on the "hello" attribute.
+packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
+
 > 1 | <div hello('a')/>
-    |      ^^^^^^^^^^
+    |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko(1,6): Unsupported arguments on the "hello" attribute.
+packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
+
 > 1 | <div hello('a')/>
-    |      ^^^^^^^^^^
+    |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko(1,6): Unsupported arguments on the "hello" attribute.
+packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
+
 > 1 | <div hello('a')/>
-    |      ^^^^^^^^^^
+    |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/cjs-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko(9,6): @tags must be within a custom element.
+packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
+
    7 |     Body content
    8 |
 >  9 |     <@footer class="my-footer">
-     |      ^^^^^^^
+     |      ^^^^^^^ @tags must be within a custom element.
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/html-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko(9,6): @tags must be within a custom element.
+packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
+
    7 |     Body content
    8 |
 >  9 |     <@footer class="my-footer">
-     |      ^^^^^^^
+     |      ^^^^^^^ @tags must be within a custom element.
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/htmlProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko(9,6): @tags must be within a custom element.
+packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
+
    7 |     Body content
    8 |
 >  9 |     <@footer class="my-footer">
-     |      ^^^^^^^
+     |      ^^^^^^^ @tags must be within a custom element.
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdom-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko(9,6): @tags must be within a custom element.
+packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
+
    7 |     Body content
    8 |
 >  9 |     <@footer class="my-footer">
-     |      ^^^^^^^
+     |      ^^^^^^^ @tags must be within a custom element.
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdomProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko(9,6): @tags must be within a custom element.
+packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
+
    7 |     Body content
    8 |
 >  9 |     <@footer class="my-footer">
-     |      ^^^^^^^
+     |      ^^^^^^^ @tags must be within a custom element.
   10 |         Footer content
   11 |     </@footer>
   12 | </div>

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko(1,2): @tags must be nested within another element.
+packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
+
 > 1 | <@header class="my-header">
-    |  ^^^^^^^
+    |  ^^^^^^^ @tags must be nested within another element.
   2 |     Header content
   3 | </@header>
   4 |

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko(1,2): @tags must be nested within another element.
+packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
+
 > 1 | <@header class="my-header">
-    |  ^^^^^^^
+    |  ^^^^^^^ @tags must be nested within another element.
   2 |     Header content
   3 | </@header>
   4 |

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko(1,2): @tags must be nested within another element.
+packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
+
 > 1 | <@header class="my-header">
-    |  ^^^^^^^
+    |  ^^^^^^^ @tags must be nested within another element.
   2 |     Header content
   3 | </@header>
   4 |

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko(1,2): @tags must be nested within another element.
+packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
+
 > 1 | <@header class="my-header">
-    |  ^^^^^^^
+    |  ^^^^^^^ @tags must be nested within another element.
   2 |     Header content
   3 | </@header>
   4 |

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko(1,2): @tags must be nested within another element.
+packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
+
 > 1 | <@header class="my-header">
-    |  ^^^^^^^
+    |  ^^^^^^^ @tags must be nested within another element.
   2 |     Header content
   3 | </@header>
   4 |

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko(1,2): You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
+packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
+
 > 1 | <await>
-    |  ^^^^^
+    |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko(1,2): You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
+packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
+
 > 1 | <await>
-    |  ^^^^^
+    |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko(1,2): You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
+packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
+
 > 1 | <await>
-    |  ^^^^^
+    |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko(1,2): You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
+packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
+
 > 1 | <await>
-    |  ^^^^^
+    |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko(1,2): You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
+packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
+
 > 1 | <await>
-    |  ^^^^^
+    |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko(1,11): You can only pass one argument to the "<await>" tag.
+packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
+
 > 1 | <await(a, b)>
-    |           ^
+    |           ^ You can only pass one argument to the "<await>" tag.
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko(1,11): You can only pass one argument to the "<await>" tag.
+packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
+
 > 1 | <await(a, b)>
-    |           ^
+    |           ^ You can only pass one argument to the "<await>" tag.
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko(1,11): You can only pass one argument to the "<await>" tag.
+packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
+
 > 1 | <await(a, b)>
-    |           ^
+    |           ^ You can only pass one argument to the "<await>" tag.
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko(1,11): You can only pass one argument to the "<await>" tag.
+packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
+
 > 1 | <await(a, b)>
-    |           ^
+    |           ^ You can only pass one argument to the "<await>" tag.
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko(1,11): You can only pass one argument to the "<await>" tag.
+packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
+
 > 1 | <await(a, b)>
-    |           ^
+    |           ^ You can only pass one argument to the "<await>" tag.
   2 |   <@then|result|>
   3 |     ${result}
   4 |   </@then>

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-bad-expression/template.marko(1,18): Unexpected token, expected ","
+packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
+
 > 1 | <div class=(this is not valid)></div>
-    |                  ^
+    |                  ^ Unexpected token, expected ","
   2 |

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/cjs-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/generated-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/html-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/htmlProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/hydrate-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdom-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdomProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-constructor/template.marko(2,3): The constructor method should not be used for a component, use onCreate instead.
+packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
+
   1 | class {
 > 2 |   constructor() {
-    |   ^^^^^^^^^^^
+    |   ^^^^^^^^^^^ The constructor method should not be used for a component, use onCreate instead.
   3 |     
   4 |   }
   5 | }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/generated-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/hydrate-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko(1,1): A Marko file can either have an inline class, or an external "component.js", but not both.
+packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
+
 > 1 | class {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/cjs-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/generated-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/html-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/htmlProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/hydrate-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdom-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdomProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-class-not-root/template.marko(2,3): "class" can only be used at the root of the template.
+packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
+
   1 | div
 > 2 |   class extends Test {
-    |   ^^^^^
+    |   ^^^^^ "class" can only be used at the root of the template.
   3 |     onCreate() {
   4 |
   5 |     }

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-private-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
+
   1 | class {
 > 2 |   #x = 1;
-    |   ^^^^^^^
+    |   ^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-private-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
+
   1 | class {
 > 2 |   #x = 1;
-    |   ^^^^^^^
+    |   ^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-private-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
+
   1 | class {
 > 2 |   #x = 1;
-    |   ^^^^^^^
+    |   ^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-private-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
+
   1 | class {
 > 2 |   #x = 1;
-    |   ^^^^^^^
+    |   ^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-private-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
+
   1 | class {
 > 2 |   #x = 1;
-    |   ^^^^^^^
+    |   ^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-static-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
+
   1 | class {
 > 2 |   static x = 1;
-    |   ^^^^^^^^^^^^^
+    |   ^^^^^^^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-static-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
+
   1 | class {
 > 2 |   static x = 1;
-    |   ^^^^^^^^^^^^^
+    |   ^^^^^^^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-static-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
+
   1 | class {
 > 2 |   static x = 1;
-    |   ^^^^^^^^^^^^^
+    |   ^^^^^^^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-static-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
+
   1 | class {
 > 2 |   static x = 1;
-    |   ^^^^^^^^^^^^^
+    |   ^^^^^^^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-static-properties/template.marko(2,3): Unsupported class property on component.
+packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
+
   1 | class {
 > 2 |   static x = 1;
-    |   ^^^^^^^^^^^^^
+    |   ^^^^^^^^^^^^^ Unsupported class property on component.
   3 | }
   4 | <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
+
   1 | class {}
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/generated-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/hydrate-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-name/template.marko(1,7): Component class cannot have a name.
+packages/translator-default/test/fixtures/error-class-with-name/template.marko:1:7
+
 > 1 | class Test {
-    |       ^^^^
+    |       ^^^^ Component class cannot have a name.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/generated-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/hydrate-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-class-with-super-class/template.marko(1,15): Component class cannot have a super class.
+packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
+
 > 1 | class extends Test {
-    |               ^^^^
+    |               ^^^^ Component class cannot have a super class.
   2 |   onCreate() {
   3 |
   4 |   }

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko(1,13): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
+
 > 1 | <custom-tag(a, b, { c })/>
-    |             ^^^^^^^^^^^
+    |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko(1,13): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
+
 > 1 | <custom-tag(a, b, { c })/>
-    |             ^^^^^^^^^^^
+    |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko(1,13): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
+
 > 1 | <custom-tag(a, b, { c })/>
-    |             ^^^^^^^^^^^
+    |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko(1,13): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
+
 > 1 | <custom-tag(a, b, { c })/>
-    |             ^^^^^^^^^^^
+    |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko(1,13): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
+
 > 1 | <custom-tag(a, b, { c })/>
-    |             ^^^^^^^^^^^
+    |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko(1,19): Duplicate event handlers are not supported.
+packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
+
 > 1 | <div onClick('a') onClick('b')/>
-    |                   ^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko(1,19): Duplicate event handlers are not supported.
+packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
+
 > 1 | <div onClick('a') onClick('b')/>
-    |                   ^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko(1,19): Duplicate event handlers are not supported.
+packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
+
 > 1 | <div onClick('a') onClick('b')/>
-    |                   ^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko(1,19): Duplicate event handlers are not supported.
+packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
+
 > 1 | <div onClick('a') onClick('b')/>
-    |                   ^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko(1,19): Duplicate event handlers are not supported.
+packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
+
 > 1 | <div onClick('a') onClick('b')/>
-    |                   ^^^^^^^^^^^^
+    |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko(1,4): Invalid placeholder, the expression cannot be missing
+packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
+
 > 1 | <${}/>
-    |    ^
+    |    ^ Invalid placeholder, the expression cannot be missing
   2 |

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko(4,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
+
   2 | </if>
   3 | <div/>
 > 4 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   5 | </else>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko(4,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
+
   2 | </if>
   3 | <div/>
 > 4 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   5 | </else>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko(4,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
+
   2 | </if>
   3 | <div/>
 > 4 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   5 | </else>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko(4,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
+
   2 | </if>
   3 | <div/>
 > 4 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   5 | </else>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko(4,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
+
   2 | </if>
   3 | <div/>
 > 4 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   5 | </else>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko(1,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
+
 > 1 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   2 |   Hello
   3 | </else>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko(1,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
+
 > 1 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   2 |   Hello
   3 | </else>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko(1,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
+
 > 1 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   2 |   Hello
   3 | </else>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko(1,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
+
 > 1 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   2 |   Hello
   3 | </else>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko(1,2): Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
+packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
+
 > 1 | <else>
-    |  ^^^^
+    |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.
   2 |   Hello
   3 | </else>

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/generated-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/hydrate-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-eof/template.marko(1,7): EOF reached while parsing attribute name for the "style" tag
+packages/translator-default/test/fixtures/error-eof/template.marko:1:7
+
 > 1 | style {
-    |       ^
+    |       ^ EOF reached while parsing attribute name for the "style" tag
   2 |   div {
   3 |     color: green;
   4 | }

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko(1,6): Event handler is missing arguments.
+packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
+
 > 1 | <div onClick()/>
-    |      ^^^^^^^^^
+    |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko(1,6): Event handler is missing arguments.
+packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
+
 > 1 | <div onClick()/>
-    |      ^^^^^^^^^
+    |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko(1,6): Event handler is missing arguments.
+packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
+
 > 1 | <div onClick()/>
-    |      ^^^^^^^^^
+    |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko(1,6): Event handler is missing arguments.
+packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
+
 > 1 | <div onClick()/>
-    |      ^^^^^^^^^
+    |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko(1,6): Event handler is missing arguments.
+packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
+
 > 1 | <div onClick()/>
-    |      ^^^^^^^^^
+    |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-value/template.marko(1,19): "onClick(handler, ...args)" does not accept a value.
+packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
+
 > 1 | <div onClick('a')=b/>
-    |                   ^
+    |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-value/template.marko(1,19): "onClick(handler, ...args)" does not accept a value.
+packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
+
 > 1 | <div onClick('a')=b/>
-    |                   ^
+    |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-value/template.marko(1,19): "onClick(handler, ...args)" does not accept a value.
+packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
+
 > 1 | <div onClick('a')=b/>
-    |                   ^
+    |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-value/template.marko(1,19): "onClick(handler, ...args)" does not accept a value.
+packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
+
 > 1 | <div onClick('a')=b/>
-    |                   ^
+    |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-event-handler-value/template.marko(1,19): "onClick(handler, ...args)" does not accept a value.
+packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
+
 > 1 | <div onClick('a')=b/>
-    |                   ^
+    |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
+
   1 | export { a } from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko(2,4): The "export" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <export x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko(1,2): Invalid 'for in' tag, missing |key, value| params.
+packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
+
 > 1 | <for|| in=x>
-    |  ^^^
+    |  ^^^ Invalid 'for in' tag, missing |key, value| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko(1,2): Invalid 'for in' tag, missing |key, value| params.
+packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
+
 > 1 | <for|| in=x>
-    |  ^^^
+    |  ^^^ Invalid 'for in' tag, missing |key, value| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko(1,2): Invalid 'for in' tag, missing |key, value| params.
+packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
+
 > 1 | <for|| in=x>
-    |  ^^^
+    |  ^^^ Invalid 'for in' tag, missing |key, value| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko(1,2): Invalid 'for in' tag, missing |key, value| params.
+packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
+
 > 1 | <for|| in=x>
-    |  ^^^
+    |  ^^^ Invalid 'for in' tag, missing |key, value| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko(1,2): Invalid 'for in' tag, missing |key, value| params.
+packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
+
 > 1 | <for|| in=x>
-    |  ^^^
+    |  ^^^ Invalid 'for in' tag, missing |key, value| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko(1,25): <for> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
+
 > 1 | <for|key, value| in=obj x=1>
-    |                         ^^^
+    |                         ^^^ <for> does not support the "x" attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko(1,25): <for> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
+
 > 1 | <for|key, value| in=obj x=1>
-    |                         ^^^
+    |                         ^^^ <for> does not support the "x" attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko(1,25): <for> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
+
 > 1 | <for|key, value| in=obj x=1>
-    |                         ^^^
+    |                         ^^^ <for> does not support the "x" attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko(1,25): <for> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
+
 > 1 | <for|key, value| in=obj x=1>
-    |                         ^^^
+    |                         ^^^ <for> does not support the "x" attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko(1,25): <for> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
+
 > 1 | <for|key, value| in=obj x=1>
-    |                         ^^^
+    |                         ^^^ <for> does not support the "x" attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-missing-attr/template.marko(1,2): Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
+packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
+
 > 1 | <for|x|>
-    |  ^^^
+    |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-missing-attr/template.marko(1,2): Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
+packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
+
 > 1 | <for|x|>
-    |  ^^^
+    |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-missing-attr/template.marko(1,2): Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
+packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
+
 > 1 | <for|x|>
-    |  ^^^
+    |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-missing-attr/template.marko(1,2): Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
+packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
+
 > 1 | <for|x|>
-    |  ^^^
+    |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-missing-attr/template.marko(1,2): Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
+packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
+
 > 1 | <for|x|>
-    |  ^^^
+    |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko(1,2): Invalid 'for of' tag, missing |value, index| params.
+packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
+
 > 1 | <for|| of=x>
-    |  ^^^
+    |  ^^^ Invalid 'for of' tag, missing |value, index| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko(1,2): Invalid 'for of' tag, missing |value, index| params.
+packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
+
 > 1 | <for|| of=x>
-    |  ^^^
+    |  ^^^ Invalid 'for of' tag, missing |value, index| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko(1,2): Invalid 'for of' tag, missing |value, index| params.
+packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
+
 > 1 | <for|| of=x>
-    |  ^^^
+    |  ^^^ Invalid 'for of' tag, missing |value, index| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko(1,2): Invalid 'for of' tag, missing |value, index| params.
+packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
+
 > 1 | <for|| of=x>
-    |  ^^^
+    |  ^^^ Invalid 'for of' tag, missing |value, index| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko(1,2): Invalid 'for of' tag, missing |value, index| params.
+packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
+
 > 1 | <for|| of=x>
-    |  ^^^
+    |  ^^^ Invalid 'for of' tag, missing |value, index| params.
   2 |   <div/>
   3 | </for>

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-html-element-arguments/template.marko(1,6): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
+
 > 1 | <div(a, b, { c })/>
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-html-element-arguments/template.marko(1,6): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
+
 > 1 | <div(a, b, { c })/>
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-html-element-arguments/template.marko(1,6): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
+
 > 1 | <div(a, b, { c })/>
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-html-element-arguments/template.marko(1,6): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
+
 > 1 | <div(a, b, { c })/>
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-html-element-arguments/template.marko(1,6): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
+
 > 1 | <div(a, b, { c })/>
-    |      ^^^^^^^^^^^
+    |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/generated-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/hydrate-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko(1,8): Cannot have shorthand id and id attribute.
+packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
+
 > 1 | <div#x id="y"/>
-    |        ^^^^^^
+    |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-if-missing-condition/template.marko(1,2): Invalid '<if>' tag, expected arguments like '<if(test)>'.
+packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
+
 > 1 | <if>
-    |  ^^
+    |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.
   2 |   Test
   3 | </if>

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-if-missing-condition/template.marko(1,2): Invalid '<if>' tag, expected arguments like '<if(test)>'.
+packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
+
 > 1 | <if>
-    |  ^^
+    |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.
   2 |   Test
   3 | </if>

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-if-missing-condition/template.marko(1,2): Invalid '<if>' tag, expected arguments like '<if(test)>'.
+packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
+
 > 1 | <if>
-    |  ^^
+    |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.
   2 |   Test
   3 | </if>

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-if-missing-condition/template.marko(1,2): Invalid '<if>' tag, expected arguments like '<if(test)>'.
+packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
+
 > 1 | <if>
-    |  ^^
+    |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.
   2 |   Test
   3 | </if>

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-if-missing-condition/template.marko(1,2): Invalid '<if>' tag, expected arguments like '<if(test)>'.
+packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
+
 > 1 | <if>
-    |  ^^
+    |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.
   2 |   Test
   3 | </if>

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/hydrate-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko(1,30): Unable to find entry point for custom tag <missing-component>.
+packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
+
 > 1 | import MissingComponent from "<missing-component>"
-    |                              ^^^^^^^^^^^^^^^^^^^^^
+    |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
+
   1 | import a from "b";
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko(2,4): The "import" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <import x from "y"/>
-    |    ^^^^^^
+    |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-invalid-js/template.marko(1,5): Unexpected token
+packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
+
 > 1 | $ x..y();
-    |     ^
+    |     ^ Unexpected token
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/cjs-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/generated-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/html-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/htmlProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/hydrate-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdom-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdomProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-macro-duplicate/template.marko(5,15): A macro with the name "thing" already exists.
+packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
+
   3 | </macro>
   4 |
 > 5 | <macro|stuff| name="thing">
-    |               ^^^^^^^^^^^^
+    |               ^^^^^^^^^^^^ A macro with the name "thing" already exists.
   6 |   <div>b</div>
   7 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko(1,28): The "macro" tag can only have a "name" attribute.
+packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
+
 > 1 | <macro|stuff| name="thing" x=1>
-    |                            ^^^
+    |                            ^^^ The "macro" tag can only have a "name" attribute.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko(1,20): The "name" attribute for "macro" tags must be a string literal.
+packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:20
+
 > 1 | <macro|stuff| name=1>
-    |                    ^
+    |                    ^ The "name" attribute for "macro" tags must be a string literal.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-macro-missing-name/template.marko(1,2): The "name" attribute is required on "macro" tags.
+packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:2
+
 > 1 | <macro|stuff|>
-    |  ^^^^^
+    |  ^^^^^ The "name" attribute is required on "macro" tags.
   2 |   <div/>
   3 | </macro>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko(4,1): The closing "div" tag does not match the corresponding opening "span" tag
+packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
+
   2 |   <span>
   3 |   <span>
 > 4 | </div>
-    | ^^^^^^
+    | ^^^^^^ The closing "div" tag does not match the corresponding opening "span" tag

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko(1,23): <custom-tag> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
+
 > 1 | <custom-tag name="hi" x=1/>
-    |                       ^^^
+    |                       ^^^ <custom-tag> does not support the "x" attribute.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko(1,23): <custom-tag> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
+
 > 1 | <custom-tag name="hi" x=1/>
-    |                       ^^^
+    |                       ^^^ <custom-tag> does not support the "x" attribute.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko(1,23): <custom-tag> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
+
 > 1 | <custom-tag name="hi" x=1/>
-    |                       ^^^
+    |                       ^^^ <custom-tag> does not support the "x" attribute.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko(1,23): <custom-tag> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
+
 > 1 | <custom-tag name="hi" x=1/>
-    |                       ^^^
+    |                       ^^^ <custom-tag> does not support the "x" attribute.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko(1,23): <custom-tag> does not support the "x" attribute.
+packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
+
 > 1 | <custom-tag name="hi" x=1/>
-    |                       ^^^
+    |                       ^^^ <custom-tag> does not support the "x" attribute.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
+packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
+
 > 1 | <thing/>
-    |  ^^^^^
+    |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
+packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
+
 > 1 | <thing/>
-    |  ^^^^^
+    |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
+packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
+
 > 1 | <thing/>
-    |  ^^^^^
+    |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
+packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
+
 > 1 | <thing/>
-    |  ^^^^^
+    |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko(1,2): Unable to find entry point for custom tag <thing>.
+packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
+
 > 1 | <thing/>
-    |  ^^^^^
+    |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-required-attr/template.marko(1,2): The "name" attribute is required.
+packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
+
 > 1 | <custom-tag/>
-    |  ^^^^^^^^^^
+    |  ^^^^^^^^^^ The "name" attribute is required.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-required-attr/template.marko(1,2): The "name" attribute is required.
+packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
+
 > 1 | <custom-tag/>
-    |  ^^^^^^^^^^
+    |  ^^^^^^^^^^ The "name" attribute is required.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-required-attr/template.marko(1,2): The "name" attribute is required.
+packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
+
 > 1 | <custom-tag/>
-    |  ^^^^^^^^^^
+    |  ^^^^^^^^^^ The "name" attribute is required.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-required-attr/template.marko(1,2): The "name" attribute is required.
+packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
+
 > 1 | <custom-tag/>
-    |  ^^^^^^^^^^
+    |  ^^^^^^^^^^ The "name" attribute is required.
   2 |

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-missing-required-attr/template.marko(1,2): The "name" attribute is required.
+packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
+
 > 1 | <custom-tag/>
-    |  ^^^^^^^^^^
+    |  ^^^^^^^^^^ The "name" attribute is required.
   2 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/cjs-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/generated-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/html-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/htmlProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/hydrate-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdom-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdomProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko(7,1): A Marko component can only have one top level class.
+packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
+
    5 | }
    6 |
 >  7 | class {
-     | ^^^^^
+     | ^^^^^ A Marko component can only have one top level class.
    8 |   onMount() {
    9 |
   10 |   }

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-native-tag-params/template.marko(1,6): Tag does not support parameters.
+packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
+
 > 1 | <div|x|>
-    |      ^
+    |      ^ Tag does not support parameters.
   2 |   <div/>
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-native-tag-params/template.marko(1,6): Tag does not support parameters.
+packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
+
 > 1 | <div|x|>
-    |      ^
+    |      ^ Tag does not support parameters.
   2 |   <div/>
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-native-tag-params/template.marko(1,6): Tag does not support parameters.
+packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
+
 > 1 | <div|x|>
-    |      ^
+    |      ^ Tag does not support parameters.
   2 |   <div/>
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-native-tag-params/template.marko(1,6): Tag does not support parameters.
+packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
+
 > 1 | <div|x|>
-    |      ^
+    |      ^ Tag does not support parameters.
   2 |   <div/>
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-native-tag-params/template.marko(1,6): Tag does not support parameters.
+packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
+
 > 1 | <div|x|>
-    |      ^
+    |      ^ Tag does not support parameters.
   2 |   <div/>
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/cjs-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko(2,10): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
+
   1 | <custom-tag>
 > 2 |   <@test(a, b, { c })>
-    |          ^^^^^^^^^^^
+    |          ^^^^^^^^^^^ Tag does not support arguments.
   3 |     Hi
   4 |   </@test>
   5 | </custom-tag>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/html-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko(2,10): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
+
   1 | <custom-tag>
 > 2 |   <@test(a, b, { c })>
-    |          ^^^^^^^^^^^
+    |          ^^^^^^^^^^^ Tag does not support arguments.
   3 |     Hi
   4 |   </@test>
   5 | </custom-tag>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko(2,10): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
+
   1 | <custom-tag>
 > 2 |   <@test(a, b, { c })>
-    |          ^^^^^^^^^^^
+    |          ^^^^^^^^^^^ Tag does not support arguments.
   3 |     Hi
   4 |   </@test>
   5 | </custom-tag>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdom-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko(2,10): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
+
   1 | <custom-tag>
 > 2 |   <@test(a, b, { c })>
-    |          ^^^^^^^^^^^
+    |          ^^^^^^^^^^^ Tag does not support arguments.
   3 |     Hi
   4 |   </@test>
   5 | </custom-tag>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,7 +1,8 @@
-packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko(2,10): Tag does not support arguments.
+packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
+
   1 | <custom-tag>
 > 2 |   <@test(a, b, { c })>
-    |          ^^^^^^^^^^^
+    |          ^^^^^^^^^^^ Tag does not support arguments.
   3 |     Hi
   4 |   </@test>
   5 | </custom-tag>

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko(2,5): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
+
   1 | input
 > 2 |     -- This should not be allowed!
-    |     ^
+    |     ^ Line has extra indentation at the beginning

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko(1,2): <% scriptlets %> are no longer supported.
+packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
+
 > 1 | <% console.log(x) %>
-    |  ^
+    |  ^ <% scriptlets %> are no longer supported.
   2 | <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko(2,2): Line has extra indentation at the beginning
+packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
+
   1 | static { console.log(x); }
 > 2 |  <div/>
-    |  ^
+    |  ^ Line has extra indentation at the beginning
   3 |

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko(2,4): The "static" tag is reserved and cannot be used as an HTML tag.
+packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <static { console.log(x) }/>
-    |    ^^^^^^
+    |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/cjs-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/html-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/htmlProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/hydrate-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdom-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdomProduction-error-expected.txt
@@ -1,8 +1,9 @@
-packages/translator-default/test/fixtures/error-style-block-multiple/template.marko(5,1): A Marko file can only contain a single inline style block.
+packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
+
   3 | }
   4 |
 > 5 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can only contain a single inline style block.
   6 |   span { color: green }
   7 | }
   8 |

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-style-block-root-only/template.marko(2,4): Style blocks must be at the root of your Marko template.
+packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
+
   1 | <div>
 > 2 |   <style { div { color: green; } }/>
-    |    ^^^^^
+    |    ^^^^^ Style blocks must be at the root of your Marko template.
   3 | </div>

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/cjs-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/html-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/htmlProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/hydrate-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdom-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdomProduction-error-expected.txt
@@ -1,6 +1,7 @@
-packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko(1,1): A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
+packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
+
 > 1 | style {
-    | ^^^^^
+    | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.
   2 |   body {
   3 |     color: green;
   4 |   }

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/generated-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/error-unclosed-tag/template.marko(1,1): Missing ending "div" tag
+packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
+
 > 1 | <div>
-    | ^^^^^
+    | ^^^^^ Missing ending "div" tag
   2 |   <span/>

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-modifier/template.marko(1,6): Unsupported modifier "n-update".
+packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
+
 > 1 | <div value:n-update=1/>
-    |      ^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-modifier/template.marko(1,6): Unsupported modifier "n-update".
+packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
+
 > 1 | <div value:n-update=1/>
-    |      ^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-modifier/template.marko(1,6): Unsupported modifier "n-update".
+packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
+
 > 1 | <div value:n-update=1/>
-    |      ^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-modifier/template.marko(1,6): Unsupported modifier "n-update".
+packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
+
 > 1 | <div value:n-update=1/>
-    |      ^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-modifier/template.marko(1,6): Unsupported modifier "n-update".
+packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
+
 > 1 | <div value:n-update=1/>
-    |      ^^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/cjs-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/html-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdom-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,3 +1,4 @@
-packages/translator-default/test/fixtures/error-unknown-tag/template.marko(1,2): Unable to find entry point for custom tag <some-tag>.
+packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
+
 > 1 | <some-tag/>
-    |  ^^^^^^^^
+    |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/cjs-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/generated-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/html-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/hydrate-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdom-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,5 +1,6 @@
-packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko(3,1): The closing "b" tag does not match the corresponding opening "a" tag
+packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
+
   1 | <a>
   2 |   <div/>
 > 3 | </b>
-    | ^^^^
+    | ^^^^ The closing "b" tag does not match the corresponding opening "a" tag

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
+
 > 1 | <div/myDiv/>
-    |      ^^^^^
+    |      ^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
+
 > 1 | <div/myDiv/>
-    |      ^^^^^
+    |      ^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
+
 > 1 | <div/myDiv/>
-    |      ^^^^^
+    |      ^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
+
 > 1 | <div/myDiv/>
-    |      ^^^^^
+    |      ^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/tag-with-var/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
+
 > 1 | <div/myDiv/>
-    |      ^^^^^
+    |      ^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/cjs-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
+
 > 1 | <let/x:{ y: string } = { y: "hello" }/>
-    |      ^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/html-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
+
 > 1 | <let/x:{ y: string } = { y: "hello" }/>
-    |      ^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
+
 > 1 | <let/x:{ y: string } = { y: "hello" }/>
-    |      ^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdom-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
+
 > 1 | <let/x:{ y: string } = { y: "hello" }/>
-    |      ^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^ Tag does not support a variable.
   2 |

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,5 @@
-packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko(1,6): Tag does not support a variable.
+packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
+
 > 1 | <let/x:{ y: string } = { y: "hello" }/>
-    |      ^^^^^^^^^^^^^^^
+    |      ^^^^^^^^^^^^^^^ Tag does not support a variable.
   2 |

--- a/scripts/types-babel-traverse.js
+++ b/scripts/types-babel-traverse.js
@@ -71,12 +71,7 @@ fs.readFile(
     code: string,
     opts: Record<string, unknown>,
     metadata: Record<string, unknown> & {
-      marko: {
-        id: string,
-        tags: string[],
-        deps: Array<string | { type: string, code: string, path: string, virtualPath: string, [x:string]: unknown }>,
-        watchFiles: string[]
-      }
+      marko: import("@marko/compiler").MarkoMeta
     },
     markoOpts: Required<import('@marko/compiler').Config>
 }


### PR DESCRIPTION
## Description

This pr adds a new `diagnostic` apis to `@marko/babel-utils`.
Methods here allow attaching additional diagnostic information to the compiler result, these include `warnings`, `deprecations`, `suggestions` and `errors`. These diagnostics will be made available as an array under the `meta.diagnostics` property on any compilation result.

By default `errors` will be thrown as an aggregate error at the end of the compilation. Throwing non fatal diagnostic errors can be disabled by setting the new `errorRecovery` compiler option to `true`. When the `errorRecovery` option is true, `error` diagnostics are placed into `meta.diagnostics` with the rest of the diagnostics and do cause the compilation to fail.

### Diagnostic Fixes
Diagnostics which are registered up to and including the `migration` phase of the compiler can also register a way to "fix" the issue.

For example to add a fixable deprecation you would have code like the following:

```ts
// example compiler hook for some tag.
// In this example a tag with a `old` attribute is renamed to `new`.

import { diagnosticDeprecate } from "@marko/babel-utils";

export default (tag) => {
  for (const attr of tag.get("attributes")) {
    if (attr.node.name === "old") {
      diagnosticDeprecate(attr, {
        label: "The 'old' attribute was renamed to the 'new' attribute",
        fix() {
          attr.set("name", "new");
        }
      });
    }
  }
}
```

In the example above whenever the `old` attribute is used a deprecation diagnostic is added to the compilation result and the `fix` is automatically applied at the end of the migration phase.

#### Opt in fixes

`fix`s can also be "opt in" and request a preset prompt. In this case you pass an object as the `fix` with a `type` that corresponds with how to prompt the user. (For the list of prompt types see https://github.com/marko-js/marko/commit/2a668e1ebe34d80c051a1ace4bc4c0ab1fc80855#diff-b1e546a6e371a32471e5230bc76bb2c7597a8a1550a0f5fc8a36fa6a0a422f60R273).

An example opt in fix could look like this:

```ts
diagnosticDeprecate(path, {
  label: "The 'old' attribute was removed",
  fix: {
    type: "select",
    message: "How would you like to fix this?",
    options: [{
      label: "Use the 'a' attribute instead",
      value: "a"
    },
    {
      label: "Use the 'b' attribute instead",
      value: "b"
    }],
    apply(selected = "a") {
      attr.set("name", selected);
    }
  }
});
```

With opt in deprecations you specify some options on how to prompt the user along side an `apply` method which operates the same as the `fix` method in the previous example. The `apply` method is called with the user selection data in some environments (eg vscode, migration cli). **Note that in environments that cannot prompt the user the fix is still applied with the value passed to the apply being `undefined`**.


#### Applying specific fixes
By default the compiler will apply all fixes. To apply only specific fixes and supply user input options you can pass in an `applyFixes` map as a compiler option.
This map must be from the diagnostic index to the value to apply the diagnostic with. Eg with our above `select` example if we imagine it is the second diagnostic we'd pass a map like this:

```ts
compiler.compileSync(..., {
  applyFixes: new Map([[1, "b"]]) // apply the fix for the second diagnostic and select `"b"` as the value.
})

```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
