### PR TITLE
fix: improve compat for legacy defineRenderer template references

### DIFF
--- a/.changeset/pretty-shirts-wait.md
+++ b/.changeset/pretty-shirts-wait.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix compat issue where markoWidgets.defineRenderer was not resolving the default export of a Marko 5 template.

--- a/packages/marko/src/runtime/components/legacy/defineRenderer-legacy.js
+++ b/packages/marko/src/runtime/components/legacy/defineRenderer-legacy.js
@@ -20,6 +20,10 @@ module.exports = function defineRenderer(renderingLogic) {
     template = req(template);
   }
 
+  if (template && template.default) {
+    template = template.default;
+  }
+
   if (!renderer) {
     var getInitialProps;
     var getTemplateData;


### PR DESCRIPTION
## Description

Improves compat for legacy v3 widgets using the `markoWidgets.defineRenderer` api when passing in a template.
This api will now accept template modules with a default export.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
