### PR TITLE
fix: batching to prevent treeshaking issues

### DIFF
--- a/.changeset/friendly-mangos-sleep.md
+++ b/.changeset/friendly-mangos-sleep.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Simplify batching, prevent treeshaking bug

--- a/packages/marko/src/runtime/components/update-manager.js
+++ b/packages/marko/src/runtime/components/update-manager.js
@@ -53,9 +53,7 @@ function batchUpdate(func) {
   // is the outer batched update. After the outer
   // batched update completes we invoke the "afterUpdate"
   // event listeners.
-  var batch = {
-    ___queue: null,
-  };
+  var batch = [];
 
   batchStack.push(batch);
 
@@ -65,9 +63,7 @@ function batchUpdate(func) {
     try {
       // Update all of the components that where queued up
       // in this batch (if any)
-      if (batch.___queue) {
-        updateComponents(batch.___queue);
-      }
+      updateComponents(batch);
     } finally {
       // Now that we have completed the update of all the components
       // in this batch we need to remove it off the top of the stack
@@ -84,20 +80,11 @@ function queueComponentUpdate(component) {
     // If the stack has a non-zero length then we know that a batch has
     // been started so we can just queue the component on the top batch. When
     // the batch is ended this component will be updated.
-    var batch = batchStack[batchStackLen - 1];
-
-    // We default the batch queue to null to avoid creating an Array instance
-    // unnecessarily. If it is null then we create a new Array, otherwise
-    // we push it onto the existing Array queue
-    if (batch.___queue) {
-      batch.___queue.push(component);
-    } else {
-      batch.___queue = [component];
-    }
+    batchStack[batchStackLen - 1].push(component);
   } else {
     // We are not within a batched update. We need to schedule a batch update
     // for the nextTick (if that hasn't been done already) and we will
-    // add the component to the unbatched queued
+    // add the component to the unbatched queue
     scheduleUpdates();
     unbatchedQueue.push(component);
   }

--- a/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/components/counter.marko
+++ b/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/components/counter.marko
@@ -1,0 +1,15 @@
+class {
+    onCreate(input) {
+        this.state = {
+            count: 0
+        }
+    }
+    handleClick() {
+        this.state.count++;
+        this.once('update', () => {
+            this.emit('change', this.state.count);
+        });
+    }
+}
+
+<button key="button" on-click('handleClick')>${state.count}</button>

--- a/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/index.marko
+++ b/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/index.marko
@@ -1,0 +1,13 @@
+class {
+    onCreate() {
+        this.state = {
+            count: 0
+        }
+    }
+    handleCountChange(value) {
+        this.state.count = value
+    }
+}
+
+<counter key="counter" on-change('handleCountChange')/>
+<div>${state.count}</div>

--- a/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/test.js
+++ b/packages/marko/test/components-browser/fixtures/component-update-batch-not-empty/test.js
@@ -1,0 +1,17 @@
+var expect = require("chai").expect;
+
+module.exports = function (helpers, done) {
+  var component = helpers.mount(require.resolve("./index"), {});
+  var counter = component.getComponent("counter");
+  var button = counter.getEl("button");
+
+  expect(component.state.count).to.equal(0);
+  expect(counter.state.count).to.equal(0);
+  button.click();
+
+  setTimeout(() => {
+    expect(component.state.count).to.equal(1);
+    expect(counter.state.count).to.equal(1);
+    done();
+  }, 100);
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Refactors batching code to simplify the logic and prevent an issue when bundling with Rollup. Rollup's default treeshaking causes [part of the batching code](https://github.com/marko-js/marko/blob/1122f64b3a857ba4ebe8589469ffee4718bbd1a9/packages/marko/src/runtime/components/update-manager.js#L69) to be incorrectly omitted.

```js
function batchUpdate(func) {
  const batch = {
    ___queue: null
  };

  batchStack.push(batch);

  try {
    func();
  } finally {
    try {
      if (batch.___queue) {
        updateComponents(batch.___queue);
      }
    } finally {
      batchStack.length--;
    }
  }
}
````

becomes

```js
function batchUpdate(func) {
  const batch = {
    ___queue: null
  };

  batchStack.push(batch);

  try {
    func();
  } finally {
    try {
      if (batch.___queue) {
        ;
      }
    } finally {
      batchStack.length--;
    }
  }
}
````

which prevents component changes batched during a render to be lost and left in a broken state.


<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
