### PR TITLE
fix: legacy compatibility issue with esm templates and defineWidget

### DIFF
--- a/.changeset/spicy-turtles-travel.md
+++ b/.changeset/spicy-turtles-travel.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Improve compatibility of legacy Marko widgets loading a template compiled as esm.

--- a/packages/marko/src/node_modules/@internal/components-define-widget-legacy/index-browser.js
+++ b/packages/marko/src/node_modules/@internal/components-define-widget-legacy/index-browser.js
@@ -320,7 +320,7 @@ module.exports = function defineWidget(def, renderer) {
       template = req(template);
     }
 
-    registry.r(template.___typeName, function () {
+    registry.r((template.default || template).___typeName, function () {
       return Component;
     });
   }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixes an issue where if the `require('marko-component').defineComponent` is passed a template which is compiled in esm mode.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
