### PR TITLE
Dedupe enums

### DIFF
--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -22,34 +22,34 @@ export type Scope<
   [x: string | number]: any;
 } & T;
 
-// TODO: SECTION_SIBLING that is both a SECTION_START and a SECTION_END (<for> siblings)
+// TODO: SectionSiblings that is both a SectionStart and a SectionEnd (<for> siblings)
 //       NODE that doesn't have a sectionId and uses the previous sectionId
-export const enum ResumeSymbols {
-  DEFAULT_RUNTIME_ID = "M",
-  SECTION_START = "[",
-  SECTION_END = "]",
-  SECTION_SINGLE_NODES_END = "|",
-  NODE = "*",
-  PLACEHOLDER_START = "",
-  PLACEHOLDER_END = "",
-  REPLACEMENT_ID = "",
-  VAR_RESUME = "$h",
-  VAR_REORDER_RUNTIME = "$r",
+export enum ResumeSymbol {
+  DefaultRuntimeId = "M",
+  SectionStart = "[",
+  SectionEnd = "]",
+  SectionSingleNodesEnd = "|",
+  Node = "*",
+  PlaceholderStart = "",
+  PlaceholderEnd = "",
+  ReplacementId = "",
+  VarResume = "$h",
+  VarReorderRuntime = "$r",
 }
 
-export const enum AccessorChars {
-  DYNAMIC = "?",
-  MARK = "#",
-  STALE = "&",
-  SUBSCRIBERS = "*",
-  LIFECYCLE_ABORT_CONTROLLER = "-",
-  TAG_VARIABLE = "/",
-  COND_SCOPE = "!",
-  LOOP_SCOPE_ARRAY = "!",
-  COND_RENDERER = "(",
-  LOOP_SCOPE_MAP = "(",
-  LOOP_VALUE = ")",
-  PREVIOUS_ATTRIBUTES = "~",
+export enum AccessorChar {
+  Dynamic = "?",
+  Mark = "#",
+  Stale = "&",
+  Subscribers = "*",
+  LifecycleAbortController = "-",
+  TagVariable = "/",
+  ConditionalScope = "!",
+  ConditionalRenderer = "(",
+  LoopScopeArray = "!",
+  LoopScopeMap = "(",
+  LoopValue = ")",
+  PreviousAttributes = "~",
 }
 
 export type Accessor = string | number;

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -52,6 +52,49 @@ export enum AccessorChar {
   PreviousAttributes = "~",
 }
 
+export enum NodeType {
+  Element = 1,
+  Text = 3,
+  Comment = 8,
+  DocumentFragment = 11,
+}
+
+// Reserved Character Codes
+// 0-31 [control characters]
+// 34 " [double quote]
+// 39 ' [single quote]
+// 92 \ [backslash]
+// 96 ` [backtick]
+export enum WalkCode {
+  Get = 32,
+  Before = 33,
+  After = 35,
+  Inside = 36,
+  Replace = 37,
+  EndChild = 38,
+
+  BeginChild = 47,
+
+  Next = 67,
+  NextEnd = 91,
+
+  Over = 97,
+  OverEnd = 106,
+
+  Out = 107,
+  OutEnd = 116,
+
+  Multiplier = 117,
+  MultiplierEnd = 126,
+}
+
+export enum WalkRangeSize {
+  Next = 20, // 67 through 91
+  Over = 10, // 97 through 106
+  Out = 10, // 107 through 116
+  Multiplier = 10, // 117 through 126
+}
+
 export type Accessor = string | number;
 export type Input = Record<string, unknown>;
 export type Context = Record<string, unknown>;

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -1,4 +1,4 @@
-import { type Accessor, AccessorChars, type Scope } from "../common/types";
+import { type Accessor, AccessorChar, type Scope } from "../common/types";
 import { defaultFragment } from "./fragment";
 import { reconcile } from "./reconcile";
 import {
@@ -34,8 +34,8 @@ export let conditional = function conditional(
   intersection?: IntersectionSignal,
   valueWithIntersection?: ValueSignal,
 ): ValueSignal<RendererOrElementName | undefined> {
-  const rendererAccessor = nodeAccessor + AccessorChars.COND_RENDERER;
-  const childScopeAccessor = nodeAccessor + AccessorChars.COND_SCOPE;
+  const rendererAccessor = nodeAccessor + AccessorChar.ConditionalRenderer;
+  const childScopeAccessor = nodeAccessor + AccessorChar.ConditionalScope;
   return (scope, newRenderer, clean) => {
     newRenderer = newRenderer
       ? (newRenderer as any as Template)._ || newRenderer
@@ -60,8 +60,8 @@ export function inConditionalScope<S extends Scope>(
   signal: IntersectionSignal,
   nodeAccessor: Accessor /* branch?: Renderer */,
 ): IntersectionSignal {
-  const scopeAccessor = nodeAccessor + AccessorChars.COND_SCOPE;
-  const rendererAccessor = nodeAccessor + AccessorChars.COND_RENDERER;
+  const scopeAccessor = nodeAccessor + AccessorChar.ConditionalScope;
+  const rendererAccessor = nodeAccessor + AccessorChar.ConditionalRenderer;
   return (scope: Scope, clean?: boolean | 1) => {
     const conditionalScope = scope[scopeAccessor] as S;
     if (conditionalScope) {
@@ -82,17 +82,19 @@ export function setConditionalRenderer<ChildScope extends Scope>(
   newRenderer: RendererOrElementName | undefined,
 ) {
   let newScope: ChildScope;
-  let prevScope = scope[nodeAccessor + AccessorChars.COND_SCOPE] as ChildScope;
+  let prevScope = scope[
+    nodeAccessor + AccessorChar.ConditionalScope
+  ] as ChildScope;
   const newFragment = newRenderer?.___fragment ?? defaultFragment;
   const prevFragment = prevScope?.___renderer?.___fragment ?? defaultFragment;
 
   if (newRenderer) {
-    newScope = scope[nodeAccessor + AccessorChars.COND_SCOPE] =
+    newScope = scope[nodeAccessor + AccessorChar.ConditionalScope] =
       createScopeWithRenderer(newRenderer, scope.$global, scope) as ChildScope;
     prevScope = prevScope || getEmptyScope(scope[nodeAccessor] as Comment);
   } else {
     newScope = getEmptyScope(scope[nodeAccessor] as Comment) as ChildScope;
-    scope[nodeAccessor + AccessorChars.COND_SCOPE] = undefined;
+    scope[nodeAccessor + AccessorChar.ConditionalScope] = undefined;
   }
 
   newFragment.___insertBefore(
@@ -107,8 +109,8 @@ export let conditionalOnlyChild = function conditionalOnlyChild(
   nodeAccessor: Accessor,
   action?: ValueSignal<RendererOrElementName | undefined>,
 ): ValueSignal<RendererOrElementName | undefined> {
-  const rendererAccessor = nodeAccessor + AccessorChars.COND_RENDERER;
-  const childScopeAccessor = nodeAccessor + AccessorChars.COND_SCOPE;
+  const rendererAccessor = nodeAccessor + AccessorChar.ConditionalRenderer;
+  const childScopeAccessor = nodeAccessor + AccessorChar.ConditionalScope;
   return (scope, newRenderer, clean) => {
     let currentRenderer = scope[rendererAccessor] as
       | RendererOrElementName
@@ -127,12 +129,14 @@ export function setConditionalRendererOnlyChild(
   nodeAccessor: Accessor,
   newRenderer: RendererOrElementName | undefined,
 ) {
-  const prevScope = scope[nodeAccessor + AccessorChars.COND_SCOPE] as Scope;
+  const prevScope = scope[
+    nodeAccessor + AccessorChar.ConditionalScope
+  ] as Scope;
   const referenceNode = scope[nodeAccessor] as Element;
   referenceNode.textContent = "";
 
   if (newRenderer) {
-    const newScope = (scope[nodeAccessor + AccessorChars.COND_SCOPE] =
+    const newScope = (scope[nodeAccessor + AccessorChar.ConditionalScope] =
       createScopeWithRenderer(newRenderer, scope.$global, scope));
     (newRenderer.___fragment ?? defaultFragment).___insertBefore(
       newScope,
@@ -197,7 +201,7 @@ function loop(
   renderer: Renderer,
   forEach: LoopForEach,
 ) {
-  const loopScopeAccessor = nodeAccessor + AccessorChars.LOOP_SCOPE_ARRAY;
+  const loopScopeAccessor = nodeAccessor + AccessorChar.LoopScopeArray;
   const closureSignals = renderer.___closureSignals;
   const params = renderer.___args;
   return (
@@ -222,12 +226,12 @@ function loop(
       referenceNode.nodeType === 8 /* Comment */ ||
       referenceNode.nodeType === 3; /* Text */
     const oldMap =
-      (scope[nodeAccessor + AccessorChars.LOOP_SCOPE_MAP] as Map<
+      (scope[nodeAccessor + AccessorChar.LoopScopeMap] as Map<
         unknown,
         Scope
       >) || (referenceIsMarker ? emptyMarkerMap : emptyMap);
     const oldArray =
-      (scope[nodeAccessor + AccessorChars.LOOP_SCOPE_ARRAY] as Scope[]) ||
+      (scope[nodeAccessor + AccessorChar.LoopScopeArray] as Scope[]) ||
       Array.from(oldMap.values());
 
     let newMap!: Map<unknown, Scope>;
@@ -306,8 +310,8 @@ function loop(
       );
     }
 
-    scope[nodeAccessor + AccessorChars.LOOP_SCOPE_MAP] = newMap;
-    scope[nodeAccessor + AccessorChars.LOOP_SCOPE_ARRAY] = newArray;
+    scope[nodeAccessor + AccessorChar.LoopScopeMap] = newMap;
+    scope[nodeAccessor + AccessorChar.LoopScopeArray] = newArray;
   };
 }
 
@@ -316,7 +320,7 @@ export function inLoopScope(
   signal: IntersectionSignal,
   loopNodeAccessor: Accessor,
 ) {
-  const loopScopeAccessor = loopNodeAccessor + AccessorChars.LOOP_SCOPE_ARRAY;
+  const loopScopeAccessor = loopNodeAccessor + AccessorChar.LoopScopeArray;
   return (scope: Scope, clean?: boolean | 1) => {
     const loopScopes = scope[loopScopeAccessor] ?? [];
     for (const scope of loopScopes) {

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -1,5 +1,5 @@
 import { classValue, styleValue } from "../common/helpers";
-import { type Accessor, AccessorChars, type Scope } from "../common/types";
+import { type Accessor, AccessorChar, type Scope } from "../common/types";
 import { getAbortSignal } from "./abort-signal";
 import { write } from "./scope";
 
@@ -44,9 +44,9 @@ export function attrs(
   elementAccessor: Accessor,
   nextAttrs: Record<string, unknown>,
 ) {
-  const prevAttrs = scope[
-    elementAccessor + AccessorChars.PREVIOUS_ATTRIBUTES
-  ] as typeof nextAttrs | undefined;
+  const prevAttrs = scope[elementAccessor + AccessorChar.PreviousAttributes] as
+    | typeof nextAttrs
+    | undefined;
   const element = scope[elementAccessor] as Element;
 
   if (prevAttrs) {
@@ -69,7 +69,7 @@ export function attrs(
     }
   }
 
-  scope[elementAccessor + AccessorChars.PREVIOUS_ATTRIBUTES] = nextAttrs;
+  scope[elementAccessor + AccessorChar.PreviousAttributes] = nextAttrs;
 }
 
 const doc = document;
@@ -142,7 +142,7 @@ export function lifecycle(
     thisObj.onMount?.();
     getAbortSignal(
       scope,
-      AccessorChars.LIFECYCLE_ABORT_CONTROLLER + index,
+      AccessorChar.LifecycleAbortController + index,
     ).onabort = () => thisObj.onDestroy?.();
   }
 }

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -1,14 +1,12 @@
 import { classValue, styleValue } from "../common/helpers";
-import { type Accessor, AccessorChar, type Scope } from "../common/types";
+import {
+  type Accessor,
+  AccessorChar,
+  NodeType,
+  type Scope,
+} from "../common/types";
 import { getAbortSignal } from "./abort-signal";
 import { write } from "./scope";
-
-export enum NodeType {
-  Element = 1,
-  Text = 3,
-  Comment = 8,
-  DocumentFragment = 11,
-}
 
 export function isDocumentFragment(node: Node): node is DocumentFragment {
   return node.nodeType === NodeType.DocumentFragment;

--- a/packages/runtime-tags/src/dom/fragment.ts
+++ b/packages/runtime-tags/src/dom/fragment.ts
@@ -1,4 +1,4 @@
-import { type Accessor, AccessorChars, type Scope } from "../common/types";
+import { type Accessor, AccessorChar, type Scope } from "../common/types";
 import { emptyMarkerArray } from "./control-flow";
 
 export type DOMFragment = {
@@ -71,7 +71,7 @@ function getFirstNode(
   let scopeOrScopes: Scope | Scope[];
 
   if (MARKO_DEBUG) {
-    if (AccessorChars.COND_SCOPE !== AccessorChars.LOOP_SCOPE_ARRAY) {
+    if (AccessorChar.ConditionalScope !== AccessorChar.LoopScopeArray) {
       throw new Error("Offset mismatch between conditionals and loops");
     }
   }
@@ -79,7 +79,7 @@ function getFirstNode(
   return typeof nodeOrAccessor === "object"
     ? nodeOrAccessor
     : !(scopeOrScopes = currentScope[
-          nodeOrAccessor + AccessorChars.COND_SCOPE
+          nodeOrAccessor + AccessorChar.ConditionalScope
         ] as Scope | Scope[]) || scopeOrScopes === emptyMarkerArray
       ? (currentScope[nodeOrAccessor] as Comment)
       : (last ? getLastNode : getFirstNode)(

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -2,17 +2,17 @@ import type { Scope } from "../common/types";
 import { schedule } from "./schedule";
 import type { ValueSignal } from "./signals";
 
-const enum BatchOffsets {
-  SCOPE = 0,
-  SIGNAL = 1,
-  VALUE = 2,
-  TOTAL = 3,
+const enum BatchOffset {
+  Scope = 0,
+  Signal = 1,
+  Value = 2,
+  Total = 3,
 }
 
-const enum EffectOffsets {
-  SCOPE = 0,
-  FN = 1,
-  TOTAL = 2,
+const enum EffectOffset {
+  Scope = 0,
+  Function = 1,
+  Total = 2,
 }
 
 type ExecFn<S extends Scope = Scope> = (scope: S, arg?: any) => void;
@@ -79,7 +79,7 @@ export function prepare(fn: () => void) {
 }
 
 export function runEffects(effects: unknown[] = currentEffects) {
-  for (let i = 0; i < effects.length; i += EffectOffsets.TOTAL) {
+  for (let i = 0; i < effects.length; i += EffectOffset.Total) {
     const scope = effects[i] as Scope;
     const fn = effects[i + 1] as (scope: Scope) => void;
     fn(scope);
@@ -87,10 +87,10 @@ export function runEffects(effects: unknown[] = currentEffects) {
 }
 
 function runBatch() {
-  for (let i = 0; i < currentBatch.length; i += BatchOffsets.TOTAL) {
-    const scope = currentBatch[i + BatchOffsets.SCOPE] as Scope;
-    const signal = currentBatch[i + BatchOffsets.SIGNAL] as ValueSignal;
-    const value = currentBatch[i + BatchOffsets.VALUE] as unknown;
+  for (let i = 0; i < currentBatch.length; i += BatchOffset.Total) {
+    const scope = currentBatch[i + BatchOffset.Scope] as Scope;
+    const signal = currentBatch[i + BatchOffset.Signal] as ValueSignal;
+    const value = currentBatch[i + BatchOffset.Value] as unknown;
     signal(scope, value);
   }
 }

--- a/packages/runtime-tags/src/dom/renderer.ts
+++ b/packages/runtime-tags/src/dom/renderer.ts
@@ -1,10 +1,16 @@
-import { type Accessor, AccessorChar, type Scope } from "../common/types";
+import {
+  type Accessor,
+  AccessorChar,
+  NodeType,
+  WalkCode,
+  type Scope,
+} from "../common/types";
 import { setConditionalRendererOnlyChild } from "./control-flow";
-import { NodeType, attrs } from "./dom";
+import { attrs } from "./dom";
 import { type DOMFragment } from "./fragment";
 import { bindRenderer, createScope } from "./scope";
 import type { IntersectionSignal, ValueSignal } from "./signals";
-import { WalkCode, trimWalkString, walk } from "./walker";
+import { trimWalkString, walk } from "./walker";
 
 export type Renderer = {
   ___template: string;

--- a/packages/runtime-tags/src/dom/renderer.ts
+++ b/packages/runtime-tags/src/dom/renderer.ts
@@ -1,17 +1,10 @@
-import { type Accessor, AccessorChars, type Scope } from "../common/types";
+import { type Accessor, AccessorChar, type Scope } from "../common/types";
 import { setConditionalRendererOnlyChild } from "./control-flow";
-import { attrs } from "./dom";
+import { NodeType, attrs } from "./dom";
 import { type DOMFragment } from "./fragment";
 import { bindRenderer, createScope } from "./scope";
 import type { IntersectionSignal, ValueSignal } from "./signals";
-import { WalkCodes, trimWalkString, walk } from "./walker";
-
-const enum NodeType {
-  Element = 1,
-  Text = 3,
-  Comment = 8,
-  DocumentFragment = 11,
-}
+import { WalkCode, trimWalkString, walk } from "./walker";
 
 export type Renderer = {
   ___template: string;
@@ -94,14 +87,14 @@ export function dynamicTagAttrs(
     clean?: boolean | 1,
   ) => {
     const renderer = scope[
-      nodeAccessor + AccessorChars.COND_RENDERER
+      nodeAccessor + AccessorChar.ConditionalRenderer
     ] as Renderer;
 
     if (!renderer || renderer === renderBody || (clean && !renderer.___args)) {
       return;
     }
 
-    const childScope = scope[nodeAccessor + AccessorChars.COND_SCOPE];
+    const childScope = scope[nodeAccessor + AccessorChar.ConditionalScope];
     if (typeof renderer === "string") {
       // This will always be 0 because in dynamicRenderer we used WalkCodes.Get
       const elementAccessor = MARKO_DEBUG ? `#${renderer}/0` : 0;
@@ -177,7 +170,7 @@ function _clone(this: Renderer) {
     const ensureFragment =
       walks &&
       walks.length < 4 &&
-      walks.charCodeAt(walks.length - 1) !== WalkCodes.Get;
+      walks.charCodeAt(walks.length - 1) !== WalkCode.Get;
     this.___sourceNode = sourceNode = parse(
       this.___template,
       ensureFragment as boolean,

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -1,4 +1,4 @@
-import { ResumeSymbols, type Scope } from "../common/types";
+import { ResumeSymbol, type Scope } from "../common/types";
 import type { Renderer } from "./renderer";
 import { bindFunction, bindRenderer } from "./scope";
 import type { IntersectionSignal, ValueSignal } from "./signals";
@@ -19,10 +19,10 @@ export function register<T>(id: string, obj: T): T {
 export const scopeLookup = {} as Record<number | string, Scope>;
 
 export function init(
-  runtimeId = ResumeSymbols.DEFAULT_RUNTIME_ID /* [a-zA-Z0-9]+ */,
+  runtimeId = ResumeSymbol.DefaultRuntimeId /* [a-zA-Z0-9]+ */,
 ) {
   const runtimeLength = runtimeId.length;
-  const resumeVar = runtimeId + ResumeSymbols.VAR_RESUME;
+  const resumeVar = runtimeId + ResumeSymbol.VarResume;
   // TODO: check if this is a fakeArray
   // and warn in dev that there are conflicting runtime ids
   const initialHydration = (window as any)[resumeVar];
@@ -101,13 +101,13 @@ export function init(
         const scope = getScope(scopeId);
         const data = nodeValue.slice(nodeValue.indexOf(" ") + 1);
 
-        if (token === ResumeSymbols.NODE) {
+        if (token === ResumeSymbol.Node) {
           scope[data] = currentNode.previousSibling;
-        } else if (token === ResumeSymbols.SECTION_START) {
+        } else if (token === ResumeSymbol.SectionStart) {
           stack.push(currentScopeId);
           currentScopeId = scopeId;
           scope.___startNode = currentNode;
-        } else if (token === ResumeSymbols.SECTION_END) {
+        } else if (token === ResumeSymbol.SectionEnd) {
           scope[data] = currentNode;
           if (scopeId < currentScopeId) {
             const currScope = scopeLookup[currentScopeId];
@@ -119,7 +119,7 @@ export function init(
             currScope.___endNode = currentNode.previousSibling!;
             currentScopeId = stack.pop()!;
           }
-        } else if (token === ResumeSymbols.SECTION_SINGLE_NODES_END) {
+        } else if (token === ResumeSymbol.SectionSingleNodesEnd) {
           scope[
             MARKO_DEBUG ? data.slice(0, data.indexOf(" ")) : parseInt(data)
           ] = currentNode;

--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -1,4 +1,4 @@
-import { type Accessor, AccessorChars, type Scope } from "../common/types";
+import { type Accessor, AccessorChar, type Scope } from "../common/types";
 import type { RendererOrElementName } from "./renderer";
 import { bindFunction } from "./scope";
 
@@ -32,7 +32,7 @@ export function initValue<T>(
   valueAccessor: Accessor,
   fn: ValueSignal<T>,
 ): ValueSignal<T> {
-  const markAccessor = valueAccessor + AccessorChars.MARK;
+  const markAccessor = valueAccessor + AccessorChar.Mark;
   return (scope, nextValue, clean) => {
     if (clean !== 1 && scope[markAccessor] === undefined) {
       fn(scope, nextValue, clean);
@@ -46,7 +46,7 @@ export function value<T>(
   intersection?: IntersectionSignal,
   valueWithIntersection?: ValueSignal<any>,
 ): ValueSignal<T> {
-  const markAccessor = valueAccessor + AccessorChars.MARK;
+  const markAccessor = valueAccessor + AccessorChar.Mark;
   return (scope, nextValue, clean) => {
     let creation: boolean | undefined;
     let currentMark: number;
@@ -87,8 +87,8 @@ export function intersection(
   intersection?: IntersectionSignal,
   valueWithIntersection?: ValueSignal,
 ): IntersectionSignal {
-  const cleanAccessor = AccessorChars.DYNAMIC + accessorId++;
-  const markAccessor = cleanAccessor + AccessorChars.MARK;
+  const cleanAccessor = AccessorChar.Dynamic + accessorId++;
+  const markAccessor = cleanAccessor + AccessorChar.Mark;
   return (scope, clean) => {
     let currentMark;
     if (clean === 1) {
@@ -123,7 +123,7 @@ export function closure<T>(
   intersection?: IntersectionSignal,
   valueWithIntersection?: ValueSignal<any>,
 ): IntersectionSignal {
-  const cleanAccessor = AccessorChars.DYNAMIC + accessorId++;
+  const cleanAccessor = AccessorChar.Dynamic + accessorId++;
   const markAccessor = cleanAccessor + 1;
   const getOwnerScope = _getOwnerScope || defaultGetOwnerScope;
   const getOwnerValueAccessor =
@@ -138,7 +138,7 @@ export function closure<T>(
       if (scope[markAccessor] === undefined) {
         ownerScope = getOwnerScope(scope);
         ownerValueAccessor = getOwnerValueAccessor(scope);
-        const ownerMark = ownerScope[ownerValueAccessor + AccessorChars.MARK];
+        const ownerMark = ownerScope[ownerValueAccessor + AccessorChar.Mark];
         const ownerHasRun =
           ownerMark === undefined ? !ownerScope.___client : ownerMark === 0;
         scope[markAccessor] = (currentMark = ownerHasRun ? 1 : 2) - 1;
@@ -185,7 +185,7 @@ export function dynamicClosure<T>(
     ___subscribe(scope: Scope) {
       const ownerScope = getOwnerScope(scope);
       const providerSubscriptionsAccessor =
-        getOwnerValueAccessor(scope) + AccessorChars.SUBSCRIBERS;
+        getOwnerValueAccessor(scope) + AccessorChar.Subscribers;
       ownerScope[providerSubscriptionsAccessor] ??= new Set();
       ownerScope[providerSubscriptionsAccessor].add(
         bindFunction(scope, signalFn as any),
@@ -194,7 +194,7 @@ export function dynamicClosure<T>(
     ___unsubscribe(scope: Scope) {
       const ownerScope = getOwnerScope(scope);
       const providerSubscriptionsAccessor =
-        getOwnerValueAccessor(scope) + AccessorChars.SUBSCRIBERS;
+        getOwnerValueAccessor(scope) + AccessorChar.Subscribers;
       ownerScope[providerSubscriptionsAccessor]?.delete(
         bindFunction(scope, signalFn as any),
       );
@@ -229,7 +229,7 @@ export function childClosures(
 }
 
 export function dynamicSubscribers(valueAccessor: Accessor) {
-  const subscribersAccessor = valueAccessor + AccessorChars.SUBSCRIBERS;
+  const subscribersAccessor = valueAccessor + AccessorChar.Subscribers;
   return (scope: Scope, clean?: boolean | 1) => {
     const subscribers = scope[
       subscribersAccessor
@@ -247,7 +247,7 @@ export function setTagVar(
   childAccessor: Accessor,
   tagVarSignal: ValueSignal,
 ) {
-  scope[childAccessor][AccessorChars.TAG_VARIABLE] = bindFunction(
+  scope[childAccessor][AccessorChar.TagVariable] = bindFunction(
     scope,
     tagVarSignal as any,
   ) as BoundValueSignal;
@@ -257,7 +257,7 @@ export const tagVarSignal = (
   scope: Scope,
   value: unknown,
   clean?: boolean | 1,
-) => scope[AccessorChars.TAG_VARIABLE]?.(value, clean);
+) => scope[AccessorChar.TagVariable]?.(value, clean);
 
 export const renderBodyClosures = (
   renderBody: RendererOrElementName | undefined,

--- a/packages/runtime-tags/src/dom/walker.ts
+++ b/packages/runtime-tags/src/dom/walker.ts
@@ -24,7 +24,7 @@ export const walker = /* @__PURE__ */ document.createTreeWalker(document);
 // 39 ' [single quote]
 // 92 \ [backslash]
 // 96 ` [backtick]
-export const enum WalkCodes {
+export enum WalkCode {
   Get = 32,
   Before = 33,
   After = 35,
@@ -47,7 +47,7 @@ export const enum WalkCodes {
   MultiplierEnd = 126,
 }
 
-export const enum WalkRangeSizes {
+export enum WalkRangeSize {
   Next = 20, // 67 through 91
   Over = 10, // 97 through 106
   Out = 10, // 107 through 116
@@ -56,7 +56,7 @@ export const enum WalkRangeSizes {
 
 export function trimWalkString(walkString: string): string {
   let end = walkString.length;
-  while (walkString.charCodeAt(--end) > WalkCodes.BeginChild);
+  while (walkString.charCodeAt(--end) > WalkCode.BeginChild);
   return walkString.slice(0, end + 1);
 }
 
@@ -79,28 +79,28 @@ function walkInternal(
   while ((value = walkCodes.charCodeAt(currentWalkIndex++))) {
     currentMultiplier = storedMultiplier;
     storedMultiplier = 0;
-    if (value >= WalkCodes.Multiplier) {
+    if (value >= WalkCode.Multiplier) {
       storedMultiplier =
-        currentMultiplier * WalkRangeSizes.Multiplier +
+        currentMultiplier * WalkRangeSize.Multiplier +
         value -
-        WalkCodes.Multiplier;
-    } else if (value >= WalkCodes.Out) {
-      value = WalkRangeSizes.Out * currentMultiplier + value - WalkCodes.Out;
+        WalkCode.Multiplier;
+    } else if (value >= WalkCode.Out) {
+      value = WalkRangeSize.Out * currentMultiplier + value - WalkCode.Out;
       while (value--) {
         walker.parentNode();
       }
       walker.nextSibling();
-    } else if (value >= WalkCodes.Over) {
-      value = WalkRangeSizes.Over * currentMultiplier + value - WalkCodes.Over;
+    } else if (value >= WalkCode.Over) {
+      value = WalkRangeSize.Over * currentMultiplier + value - WalkCode.Over;
       while (value--) {
         !walker.nextSibling() && !walker.nextNode();
       }
-    } else if (value >= WalkCodes.Next) {
-      value = WalkRangeSizes.Next * currentMultiplier + value - WalkCodes.Next;
+    } else if (value >= WalkCode.Next) {
+      value = WalkRangeSize.Next * currentMultiplier + value - WalkCode.Next;
       while (value--) {
         walker.nextNode();
       }
-    } else if (value === WalkCodes.BeginChild) {
+    } else if (value === WalkCode.BeginChild) {
       currentWalkIndex = walkInternal(
         walkCodes,
         (scope[
@@ -110,9 +110,9 @@ function walkInternal(
         ] = createScope(scope.$global)),
         currentWalkIndex,
       )!;
-    } else if (value === WalkCodes.EndChild) {
+    } else if (value === WalkCode.EndChild) {
       return currentWalkIndex;
-    } else if (value === WalkCodes.Get) {
+    } else if (value === WalkCode.Get) {
       scope[
         MARKO_DEBUG
           ? getDebugKey(currentScopeIndex++, walker.currentNode)
@@ -127,13 +127,13 @@ function walkInternal(
       const current = walker.currentNode;
       const parentNode = current.parentNode!;
 
-      if (value === WalkCodes.Before) {
+      if (value === WalkCode.Before) {
         parentNode.insertBefore(newNode, current);
       } else {
-        if (value === WalkCodes.After) {
+        if (value === WalkCode.After) {
           parentNode.insertBefore(newNode, current.nextSibling);
         } else {
-          if (MARKO_DEBUG && value !== WalkCodes.Replace) {
+          if (MARKO_DEBUG && value !== WalkCode.Replace) {
             throw new Error(`Unknown walk code: ${value}`);
           }
           parentNode.replaceChild(newNode, current);

--- a/packages/runtime-tags/src/dom/walker.ts
+++ b/packages/runtime-tags/src/dom/walker.ts
@@ -1,5 +1,4 @@
-import type { Scope } from "../common/types";
-import { NodeType } from "./dom";
+import { type Scope, NodeType, WalkCode, WalkRangeSize } from "../common/types";
 import { createScope } from "./scope";
 
 export const walker = /* @__PURE__ */ document.createTreeWalker(document);
@@ -17,42 +16,6 @@ export const walker = /* @__PURE__ */ document.createTreeWalker(document);
 //    - Before must be done before walking into the node
 //    - Next would walk back in the node we just walked Out of
 //  - A component must assume the walker is on its first node, and include instructions for walking to its assumed nextSibling
-
-// Reserved Character Codes
-// 0-31 [control characters]
-// 34 " [double quote]
-// 39 ' [single quote]
-// 92 \ [backslash]
-// 96 ` [backtick]
-export enum WalkCode {
-  Get = 32,
-  Before = 33,
-  After = 35,
-  Inside = 36,
-  Replace = 37,
-  EndChild = 38,
-
-  BeginChild = 47,
-
-  Next = 67,
-  NextEnd = 91,
-
-  Over = 97,
-  OverEnd = 106,
-
-  Out = 107,
-  OutEnd = 116,
-
-  Multiplier = 117,
-  MultiplierEnd = 126,
-}
-
-export enum WalkRangeSize {
-  Next = 20, // 67 through 91
-  Over = 10, // 97 through 106
-  Out = 10, // 107 through 116
-  Multiplier = 10, // 117 through 126
-}
 
 export function trimWalkString(walkString: string): string {
   let end = walkString.length;

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1,8 +1,8 @@
-import { type Accessor, type Renderer, ResumeSymbols } from "../common/types";
+import { type Accessor, type Renderer, ResumeSymbol } from "../common/types";
 import reorderRuntime from "./reorder-runtime";
 import { Serializer } from "./serializer";
 
-const runtimeId = ResumeSymbols.DEFAULT_RUNTIME_ID;
+const runtimeId = ResumeSymbol.DefaultRuntimeId;
 const reorderRuntimeString = String(reorderRuntime).replace(
   "RUNTIME_ID",
   runtimeId,
@@ -422,7 +422,7 @@ function addReplacementWrapper(
   replacementStart: Buffer,
   replacementEnd: Buffer,
 ) {
-  let runtimeCall = runtimeId + ResumeSymbols.VAR_REORDER_RUNTIME;
+  let runtimeCall = runtimeId + ResumeSymbol.VarReorderRuntime;
   if (!$_streamData!.runtimeFlushed) {
     runtimeCall = `(${runtimeCall}=${reorderRuntimeString})`;
     $_streamData!.runtimeFlushed = true;
@@ -482,17 +482,17 @@ export function writeScope(
 
 export function markResumeNode(scopeId: number, index: Accessor) {
   // TODO: can we only include the scope id when it differs from the prvious node marker?
-  return `<!${runtimeId}${ResumeSymbols.NODE}${scopeId} ${index}>`;
+  return `<!${runtimeId}${ResumeSymbol.Node}${scopeId} ${index}>`;
 }
 
 export function markResumeScopeStart(scopeId: number, key?: string) {
-  return `<!${runtimeId}${ResumeSymbols.SECTION_START}${scopeId}${
+  return `<!${runtimeId}${ResumeSymbol.SectionStart}${scopeId}${
     key ? " " + key : ""
   }>`;
 }
 
 export function markResumeControlEnd(scopeId: number, index: Accessor) {
-  return `<!${runtimeId}${ResumeSymbols.SECTION_END}${scopeId} ${index}>`;
+  return `<!${runtimeId}${ResumeSymbol.SectionEnd}${scopeId} ${index}>`;
 }
 
 export function markResumeControlSingleNodeEnd(
@@ -501,7 +501,7 @@ export function markResumeControlSingleNodeEnd(
   childScopeIds?: number | number[],
 ) {
   return `<!${runtimeId}${
-    ResumeSymbols.SECTION_SINGLE_NODES_END
+    ResumeSymbol.SectionSingleNodesEnd
   }${scopeId} ${index} ${childScopeIds ?? ""}>`;
 }
 
@@ -520,8 +520,8 @@ function getResumeScript(
     }
     return `<script>${
       isFirstFlush
-        ? `(${runtimeId + ResumeSymbols.VAR_RESUME}=[])`
-        : runtimeId + ResumeSymbols.VAR_RESUME
+        ? `(${runtimeId + ResumeSymbol.VarResume}=[])`
+        : runtimeId + ResumeSymbol.VarResume
     }.push(${serializer.stringify(scopes)},[${calls}])</script>`;
   }
   return "";

--- a/packages/translator-tags/src/core/condition/if.ts
+++ b/packages/translator-tags/src/core/condition/if.ts
@@ -1,5 +1,6 @@
 import { type Tag, assertNoParams, assertNoVar } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { WalkCode } from "@marko/runtime-tags/common/types";
 import { isCoreTagName } from "../../util/is-core-tag";
 import { isOutputDOM, isOutputHTML } from "../../util/marko-config";
 import analyzeAttributeTags from "../../util/nested-attribute-tags";
@@ -83,7 +84,7 @@ export default {
         }
       }
 
-      walks.visit(tag, walks.WalkCode.Replace);
+      walks.visit(tag, WalkCode.Replace);
       walks.enterShallow(tag);
       if (isOutputHTML()) {
         writer.flushBefore(tag);

--- a/packages/translator-tags/src/core/condition/if.ts
+++ b/packages/translator-tags/src/core/condition/if.ts
@@ -83,7 +83,7 @@ export default {
         }
       }
 
-      walks.visit(tag, walks.WalkCodes.Replace);
+      walks.visit(tag, walks.WalkCode.Replace);
       walks.enterShallow(tag);
       if (isOutputHTML()) {
         writer.flushBefore(tag);

--- a/packages/translator-tags/src/core/for.ts
+++ b/packages/translator-tags/src/core/for.ts
@@ -80,7 +80,7 @@ export default {
         extra: { isOnlyChild },
       } = tag.node;
       if (!isOnlyChild) {
-        walks.visit(tag, walks.WalkCodes.Replace);
+        walks.visit(tag, walks.WalkCode.Replace);
         walks.enterShallow(tag);
       }
       if (isOutputHTML()) {

--- a/packages/translator-tags/src/core/for.ts
+++ b/packages/translator-tags/src/core/for.ts
@@ -5,6 +5,7 @@ import {
   getTagDef,
 } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { WalkCode } from "@marko/runtime-tags/common/types";
 import { isOutputHTML } from "../util/marko-config";
 import analyzeAttributeTags from "../util/nested-attribute-tags";
 import { mergeReferences } from "../util/references";
@@ -80,7 +81,7 @@ export default {
         extra: { isOnlyChild },
       } = tag.node;
       if (!isOnlyChild) {
-        walks.visit(tag, walks.WalkCode.Replace);
+        walks.visit(tag, WalkCode.Replace);
         walks.enterShallow(tag);
       }
       if (isOutputHTML()) {

--- a/packages/translator-tags/src/util/sections.ts
+++ b/packages/translator-tags/src/util/sections.ts
@@ -1,6 +1,6 @@
 import { types as t } from "@marko/compiler";
 import { currentProgramPath } from "../visitors/program";
-import analyzeTagNameType, { TagNameTypes } from "./tag-name-type";
+import analyzeTagNameType, { TagNameType } from "./tag-name-type";
 
 export type Section = {
   id: number;
@@ -62,7 +62,7 @@ export function getOrCreateSection(path: t.NodePath<any>) {
       cur.type === "Program" ||
       (cur.type === "MarkoTagBody" &&
         analyzeTagNameType(cur.parentPath as t.NodePath<t.MarkoTag>) !==
-          TagNameTypes.NativeTag)
+          TagNameType.NativeTag)
     ) {
       return startSection(cur);
     }

--- a/packages/translator-tags/src/util/signals.ts
+++ b/packages/translator-tags/src/util/signals.ts
@@ -56,18 +56,19 @@ export type Signal = {
 };
 
 /** TODO: temporary location - duplicated from "@marko/runtime-tags/common/types" */
-const enum AccessorChars {
-  DYNAMIC = "?",
-  MARK = "#",
-  STALE = "&",
-  SUBSCRIBERS = "*",
-  CLEANUP = "-",
-  TAG_VARIABLE = "/",
-  COND_SCOPE = "!",
-  LOOP_SCOPE_ARRAY = "!",
-  COND_RENDERER = "(",
-  LOOP_SCOPE_MAP = "(",
-  LOOP_VALUE = ")",
+const enum AccessorChar {
+  Dynamic = "?",
+  Mark = "#",
+  Stale = "&",
+  Subscribers = "*",
+  Cleanup = "-",
+  TagVariable = "/",
+  ConditionalScope = "!",
+  ConditionalRenderer = "(",
+  LoopScopeArray = "!",
+  LoopScopeMap = "(",
+  LoopValue = ")",
+  PreviousAttributes = "~",
 }
 
 const [getSignals] = createSectionState<Map<unknown, Signal>>(
@@ -788,7 +789,7 @@ export function writeHTMLResumeStatements(
   if (tagVarIdentifier && returnId(section) !== undefined) {
     serializedProperties.push(
       t.objectProperty(
-        t.stringLiteral(AccessorChars.TAG_VARIABLE),
+        t.stringLiteral(AccessorChar.TagVariable),
         tagVarIdentifier,
       ),
     );

--- a/packages/translator-tags/src/util/signals.ts
+++ b/packages/translator-tags/src/util/signals.ts
@@ -1,5 +1,6 @@
 import { getTemplateId } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { AccessorChar } from "@marko/runtime-tags/common/types";
 import { returnId } from "../core/return";
 import {
   cleanIdentifier,
@@ -54,22 +55,6 @@ export type Signal = {
   hasDownstreamIntersections: () => boolean;
   hasDynamicSubscribers?: true;
 };
-
-/** TODO: temporary location - duplicated from "@marko/runtime-tags/common/types" */
-const enum AccessorChar {
-  Dynamic = "?",
-  Mark = "#",
-  Stale = "&",
-  Subscribers = "*",
-  Cleanup = "-",
-  TagVariable = "/",
-  ConditionalScope = "!",
-  ConditionalRenderer = "(",
-  LoopScopeArray = "!",
-  LoopScopeMap = "(",
-  LoopValue = ")",
-  PreviousAttributes = "~",
-}
 
 const [getSignals] = createSectionState<Map<unknown, Signal>>(
   "signals",

--- a/packages/translator-tags/src/util/walks.ts
+++ b/packages/translator-tags/src/util/walks.ts
@@ -1,4 +1,5 @@
 import { types as t } from "@marko/compiler";
+import { WalkCode, WalkRangeSize } from "@marko/runtime-tags/common/types";
 import { ReserveType } from "../util/reserve";
 import { type Section, createSectionState, getSection } from "../util/sections";
 import { isOutputHTML } from "./marko-config";
@@ -16,36 +17,6 @@ const [getWalkComment] = createSectionState<(string | t.Expression)[]>(
   () => [],
 );
 const [getSteps] = createSectionState<Step[]>("steps", () => []);
-
-export enum WalkCode {
-  Get = 32,
-  Before = 33,
-  After = 35,
-  Inside = 36,
-  Replace = 37,
-  EndChild = 38,
-
-  BeginChild = 47,
-
-  Next = 67,
-  NextEnd = 91,
-
-  Over = 97,
-  OverEnd = 106,
-
-  Out = 107,
-  OutEnd = 116,
-
-  Multiplier = 117,
-  MultiplierEnd = 126,
-}
-
-export enum WalkRangeSize {
-  Next = 20, // 67 through 91
-  Over = 10, // 97 through 106
-  Out = 10, // 107 through 116
-  Multiplier = 10, // 117 through 126
-}
 
 export enum Step {
   Enter,

--- a/packages/translator-tags/src/util/walks.ts
+++ b/packages/translator-tags/src/util/walks.ts
@@ -17,7 +17,7 @@ const [getWalkComment] = createSectionState<(string | t.Expression)[]>(
 );
 const [getSteps] = createSectionState<Step[]>("steps", () => []);
 
-export enum WalkCodes {
+export enum WalkCode {
   Get = 32,
   Before = 33,
   After = 35,
@@ -40,7 +40,7 @@ export enum WalkCodes {
   MultiplierEnd = 126,
 }
 
-export enum WalkRangeSizes {
+export enum WalkRangeSize {
   Next = 20, // 67 through 91
   Over = 10, // 97 through 106
   Out = 10, // 107 through 116
@@ -48,57 +48,57 @@ export enum WalkRangeSizes {
 }
 
 export enum Step {
-  enter,
-  exit,
+  Enter,
+  Exit,
 }
 
 const walkCodeToName = {
-  [WalkCodes.Get]: "get",
-  [WalkCodes.Before]: "before",
-  [WalkCodes.After]: "after",
-  [WalkCodes.Inside]: "inside",
-  [WalkCodes.Replace]: "replace",
-  [WalkCodes.EndChild]: "endChild",
-  [WalkCodes.BeginChild]: "beginChild",
-  [WalkCodes.Next]: "next",
-  [WalkCodes.Over]: "over",
-  [WalkCodes.Out]: "out",
-  [WalkCodes.Multiplier]: "multiplier",
-  [WalkCodes.NextEnd]: "nextEnd",
-  [WalkCodes.OverEnd]: "overEnd",
-  [WalkCodes.OutEnd]: "outEnd",
-  [WalkCodes.MultiplierEnd]: "multiplierEnd",
+  [WalkCode.Get]: "get",
+  [WalkCode.Before]: "before",
+  [WalkCode.After]: "after",
+  [WalkCode.Inside]: "inside",
+  [WalkCode.Replace]: "replace",
+  [WalkCode.EndChild]: "endChild",
+  [WalkCode.BeginChild]: "beginChild",
+  [WalkCode.Next]: "next",
+  [WalkCode.Over]: "over",
+  [WalkCode.Out]: "out",
+  [WalkCode.Multiplier]: "multiplier",
+  [WalkCode.NextEnd]: "nextEnd",
+  [WalkCode.OverEnd]: "overEnd",
+  [WalkCode.OutEnd]: "outEnd",
+  [WalkCode.MultiplierEnd]: "multiplierEnd",
 };
 
 type VisitCodes =
-  | WalkCodes.Get
-  | WalkCodes.Before
-  | WalkCodes.After
-  | WalkCodes.Inside
-  | WalkCodes.Replace;
+  | WalkCode.Get
+  | WalkCode.Before
+  | WalkCode.After
+  | WalkCode.Inside
+  | WalkCode.Replace;
 
 export function enter(path: t.NodePath<any>) {
-  getSteps(getSection(path)).push(Step.enter);
+  getSteps(getSection(path)).push(Step.Enter);
 }
 
 export function exit(path: t.NodePath<any>) {
-  getSteps(getSection(path)).push(Step.exit);
+  getSteps(getSection(path)).push(Step.Exit);
 }
 
 export function enterShallow(path: t.NodePath<any>) {
-  getSteps(getSection(path)).push(Step.enter, Step.exit);
+  getSteps(getSection(path)).push(Step.Enter, Step.Exit);
 }
 
 export function injectWalks(path: t.NodePath<any>, expr: t.Expression) {
   const walks = getWalks(getSection(path));
   const walkComment = getWalkComment(getSection(path));
   walkComment.push(
-    `${walkCodeToName[WalkCodes.BeginChild]}`,
+    `${walkCodeToName[WalkCode.BeginChild]}`,
     (expr as t.Identifier).name,
-    walkCodeToName[WalkCodes.EndChild],
+    walkCodeToName[WalkCode.EndChild],
   );
-  appendLiteral(walks, String.fromCharCode(WalkCodes.BeginChild));
-  walks.push(expr, String.fromCharCode(WalkCodes.EndChild));
+  appendLiteral(walks, String.fromCharCode(WalkCode.BeginChild));
+  walks.push(expr, String.fromCharCode(WalkCode.EndChild));
 }
 
 export function visit(
@@ -124,23 +124,23 @@ export function visit(
   let walkString = "";
 
   if (steps.length) {
-    const walks: WalkCodes[] = [];
+    const walks: WalkCode[] = [];
     let depth = 0;
 
     for (const step of steps) {
-      if (step === Step.enter) {
+      if (step === Step.Enter) {
         depth++;
-        walks.push(WalkCodes.Next);
+        walks.push(WalkCode.Next);
       } else {
         depth--;
         if (depth >= 0) {
           // delete back to and including previous NEXT
-          walks.length = walks.lastIndexOf(WalkCodes.Next);
-          walks.push(WalkCodes.Over);
+          walks.length = walks.lastIndexOf(WalkCode.Next);
+          walks.push(WalkCode.Over);
         } else {
           // delete back to previous OUT
-          walks.length = walks.lastIndexOf(WalkCodes.Out) + 1;
-          walks.push(WalkCodes.Out);
+          walks.length = walks.lastIndexOf(WalkCode.Out) + 1;
+          walks.push(WalkCode.Out);
           depth = 0;
         }
       }
@@ -166,7 +166,7 @@ export function visit(
   }
 
   if (code !== undefined) {
-    if (code !== WalkCodes.Get) {
+    if (code !== WalkCode.Get) {
       writeTo(path)`<!>`;
     }
     walkComment.push(`${walkCodeToName[code]}`);
@@ -176,14 +176,14 @@ export function visit(
   appendLiteral(walks, walkString);
 }
 
-function nCodeString(code: WalkCodes, number: number) {
+function nCodeString(code: WalkCode, number: number) {
   switch (code) {
-    case WalkCodes.Next:
-      return toCharString(number, code, WalkRangeSizes.Next);
-    case WalkCodes.Over:
-      return toCharString(number, code, WalkRangeSizes.Over);
-    case WalkCodes.Out:
-      return toCharString(number, code, WalkRangeSizes.Out);
+    case WalkCode.Next:
+      return toCharString(number, code, WalkRangeSize.Next);
+    case WalkCode.Over:
+      return toCharString(number, code, WalkRangeSize.Over);
+    case WalkCode.Out:
+      return toCharString(number, code, WalkRangeSize.Out);
     default:
       throw new Error(`Unexpected walk code: ${code}`);
   }
@@ -196,8 +196,8 @@ function toCharString(number: number, startCode: number, rangeSize: number) {
     const multiplier = Math.floor(number / rangeSize);
     result += toCharString(
       multiplier,
-      WalkCodes.Multiplier,
-      WalkRangeSizes.Multiplier,
+      WalkCode.Multiplier,
+      WalkRangeSize.Multiplier,
     );
     number -= multiplier * rangeSize;
   }

--- a/packages/translator-tags/src/visitors/placeholder.ts
+++ b/packages/translator-tags/src/visitors/placeholder.ts
@@ -1,5 +1,6 @@
 import { isNativeTag } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { WalkCode } from "@marko/runtime-tags/common/types";
 import evaluate from "../util/evaluate";
 import { isCoreTag } from "../util/is-core-tag";
 import { isOutputHTML } from "../util/marko-config";
@@ -59,10 +60,10 @@ export default {
         write`${getHTMLRuntime()[method as HTMLMethod](computed)}`;
       } else {
         if (extra.needsMarker) {
-          walks.visit(placeholder, walks.WalkCode.Replace);
+          walks.visit(placeholder, WalkCode.Replace);
         } else {
           if (!isHTML) write` `;
-          walks.visit(placeholder, walks.WalkCode.Get);
+          walks.visit(placeholder, WalkCode.Get);
         }
 
         if (isHTML) {

--- a/packages/translator-tags/src/visitors/placeholder.ts
+++ b/packages/translator-tags/src/visitors/placeholder.ts
@@ -59,10 +59,10 @@ export default {
         write`${getHTMLRuntime()[method as HTMLMethod](computed)}`;
       } else {
         if (extra.needsMarker) {
-          walks.visit(placeholder, walks.WalkCodes.Replace);
+          walks.visit(placeholder, walks.WalkCode.Replace);
         } else {
           if (!isHTML) write` `;
-          walks.visit(placeholder, walks.WalkCodes.Get);
+          walks.visit(placeholder, walks.WalkCode.Get);
         }
 
         if (isHTML) {

--- a/packages/translator-tags/src/visitors/tag/attribute-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/attribute-tag.ts
@@ -2,7 +2,7 @@ import { assertNoVar, findParentTag } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import attrsToObject from "../../util/attrs-to-object";
 import { getSection, startSection } from "../../util/sections";
-import { TagNameTypes } from "../../util/tag-name-type";
+import { TagNameType } from "../../util/tag-name-type";
 import * as writer from "../../util/writer";
 
 export default {
@@ -39,7 +39,7 @@ export default {
 
       const parentExtra = parentTag.node.extra;
 
-      if (parentExtra.tagNameType === TagNameTypes.NativeTag) {
+      if (parentExtra.tagNameType === TagNameType.NativeTag) {
         throw tag
           .get("name")
           .buildCodeFrameError("@tags cannot be nested under native tags.");

--- a/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
@@ -5,6 +5,7 @@ import {
   loadFileForTag,
 } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { WalkCode } from "@marko/runtime-tags/common/types";
 import attrsToObject, { getRenderBodyProp } from "../../util/attrs-to-object";
 import { isOptimize, isOutputHTML } from "../../util/marko-config";
 import { addBindingToReferences, mergeReferences } from "../../util/references";
@@ -73,7 +74,7 @@ export default {
   },
   translate: {
     enter(tag: t.NodePath<t.MarkoTag>) {
-      walks.visit(tag, walks.WalkCode.Replace);
+      walks.visit(tag, WalkCode.Replace);
       walks.enterShallow(tag);
 
       if (isOutputHTML()) {

--- a/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
@@ -73,7 +73,7 @@ export default {
   },
   translate: {
     enter(tag: t.NodePath<t.MarkoTag>) {
-      walks.visit(tag, walks.WalkCodes.Replace);
+      walks.visit(tag, walks.WalkCode.Replace);
       walks.enterShallow(tag);
 
       if (isOutputHTML()) {

--- a/packages/translator-tags/src/visitors/tag/index.ts
+++ b/packages/translator-tags/src/visitors/tag/index.ts
@@ -10,7 +10,7 @@ import { types as t } from "@marko/compiler";
 import { isOutputHTML } from "../../util/marko-config";
 import analyzeAttributeTags from "../../util/nested-attribute-tags";
 import * as hooks from "../../util/plugin-hooks";
-import analyzeTagNameType, { TagNameTypes } from "../../util/tag-name-type";
+import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
 import AttributeTag from "./attribute-tag";
 import CustomTag from "./custom-tag";
 import DynamicTag from "./dynamic-tag";
@@ -29,16 +29,16 @@ export default {
       }
 
       switch (type) {
-        case TagNameTypes.NativeTag:
+        case TagNameType.NativeTag:
           NativeTag.analyze.enter(tag);
           break;
-        case TagNameTypes.CustomTag:
+        case TagNameType.CustomTag:
           CustomTag.analyze.enter(tag);
           break;
-        case TagNameTypes.AttributeTag:
+        case TagNameType.AttributeTag:
           AttributeTag.analyze.enter(tag);
           break;
-        case TagNameTypes.DynamicTag:
+        case TagNameType.DynamicTag:
           DynamicTag.analyze.enter(tag);
           break;
       }
@@ -53,20 +53,20 @@ export default {
         return;
       }
 
-      if (type === TagNameTypes.NativeTag) {
+      if (type === TagNameType.NativeTag) {
         // NativeTag.analyze.exit(tag);
         return;
       }
 
       analyzeAttributeTags(tag);
       switch (type) {
-        case TagNameTypes.CustomTag:
+        case TagNameType.CustomTag:
           CustomTag.analyze.exit(tag);
           break;
-        case TagNameTypes.AttributeTag:
+        case TagNameType.AttributeTag:
           // AttributeTag.analyze.exit(tag);
           break;
-        case TagNameTypes.DynamicTag:
+        case TagNameType.DynamicTag:
           DynamicTag.analyze.exit(tag);
           break;
       }
@@ -123,19 +123,19 @@ export default {
       }
 
       switch (extra.tagNameType) {
-        case TagNameTypes.NativeTag:
+        case TagNameType.NativeTag:
           assertNoArgs(tag);
           NativeTag.translate.enter(tag);
           break;
-        case TagNameTypes.CustomTag:
+        case TagNameType.CustomTag:
           assertAttributesOrSingleArg(tag);
           CustomTag.translate.enter(tag);
           break;
-        case TagNameTypes.DynamicTag:
+        case TagNameType.DynamicTag:
           assertAttributesOrArgs(tag);
           DynamicTag.translate.enter(tag);
           break;
-        case TagNameTypes.AttributeTag:
+        case TagNameType.AttributeTag:
           assertNoArgs(tag);
           AttributeTag.translate.enter(tag);
           break;
@@ -151,16 +151,16 @@ export default {
       }
 
       switch (tag.node.extra.tagNameType) {
-        case TagNameTypes.NativeTag:
+        case TagNameType.NativeTag:
           NativeTag.translate.exit(tag);
           break;
-        case TagNameTypes.CustomTag:
+        case TagNameType.CustomTag:
           CustomTag.translate.exit(tag);
           break;
-        case TagNameTypes.DynamicTag:
+        case TagNameType.DynamicTag:
           DynamicTag.translate.exit(tag);
           break;
-        case TagNameTypes.AttributeTag:
+        case TagNameType.AttributeTag:
           AttributeTag.translate.exit(tag);
           break;
       }

--- a/packages/translator-tags/src/visitors/tag/native-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/native-tag.ts
@@ -1,5 +1,6 @@
 import { getTagDef } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
+import { WalkCode } from "@marko/runtime-tags/common/types";
 import attrsToObject from "../../util/attrs-to-object";
 import evaluate from "../../util/evaluate";
 import { isOutputHTML } from "../../util/marko-config";
@@ -144,7 +145,7 @@ export default {
       let visitAccessor: t.StringLiteral | t.NumericLiteral | undefined;
       if (extra.reserve) {
         visitAccessor = getScopeAccessorLiteral(extra.reserve);
-        walks.visit(tag, walks.WalkCode.Get);
+        walks.visit(tag, WalkCode.Get);
       }
 
       write`<${name.node}`;

--- a/packages/translator-tags/src/visitors/tag/native-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/native-tag.ts
@@ -144,7 +144,7 @@ export default {
       let visitAccessor: t.StringLiteral | t.NumericLiteral | undefined;
       if (extra.reserve) {
         visitAccessor = getScopeAccessorLiteral(extra.reserve);
-        walks.visit(tag, walks.WalkCodes.Get);
+        walks.visit(tag, walks.WalkCode.Get);
       }
 
       write`<${name.node}`;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This all might be bad but...

- Normalize enum naming/casing/pluralization
- Deduplicate enums shared between tags translator and runtime by moving them into the runtime. This also required moving the shared enums into the `/runtime-tags/common/types.ts` file (otherwise the tests would end up trying to run module scope code that relies on `document`).

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
