### PR TITLE
fix: use unique identifers for scope name reserves

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 12923,
-        "gzip": 5534,
+        "gzip": 5526,
         "brotli": 5028
       }
     },
@@ -16,17 +16,17 @@
       "name": "counter",
       "user": {
         "min": 351,
-        "gzip": 275,
+        "gzip": 274,
         "brotli": 234
       },
       "runtime": {
         "min": 4130,
-        "gzip": 1924,
+        "gzip": 1910,
         "brotli": 1711
       },
       "total": {
         "min": 4481,
-        "gzip": 2199,
+        "gzip": 2184,
         "brotli": 1945
       }
     },
@@ -34,17 +34,17 @@
       "name": "counter 💧",
       "user": {
         "min": 204,
-        "gzip": 179,
+        "gzip": 178,
         "brotli": 154
       },
       "runtime": {
         "min": 2664,
-        "gzip": 1363,
+        "gzip": 1370,
         "brotli": 1223
       },
       "total": {
         "min": 2868,
-        "gzip": 1542,
+        "gzip": 1548,
         "brotli": 1377
       }
     },
@@ -52,17 +52,17 @@
       "name": "comments",
       "user": {
         "min": 1248,
-        "gzip": 705,
+        "gzip": 714,
         "brotli": 645
       },
       "runtime": {
         "min": 7535,
-        "gzip": 3479,
+        "gzip": 3488,
         "brotli": 3141
       },
       "total": {
         "min": 8783,
-        "gzip": 4184,
+        "gzip": 4202,
         "brotli": 3786
       }
     },
@@ -70,17 +70,17 @@
       "name": "comments 💧",
       "user": {
         "min": 984,
-        "gzip": 585,
+        "gzip": 590,
         "brotli": 553
       },
       "runtime": {
         "min": 8039,
-        "gzip": 3675,
+        "gzip": 3685,
         "brotli": 3339
       },
       "total": {
         "min": 9023,
-        "gzip": 4260,
+        "gzip": 4275,
         "brotli": 3892
       }
     }

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
@@ -3,15 +3,16 @@ import _classCounter from "./components/class-counter.marko";
 import _marko_tags_compat from "marko/src/runtime/helpers/tags-compat-dom.js";
 _register("packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/components/class-counter.marko", _classCounter);
 const _classCounter_input = _dynamicTagAttrs("#text/2");
-const _expr_dynamicTagName_ChildScope_count = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName__childScope_count = /* @__PURE__ */_intersection(2, _scope => {
   const {
+    "#text/2": _dynamicTagName__childScope,
     count
   } = _scope;
   _classCounter_input(_scope, () => ({
     count: count
   }));
 });
-const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_ChildScope_count);
+const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName__childScope_count);
 const _count_effect = _register("packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     count
@@ -21,10 +22,10 @@ const _count_effect = _register("packages/translator-interop/src/__tests__/fixtu
 const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _queueEffect(_scope, _count_effect);
-}, _expr_dynamicTagName_ChildScope_count);
+}, _expr__dynamicTagName__childScope_count);
 const _setup = _scope => {
   _count(_scope, 0);
-  _dynamicTagName_ChildScope(_scope, _classCounter);
+  _dynamicTagName__childScope(_scope, _classCounter);
 };
 export const template = "<button id=tags> </button><!>";
 export const walks = /* get, next(1), get, out(1), replace, over(1) */" D l%b";

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
@@ -3,16 +3,15 @@ import _classCounter from "./components/class-counter.marko";
 import _marko_tags_compat from "marko/src/runtime/helpers/tags-compat-dom.js";
 _register("packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/components/class-counter.marko", _classCounter);
 const _classCounter_input = _dynamicTagAttrs("#text/2");
-const _expr__dynamicTagName__childScope_count = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_ChildScope_count = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": _dynamicTagName__childScope,
     count
   } = _scope;
   _classCounter_input(_scope, () => ({
     count: count
   }));
 });
-const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName__childScope_count);
+const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_ChildScope_count);
 const _count_effect = _register("packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/template.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     count
@@ -22,10 +21,10 @@ const _count_effect = _register("packages/translator-interop/src/__tests__/fixtu
 const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _queueEffect(_scope, _count_effect);
-}, _expr__dynamicTagName__childScope_count);
+}, _expr__dynamicTagName_ChildScope_count);
 const _setup = _scope => {
   _count(_scope, 0);
-  _dynamicTagName__childScope(_scope, _classCounter);
+  _dynamicTagName_ChildScope(_scope, _classCounter);
 };
 export const template = "<button id=tags> </button><!>";
 export const walks = /* get, next(1), get, out(1), replace, over(1) */" D l%b";

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
@@ -16,11 +16,11 @@ const _count$classLayoutBody = _registerSubscriber("packages/translator-interop/
 }));
 const _classLayoutBody = /* @__PURE__ */_createRenderer("<button id=tags> </button>", /* get, next(1), get */" D ", void 0, [_count$classLayoutBody]);
 const _classLayout_input = _dynamicTagAttrs("#text/0", _classLayoutBody);
-const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
+const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
 const _count = /* @__PURE__ */_value("count", null, _dynamicSubscribers("count"));
 const _setup = _scope => {
   _count(_scope, 0);
-  _dynamicTagName__childScope(_scope, _classLayout || _classLayoutBody);
+  _dynamicTagName_ChildScope(_scope, _classLayout || _classLayoutBody);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
@@ -16,11 +16,11 @@ const _count$classLayoutBody = _registerSubscriber("packages/translator-interop/
 }));
 const _classLayoutBody = /* @__PURE__ */_createRenderer("<button id=tags> </button>", /* get, next(1), get */" D ", void 0, [_count$classLayoutBody]);
 const _classLayout_input = _dynamicTagAttrs("#text/0", _classLayoutBody);
-const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
+const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
 const _count = /* @__PURE__ */_value("count", null, _dynamicSubscribers("count"));
 const _setup = _scope => {
   _count(_scope, 0);
-  _dynamicTagName_ChildScope(_scope, _classLayout || _classLayoutBody);
+  _dynamicTagName__childScope(_scope, _classLayout || _classLayoutBody);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -1,13 +1,13 @@
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/dist/debug/dom";
 const _inputRenderBody_input = _dynamicTagAttrs("#text/2", void 0, true);
-const _expr_dynamicTagName_count = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_count = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     count
   } = _scope;
   _inputRenderBody_input(_scope, () => [count, "hello"]);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_count);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_count);
 const _count_effect = _register("packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/components/tags-layout.marko_0_count", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     count
@@ -17,7 +17,7 @@ const _count_effect = _register("packages/translator-interop/src/__tests__/fixtu
 const _count = /* @__PURE__ */_value("count", (_scope, count) => {
   _data(_scope["#text/1"], count);
   _queueEffect(_scope, _count_effect);
-}, _expr_dynamicTagName_count);
+}, _expr__dynamicTagName_count);
 const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), void 0, _dynamicTagName);
 const _setup = _scope => {
   _count(_scope, 0);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
@@ -32,11 +32,11 @@ const _classLayoutBody = /* @__PURE__ */_createRenderer("<h1> </h1><button id=ta
   _message$classLayoutBody(_scope, message, _clean);
 });
 const _classLayout_input = _dynamicTagAttrs("#text/0", _classLayoutBody);
-const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
+const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
 const _multiplier = /* @__PURE__ */_value("multiplier", null, _dynamicSubscribers("multiplier"));
 const _setup = _scope => {
   _multiplier(_scope, 1);
-  _dynamicTagName_ChildScope(_scope, _classLayout || _classLayoutBody);
+  _dynamicTagName__childScope(_scope, _classLayout || _classLayoutBody);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
@@ -32,11 +32,11 @@ const _classLayoutBody = /* @__PURE__ */_createRenderer("<h1> </h1><button id=ta
   _message$classLayoutBody(_scope, message, _clean);
 });
 const _classLayout_input = _dynamicTagAttrs("#text/0", _classLayoutBody);
-const _dynamicTagName__childScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
+const _dynamicTagName_ChildScope = /* @__PURE__ */_conditional("#text/0", _scope => _classLayout_input(_scope, () => ({})), void 0, _classLayout_input);
 const _multiplier = /* @__PURE__ */_value("multiplier", null, _dynamicSubscribers("multiplier"));
 const _setup = _scope => {
   _multiplier(_scope, 1);
-  _dynamicTagName__childScope(_scope, _classLayout || _classLayoutBody);
+  _dynamicTagName_ChildScope(_scope, _classLayout || _classLayoutBody);
 };
 export const template = "<!>";
 export const walks = /* replace, over(1) */"%b";

--- a/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -3,9 +3,9 @@ import { setup as _customTag, template as _customTag_template, walks as _customT
 const _testBody = /* @__PURE__ */_createRenderer("", "");
 const _inputTestBody = /* @__PURE__ */_createRenderer("", "");
 const _inputTest_input = _dynamicTagAttrs("#text/3", _inputTestBody);
-const _expr_dynamicTagName_c_d = /* @__PURE__ */_intersection(3, _scope => {
+const _expr__dynamicTagName_c_d = /* @__PURE__ */_intersection(3, _scope => {
   const {
-    "#text/3": dynamicTagName,
+    "#text/3": _dynamicTagName,
     c,
     d
   } = _scope;
@@ -35,9 +35,9 @@ const _expr_c_d = /* @__PURE__ */_intersection(2, _scope => {
     d
   }]);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", null, _expr_dynamicTagName_c_d);
-const _d = /* @__PURE__ */_value("d", null, _intersections([_expr_c_d, _expr_dynamicTagName_c_d]));
-const _c = /* @__PURE__ */_value("c", null, _intersections([_expr_c_d, _expr_dynamicTagName_c_d]));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", null, _expr__dynamicTagName_c_d);
+const _d = /* @__PURE__ */_value("d", null, _intersections([_expr_c_d, _expr__dynamicTagName_c_d]));
+const _c = /* @__PURE__ */_value("c", null, _intersections([_expr_c_d, _expr__dynamicTagName_c_d]));
 const _destructure2 = (_scope, _destructure, _clean) => {
   let c, d;
   if (!_clean) ({

--- a/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const _forBody = /* @__PURE__ */_createRenderer("<li> </li>", /* next(1), get */
   if (!_clean) [x] = _destructure;
   _x$forBody(_scope, x, _clean);
 });
-const _ul_for = /* @__PURE__ */_loopOf("#ul/0", _forBody);
+const _ul__for = /* @__PURE__ */_loopOf("#ul/0", _forBody);
 const _list_effect = _register("packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/template.marko_0_list", _scope => _on(_scope["#button/2"], "click", function () {
   const {
     list
@@ -14,7 +14,7 @@ const _list_effect = _register("packages/translator-tags/src/__tests__/fixtures/
 }));
 const _list = /* @__PURE__ */_value("list", (_scope, list) => {
   _queueEffect(_scope, _list_effect);
-  _ul_for(_scope, [list, function (x) {
+  _ul__for(_scope, [list, function (x) {
     return x;
   }]);
 });

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -1,8 +1,8 @@
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, register as _register, queueEffect as _queueEffect, conditional as _conditional, intersections as _intersections, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _inputRenderBody_input = _dynamicTagAttrs("#text/3", void 0, true);
-const _expr_dynamicTagName_x_y = /* @__PURE__ */_intersection(3, _scope => {
+const _expr__dynamicTagName_x_y = /* @__PURE__ */_intersection(3, _scope => {
   const {
-    "#text/3": dynamicTagName,
+    "#text/3": _dynamicTagName,
     x,
     y
   } = _scope;
@@ -23,9 +23,9 @@ const _expr_x_y = /* @__PURE__ */_intersection(2, _scope => {
   } = _scope;
   _queueEffect(_scope, _expr_x_y_effect);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", null, _expr_dynamicTagName_x_y);
-const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/2"], y), _intersections([_expr_x_y, _expr_dynamicTagName_x_y]));
-const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/1"], x), _intersections([_expr_x_y, _expr_dynamicTagName_x_y]));
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/3", null, _expr__dynamicTagName_x_y);
+const _y = /* @__PURE__ */_value("y", (_scope, y) => _data(_scope["#text/2"], y), _intersections([_expr_x_y, _expr__dynamicTagName_x_y]));
+const _x = /* @__PURE__ */_value("x", (_scope, x) => _data(_scope["#text/1"], x), _intersections([_expr_x_y, _expr__dynamicTagName_x_y]));
 const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), void 0, _dynamicTagName);
 const _setup = _scope => {
   _x(_scope, 1);

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/components/custom-tag.js
@@ -1,8 +1,8 @@
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _inputRenderBody_input = _dynamicTagAttrs("#text/2");
-const _expr_dynamicTagName_input_x = /* @__PURE__ */_intersection(3, _scope => {
+const _expr__dynamicTagName_input_x = /* @__PURE__ */_intersection(3, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     input,
     x
   } = _scope;
@@ -11,7 +11,7 @@ const _expr_dynamicTagName_input_x = /* @__PURE__ */_intersection(3, _scope => {
     name: input.name
   }));
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_input_x);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_input_x);
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/components/custom-tag.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     x
@@ -21,8 +21,8 @@ const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/cus
 const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/1"], x);
   _queueEffect(_scope, _x_effect);
-}, _expr_dynamicTagName_input_x);
-const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), _expr_dynamicTagName_input_x, _dynamicTagName);
+}, _expr__dynamicTagName_input_x);
+const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), _expr__dynamicTagName_input_x, _dynamicTagName);
 const _setup = _scope => {
   _x(_scope, 1);
 };

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/components/custom-tag.js
@@ -1,13 +1,13 @@
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _inputRenderBody_input = _dynamicTagAttrs("#text/2");
-const _expr_dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     x
   } = _scope;
   _inputRenderBody_input(_scope, () => x);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_x);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_x);
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/components/custom-tag.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     x
@@ -17,7 +17,7 @@ const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/cus
 const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/1"], x);
   _queueEffect(_scope, _x_effect);
-}, _expr_dynamicTagName_x);
+}, _expr__dynamicTagName_x);
 const _input = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), void 0, _dynamicTagName);
 const _setup = _scope => {
   _x(_scope, 1);

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -1,17 +1,17 @@
 import { on as _on, queueSource as _queueSource, createRenderer as _createRenderer, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _tagNameBody = /* @__PURE__ */_createRenderer("body content", "");
 const _tagName_input = _dynamicTagAttrs("#text/0", _tagNameBody);
-const _expr_dynamicTagName_className = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_className = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/0": dynamicTagName,
+    "#text/0": _dynamicTagName,
     className
   } = _scope;
   _tagName_input(_scope, () => ({
     class: className
   }));
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr_dynamicTagName_className);
-const _className = /* @__PURE__ */_value("className", null, _expr_dynamicTagName_className);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr__dynamicTagName_className);
+const _className = /* @__PURE__ */_value("className", null, _expr__dynamicTagName_className);
 const _tagName_effect = _register("packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     tagName

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
@@ -2,14 +2,14 @@ import customTag from './components/custom-tag.marko';
 const tags = [customTag];
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _tags0_input = _dynamicTagAttrs("#text/2");
-const _expr_dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     x
   } = _scope;
   _tags0_input(_scope, () => x);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_x);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_x);
 const _y = "SIGNAL NOT INITIALIZED";
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/template.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const {
@@ -20,7 +20,7 @@ const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dyn
 const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/1"], x);
   _queueEffect(_scope, _x_effect);
-}, _expr_dynamicTagName_x);
+}, _expr__dynamicTagName_x);
 const _setup = _scope => {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
@@ -2,14 +2,14 @@ import customTag from './components/custom-tag.marko';
 const tags = [customTag];
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _tags0_input = _dynamicTagAttrs("#text/2", void 0, true);
-const _expr_dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     x
   } = _scope;
   _tags0_input(_scope, () => [x, 'foo']);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_x);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_x);
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/template.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     x
@@ -19,7 +19,7 @@ const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dyn
 const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/1"], x);
   _queueEffect(_scope, _x_effect);
-}, _expr_dynamicTagName_x);
+}, _expr__dynamicTagName_x);
 const _setup = _scope => {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -2,17 +2,17 @@ import child1 from "./components/child1.marko";
 import child2 from "./components/child2.marko";
 import { on as _on, queueSource as _queueSource, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, value as _value, register as _register, queueEffect as _queueEffect, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _tagName_input = _dynamicTagAttrs("#text/0");
-const _expr_dynamicTagName_val = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_val = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/0": dynamicTagName,
+    "#text/0": _dynamicTagName,
     val
   } = _scope;
   _tagName_input(_scope, () => ({
     value: val
   }));
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr_dynamicTagName_val);
-const _val = /* @__PURE__ */_value("val", null, _expr_dynamicTagName_val);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", null, _expr__dynamicTagName_val);
+const _val = /* @__PURE__ */_value("val", null, _expr__dynamicTagName_val);
 const _tagName_effect = _register("packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/template.marko_0_tagName", _scope => _on(_scope["#button/1"], "click", function () {
   const {
     tagName

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
@@ -2,14 +2,14 @@ import customTag from './components/custom-tag.marko';
 const tags = [customTag];
 import { on as _on, queueSource as _queueSource, data as _data, dynamicTagAttrs as _dynamicTagAttrs, intersection as _intersection, conditional as _conditional, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _tags0_input = _dynamicTagAttrs("#text/2");
-const _expr_dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
+const _expr__dynamicTagName_x = /* @__PURE__ */_intersection(2, _scope => {
   const {
-    "#text/2": dynamicTagName,
+    "#text/2": _dynamicTagName,
     x
   } = _scope;
   _tags0_input(_scope, () => x);
 });
-const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr_dynamicTagName_x);
+const _dynamicTagName = /* @__PURE__ */_conditional("#text/2", null, _expr__dynamicTagName_x);
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/template.marko_0_x", _scope => _on(_scope["#button/0"], "click", function () {
   const {
     x
@@ -19,7 +19,7 @@ const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/dyn
 const _x = /* @__PURE__ */_value("x", (_scope, x) => {
   _data(_scope["#text/1"], x);
   _queueEffect(_scope, _x_effect);
-}, _expr_dynamicTagName_x);
+}, _expr__dynamicTagName_x);
 const _setup = _scope => {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);

--- a/packages/translator-tags/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
@@ -21,14 +21,14 @@ const _forBody8 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></
   if (!_clean) [i] = _destructure2;
   _i$forBody6(_scope, i, _clean);
 });
-const _for$forBody = /* @__PURE__ */_loopTo("#text/3", _forBody8);
+const _for8$forBody = /* @__PURE__ */_loopTo("#text/3", _forBody8);
 const _i$forBody5 = /* @__PURE__ */_value("i", (_scope, i) => {
   _attr(_scope["#div/0"], "key", i);
   _data(_scope["#text/1"], i);
   _attr(_scope["#div/2"], "key", `other-${i}`);
 });
 const _setup$forBody = _scope => {
-  _for$forBody(_scope, [10, 0, 2]);
+  _for8$forBody(_scope, [10, 0, 2]);
 };
 const _forBody7 = /* @__PURE__ */_createRenderer("<div> </div><div></div><div></div><!>", /* get, next(1), get, out(1), over(1), get, over(1), replace */" D lb b%", _setup$forBody, void 0, void 0, void 0, void 0, void 0, (_scope, _destructure3, _clean) => {
   let i;

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
@@ -1,7 +1,7 @@
 import { queueSource as _queueSource, lifecycle as _lifecycle, data as _data, on as _on, value as _value, register as _register, queueEffect as _queueEffect, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _prev = /* @__PURE__ */_value("prev", (_scope, prev) => _data(_scope["#text/1"], prev));
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/template.marko_0_x", _scope => {
-  _lifecycle(_scope, "cleanup", {
+  _lifecycle(_scope, "_cleanup", {
     onMount: function () {
       const {
         x

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -1,5 +1,5 @@
 import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, closure as _closure, createRenderer as _createRenderer, conditional as _conditional, value as _value, inConditionalScope as _inConditionalScope, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
-const _x$ifBody_effect = _register("packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_x", _scope => _lifecycle(_scope, "cleanup", {
+const _x$ifBody_effect = _register("packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko_1_x", _scope => _lifecycle(_scope, "_cleanup", {
   onMount: function () {
     const {
       _: {

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/template.marko_0_x", _scope => {
-  _lifecycle(_scope, "cleanup", {
+  _lifecycle(_scope, "_cleanup", {
     onMount: function () {
       this.onUpdate();
     },

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 import { lifecycle as _lifecycle, on as _on, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/src/dom";
 const _x_effect = _register("packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/template.marko_0_x", _scope => {
-  _lifecycle(_scope, "cleanup", {
+  _lifecycle(_scope, "_cleanup", {
     onMount: function () {
       const {
         x

--- a/packages/translator-tags/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/user-effect-cleanup/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const _expr_a_b = /* @__PURE__ */_intersection(2, _scope => {
 });
 const _b = /* @__PURE__ */_value("b", null, _expr_a_b);
 const _a = /* @__PURE__ */_value("a", null, _expr_a_b);
-const _input_effect = _register("packages/translator-tags/src/__tests__/fixtures/user-effect-cleanup/template.marko_0_input", _scope => _userEffect(_scope, "cleanup", function () {
+const _input_effect = _register("packages/translator-tags/src/__tests__/fixtures/user-effect-cleanup/template.marko_0_input", _scope => _userEffect(_scope, "_cleanup", function () {
   const {
     input
   } = _scope;

--- a/packages/translator-tags/src/core/condition/if.ts
+++ b/packages/translator-tags/src/core/condition/if.ts
@@ -41,7 +41,7 @@ export default {
         ReserveType.Visit,
         getOrCreateSection(tag),
         tag.node,
-        "if",
+        tag.scope.generateUid("if"),
         "#text",
       );
       customTag.analyze.enter(tag);

--- a/packages/translator-tags/src/core/effect.ts
+++ b/packages/translator-tags/src/core/effect.ts
@@ -24,7 +24,7 @@ export default {
       ReserveType.Store,
       getOrCreateSection(tag),
       tag.node,
-      "cleanup",
+      tag.scope.generateUid("cleanup"),
     );
     (currentProgramPath.node.extra ?? {}).isInteractive = true;
   },

--- a/packages/translator-tags/src/core/for.ts
+++ b/packages/translator-tags/src/core/for.ts
@@ -46,7 +46,7 @@ export default {
         ReserveType.Visit,
         getOrCreateSection(tag),
         isOnlyChild ? parentTag : tag.node,
-        "for",
+        tag.scope.generateUid("for"),
         isOnlyChild ? `#${parentTagName}` : "#text",
       );
       customTag.analyze.enter(tag);

--- a/packages/translator-tags/src/core/lifecycle.ts
+++ b/packages/translator-tags/src/core/lifecycle.ts
@@ -32,7 +32,7 @@ export default {
         ReserveType.Store,
         getOrCreateSection(tag),
         tag.node,
-        "cleanup",
+        tag.scope.generateUid("cleanup"),
       );
       (currentProgramPath.node.extra ?? {}).isInteractive = true;
     },

--- a/packages/translator-tags/src/util/reserve.ts
+++ b/packages/translator-tags/src/util/reserve.ts
@@ -59,7 +59,7 @@ export function reserveScope(
   name: string,
   debugKey: string = name,
 ): Reserve {
-  const extra = (node.extra ??= {} as typeof node.extra);
+  const extra = (node.extra ??= {});
 
   if (extra.reserve) {
     const reserve = extra.reserve as Reserve;

--- a/packages/translator-tags/src/visitors/placeholder.ts
+++ b/packages/translator-tags/src/visitors/placeholder.ts
@@ -33,7 +33,7 @@ export default {
         ReserveType.Visit,
         getOrCreateSection(placeholder),
         node,
-        "placeholder",
+        placeholder.scope.generateUid("placeholder"),
         "#text",
       );
       needsMarker(placeholder);

--- a/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
@@ -43,7 +43,7 @@ export default {
         ReserveType.Visit,
         getOrCreateSection(tag),
         tag.node as any as t.Identifier,
-        "dynamicTagName",
+        tag.scope.generateUid("dynamicTagName"),
         "#text",
       );
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Resolve collisions by using `generateUid` when passing a name into `reserveScope`
- Didn't update `"#child-scope"` from `custom-tag`, because it was breaking things
- Didn't add any tests

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
