### PR TITLE
fix: renderBody regression with attribute tags

### DIFF
--- a/.changeset/mighty-pugs-burn.md
+++ b/.changeset/mighty-pugs-burn.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix regression where attribute tags used without renderBody content was clearing existing renderBody content in the input, eg via a spread.

--- a/packages/marko/src/runtime/helpers/attr-tag.js
+++ b/packages/marko/src/runtime/helpers/attr-tag.js
@@ -28,7 +28,10 @@ exports.i = function attrTagInput(render, input) {
   var prevOwnerInput = ownerInput;
   ownerInput = input || {};
   try {
-    ownerInput.renderBody = render();
+    var renderBody = render();
+    if (renderBody) {
+      ownerInput.renderBody = renderBody;
+    }
     return ownerInput;
   } finally {
     ownerInput = prevOwnerInput;


### PR DESCRIPTION
## Description
Fixes a regression where if you specify attribute tags and no renderBody content that it'd override existing renderBody in the input. 

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
