### PR TITLE
Fixable parse errors

### DIFF
--- a/.changeset/fluffy-paws-cross.md
+++ b/.changeset/fluffy-paws-cross.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix issue that could happen if DOMContentLoaded was manually invoked multiple times.

--- a/.changeset/soft-points-work.md
+++ b/.changeset/soft-points-work.md
@@ -1,0 +1,15 @@
+---
+"@marko/babel-utils": major
+"@marko/translator-default": minor
+"@marko/compiler": minor
+"marko": minor
+---
+
+Allow parse errors to be recovered from by migrations. This adds a new ast node type of MarkoParseError.
+MarkoParseError nodes can be removed during the migration stage to handle legacy syntaxes. Any MarkoParseError
+left in the AST at the end of the migration phase will throw an error similar to what it would have previously
+thrown synchronously.
+
+This also means that all parse errors can be surfaced as an aggregate error instead of bailing on the first
+parse error. When the compiler is ran with `errorRecovery: true` these errors become diagnostics instead of
+being thrown.

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -9,7 +9,7 @@ function escapeFileNames(commands) {
   return filenames => {
     const allFiles = filenames.join(" ");
     const allFilesEscaped = filenames
-      .map(filename => `"${escape([filename])}"`)
+      .map(filename => `"${escape([filename]).replace(/\\@/g, "@")}"`)
       .join(" ");
     return commands.map(
       command =>

--- a/packages/babel-utils/index.d.ts
+++ b/packages/babel-utils/index.d.ts
@@ -208,7 +208,7 @@ export function normalizeTemplateString(
   expressions: t.Expression[]
 ): t.TemplateLiteral;
 
-type Loc = { line: number; column: number };
+type Loc = { line: number; column: number; index?: number };
 type LocRange = { start: Loc; end: Loc };
 
 export function getLoc(file: t.BabelFile, pos: number): Loc;
@@ -224,16 +224,67 @@ export function withLoc<T extends t.Node>(
   end: number
 ): T;
 
-export function parseScript(
+export function parseStatements(file: t.BabelFile, str: string): t.Statement[];
+export function parseStatements(
   file: t.BabelFile,
   str: string,
-  start?: number
-): t.Program;
+  sourceStart: number,
+  sourceEnd: number,
+  sourceOffset?: number
+): t.Statement[];
+
+export function parseExpression(file: t.BabelFile, str: string): t.Expression;
 export function parseExpression(
   file: t.BabelFile,
   str: string,
-  start?: number
+  sourceStart: number,
+  sourceEnd: number,
+  sourceOffset?: number
 ): t.Expression;
+
+export function parseParams(
+  file: t.BabelFile,
+  str: string
+): t.Function["params"];
+export function parseParams(
+  file: t.BabelFile,
+  str: string,
+  sourceStart: number,
+  sourceEnd: number
+): t.Function["params"];
+
+export function parseArgs(
+  file: t.BabelFile,
+  str: string
+): t.CallExpression["arguments"];
+export function parseArgs(
+  file: t.BabelFile,
+  str: string,
+  sourceStart: number,
+  sourceEnd: number
+): t.CallExpression["arguments"];
+
+export function parseVar(
+  file: t.BabelFile,
+  str: string
+): t.VariableDeclarator["id"];
+export function parseVar(
+  file: t.BabelFile,
+  str: string,
+  sourceStart: number,
+  sourceEnd: number
+): t.VariableDeclarator["id"];
+
+export function parseTemplateLiteral(
+  file: t.BabelFile,
+  str: string
+): t.TemplateLiteral;
+export function parseTemplateLiteral(
+  file: t.BabelFile,
+  str: string,
+  sourceStart: number,
+  sourceEnd: number
+): t.TemplateLiteral;
 
 export function resolveRelativePath(file: t.BabelFile, request: string): string;
 export function importDefault(

--- a/packages/babel-utils/src/index.js
+++ b/packages/babel-utils/src/index.js
@@ -28,7 +28,14 @@ export { normalizeTemplateString } from "./template-string";
 
 export { getLoc, getLocRange, withLoc } from "./loc";
 
-export { parseScript, parseExpression } from "./parse";
+export {
+  parseStatements,
+  parseExpression,
+  parseParams,
+  parseArgs,
+  parseVar,
+  parseTemplateLiteral
+} from "./parse";
 
 export { resolveRelativePath, importDefault, importNamed } from "./imports";
 

--- a/packages/babel-utils/src/loc.js
+++ b/packages/babel-utils/src/loc.js
@@ -1,16 +1,16 @@
-const LINE_POS_KEY = Symbol();
+const LINE_INDEX_KEY = Symbol();
 
-export function getLoc(file, pos) {
-  return findLoc(getLinePositions(file), 0, pos);
+export function getLoc(file, index) {
+  return findLoc(getLineIndexes(file), 0, index);
 }
 
 export function getLocRange(file, start, end) {
-  const linePositions = getLinePositions(file);
-  const startLoc = findLoc(linePositions, 0, start);
+  const lineIndexes = getLineIndexes(file);
+  const startLoc = findLoc(lineIndexes, 0, start);
 
   if (startLoc) {
     const endLoc =
-      start === end ? startLoc : findLoc(linePositions, startLoc.line - 1, end);
+      start === end ? startLoc : findLoc(lineIndexes, startLoc.line - 1, end);
 
     return {
       start: startLoc,
@@ -26,44 +26,45 @@ export function withLoc(file, node, start, end) {
   return node;
 }
 
-function getLinePositions(file) {
-  let linePositions = file.metadata.marko[LINE_POS_KEY];
+function getLineIndexes(file) {
+  let lineIndexes = file.metadata.marko[LINE_INDEX_KEY];
 
-  if (!linePositions) {
-    linePositions = [0];
+  if (!lineIndexes) {
+    lineIndexes = [0];
     for (let i = 0; i < file.code.length; i++) {
       if (file.code[i] === "\n") {
-        linePositions.push(i);
+        lineIndexes.push(i);
       }
     }
 
-    file.metadata.marko[LINE_POS_KEY] = linePositions;
+    file.metadata.marko[LINE_INDEX_KEY] = lineIndexes;
   }
 
-  return linePositions;
+  return lineIndexes;
 }
 
-function findLoc(linePositions, startLine, pos) {
-  const endLine = linePositions.length - 1;
+function findLoc(lineIndexes, startLine, index) {
+  const endLine = lineIndexes.length - 1;
   let max = endLine;
   let line = startLine;
 
   while (line < max) {
     const mid = (line + max) >>> 1;
-    if (linePositions[mid] < pos) {
+    if (lineIndexes[mid] < index) {
       line = mid + 1;
     } else {
       max = mid;
     }
   }
 
-  let linePos = linePositions[line];
-  if (linePos > pos) {
-    linePos = linePositions[--line];
+  let lineIndex = lineIndexes[line];
+  if (lineIndex > index) {
+    lineIndex = lineIndexes[--line];
   }
 
   return {
+    index,
     line: line + 1,
-    column: pos === linePos ? 0 : pos - linePos - (line === 0 ? 0 : 1)
+    column: index === lineIndex ? 0 : index - lineIndex - (line === 0 ? 0 : 1)
   };
 }

--- a/packages/babel-utils/src/parse.js
+++ b/packages/babel-utils/src/parse.js
@@ -1,40 +1,172 @@
 import * as babelParser from "@babel/parser";
+import { getLocRange } from "./loc";
+import { types as t } from "@marko/compiler";
 
 const CODE_AS_WHITE_SPACE_KEY = Symbol();
 
-export function parseScript(file, str, start) {
-  return tryParse(file, false, str, start);
+export function parseStatements(
+  file,
+  str,
+  sourceStart,
+  sourceEnd,
+  sourceOffset
+) {
+  return tryParse(file, false, str, sourceStart, sourceEnd, sourceOffset);
 }
 
-export function parseExpression(file, str, start) {
-  return tryParse(file, true, str, start);
+export function parseExpression(
+  file,
+  str,
+  sourceStart,
+  sourceEnd,
+  sourceOffset
+) {
+  return tryParse(file, true, str, sourceStart, sourceEnd, sourceOffset);
 }
 
-function tryParse(file, isExpression, str, start) {
-  if (start) {
-    let whitespace = file.metadata.marko[CODE_AS_WHITE_SPACE_KEY];
+export function parseParams(file, str, sourceStart, sourceEnd) {
+  const parsed = parseExpression(
+    file,
+    `(${str})=>{}`,
+    sourceStart,
+    sourceEnd,
+    1
+  );
 
-    if (whitespace === undefined) {
-      file.metadata.marko[CODE_AS_WHITE_SPACE_KEY] = whitespace =
-        file.code.replace(/[^\s]/g, " ");
-    }
-
-    str = whitespace.slice(0, start) + str;
+  if (parsed.type === "ArrowFunctionExpression") {
+    return parsed.params;
   }
 
-  try {
-    return isExpression
-      ? babelParser.parseExpression(str, file.opts.parserOpts)
-      : babelParser.parse(str, file.opts.parserOpts).program;
-  } catch (err) {
-    let { loc, message } = err;
-    if (loc) {
-      throw file.buildCodeFrameError(
-        { loc: { start: loc } },
-        message.replace(/ *\(\d+:\d+\)$/, "")
+  return [ensureParseError(file, parsed, sourceStart, sourceEnd)];
+}
+
+export function parseArgs(file, str, sourceStart, sourceEnd) {
+  const parsed = parseExpression(file, `_(${str})`, sourceStart, sourceEnd, 2);
+
+  if (parsed.type === "CallExpression") {
+    return parsed.arguments;
+  }
+
+  return [ensureParseError(file, parsed, sourceStart, sourceEnd)];
+}
+
+export function parseVar(file, str, sourceStart, sourceEnd) {
+  const parsed = parseExpression(
+    file,
+    `(${str})=>{}`,
+    sourceStart,
+    sourceEnd,
+    1
+  );
+
+  if (parsed.type === "ArrowFunctionExpression" && parsed.params.length === 1) {
+    return parsed.params[0];
+  }
+
+  return ensureParseError(file, parsed, sourceStart, sourceEnd);
+}
+
+export function parseTemplateLiteral(file, str, sourceStart, sourceEnd) {
+  const parsed = parseExpression(
+    file,
+    "`" + str + "`",
+    sourceStart,
+    sourceEnd,
+    1
+  );
+
+  if (parsed.type === "TemplateLiteral") {
+    return parsed;
+  }
+
+  return ensureParseError(file, parsed, sourceStart, sourceEnd);
+}
+
+function tryParse(
+  file,
+  isExpression,
+  str,
+  sourceStart,
+  sourceEnd,
+  sourceOffset
+) {
+  const { parserOpts } = file.opts;
+  let code = str;
+
+  if (typeof sourceStart === "number") {
+    const whitespace =
+      file.metadata.marko[CODE_AS_WHITE_SPACE_KEY] ||
+      (file.metadata.marko[CODE_AS_WHITE_SPACE_KEY] = file.code.replace(
+        /[^\s]/g,
+        " "
+      ));
+    code =
+      whitespace.slice(
+        0,
+        sourceOffset ? sourceStart - sourceOffset : sourceStart
+      ) + str;
+
+    try {
+      return isExpression
+        ? babelParser.parseExpression(code, parserOpts)
+        : babelParser.parse(code, parserOpts).program.body;
+    } catch (err) {
+      const parseError = createParseError(
+        file,
+        sourceStart,
+        sourceEnd,
+        err.message,
+        err.loc
       );
-    } else {
-      throw err;
+
+      if (isExpression) {
+        return parseError;
+      } else {
+        return [parseError];
+      }
     }
+  } else {
+    return isExpression
+      ? t.cloneDeepWithoutLoc(babelParser.parseExpression(code, parserOpts))
+      : babelParser
+          .parse(code, parserOpts)
+          .program.body.map(node => t.cloneDeepWithoutLoc(node));
+  }
+}
+
+function ensureParseError(file, node, sourceStart, sourceEnd) {
+  if (node.type === "MarkoParseError") return node;
+  return createParseError(
+    file,
+    sourceStart,
+    sourceEnd,
+    `Unexpected node of type ${node.type} returned while parsing.`
+  );
+}
+
+function createParseError(file, sourceStart, sourceEnd, label, errorLoc) {
+  file.___hasParseErrors = true;
+  const loc = getLocRange(file, sourceStart, sourceEnd);
+  return {
+    type: "MarkoParseError",
+    source: file.code.slice(sourceStart, sourceEnd),
+    label: label.replace(/ *\(\d+:\d+\)$/, ""),
+    errorLoc: errorLoc && getBoundedRange(loc, errorLoc),
+    loc,
+    start: sourceStart,
+    end: sourceEnd
+  };
+}
+
+function getBoundedRange(sourceRange, start) {
+  if (start && typeof start.index === "number") {
+    if (
+      start.index < sourceRange.start.index ||
+      start.index >= sourceRange.end.index
+    ) {
+      return sourceRange;
+    }
+
+    return { start, end: start };
   }
 }

--- a/packages/compiler/src/babel-types/generator/patch.js
+++ b/packages/compiler/src/babel-types/generator/patch.js
@@ -15,6 +15,9 @@ const UNENCLOSED_WHITESPACE_TYPES = [
 ];
 
 Object.assign(Printer.prototype, {
+  MarkoParseError(node) {
+    this.token(node.source);
+  },
   MarkoDocumentType(node) {
     this.token("<!");
     this.token(node.value);

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -13,6 +13,22 @@ const valueFieldCommon = {
 };
 
 const MarkoDefinitions = {
+  MarkoParseError: {
+    aliases: ["Marko", "Expression", "Statement"],
+    builder: ["source", "label", "errorLoc"],
+    fields: {
+      source: {
+        validate: assertValueType("string")
+      },
+      label: {
+        validate: assertValueType("string")
+      },
+      errorLoc: {
+        optional: true,
+        validate: assertValueType("object")
+      }
+    }
+  },
   MarkoDocumentType: {
     aliases: ["Marko", "Statement"],
     builder: ["value"],

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -1,6 +1,5 @@
 export * as types from "./babel-types";
 import path from "path";
-import color from "kleur";
 import * as babel from "@babel/core";
 import cjsPlugin from "@babel/plugin-transform-modules-commonjs";
 import tsSyntaxPlugin from "@babel/plugin-syntax-typescript";
@@ -12,6 +11,7 @@ import * as taglib from "./taglib";
 import shouldOptimize from "./util/should-optimize";
 import tryLoadTranslator from "./util/try-load-translator";
 import { buildCodeFrameError } from "./util/build-code-frame";
+import throwAggregateError from "./util/merge-errors";
 export { taglib };
 
 let globalConfig = { ...defaultConfig };
@@ -134,32 +134,7 @@ function buildResult(src, filename, errorRecovery, babelResult) {
       }
     }
 
-    switch (errors.length) {
-      case 0:
-        break;
-      case 1: {
-        throw errors[0];
-      }
-      default: {
-        let err;
-        const message = `${color.red("AggregationError:")}\n${errors
-          .map(err => err.message)
-          .join("\n\n")
-          .replace(/^(?!\s*$)/gm, "\t")}\n`;
-
-        if (typeof AggregateError === "function") {
-          err = new AggregateError(errors, message);
-        } else {
-          err = new Error(message);
-          err.name = "AggregateError";
-          err.errors = errors;
-        }
-
-        // Remove the stack trace from the error since it is not useful.
-        err.stack = "";
-        throw err;
-      }
-    }
+    throwAggregateError(errors);
   }
 
   return { ast, map, code, meta };

--- a/packages/compiler/src/util/merge-errors.js
+++ b/packages/compiler/src/util/merge-errors.js
@@ -1,0 +1,28 @@
+import color from "kleur";
+
+export default function throwAggregateError(errors) {
+  switch (errors.length) {
+    case 0:
+      return;
+    case 1:
+      throw errors[0];
+  }
+
+  let err;
+  const message = `${color.red("AggregationError:")}\n${errors
+    .map(err => err.message)
+    .join("\n\n")
+    .replace(/^(?!\s*$)/gm, "\t")}\n`;
+
+  if (typeof AggregateError === "function") {
+    err = new AggregateError(errors, message);
+  } else {
+    err = new Error(message);
+    err.name = "AggregateError";
+    err.errors = errors;
+  }
+
+  // Remove the stack trace from the error since it is not useful.
+  err.stack = "";
+  throw err;
+}

--- a/packages/marko/src/node_modules/@internal/components-registry/index-browser.js
+++ b/packages/marko/src/node_modules/@internal/components-registry/index-browser.js
@@ -514,7 +514,7 @@ function tryHydrateComponent(rawDef, meta, host, runtimeId) {
           })
           .reverse()
           .forEach(tryInvoke);
-        deferredDefs = undefined;
+        deferredDefs.length = 0;
       });
     }
   }

--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -6,7 +6,7 @@ import {
   resolveRelativePath,
   importNamed,
   importDefault,
-  parseScript,
+  parseStatements,
   isNativeTag,
   isMacroTag,
   isDynamicTag,
@@ -193,7 +193,13 @@ export const translate = {
 
       if (file.metadata.marko.moduleCode) {
         path
-          .replaceWith(parseScript(file, file.metadata.marko.moduleCode))[0]
+          .replaceWith(
+            t.program(
+              parseStatements(file, file.metadata.marko.moduleCode),
+              undefined,
+              file.markoOpts.modules === "cjs" ? "script" : "module"
+            )
+          )[0]
           .skip();
         return;
       }
@@ -427,7 +433,7 @@ export const translate = {
           metaObject.properties.push(
             t.objectProperty(
               t.identifier("deps"),
-              parseExpression(file, JSON.stringify(meta.deps), file.code.length)
+              parseExpression(file, JSON.stringify(meta.deps))
             )
           );
         }

--- a/packages/translator-default/src/taglib/core/parse-class.js
+++ b/packages/translator-default/src/taglib/core/parse-class.js
@@ -9,7 +9,7 @@ export default function (path) {
   } = path;
   const {
     rawValue: code,
-    name: { start }
+    name: { start, end }
   } = node;
   const meta = file.metadata.marko;
 
@@ -29,7 +29,7 @@ export default function (path) {
       );
   }
 
-  const parsed = parseExpression(file, code.replace(/;\s*$/, ""), start);
+  const parsed = parseExpression(file, code.replace(/;\s*$/, ""), start, end);
 
   if (parsed.id) {
     throw file.buildCodeFrameError(

--- a/packages/translator-default/src/taglib/core/parse-export.js
+++ b/packages/translator-default/src/taglib/core/parse-export.js
@@ -1,4 +1,4 @@
-import { parseScript } from "@marko/babel-utils";
+import { parseStatements } from "@marko/babel-utils";
 
 export default function (path) {
   const {
@@ -7,8 +7,8 @@ export default function (path) {
   } = path;
   const {
     rawValue,
-    name: { start }
+    name: { start, end }
   } = node;
-  const [exportNode] = parseScript(file, rawValue, start).body;
+  const [exportNode] = parseStatements(file, rawValue, start, end);
   path.replaceWith(exportNode);
 }

--- a/packages/translator-default/src/taglib/core/parse-import.js
+++ b/packages/translator-default/src/taglib/core/parse-import.js
@@ -1,4 +1,4 @@
-import { parseScript } from "@marko/babel-utils";
+import { parseStatements } from "@marko/babel-utils";
 
 export default function (path) {
   const {
@@ -7,8 +7,8 @@ export default function (path) {
   } = path;
   const {
     rawValue,
-    name: { start }
+    name: { start, end }
   } = node;
-  const [importNode] = parseScript(file, rawValue, start).body;
+  const [importNode] = parseStatements(file, rawValue, start, end);
   path.replaceWith(importNode);
 }

--- a/packages/translator-default/src/taglib/core/parse-static.js
+++ b/packages/translator-default/src/taglib/core/parse-static.js
@@ -1,15 +1,15 @@
 import { types as t } from "@marko/compiler";
-import { parseScript } from "@marko/babel-utils";
+import { parseStatements } from "@marko/babel-utils";
 
 export default function (path) {
   const {
     node,
     hub: { file }
   } = path;
-  const { rawValue } = node;
+  const { rawValue, end } = node;
   const code = rawValue.replace(/^static\s*/, "").trim();
   const start = node.name.start + (rawValue.length - code.length);
-  let { body } = parseScript(file, code, start);
+  let body = parseStatements(file, code, start, end);
   if (body.length === 1 && t.isBlockStatement(body[0])) {
     body = body[0].body;
   }

--- a/packages/translator-default/test/fixtures/module-code/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/module-code/snapshots/cjs-expected.js
@@ -1,3 +1,1 @@
-"use strict";
-
 module.exports = require("./src/index");


### PR DESCRIPTION
Allow parse errors to be recovered from by migrations. This adds a new ast node type of MarkoParseError.
MarkoParseError nodes can be removed during the migration stage to handle legacy syntaxes. Any MarkoParseError
left in the AST at the end of the migration phase will throw an error similar to what it would have previously
thrown synchronously.

This also means that all parse errors can be surfaced as an aggregate error instead of bailing on the first
parse error. When the compiler is ran with `errorRecovery: true` these errors become diagnostics instead of
being thrown.