### PR TITLE
fix: handle errors thrown in await catch attrs

### DIFF
--- a/.changeset/gold-timers-sleep.md
+++ b/.changeset/gold-timers-sleep.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Handle errors thrown in await catch attribute

--- a/packages/marko/src/core-tags/core/await/renderer.js
+++ b/packages/marko/src/core-tags/core/await/renderer.js
@@ -220,7 +220,11 @@ function renderContents(err, data, input, out) {
   if (err) {
     if (input.catch) {
       if (errorRenderer) {
-        errorRenderer(out, err);
+        try {
+          errorRenderer(out, err);
+        } catch (err2) {
+          out.error(err2);
+        }
       }
     } else {
       out.error(err);

--- a/packages/marko/test/render/fixtures/await-error-rethrow-catch/template.marko
+++ b/packages/marko/test/render/fixtures/await-error-rethrow-catch/template.marko
@@ -1,0 +1,10 @@
+---
+BEFORE
+<await(Promise.reject(new Error("Something went wrong!")))>
+    <@then|testData|>Success!</@then>
+    <@catch|err|>
+        $ throw err
+    </@catch>
+</await>
+AFTER
+---

--- a/packages/marko/test/render/fixtures/await-error-rethrow-catch/test.js
+++ b/packages/marko/test/render/fixtures/await-error-rethrow-catch/test.js
@@ -1,0 +1,10 @@
+var expect = require("chai").expect;
+
+exports.templateData = {};
+
+exports.skip_vdom = "VDOM does not support async components";
+
+exports.checkError = function (e) {
+  var message = e.toString();
+  expect(message).to.contain("Something went wrong");
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Handles errors thrown within an `await` catch attribute using `out.error` to propagate the error to the response in the same way an await tag without a catch would.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

Throwing an error in catch would be an unhandled error which could cause the server to crash.

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
