### PR TITLE
fix: issue removing exports in stripTypes mode

### DIFF
--- a/.changeset/eighty-beers-speak.md
+++ b/.changeset/eighty-beers-speak.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"marko": patch
+"@marko/translator-default": patch
+---
+
+Fix issue where additional exports were being removed when stripping typescript types.

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -132,11 +132,13 @@ export default (api, markoOpts) => {
             },
             ExportNamedDeclaration: {
               exit(path) {
+                const { node } = path;
                 // The babel typescript plugin will add an empty export declaration
                 // if there are no other imports/exports in the file.
                 // This is not needed for Marko file outputs since there is always
                 // a default export.
-                if (path.node.specifiers.length === 0) path.remove();
+                if (!(node.declaration || node.specifiers.length))
+                  path.remove();
               },
             },
           }


### PR DESCRIPTION
## Description
Fixes a bug where if you ask the Marko compiler to strip types from a template (not when outputting actual js) that additional template exports were removed.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
