### PR TITLE
fix: text area null regression

### DIFF
--- a/.changeset/selfish-bananas-exercise.md
+++ b/.changeset/selfish-bananas-exercise.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix regression where a textarea created with no value in the browser was setting `null` as the value.

--- a/packages/marko/src/runtime/vdom/VElement.js
+++ b/packages/marko/src/runtime/vdom/VElement.js
@@ -116,7 +116,7 @@ function VElement(
   this.___attributes = attrs || EMPTY_OBJECT;
   this.___properties = props || EMPTY_OBJECT;
   this.___nodeName = tagName;
-  this.___valueInternal = null;
+  this.___valueInternal = "";
   this.___constId = constId;
   this.___preserve = false;
   this.___preserveBody = false;

--- a/packages/marko/src/runtime/vdom/VNode.js
+++ b/packages/marko/src/runtime/vdom/VNode.js
@@ -50,8 +50,7 @@ VNode.prototype = {
 
     if (this.___nodeName === "textarea") {
       if (child.___Text) {
-        var childValue = child.___nodeValue;
-        this.___valueInternal = (this.___valueInternal || "") + childValue;
+        this.___valueInternal += child.___nodeValue;
       } else {
         throw TypeError();
       }

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -696,10 +696,8 @@ function morphdom(fromNode, toNode, host, componentsContext) {
     }
 
     if (nodeName === "textarea") {
-      var newValue = toEl.___valueInternal || "";
-      var oldValue = vFromEl.___valueInternal || "";
-      if (oldValue !== newValue) {
-        fromEl.value = newValue;
+      if (toEl.___valueInternal !== vFromEl.___valueInternal) {
+        fromEl.value = toEl.___valueInternal;
       }
     } else {
       morphChildren(fromEl, toEl, parentComponent);


### PR DESCRIPTION
## Description

Fix regression where a textarea created with no value in the browser was setting `null` as the value.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
