### PR TITLE
fix: split text node hydrate issue

### DIFF
--- a/.changeset/modern-toes-exist.md
+++ b/.changeset/modern-toes-exist.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix issue where splitText was incorrectly called during hydrate when the text node content did not match up.

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -179,7 +179,7 @@ function morphdom(fromNode, toNode, host, componentsContext) {
           (matchingFromComponent = existingComponentLookup[component.id]) ===
           undefined
         ) {
-          if (isHydrate === true) {
+          if (isHydrate) {
             var rootNode = beginFragmentNode(curFromNodeChild, fromNode);
             component.___rootNode = rootNode;
             componentByDOMNode.set(rootNode, component);
@@ -321,7 +321,7 @@ function morphdom(fromNode, toNode, host, componentsContext) {
             matchingFromEl === undefined ||
             matchingFromEl === curFromNodeChild
           ) {
-            if (isHydrate === true && curFromNodeChild) {
+            if (isHydrate && curFromNodeChild) {
               if (
                 curFromNodeChild.nodeType === ELEMENT_NODE &&
                 (curToNodeChild.___preserve ||
@@ -544,7 +544,7 @@ function morphdom(fromNode, toNode, host, componentsContext) {
             // Both nodes being compared are Element nodes
             curVFromNodeChild = vElementByDOMNode.get(curFromNodeChild);
             if (curVFromNodeChild === undefined) {
-              if (isHydrate === true) {
+              if (isHydrate) {
                 curVFromNodeChild = virtualizeElement(curFromNodeChild);
 
                 if (
@@ -587,21 +587,24 @@ function morphdom(fromNode, toNode, host, componentsContext) {
           ) {
             // Both nodes being compared are Text or Comment nodes
             isCompatible = true;
-            // Simply update nodeValue on the original node to
-            // change the text value
-
-            if (
-              isHydrate === true &&
-              toNextSibling &&
-              curFromNodeType === TEXT_NODE &&
-              toNextSibling.___nodeType === TEXT_NODE
-            ) {
-              fromNextSibling = curFromNodeChild.splitText(
-                curToNodeChild.___nodeValue.length,
-              );
-            }
-            if (curFromNodeChild.nodeValue !== curToNodeChild.___nodeValue) {
-              curFromNodeChild.nodeValue = curToNodeChild.___nodeValue;
+            var curToNodeValue = curToNodeChild.___nodeValue;
+            var curFromNodeValue = curFromNodeChild.nodeValue;
+            if (curFromNodeValue !== curToNodeValue) {
+              if (
+                isHydrate &&
+                curFromNodeType === TEXT_NODE &&
+                curFromNodeValue.startsWith(curToNodeValue)
+              ) {
+                // In hydrate mode we can use splitText to more efficiently handle
+                // adjacent text vdom nodes that were merged.
+                fromNextSibling = curFromNodeChild.splitText(
+                  curToNodeValue.length,
+                );
+              } else {
+                // Simply update nodeValue on the original node to
+                // change the text value
+                curFromNodeChild.nodeValue = curToNodeValue;
+              }
             }
           }
         }


### PR DESCRIPTION
## Description
In hydrate mode we use the [splitText](https://developer.mozilla.org/en-US/docs/Web/API/Text/splitText) api to break up text nodes which would have been merged after being rendered on the server.

The existing check had a bug though and did not verify that the previous content was long enough, which means if there was a hydration mismatch you could get errors like `Uncaught DOMException: Failed to execute 'splitText' on 'Text': The offset 1 is larger than the Text`.

This PR updates the logic to only call splitText if the current node actually starts with the expected content while hydrating.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
