### PR TITLE
fix: hydrate commonjs output bug

### DIFF
--- a/.changeset/lazy-apricots-joke.md
+++ b/.changeset/lazy-apricots-joke.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Fix issue when outputting hydrate code with commonjs modules enabled.

--- a/packages/translator-default/src/util/add-dependencies.js
+++ b/packages/translator-default/src/util/add-dependencies.js
@@ -4,7 +4,7 @@ import { types as t } from "@marko/compiler";
 import { loadFileForImport, resolveRelativePath } from "@marko/babel-utils";
 
 export default (entryFile, isHydrate) => {
-  const { modules, resolveVirtualDependency, hydrateIncludeImports } =
+  const { resolveVirtualDependency, hydrateIncludeImports } =
     entryFile.markoOpts;
   const hydratedFiles = new Set();
   const program = entryFile.path;
@@ -164,12 +164,6 @@ export default (entryFile, isHydrate) => {
   }
 
   function importPath(path) {
-    if (modules === "cjs") {
-      return t.expressionStatement(
-        t.callExpression(t.identifier("require"), [t.stringLiteral(path)])
-      );
-    }
-
     return t.importDeclaration([], t.stringLiteral(path));
   }
 };


### PR DESCRIPTION
## Description

When telling the compiler to output the `hydrate` entry point with `modules` as `cjs` there is currently a compiler error since part of the hydrate compilation expects the imports to be actual esm import nodes.

This PR fixes the issue by avoiding adding `require` statements in the hydrate compilation and instead relying on the babel commonjs transform which happens later.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
