### PR TITLE
fix: deleting error properties regression

### DIFF
--- a/.changeset/twenty-beers-repeat.md
+++ b/.changeset/twenty-beers-repeat.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"marko": patch
+"@marko/translator-default": patch
+---
+
+Fix regression which would happen if tools tried to "delete" the `loc` property on error instances returned from Marko. This property is now configurable and can be deleted again.

--- a/packages/compiler/src/util/build-code-frame.js
+++ b/packages/compiler/src/util/build-code-frame.js
@@ -17,17 +17,29 @@ class CompileError extends Error {
       : `CompileError: ${prettyMessage}\n${indent}at ${prettyFileName}`;
 
     Object.defineProperties(this, {
-      loc: { value: loc, enumerable: false, writable: true },
-      label: { value: message, enumerable: false, writable: true },
+      loc: {
+        value: loc,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      },
+      label: {
+        value: message,
+        enumerable: false,
+        writable: true,
+        configurable: true
+      },
       // Ignore some mutations from Babel.
       code: {
         enumerable: false,
+        configurable: true,
         get() {
           return undefined;
         },
         set() {}
       },
       message: {
+        configurable: true,
         enumerable: false,
         get() {
           return `${prettyFileName}: ${message}`;


### PR DESCRIPTION
Resolves https://github.com/marko-js/vite/issues/74