### PR TITLE
fix: improve compile error output

### DIFF
--- a/.changeset/fresh-swans-hear.md
+++ b/.changeset/fresh-swans-hear.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Improve compile error output.

--- a/packages/compiler/src/util/strip-ansi.js
+++ b/packages/compiler/src/util/strip-ansi.js
@@ -1,0 +1,7 @@
+const ansiReg =
+  // eslint-disable-next-line no-control-regex
+  /([\u001b\u009b][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><])/g;
+
+export function stripAnsi(str) {
+  return str.replace(ansiReg, "");
+}

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
     > 1 | <div hello('a')/>
         |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
     > 1 | <div hello('a')/>
         |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
     > 1 | <div hello('a')/>
         |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
     > 1 | <div hello('a')/>
         |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-arguments-on-non-event-attribute/template.marko:1:6
     > 1 | <div hello('a')/>
         |      ^^^^^^^^^^ Unsupported arguments on the "hello" attribute.

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
        7 |     Body content
        8 |

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
        7 |     Body content
        8 |

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
        7 |     Body content
        8 |

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
        7 |     Body content
        8 |

--- a/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-native-tag-parent/template.marko:9:6
        7 |     Body content
        8 |

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
     > 1 | <@header class="my-header">
         |  ^^^^^^^ @tags must be nested within another element.

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
     > 1 | <@header class="my-header">
         |  ^^^^^^^ @tags must be nested within another element.

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
     > 1 | <@header class="my-header">
         |  ^^^^^^^ @tags must be nested within another element.

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-at-tags-top-level/template.marko:1:2
     > 1 | <@header class="my-header">
         |  ^^^^^^^ @tags must be nested within another element.

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
     > 1 | <await>
         |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
     > 1 | <await>
         |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
     > 1 | <await>
         |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
     > 1 | <await>
         |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".

--- a/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-missing-provider/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-missing-provider/template.marko:1:2
     > 1 | <await>
         |  ^^^^^ You must provide a promise argument to the "<await>" tag, eg: "<await(promise)>".

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
     > 1 | <await(a, b)>
         |           ^ You can only pass one argument to the "<await>" tag.

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
     > 1 | <await(a, b)>
         |           ^ You can only pass one argument to the "<await>" tag.

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
     > 1 | <await(a, b)>
         |           ^ You can only pass one argument to the "<await>" tag.

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
     > 1 | <await(a, b)>
         |           ^ You can only pass one argument to the "<await>" tag.

--- a/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-await-tag-multiple-arguments/template.marko:1:11
     > 1 | <await(a, b)>
         |           ^ You can only pass one argument to the "<await>" tag.

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-bad-expression/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-bad-expression/template.marko:1:18
     > 1 | <div class=(this is not valid)></div>
         |                  ^ Unexpected token, expected ","

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-constructor/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-constructor/template.marko:2:3
       1 | class {
     > 2 |   constructor() {

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-file-and-inline/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-file-and-inline/template.marko:1:1
     > 1 | class {
         | ^^^^^ A Marko file can either have an inline class, or an external "component.js", but not both.

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-not-root/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-not-root/template.marko:2:3
       1 | div
     > 2 |   class extends Test {

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
       1 | class {
     > 2 |   #x = 1;

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
       1 | class {
     > 2 |   #x = 1;

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
       1 | class {
     > 2 |   #x = 1;

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
       1 | class {
     > 2 |   #x = 1;

--- a/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-private-properties/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-private-properties/template.marko:2:3
       1 | class {
     > 2 |   #x = 1;

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
       1 | class {
     > 2 |   static x = 1;

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
       1 | class {
     > 2 |   static x = 1;

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
       1 | class {
     > 2 |   static x = 1;

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
       1 | class {
     > 2 |   static x = 1;

--- a/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-static-properties/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-static-properties/template.marko:2:3
       1 | class {
     > 2 |   static x = 1;

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-tag-nested-content/template.marko:2:2
       1 | class {}
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-class-with-super-class/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-class-with-super-class/template.marko:1:15
     > 1 | class extends Test {
         |               ^^^^ Component class cannot have a super class.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
     > 1 | <custom-tag(a, b, { c })/>
         |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
     > 1 | <custom-tag(a, b, { c })/>
         |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
     > 1 | <custom-tag(a, b, { c })/>
         |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
     > 1 | <custom-tag(a, b, { c })/>
         |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-custom-tag-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-custom-tag-arguments/template.marko:1:13
     > 1 | <custom-tag(a, b, { c })/>
         |             ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
     > 1 | <div onClick('a') onClick('b')/>
         |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
     > 1 | <div onClick('a') onClick('b')/>
         |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
     > 1 | <div onClick('a') onClick('b')/>
         |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
     > 1 | <div onClick('a') onClick('b')/>
         |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko:1:19
     > 1 | <div onClick('a') onClick('b')/>
         |                   ^^^^^^^^^^^^ Duplicate event handlers are not supported.

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-dynamic-tag-no-value/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-dynamic-tag-no-value/template.marko:1:4
     > 1 | <${}/>
         |    ^ Invalid placeholder, the expression cannot be missing

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
       2 | </if>
       3 | <div/>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
       2 | </if>
       3 | <div/>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
       2 | </if>
       3 | <div/>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
       2 | </if>
       3 | <div/>

--- a/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-if-tag-missing-if/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-if-tag-missing-if/template.marko:4:2
       2 | </if>
       3 | <div/>

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
     > 1 | <else>
         |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
     > 1 | <else>
         |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
     > 1 | <else>
         |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
     > 1 | <else>
         |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.

--- a/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-else-tag-missing-if/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-else-tag-missing-if/template.marko:1:2
     > 1 | <else>
         |  ^^^^ Invalid 'else' tag, expected preceding 'if' or 'else-if' tag.

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-eof/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-eof/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-eof/template.marko:1:7
     > 1 | style {
         |       ^ EOF reached while parsing attribute name for the "style" tag

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
     > 1 | <div onClick()/>
         |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
     > 1 | <div onClick()/>
         |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
     > 1 | <div onClick()/>
         |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
     > 1 | <div onClick()/>
         |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-missing-args/template.marko:1:6
     > 1 | <div onClick()/>
         |      ^^^^^^^^^ Event handler is missing arguments.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
     > 1 | <div onClick('a')=b/>
         |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
     > 1 | <div onClick('a')=b/>
         |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
     > 1 | <div onClick('a')=b/>
         |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
     > 1 | <div onClick('a')=b/>
         |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-event-handler-value/template.marko:1:19
     > 1 | <div onClick('a')=b/>
         |                   ^ "onClick(handler, ...args)" does not accept a value.

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-nested-content/template.marko:2:2
       1 | export { a } from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-export-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
     > 1 | <for|| in=x>
         |  ^^^ Invalid 'for in' tag, missing |key, value| params.

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
     > 1 | <for|| in=x>
         |  ^^^ Invalid 'for in' tag, missing |key, value| params.

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
     > 1 | <for|| in=x>
         |  ^^^ Invalid 'for in' tag, missing |key, value| params.

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
     > 1 | <for|| in=x>
         |  ^^^ Invalid 'for in' tag, missing |key, value| params.

--- a/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-in-missing-params/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-in-missing-params/template.marko:1:2
     > 1 | <for|| in=x>
         |  ^^^ Invalid 'for in' tag, missing |key, value| params.

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
     > 1 | <for|key, value| in=obj x=1>
         |                         ^^^ <for> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
     > 1 | <for|key, value| in=obj x=1>
         |                         ^^^ <for> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
     > 1 | <for|key, value| in=obj x=1>
         |                         ^^^ <for> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
     > 1 | <for|key, value| in=obj x=1>
         |                         ^^^ <for> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-invalid-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-invalid-attribute/template.marko:1:25
     > 1 | <for|key, value| in=obj x=1>
         |                         ^^^ <for> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
     > 1 | <for|x|>
         |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
     > 1 | <for|x|>
         |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
     > 1 | <for|x|>
         |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
     > 1 | <for|x|>
         |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.

--- a/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-missing-attr/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-missing-attr/template.marko:1:2
     > 1 | <for|x|>
         |  ^^^ Invalid 'for' tag, missing an 'of', 'in' or 'to' attribute.

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
     > 1 | <for|| of=x>
         |  ^^^ Invalid 'for of' tag, missing |value, index| params.

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
     > 1 | <for|| of=x>
         |  ^^^ Invalid 'for of' tag, missing |value, index| params.

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
     > 1 | <for|| of=x>
         |  ^^^ Invalid 'for of' tag, missing |value, index| params.

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
     > 1 | <for|| of=x>
         |  ^^^ Invalid 'for of' tag, missing |value, index| params.

--- a/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-for-of-missing-params/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-for-of-missing-params/template.marko:1:2
     > 1 | <for|| of=x>
         |  ^^^ Invalid 'for of' tag, missing |value, index| params.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
     > 1 | <div(a, b, { c })/>
         |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
     > 1 | <div(a, b, { c })/>
         |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
     > 1 | <div(a, b, { c })/>
         |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
     > 1 | <div(a, b, { c })/>
         |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-html-element-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-html-element-arguments/template.marko:1:6
     > 1 | <div(a, b, { c })/>
         |      ^^^^^^^^^^^ Tag does not support arguments.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-id-shorthand-and-attribute/template.marko:1:8
     > 1 | <div#x id="y"/>
         |        ^^^^^^ Cannot have shorthand id and id attribute.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
     > 1 | <if>
         |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
     > 1 | <if>
         |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
     > 1 | <if>
         |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
     > 1 | <if>
         |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.

--- a/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-if-missing-condition/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-if-missing-condition/template.marko:1:2
     > 1 | <if>
         |  ^^ Invalid '<if>' tag, expected arguments like '<if(test)>'.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-component-missing/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-component-missing/template.marko:1:30
     > 1 | import MissingComponent from "<missing-component>"
         |                              ^^^^^^^^^^^^^^^^^^^^^ Unable to find entry point for custom tag <missing-component>.

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-nested-content/template.marko:2:2
       1 | import a from "b";
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-import-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-invalid-js/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-invalid-js/template.marko:1:5
     > 1 | $ x..y();
         |     ^ Unexpected token

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-duplicate/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-duplicate/template.marko:5:15
       3 | </macro>
       4 |

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
     > 1 | <macro|stuff| name="thing" x=1>
         |                            ^^^ <macro> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
     > 1 | <macro|stuff| name="thing" x=1>
         |                            ^^^ <macro> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
     > 1 | <macro|stuff| name="thing" x=1>
         |                            ^^^ <macro> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
     > 1 | <macro|stuff| name="thing" x=1>
         |                            ^^^ <macro> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-attributes/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-attributes/template.marko:1:28
     > 1 | <macro|stuff| name="thing" x=1>
         |                            ^^^ <macro> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:15
     > 1 | <macro|stuff| name=1>
         |               ^^^^^^ The 'name' attribute for 'macro' tags must be a string literal.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:15
     > 1 | <macro|stuff| name=1>
         |               ^^^^^^ The 'name' attribute for 'macro' tags must be a string literal.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:15
     > 1 | <macro|stuff| name=1>
         |               ^^^^^^ The 'name' attribute for 'macro' tags must be a string literal.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:15
     > 1 | <macro|stuff| name=1>
         |               ^^^^^^ The 'name' attribute for 'macro' tags must be a string literal.

--- a/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-invalid-name-attribute/template.marko:1:15
     > 1 | <macro|stuff| name=1>
         |               ^^^^^^ The 'name' attribute for 'macro' tags must be a string literal.

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:1
     > 1 | <macro|stuff|>
         | ^ The 'macro' tag must have a 'name' attribute.

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:1
     > 1 | <macro|stuff|>
         | ^ The 'macro' tag must have a 'name' attribute.

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:1
     > 1 | <macro|stuff|>
         | ^ The 'macro' tag must have a 'name' attribute.

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:1
     > 1 | <macro|stuff|>
         | ^ The 'macro' tag must have a 'name' attribute.

--- a/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-macro-missing-name/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-macro-missing-name/template.marko:1:1
     > 1 | <macro|stuff|>
         | ^ The 'macro' tag must have a 'name' attribute.

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-mismatched-closing-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-mismatched-closing-tag/template.marko:4:1
       2 |   <span>
       3 |   <span>

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
     > 1 | <custom-tag name="hi" x=1/>
         |                       ^^^ <custom-tag> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
     > 1 | <custom-tag name="hi" x=1/>
         |                       ^^^ <custom-tag> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
     > 1 | <custom-tag name="hi" x=1/>
         |                       ^^^ <custom-tag> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
     > 1 | <custom-tag name="hi" x=1/>
         |                       ^^^ <custom-tag> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-attribute-from-tag-def/template.marko:1:23
     > 1 | <custom-tag name="hi" x=1/>
         |                       ^^^ <custom-tag> does not support the "x" attribute.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
     > 1 | <thing/>
         |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
     > 1 | <thing/>
         |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
     > 1 | <thing/>
         |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
     > 1 | <thing/>
         |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-component-missing-file/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-component-missing-file/template.marko:1:2
     > 1 | <thing/>
         |  ^^^^^ Unable to find entry point for custom tag <thing>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-json/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-entry-marko-tag-json/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
     > 1 | <custom-tag/>
         |  ^^^^^^^^^^ The "name" attribute is required.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
     > 1 | <custom-tag/>
         |  ^^^^^^^^^^ The "name" attribute is required.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
     > 1 | <custom-tag/>
         |  ^^^^^^^^^^ The "name" attribute is required.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
     > 1 | <custom-tag/>
         |  ^^^^^^^^^^ The "name" attribute is required.

--- a/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-missing-required-attr/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-missing-required-attr/template.marko:1:2
     > 1 | <custom-tag/>
         |  ^^^^^^^^^^ The "name" attribute is required.

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-inline-class/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-multiple-inline-class/template.marko:7:1
        5 | }
        6 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/cjs-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/generated-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/html-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/htmlProduction-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/hydrate-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/vdom-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/snapshots/vdomProduction-error-expected.txt
@@ -1,12 +1,14 @@
-CompileErrors
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:11
-        > 1 | <div a=(a b) b=(a b)/>
-            |           ^ Unexpected token, expected ","
-          2 |
+CompileErrors: 
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:11
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |           ^ Unexpected token, expected ","
+      4 |
 
-    CompileError
-        at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:1:19
-        > 1 | <div a=(a b) b=(a b)/>
-            |                   ^ Unexpected token, expected ","
-          2 |
+    at packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko:3:19
+      1 | $ const a = 1;
+      2 | $ const b = 2;
+    > 3 | <div a=(a b) b=(a b)/>
+        |                   ^ Unexpected token, expected ","
+      4 |

--- a/packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko
+++ b/packages/translator-default/test/fixtures/error-multiple-syntax-errors/template.marko
@@ -1,1 +1,3 @@
+$ const a = 1;
+$ const b = 2;
 <div a=(a b) b=(a b)/>

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
     > 1 | <div|x|>
         |      ^ Tag does not support parameters.

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
     > 1 | <div|x|>
         |      ^ Tag does not support parameters.

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
     > 1 | <div|x|>
         |      ^ Tag does not support parameters.

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
     > 1 | <div|x|>
         |      ^ Tag does not support parameters.

--- a/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-native-tag-params/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-native-tag-params/template.marko:1:6
     > 1 | <div|x|>
         |      ^ Tag does not support parameters.

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
       1 | <custom-tag>
     > 2 |   <@test(a, b, { c })>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
       1 | <custom-tag>
     > 2 |   <@test(a, b, { c })>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
       1 | <custom-tag>
     > 2 |   <@test(a, b, { c })>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
       1 | <custom-tag>
     > 2 |   <@test(a, b, { c })>

--- a/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-nested-tag-arguments/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-nested-tag-arguments/template.marko:2:10
       1 | <custom-tag>
     > 2 |   <@test(a, b, { c })>

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-open-tag-only-concise/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-open-tag-only-concise/template.marko:2:5
       1 | input
     > 2 |     -- This should not be allowed!

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-scriptlets-not-supported/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-scriptlets-not-supported/template.marko:1:2
     > 1 | <% console.log(x) %>
         |  ^ <% scriptlets %> are no longer supported.

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-nested-content/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-nested-content/template.marko:2:2
       1 | static { console.log(x); }
     > 2 |  <div/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-static-tag-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-multiple/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-multiple/template.marko:5:1
       3 | }
       4 |

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-block-root-only/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-block-root-only/template.marko:2:4
       1 | <div>
     > 2 |   <style { div { color: green; } }/>

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-style-file-and-inline/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-style-file-and-inline/template.marko:1:1
     > 1 | style {
         | ^^^^^ A Marko file can either have an inline style block, or an external "style.ext" file, but not both.

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unclosed-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unclosed-tag/template.marko:1:1
     > 1 | <div>
         | ^^^^^ Missing ending "div" tag

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
     > 1 | <div value:n-update=1/>
         |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
     > 1 | <div value:n-update=1/>
         |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
     > 1 | <div value:n-update=1/>
         |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
     > 1 | <div value:n-update=1/>
         |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-modifier/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-modifier/template.marko:1:6
     > 1 | <div value:n-update=1/>
         |      ^^^^^^^^^^^^^^^^ Unsupported modifier "n-update".

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-unknown-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-unknown-tag/template.marko:1:2
     > 1 | <some-tag/>
         |  ^^^^^^^^ Unable to find entry point for custom tag <some-tag>.

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/generated-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/generated-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/hydrate-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/hydrate-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/error-wrong-closing-tag/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/error-wrong-closing-tag/template.marko:3:1
       1 | <a>
       2 |   <div/>

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
     > 1 | <div/myDiv/>
         |      ^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
     > 1 | <div/myDiv/>
         |      ^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
     > 1 | <div/myDiv/>
         |      ^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
     > 1 | <div/myDiv/>
         |      ^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/tag-with-var/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/tag-with-var/template.marko:1:6
     > 1 | <div/myDiv/>
         |      ^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/cjs-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/cjs-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
     > 1 | <let/x:{ y: string } = { y: "hello" }/>
         |      ^^^^^^^^^^^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/html-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/html-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
     > 1 | <let/x:{ y: string } = { y: "hello" }/>
         |      ^^^^^^^^^^^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/htmlProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/htmlProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
     > 1 | <let/x:{ y: string } = { y: "hello" }/>
         |      ^^^^^^^^^^^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdom-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdom-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
     > 1 | <let/x:{ y: string } = { y: "hello" }/>
         |      ^^^^^^^^^^^^^^^ Tag does not support a variable.

--- a/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdomProduction-error-expected.txt
+++ b/packages/translator-default/test/fixtures/typescript-with-tag-variable/snapshots/vdomProduction-error-expected.txt
@@ -1,4 +1,4 @@
-CompileError
+CompileError: 
     at packages/translator-default/test/fixtures/typescript-with-tag-variable/template.marko:1:6
     > 1 | <let/x:{ y: string } = { y: "hello" }/>
         |      ^^^^^^^^^^^^^^^ Tag does not support a variable.


### PR DESCRIPTION
## Description
* Fixes an issue where aggregated compile errors were not printing properly.
* Automatically strip ansi colors when error is `toString` or `toJSON`'d.
* Avoid creating stack trace for compile errors.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
