### PR TITLE
fix: module-code not outputting cjs when configured to do so

### DIFF
--- a/.changeset/lovely-keys-whisper.md
+++ b/.changeset/lovely-keys-whisper.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/compiler": patch
+"@marko/translator-default": patch
+---
+
+Fix issue where `module-code` entries were not properly checking the expected module output (causing them to always output esm). This was previously fine due to the cjs conversion plugin running for these, however a recent change caused that plugin to no longer run for these files since (which should have been unnecessary, except for that they had the incorrect check).

--- a/packages/marko/compiler-browser.marko
+++ b/packages/marko/compiler-browser.marko
@@ -1,7 +1,7 @@
 <module-code(function(require, opts) {
     var file = `"./${opts.optimize ? "dist" : "src"}/compiler"`;
 
-    if (opts.module === "cjs") {
+    if (opts.modules === "cjs") {
         return `module.exports = require(${file});\n`;
     } else {
         return `export * from ${file};\n`;

--- a/packages/marko/components-browser.marko
+++ b/packages/marko/components-browser.marko
@@ -1,7 +1,7 @@
 <module-code(function(require, opts) {
     var file = `"./${opts.optimize ? "dist" : "src"}/runtime/components"`;
 
-    if (opts.module === "cjs") {
+    if (opts.modules === "cjs") {
         return `module.exports = require(${file});\n`;
     } else {
         return `export { default } from ${file};\nexport * from ${file};\n`;

--- a/packages/marko/index-browser.marko
+++ b/packages/marko/index-browser.marko
@@ -1,7 +1,7 @@
 <module-code(function(require, opts) {
     var file = `"./${opts.optimize ? "dist" : "src"}"`;
 
-    if (opts.module === "cjs") {
+    if (opts.modules === "cjs") {
         return `module.exports = require(${file});\n`;
     } else {
         return `export * from ${file};\n`;


### PR DESCRIPTION
Fix issue where `module-code` entries were not properly checking the expected module output (causing them to always output esm). This was previously fine due to the cjs conversion plugin running for these, however a recent change caused that plugin to no longer run for these files since (which should have been unnecessary, except for that they had the incorrect check).

Previously `module-code` sections had their `program.type` inferred from the Marko program node (which is always esm). However [this change](https://github.com/marko-js/marko/pull/1980/files#diff-4d9336a1ddb59685cb34ac4db35d17bb568725b293eab87199602d782d77d09cR197-R201) caused it to instead have the module-code program have the script type determined based on the compiler option.

The fix is to update the usages of `module-code` to have a proper check for the expected module output instead of (accidentally) relying on the esm/cjs transformation.