### PR TITLE
feat: allow destructure assignment to tag variable

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 12923,
-        "gzip": 5527,
+        "gzip": 5520,
         "brotli": 5018
       }
     },
@@ -21,12 +21,12 @@
       },
       "runtime": {
         "min": 4123,
-        "gzip": 1920,
+        "gzip": 1905,
         "brotli": 1705
       },
       "total": {
         "min": 4474,
-        "gzip": 2194,
+        "gzip": 2179,
         "brotli": 1939
       }
     },
@@ -34,17 +34,17 @@
       "name": "counter 💧",
       "user": {
         "min": 204,
-        "gzip": 179,
+        "gzip": 178,
         "brotli": 154
       },
       "runtime": {
         "min": 2664,
-        "gzip": 1363,
+        "gzip": 1370,
         "brotli": 1223
       },
       "total": {
         "min": 2868,
-        "gzip": 1542,
+        "gzip": 1548,
         "brotli": 1377
       }
     },
@@ -52,17 +52,17 @@
       "name": "comments",
       "user": {
         "min": 1216,
-        "gzip": 703,
+        "gzip": 708,
         "brotli": 638
       },
       "runtime": {
         "min": 7536,
-        "gzip": 3480,
+        "gzip": 3491,
         "brotli": 3142
       },
       "total": {
         "min": 8752,
-        "gzip": 4183,
+        "gzip": 4199,
         "brotli": 3780
       }
     },
@@ -70,17 +70,17 @@
       "name": "comments 💧",
       "user": {
         "min": 988,
-        "gzip": 588,
+        "gzip": 591,
         "brotli": 554
       },
       "runtime": {
         "min": 8047,
-        "gzip": 3681,
+        "gzip": 3690,
         "brotli": 3345
       },
       "total": {
         "min": 9035,
-        "gzip": 4269,
+        "gzip": 4281,
         "brotli": 3899
       }
     }

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render undefined
+```html
+<button>
+  0 0
+</button>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
@@ -1,6 +1,44 @@
-# Render undefined
+# Render {}
 ```html
 <button>
-  0 0
+  <pre>
+    a    1    0
+  </pre>
+  <pre>
+    b    2    0
+  </pre>
+  <pre>
+    d  {d:4}  {}
+  </pre>
+  <pre>
+    e    7    0
+  </pre>
+  <pre>
+    f   [9]   []
+  </pre>
+</button>
+```
+
+
+# Render 
+container?.querySelector("button").click()
+
+```html
+<button>
+  <pre>
+    a    1    1
+  </pre>
+  <pre>
+    b    2    2
+  </pre>
+  <pre>
+    d  {d:4}  {"d":4}
+  </pre>
+  <pre>
+    e    7    7
+  </pre>
+  <pre>
+    f   [9]   [9]
+  </pre>
 </button>
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr-sanitized.expected.md
@@ -8,10 +8,10 @@
     b    2    0
   </pre>
   <pre>
-    d  {d:4}  {}
+    c  {c:4}  0
   </pre>
   <pre>
-    e    7    0
+    d    7    0
   </pre>
   <pre>
     f   [9]   []
@@ -32,10 +32,10 @@ container?.querySelector("button").click()
     b    2    2
   </pre>
   <pre>
-    d  {d:4}  {"d":4}
+    c  {c:4}  7
   </pre>
   <pre>
-    e    7    7
+    d    7    7
   </pre>
   <pre>
     f   [9]   [9]

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
@@ -1,0 +1,11 @@
+# Render undefined
+```html
+<button>
+  0 0
+</button>
+```
+
+# Mutations
+```
+inserted button0
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
@@ -8,10 +8,10 @@
     b    2    0
   </pre>
   <pre>
-    d  {d:4}  {}
+    c  {c:4}  0
   </pre>
   <pre>
-    e    7    0
+    d    7    0
   </pre>
   <pre>
     f   [9]   []
@@ -37,10 +37,10 @@ container?.querySelector("button").click()
     b    2    2
   </pre>
   <pre>
-    d  {d:4}  {"d":4}
+    c  {c:4}  7
   </pre>
   <pre>
-    e    7    7
+    d    7    7
   </pre>
   <pre>
     f   [9]   [9]
@@ -50,9 +50,9 @@ container?.querySelector("button").click()
 
 # Mutations
 ```
-button0/pre2/#text1: "{}" => "{\"d\":4}"
-button0/pre1/#text1: "0" => "2"
 button0/pre0/#text1: "0" => "1"
-button0/pre4/#text1: "[]" => "[9]"
+button0/pre1/#text1: "0" => "2"
+button0/pre2/#text1: "0" => "7"
 button0/pre3/#text1: "0" => "7"
+button0/pre4/#text1: "[]" => "[9]"
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/csr.expected.md
@@ -1,11 +1,58 @@
-# Render undefined
+# Render {}
 ```html
 <button>
-  0 0
+  <pre>
+    a    1    0
+  </pre>
+  <pre>
+    b    2    0
+  </pre>
+  <pre>
+    d  {d:4}  {}
+  </pre>
+  <pre>
+    e    7    0
+  </pre>
+  <pre>
+    f   [9]   []
+  </pre>
 </button>
 ```
 
 # Mutations
 ```
 inserted button0
+```
+
+
+# Render 
+container?.querySelector("button").click()
+
+```html
+<button>
+  <pre>
+    a    1    1
+  </pre>
+  <pre>
+    b    2    2
+  </pre>
+  <pre>
+    d  {d:4}  {"d":4}
+  </pre>
+  <pre>
+    e    7    7
+  </pre>
+  <pre>
+    f   [9]   [9]
+  </pre>
+</button>
+```
+
+# Mutations
+```
+button0/pre2/#text1: "{}" => "{\"d\":4}"
+button0/pre1/#text1: "0" => "2"
+button0/pre0/#text1: "0" => "1"
+button0/pre4/#text1: "[]" => "[9]"
+button0/pre3/#text1: "0" => "7"
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
@@ -1,46 +1,51 @@
-import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueEffect as _queueEffect, intersection as _intersection, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
-const _expr_a_b_effect = _register("packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b", _scope => _on(_scope["#button/0"], "click", function () {
-  const {
-    a,
-    b
-  } = _scope;
-  let c = a;
+import { on as _on, queueSource as _queueSource, data as _data, value as _value, register as _register, queueEffect as _queueEffect, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
+const _f = /* @__PURE__ */_value("f", (_scope, f) => _data(_scope["#text/5"], JSON.stringify(f)));
+const _e = /* @__PURE__ */_value("e", (_scope, e) => _data(_scope["#text/4"], e));
+const _d = /* @__PURE__ */_value("d", (_scope, d) => _data(_scope["#text/3"], JSON.stringify(d)));
+const _b = /* @__PURE__ */_value("b", (_scope, b) => _data(_scope["#text/2"], b));
+const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a));
+const _setup_effect = _register("packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0", _scope => _on(_scope["#button/0"], "click", function () {
+  let c;
   let _a2;
   let _b2;
   let _d2;
   ({
     a: _a2,
-    _b: _b2,
+    _b: {
+      _b: _b2
+    },
     c,
     ..._d2
   } = {
-    a: b,
-    _b: a + b,
-    c: b,
-    foo: 1,
-    bar: 2
+    a: 1,
+    _b: {
+      _b: 2
+    },
+    c: 3,
+    d: 4
   });
   _queueSource(_scope, _d, _d2);
   _queueSource(_scope, _b, _b2);
   _queueSource(_scope, _a, _a2);
-  console.log(c);
+  let _e2;
+  let _f2;
+  [{
+    arr: [c, _e2,, ..._f2]
+  }] = [{
+    arr: [6, 7, 8, 9]
+  }];
+  _queueSource(_scope, _f, _f2);
+  _queueSource(_scope, _e, _e2);
 }));
-const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
-  const {
-    a,
-    b
-  } = _scope;
-  _queueEffect(_scope, _expr_a_b_effect);
-});
-const _d = (_scope, d) => {};
-const _b = /* @__PURE__ */_value("b", (_scope, b) => _data(_scope["#text/2"], b), _expr_a_b);
-const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a), _expr_a_b);
 const _setup = _scope => {
+  _queueEffect(_scope, _setup_effect);
   _a(_scope, 0);
   _b(_scope, 0);
   _d(_scope, {});
+  _e(_scope, 0);
+  _f(_scope, []);
 };
-export const template = "<button><!> <!></button>";
-export const walks = /* get, next(1), replace, over(2), replace, out(1) */" D%c%l";
+export const template = "<button><pre>a    1    <!></pre><pre>b    2    <!></pre><pre>d  {d:4}  <!></pre><pre>e    7    <!></pre><pre>f   [9]   <!></pre></button>";
+export const walks = /* get, next(2), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(2) */" Eb%lDb%lDb%lDb%lDb%m";
 export const setup = _setup;
 export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(template, walks, setup), "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
@@ -1,0 +1,46 @@
+import { on as _on, queueSource as _queueSource, data as _data, register as _register, queueEffect as _queueEffect, intersection as _intersection, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
+const _expr_a_b_effect = _register("packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b", _scope => _on(_scope["#button/0"], "click", function () {
+  const {
+    a,
+    b
+  } = _scope;
+  let c = a;
+  let _a2;
+  let _b2;
+  let _d2;
+  ({
+    a: _a2,
+    _b: _b2,
+    c,
+    ..._d2
+  } = {
+    a: b,
+    _b: a + b,
+    c: b,
+    foo: 1,
+    bar: 2
+  });
+  _queueSource(_scope, _d, _d2);
+  _queueSource(_scope, _b, _b2);
+  _queueSource(_scope, _a, _a2);
+  console.log(c);
+}));
+const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
+  const {
+    a,
+    b
+  } = _scope;
+  _queueEffect(_scope, _expr_a_b_effect);
+});
+const _d = (_scope, d) => {};
+const _b = /* @__PURE__ */_value("b", (_scope, b) => _data(_scope["#text/2"], b), _expr_a_b);
+const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a), _expr_a_b);
+const _setup = _scope => {
+  _a(_scope, 0);
+  _b(_scope, 0);
+  _d(_scope, {});
+};
+export const template = "<button><!> <!></button>";
+export const walks = /* get, next(1), replace, over(2), replace, out(1) */" D%c%l";
+export const setup = _setup;
+export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(template, walks, setup), "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
@@ -1,51 +1,55 @@
+function noop(_) {}
 import { on as _on, queueSource as _queueSource, data as _data, value as _value, register as _register, queueEffect as _queueEffect, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
-const _f = /* @__PURE__ */_value("f", (_scope, f) => _data(_scope["#text/5"], JSON.stringify(f)));
-const _e = /* @__PURE__ */_value("e", (_scope, e) => _data(_scope["#text/4"], e));
-const _d = /* @__PURE__ */_value("d", (_scope, d) => _data(_scope["#text/3"], JSON.stringify(d)));
+const _e = /* @__PURE__ */_value("e", (_scope, e) => _data(_scope["#text/5"], JSON.stringify(e)));
+const _d = /* @__PURE__ */_value("d", (_scope, d) => {
+  _data(_scope["#text/3"], JSON.stringify(d));
+  _data(_scope["#text/4"], d);
+});
+const _c = (_scope, c) => {};
 const _b = /* @__PURE__ */_value("b", (_scope, b) => _data(_scope["#text/2"], b));
 const _a = /* @__PURE__ */_value("a", (_scope, a) => _data(_scope["#text/1"], a));
 const _setup_effect = _register("packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0", _scope => _on(_scope["#button/0"], "click", function () {
-  let c;
+  let local;
   let _a2;
   let _b2;
-  let _d2;
+  let _c2;
   ({
     a: _a2,
     _b: {
       _b: _b2
     },
-    c,
-    ..._d2
+    local,
+    ..._c2
   } = {
     a: 1,
     _b: {
       _b: 2
     },
-    c: 3,
-    d: 4
+    local: 3,
+    c: 4
   });
-  _queueSource(_scope, _d, _d2);
-  _queueSource(_scope, _b, _b2);
   _queueSource(_scope, _a, _a2);
+  _queueSource(_scope, _b, _b2);
+  _queueSource(_scope, _c, _c2);
+  let _d2;
   let _e2;
-  let _f2;
-  [{
-    arr: [c, _e2,, ..._f2]
+  noop([{
+    arr: [local, _d2,, ..._e2]
   }] = [{
     arr: [6, 7, 8, 9]
-  }];
-  _queueSource(_scope, _f, _f2);
+  }]);
+  _queueSource(_scope, _d, _d2);
   _queueSource(_scope, _e, _e2);
 }));
 const _setup = _scope => {
   _queueEffect(_scope, _setup_effect);
   _a(_scope, 0);
   _b(_scope, 0);
-  _d(_scope, {});
-  _e(_scope, 0);
-  _f(_scope, []);
+  _c(_scope, {});
+  _d(_scope, 0);
+  _e(_scope, []);
 };
-export const template = "<button><pre>a    1    <!></pre><pre>b    2    <!></pre><pre>d  {d:4}  <!></pre><pre>e    7    <!></pre><pre>f   [9]   <!></pre></button>";
+export const template = "<button><pre>a    1    <!></pre><pre>b    2    <!></pre><pre>c  {c:4}  <!></pre><pre>d    7    <!></pre><pre>f   [9]   <!></pre></button>";
 export const walks = /* get, next(2), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(1), next(1), over(1), replace, out(2) */" Eb%lDb%lDb%lDb%lDb%m";
 export const setup = _setup;
 export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(template, walks, setup), "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
@@ -1,12 +1,13 @@
+function noop(_) {}
 import { escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _write, writeEffect as _writeEffect, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/html";
 const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const a = 0;
   const b = 0;
-  const d = {};
-  const e = 0;
-  const f = [];
-  _write(`<button><pre>a    1    <!>${_escapeXML(a)}${_markResumeNode(_scope0_id, "#text/1")}</pre><pre>b    2    <!>${_escapeXML(b)}${_markResumeNode(_scope0_id, "#text/2")}</pre><pre>d  {d:4}  <!>${_escapeXML(JSON.stringify(d))}${_markResumeNode(_scope0_id, "#text/3")}</pre><pre>e    7    <!>${_escapeXML(e)}${_markResumeNode(_scope0_id, "#text/4")}</pre><pre>f   [9]   <!>${_escapeXML(JSON.stringify(f))}${_markResumeNode(_scope0_id, "#text/5")}</pre></button>${_markResumeNode(_scope0_id, "#button/0")}`);
+  const c = {};
+  const d = 0;
+  const e = [];
+  _write(`<button><pre>a    1    <!>${_escapeXML(a)}${_markResumeNode(_scope0_id, "#text/1")}</pre><pre>b    2    <!>${_escapeXML(b)}${_markResumeNode(_scope0_id, "#text/2")}</pre><pre>c  {c:4}  <!>${_escapeXML(JSON.stringify(d))}${_markResumeNode(_scope0_id, "#text/3")}</pre><pre>d    7    <!>${_escapeXML(d)}${_markResumeNode(_scope0_id, "#text/4")}</pre><pre>f   [9]   <!>${_escapeXML(JSON.stringify(e))}${_markResumeNode(_scope0_id, "#text/5")}</pre></button>${_markResumeNode(_scope0_id, "#button/0")}`);
   _writeEffect(_scope0_id, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0");
 });
 export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
@@ -1,0 +1,14 @@
+import { escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _write, writeEffect as _writeEffect, writeScope as _writeScope, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/html";
+const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
+  const _scope0_id = _nextScopeId();
+  const a = 0;
+  const b = 0;
+  const d = {};
+  _write(`<button>${_escapeXML(a)}${_markResumeNode(_scope0_id, "#text/1")} <!>${_escapeXML(b)}${_markResumeNode(_scope0_id, "#text/2")}</button>${_markResumeNode(_scope0_id, "#button/0")}`);
+  _writeEffect(_scope0_id, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b");
+  _writeScope(_scope0_id, {
+    "a": a,
+    "b": b
+  });
+});
+export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
@@ -1,14 +1,12 @@
-import { escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _write, writeEffect as _writeEffect, writeScope as _writeScope, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/html";
+import { escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _write, writeEffect as _writeEffect, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/html";
 const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const a = 0;
   const b = 0;
   const d = {};
-  _write(`<button>${_escapeXML(a)}${_markResumeNode(_scope0_id, "#text/1")} <!>${_escapeXML(b)}${_markResumeNode(_scope0_id, "#text/2")}</button>${_markResumeNode(_scope0_id, "#button/0")}`);
-  _writeEffect(_scope0_id, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b");
-  _writeScope(_scope0_id, {
-    "a": a,
-    "b": b
-  });
+  const e = 0;
+  const f = [];
+  _write(`<button><pre>a    1    <!>${_escapeXML(a)}${_markResumeNode(_scope0_id, "#text/1")}</pre><pre>b    2    <!>${_escapeXML(b)}${_markResumeNode(_scope0_id, "#text/2")}</pre><pre>d  {d:4}  <!>${_escapeXML(JSON.stringify(d))}${_markResumeNode(_scope0_id, "#text/3")}</pre><pre>e    7    <!>${_escapeXML(e)}${_markResumeNode(_scope0_id, "#text/4")}</pre><pre>f   [9]   <!>${_escapeXML(JSON.stringify(f))}${_markResumeNode(_scope0_id, "#text/5")}</pre></button>${_markResumeNode(_scope0_id, "#button/0")}`);
+  _writeEffect(_scope0_id, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0");
 });
 export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render undefined
+```html
+<button>
+  0 0
+</button>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
@@ -1,6 +1,44 @@
-# Render undefined
+# Render {}
 ```html
 <button>
-  0 0
+  <pre>
+    a    1    0
+  </pre>
+  <pre>
+    b    2    0
+  </pre>
+  <pre>
+    d  {d:4}  {}
+  </pre>
+  <pre>
+    e    7    0
+  </pre>
+  <pre>
+    f   [9]   []
+  </pre>
+</button>
+```
+
+
+# Render 
+container?.querySelector("button").click()
+
+```html
+<button>
+  <pre>
+    a    1    1
+  </pre>
+  <pre>
+    b    2    2
+  </pre>
+  <pre>
+    d  {d:4}  {"d":4}
+  </pre>
+  <pre>
+    e    7    7
+  </pre>
+  <pre>
+    f   [9]   [9]
+  </pre>
 </button>
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume-sanitized.expected.md
@@ -8,10 +8,10 @@
     b    2    0
   </pre>
   <pre>
-    d  {d:4}  {}
+    c  {c:4}  0
   </pre>
   <pre>
-    e    7    0
+    d    7    0
   </pre>
   <pre>
     f   [9]   []
@@ -32,10 +32,10 @@ container?.querySelector("button").click()
     b    2    2
   </pre>
   <pre>
-    d  {d:4}  {"d":4}
+    c  {c:4}  7
   </pre>
   <pre>
-    e    7    7
+    d    7    7
   </pre>
   <pre>
     f   [9]   [9]

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
@@ -17,13 +17,13 @@
         <!--M*0 #text/2-->
       </pre>
       <pre>
-        d  {d:4}  
+        c  {c:4}  
         <!---->
-        {}
+        0
         <!--M*0 #text/3-->
       </pre>
       <pre>
-        e    7    
+        d    7    
         <!---->
         0
         <!--M*0 #text/4-->
@@ -70,13 +70,13 @@ container?.querySelector("button").click()
         <!--M*0 #text/2-->
       </pre>
       <pre>
-        d  {d:4}  
+        c  {c:4}  
         <!---->
-        {"d":4}
+        7
         <!--M*0 #text/3-->
       </pre>
       <pre>
-        e    7    
+        d    7    
         <!---->
         7
         <!--M*0 #text/4-->
@@ -98,9 +98,9 @@ container?.querySelector("button").click()
 
 # Mutations
 ```
-#document/html0/body1/button0/pre2/#text2: "{}" => "{\"d\":4}"
-#document/html0/body1/button0/pre1/#text2: "0" => "2"
 #document/html0/body1/button0/pre0/#text2: "0" => "1"
-#document/html0/body1/button0/pre4/#text2: "[]" => "[9]"
+#document/html0/body1/button0/pre1/#text2: "0" => "2"
+#document/html0/body1/button0/pre2/#text2: "0" => "7"
 #document/html0/body1/button0/pre3/#text2: "0" => "7"
+#document/html0/body1/button0/pre4/#text2: "[]" => "[9]"
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
@@ -1,19 +1,43 @@
-# Render undefined
+# Render {}
 ```html
 <html>
   <head />
   <body>
     <button>
-      0
-      <!--M*0 #text/1-->
-       
-      <!---->
-      0
-      <!--M*0 #text/2-->
+      <pre>
+        a    1    
+        <!---->
+        0
+        <!--M*0 #text/1-->
+      </pre>
+      <pre>
+        b    2    
+        <!---->
+        0
+        <!--M*0 #text/2-->
+      </pre>
+      <pre>
+        d  {d:4}  
+        <!---->
+        {}
+        <!--M*0 #text/3-->
+      </pre>
+      <pre>
+        e    7    
+        <!---->
+        0
+        <!--M*0 #text/4-->
+      </pre>
+      <pre>
+        f   [9]   
+        <!---->
+        []
+        <!--M*0 #text/5-->
+      </pre>
     </button>
     <!--M*0 #button/0-->
     <script>
-      (M$h=[]).push((b,s)=&gt;({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])
+      (M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])
     </script>
   </body>
 </html>
@@ -22,4 +46,61 @@
 # Mutations
 ```
 
+```
+
+
+# Render 
+container?.querySelector("button").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      <pre>
+        a    1    
+        <!---->
+        1
+        <!--M*0 #text/1-->
+      </pre>
+      <pre>
+        b    2    
+        <!---->
+        2
+        <!--M*0 #text/2-->
+      </pre>
+      <pre>
+        d  {d:4}  
+        <!---->
+        {"d":4}
+        <!--M*0 #text/3-->
+      </pre>
+      <pre>
+        e    7    
+        <!---->
+        7
+        <!--M*0 #text/4-->
+      </pre>
+      <pre>
+        f   [9]   
+        <!---->
+        [9]
+        <!--M*0 #text/5-->
+      </pre>
+    </button>
+    <!--M*0 #button/0-->
+    <script>
+      (M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button0/pre2/#text2: "{}" => "{\"d\":4}"
+#document/html0/body1/button0/pre1/#text2: "0" => "2"
+#document/html0/body1/button0/pre0/#text2: "0" => "1"
+#document/html0/body1/button0/pre4/#text2: "[]" => "[9]"
+#document/html0/body1/button0/pre3/#text2: "0" => "7"
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/resume.expected.md
@@ -1,0 +1,25 @@
+# Render undefined
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      0
+      <!--M*0 #text/1-->
+       
+      <!---->
+      0
+      <!--M*0 #text/2-->
+    </button>
+    <!--M*0 #button/0-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render "End"
+```html
+<button>
+  0 0
+</button>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
@@ -1,6 +1,20 @@
 # Render "End"
 ```html
 <button>
-  0 0
+  <pre>
+    a    1    0
+  </pre>
+  <pre>
+    b    2    0
+  </pre>
+  <pre>
+    d  {d:4}  {}
+  </pre>
+  <pre>
+    e    7    0
+  </pre>
+  <pre>
+    f   [9]   []
+  </pre>
 </button>
 ```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr-sanitized.expected.md
@@ -8,10 +8,10 @@
     b    2    0
   </pre>
   <pre>
-    d  {d:4}  {}
+    c  {c:4}  0
   </pre>
   <pre>
-    e    7    0
+    d    7    0
   </pre>
   <pre>
     f   [9]   []

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <button>0<!M*0 #text/1> <!>0<!M*0 #text/2></button><!M*0 #button/0><script>(M$h=[]).push((b,s)=>({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])</script>
+  <button><pre>a    1    <!>0<!M*0 #text/1></pre><pre>b    2    <!>0<!M*0 #text/2></pre><pre>d  {d:4}  <!>{}<!M*0 #text/3></pre><pre>e    7    <!>0<!M*0 #text/4></pre><pre>f   [9]   <!>[]<!M*0 #text/5></pre></button><!M*0 #button/0><script>(M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])</script>
 
 
 # Render "End"
@@ -8,16 +8,40 @@
   <head />
   <body>
     <button>
-      0
-      <!--M*0 #text/1-->
-       
-      <!---->
-      0
-      <!--M*0 #text/2-->
+      <pre>
+        a    1    
+        <!---->
+        0
+        <!--M*0 #text/1-->
+      </pre>
+      <pre>
+        b    2    
+        <!---->
+        0
+        <!--M*0 #text/2-->
+      </pre>
+      <pre>
+        d  {d:4}  
+        <!---->
+        {}
+        <!--M*0 #text/3-->
+      </pre>
+      <pre>
+        e    7    
+        <!---->
+        0
+        <!--M*0 #text/4-->
+      </pre>
+      <pre>
+        f   [9]   
+        <!---->
+        []
+        <!--M*0 #text/5-->
+      </pre>
     </button>
     <!--M*0 #button/0-->
     <script>
-      (M$h=[]).push((b,s)=&gt;({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])
+      (M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])
     </script>
   </body>
 </html>
@@ -29,12 +53,31 @@ inserted #document/html0
 inserted #document/html0/head0
 inserted #document/html0/body1
 inserted #document/html0/body1/button0
-inserted #document/html0/body1/button0/#text0
-inserted #document/html0/body1/button0/#comment1
-inserted #document/html0/body1/button0/#text2
-inserted #document/html0/body1/button0/#comment3
-inserted #document/html0/body1/button0/#text4
-inserted #document/html0/body1/button0/#comment5
+inserted #document/html0/body1/button0/pre0
+inserted #document/html0/body1/button0/pre0/#text0
+inserted #document/html0/body1/button0/pre0/#comment1
+inserted #document/html0/body1/button0/pre0/#text2
+inserted #document/html0/body1/button0/pre0/#comment3
+inserted #document/html0/body1/button0/pre1
+inserted #document/html0/body1/button0/pre1/#text0
+inserted #document/html0/body1/button0/pre1/#comment1
+inserted #document/html0/body1/button0/pre1/#text2
+inserted #document/html0/body1/button0/pre1/#comment3
+inserted #document/html0/body1/button0/pre2
+inserted #document/html0/body1/button0/pre2/#text0
+inserted #document/html0/body1/button0/pre2/#comment1
+inserted #document/html0/body1/button0/pre2/#text2
+inserted #document/html0/body1/button0/pre2/#comment3
+inserted #document/html0/body1/button0/pre3
+inserted #document/html0/body1/button0/pre3/#text0
+inserted #document/html0/body1/button0/pre3/#comment1
+inserted #document/html0/body1/button0/pre3/#text2
+inserted #document/html0/body1/button0/pre3/#comment3
+inserted #document/html0/body1/button0/pre4
+inserted #document/html0/body1/button0/pre4/#text0
+inserted #document/html0/body1/button0/pre4/#comment1
+inserted #document/html0/body1/button0/pre4/#text2
+inserted #document/html0/body1/button0/pre4/#comment3
 inserted #document/html0/body1/#comment1
 inserted #document/html0/body1/script2
 inserted #document/html0/body1/script2/#text0

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
@@ -1,0 +1,41 @@
+# Write
+  <button>0<!M*0 #text/1> <!>0<!M*0 #text/2></button><!M*0 #button/0><script>(M$h=[]).push((b,s)=>({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])</script>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      0
+      <!--M*0 #text/1-->
+       
+      <!---->
+      0
+      <!--M*0 #text/2-->
+    </button>
+    <!--M*0 #button/0-->
+    <script>
+      (M$h=[]).push((b,s)=&gt;({0:{a:0,b:0}}),[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0_a_b",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/button0
+inserted #document/html0/body1/button0/#text0
+inserted #document/html0/body1/button0/#comment1
+inserted #document/html0/body1/button0/#text2
+inserted #document/html0/body1/button0/#comment3
+inserted #document/html0/body1/button0/#text4
+inserted #document/html0/body1/button0/#comment5
+inserted #document/html0/body1/#comment1
+inserted #document/html0/body1/script2
+inserted #document/html0/body1/script2/#text0
+```

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <button><pre>a    1    <!>0<!M*0 #text/1></pre><pre>b    2    <!>0<!M*0 #text/2></pre><pre>d  {d:4}  <!>{}<!M*0 #text/3></pre><pre>e    7    <!>0<!M*0 #text/4></pre><pre>f   [9]   <!>[]<!M*0 #text/5></pre></button><!M*0 #button/0><script>(M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])</script>
+  <button><pre>a    1    <!>0<!M*0 #text/1></pre><pre>b    2    <!>0<!M*0 #text/2></pre><pre>c  {c:4}  <!>0<!M*0 #text/3></pre><pre>d    7    <!>0<!M*0 #text/4></pre><pre>f   [9]   <!>[]<!M*0 #text/5></pre></button><!M*0 #button/0><script>(M$h=[]).push(null,[0,"packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko_0",])</script>
 
 
 # Render "End"
@@ -21,13 +21,13 @@
         <!--M*0 #text/2-->
       </pre>
       <pre>
-        d  {d:4}  
+        c  {c:4}  
         <!---->
-        {}
+        0
         <!--M*0 #text/3-->
       </pre>
       <pre>
-        e    7    
+        d    7    
         <!---->
         0
         <!--M*0 #text/4-->

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
@@ -1,10 +1,25 @@
 <let/a=0/>
 <let/b=0/>
 <let/d={}/>
+<let/e=0/>
+<let/f=[]/>
 <button onClick() {
-  let c = a;
-  ({ a, _b: b, c, ...d } = { a: b, _b: a + b, c: b, foo: 1, bar: 2 });
-  console.log(c);
+  let c;
+  ({
+    a,
+    _b: { _b: b },
+    c,
+    ...d
+  } = { a: 1, _b: { _b: 2 }, c: 3, d: 4 });
+  [
+    {
+      arr: [c, e, , ...f],
+    },
+  ] = [{ arr: [6, 7, 8, 9] }];
 }>
-  ${a} ${b}
+  <pre>a    1    ${a}</pre>
+  <pre>b    2    ${b}</pre>
+  <pre>d  {d:4}  ${JSON.stringify(d)}</pre>
+  <pre>e    7    ${e}</pre>
+  <pre>f   [9]   ${JSON.stringify(f)}</pre>
 </button>

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
@@ -1,0 +1,10 @@
+<let/a=0/>
+<let/b=0/>
+<let/d={}/>
+<button onClick() {
+  let c = a;
+  ({ a, _b: b, c, ...d } = { a: b, _b: a + b, c: b, foo: 1, bar: 2 });
+  console.log(c);
+}>
+  ${a} ${b}
+</button>

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko
@@ -1,25 +1,27 @@
+static function noop(_) {}
+
 <let/a=0/>
 <let/b=0/>
-<let/d={}/>
-<let/e=0/>
-<let/f=[]/>
+<let/c={}/>
+<let/d=0/>
+<let/e=[]/>
 <button onClick() {
-  let c;
+  let local;
   ({
     a,
     _b: { _b: b },
-    c,
-    ...d
-  } = { a: 1, _b: { _b: 2 }, c: 3, d: 4 });
-  [
+    local,
+    ...c
+  } = { a: 1, _b: { _b: 2 }, local: 3, c: 4 });
+  noop([
     {
-      arr: [c, e, , ...f],
+      arr: [local, d, , ...e],
     },
-  ] = [{ arr: [6, 7, 8, 9] }];
+  ] = [{ arr: [6, 7, 8, 9] }]);
 }>
   <pre>a    1    ${a}</pre>
   <pre>b    2    ${b}</pre>
-  <pre>d  {d:4}  ${JSON.stringify(d)}</pre>
-  <pre>e    7    ${e}</pre>
-  <pre>f   [9]   ${JSON.stringify(f)}</pre>
+  <pre>c  {c:4}  ${JSON.stringify(d)}</pre>
+  <pre>d    7    ${d}</pre>
+  <pre>f   [9]   ${JSON.stringify(e)}</pre>
 </button>

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/test.ts
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/test.ts
@@ -1,0 +1,8 @@
+export const steps = [
+  {},
+  click
+]
+
+function click(container: Element) {
+  container?.querySelector("button")!.click();
+}

--- a/packages/translator-tags/src/core/let.ts
+++ b/packages/translator-tags/src/core/let.ts
@@ -2,7 +2,7 @@ import { type Tag, assertNoParams } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import { assertNoBodyContent } from "../util/assert";
 import { isOutputDOM } from "../util/marko-config";
-import { registerAssignmentReplacer } from "../util/replace-assignments";
+import { registerAssignmentGenerator } from "../util/replace-assignments";
 import { getScopeAccessorLiteral } from "../util/reserve";
 import { callRuntime } from "../util/runtime";
 import { getSection } from "../util/sections";
@@ -80,7 +80,7 @@ export default {
         addValue(section, references, source, defaultAttr.value);
       }
 
-      registerAssignmentReplacer(
+      registerAssignmentGenerator(
         tag.scope.getBinding(binding.name)!,
         (assignment, value) =>
           queueSource(source, value, getSection(assignment)),

--- a/packages/translator-tags/src/visitors/assignment-expression.ts
+++ b/packages/translator-tags/src/visitors/assignment-expression.ts
@@ -1,26 +1,55 @@
 import { types as t } from "@marko/compiler";
 import { isOutputDOM } from "../util/marko-config";
-import { getReplacement } from "../util/replace-assignments";
+import { getAssignmentGenerator } from "../util/replace-assignments";
 
 export default {
   translate: {
     exit(assignment: t.NodePath<t.AssignmentExpression>) {
       if (isOutputDOM()) {
-        const value =
-          assignment.node.operator === "="
-            ? assignment.node.right
-            : t.binaryExpression(
-                assignment.node.operator.slice(
-                  0,
-                  -1,
-                ) as t.BinaryExpression["operator"],
-                assignment.node.left as t.Identifier,
-                assignment.node.right,
-              );
-        const replacement = getReplacement(assignment, value);
+        if (assignment.node.left.type === "ObjectPattern") {
+          for (const prop of assignment.node.left.properties) {
+            const value = t.isObjectProperty(prop)
+              ? (prop.value as t.Identifier).name
+              : (prop.argument as t.Identifier).name;
 
-        if (replacement) {
-          assignment.replaceWith(replacement);
+            const generator = getAssignmentGenerator(assignment, value);
+            if (generator) {
+              const valueId = assignment.scope.generateUidIdentifier(value);
+
+              assignment.insertBefore(
+                t.variableDeclaration("let", [t.variableDeclarator(valueId)]),
+              );
+              if (t.isObjectProperty(prop)) {
+                prop.value = valueId;
+              } else {
+                prop.argument = valueId;
+              }
+              assignment.insertAfter(generator(assignment, valueId));
+            }
+          }
+        } else {
+          const generator = getAssignmentGenerator(
+            assignment,
+            (assignment.node.left as t.Identifier).name,
+          );
+
+          if (generator) {
+            assignment.replaceWith(
+              generator(
+                assignment,
+                assignment.node.operator === "="
+                  ? assignment.node.right
+                  : t.binaryExpression(
+                      assignment.node.operator.slice(
+                        0,
+                        -1,
+                      ) as t.BinaryExpression["operator"],
+                      assignment.node.left as t.Identifier,
+                      assignment.node.right,
+                    ),
+              ),
+            );
+          }
         }
       }
     },

--- a/packages/translator-tags/src/visitors/update-expression.ts
+++ b/packages/translator-tags/src/visitors/update-expression.ts
@@ -1,19 +1,25 @@
 import { types as t } from "@marko/compiler";
 import { isOutputDOM } from "../util/marko-config";
-import { getReplacement } from "../util/replace-assignments";
+import { getAssignmentGenerator } from "../util/replace-assignments";
 
 export default {
   translate: {
     exit(assignment: t.NodePath<t.UpdateExpression>) {
       if (isOutputDOM()) {
-        const value = t.binaryExpression(
-          assignment.node.operator === "++" ? "+" : "-",
-          assignment.node.argument,
-          t.numericLiteral(1),
+        const generator = getAssignmentGenerator(
+          assignment,
+          (assignment.node.argument as t.Identifier).name,
         );
-        const replacement = getReplacement(assignment, value);
 
-        if (replacement) {
+        if (generator) {
+          const replacement = generator(
+            assignment,
+            t.binaryExpression(
+              assignment.node.operator === "++" ? "+" : "-",
+              assignment.node.argument,
+              t.numericLiteral(1),
+            ),
+          );
           assignment.replaceWith(
             assignment.node.prefix ||
               assignment.parentPath.isExpressionStatement()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow destructure into tag variables, by replacing with a temporary local identifier before performing replacement.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
