### PR TITLE
chore: remove gzip from size check

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,6 @@
       "name": "*",
       "total": {
         "min": 13282,
-        "gzip": 5667,
         "brotli": 5196
       }
     },
@@ -16,17 +15,14 @@
       "name": "counter",
       "user": {
         "min": 351,
-        "gzip": 276,
         "brotli": 241
       },
       "runtime": {
         "min": 3821,
-        "gzip": 1801,
         "brotli": 1614
       },
       "total": {
         "min": 4172,
-        "gzip": 2077,
         "brotli": 1855
       }
     },
@@ -34,17 +30,14 @@
       "name": "counter 💧",
       "user": {
         "min": 204,
-        "gzip": 179,
         "brotli": 152
       },
       "runtime": {
         "min": 2683,
-        "gzip": 1369,
         "brotli": 1220
       },
       "total": {
         "min": 2887,
-        "gzip": 1548,
         "brotli": 1372
       }
     },
@@ -52,17 +45,14 @@
       "name": "comments",
       "user": {
         "min": 1182,
-        "gzip": 703,
         "brotli": 639
       },
       "runtime": {
         "min": 7358,
-        "gzip": 3401,
         "brotli": 3096
       },
       "total": {
         "min": 8540,
-        "gzip": 4104,
         "brotli": 3735
       }
     },
@@ -70,17 +60,14 @@
       "name": "comments 💧",
       "user": {
         "min": 949,
-        "gzip": 589,
         "brotli": 540
       },
       "runtime": {
         "min": 7887,
-        "gzip": 3609,
         "brotli": 3283
       },
       "total": {
         "min": 8836,
-        "gzip": 4198,
         "brotli": 3823
       }
     }


### PR DESCRIPTION
## Description
Removes gzip from the runtime size calculator (just brotli and minified now).
For some unknown reason the gzip size output was not deterministic. (this is a cry for help, fyi it does not appear to be related to the gzip headers)

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
