### PR TITLE
chore: sprcify engines.node in package.json

### DIFF
--- a/packages/babel-utils/package.json
+++ b/packages/babel-utils/package.json
@@ -35,6 +35,9 @@
   "devDependencies": {
     "@marko/compiler": "^5.34.4"
   },
+  "engines": {
+    "node": "18 || 20"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -62,6 +62,9 @@
   "devDependencies": {
     "@marko/translator-default": "^5.31.13"
   },
+  "engines": {
+    "node": "18 || 20"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/marko/package.json
+++ b/packages/marko/package.json
@@ -79,6 +79,9 @@
         "self-closing-tags": "^1.0.1",
         "warp10": "^2.1.0"
     },
+    "engines": {
+        "node": "18 || 20"
+    },
     "logo": {
         "url": "https://raw.githubusercontent.com/marko-js/branding/master/marko-logo-small.png"
     }

--- a/packages/translator-default/package.json
+++ b/packages/translator-default/package.json
@@ -41,6 +41,9 @@
     "@marko/compiler": "^5.16.1",
     "marko": "^5.17.2"
   },
+  "engines": {
+    "node": "18 || 20"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Add  `"engines": { "node": "18 || 20" }` to package.json for the following packages:

`@marko`
`@marko/compiler`
`@marko/babel-utils`
`@marko/translator-default`


## Description

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

[issue-2096](https://github.com/marko-js/marko/issues/2096)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
