### PR TITLE
fix(babel): use correct types for params and args

### DIFF
--- a/.changeset/witty-apricots-travel.md
+++ b/.changeset/witty-apricots-travel.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+fix AST types

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -208,7 +208,7 @@ export function parseMarko(file) {
       );
     },
     onTagTypeParams(part) {
-      currentTag.node.typeParameters = parseTypeParams(
+      currentBody.node.typeParameters = parseTypeParams(
         file,
         parser.read(part.value),
         part.start,

--- a/packages/compiler/src/babel-types/generator/patch.js
+++ b/packages/compiler/src/babel-types/generator/patch.js
@@ -193,12 +193,12 @@ Object.assign(Printer.prototype, {
       }
 
       if (node.body.params.length) {
-        if (node.typeParameters) {
+        if (node.body.typeParameters) {
           if (!node.typeArguments) {
             this.token(" ");
           }
           this.token("<");
-          this.printList(node.typeParameters.params, node);
+          this.printList(node.body.typeParameters.params, node);
           this.token(">");
         }
         this.token("|");

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -147,7 +147,7 @@ const MarkoDefinitions = {
   MarkoTagBody: {
     aliases: ["Marko", "BlockParent", "Scope"],
     builder: ["body", "params"],
-    visitor: ["params", "body"],
+    visitor: ["typeParameters", "params", "body"],
     fields: {
       params: {
         validate: chain(
@@ -155,6 +155,10 @@ const MarkoDefinitions = {
           assertEach(assertNodeType("Identifier", "Pattern", "RestElement"))
         ),
         default: [],
+      },
+      typeParameters: {
+        validate: assertNodeType("TSTypeParameterDeclaration"),
+        optional: true,
       },
       body: {
         validate: arrayOfType([
@@ -173,7 +177,14 @@ const MarkoDefinitions = {
   MarkoTag: {
     aliases: ["Marko", "Statement"],
     builder: ["name", "attributes", "body", "arguments", "var"],
-    visitor: ["name", "attributes", "body", "arguments", "var"],
+    visitor: [
+      "name",
+      "typeArguments",
+      "attributes",
+      "body",
+      "arguments",
+      "var",
+    ],
     fields: {
       name: {
         validate: assertNodeType("Expression"),
@@ -193,17 +204,7 @@ const MarkoDefinitions = {
         optional: true,
       },
       typeArguments: {
-        validate: chain(
-          assertValueType("array"),
-          assertEach(assertNodeType("TypeAnnotation"))
-        ),
-        optional: true,
-      },
-      typeParameters: {
-        validate: chain(
-          assertValueType("array"),
-          assertEach(assertNodeType("TypeAnnotation"))
-        ),
+        validate: assertNodeType("TSTypeParameterInstantiation"),
         optional: true,
       },
       rawValue: {


### PR DESCRIPTION
Use correct types for AST