### PR TITLE
docs: Fixing NativeTags demo (interface, not namespace)

### DIFF
--- a/packages/marko/docs/typescript.md
+++ b/packages/marko/docs/typescript.md
@@ -228,7 +228,7 @@ interface MyCustomElementAttributes {
 
 declare global {
   namespace Marko {
-    namespace NativeTags {
+    interface NativeTags {
       // By adding this entry, you can now use `my-custom-element` as a native html tag.
       "my-custom-element": MyCustomElementAttributes
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Minor fix for docs at: https://markojs.com/docs/typescript/#registering-a-new-native-tag-eg-for-custom-elements

Noticed it just repeated `namespace` instead of defining `NativeTags` as an `interface`; this fixes that. I assume it should align with structure of the `NativeTags` already defined in [`packages/marko/tags-html.d.t` ](https://github.com/marko-js/marko/blob/main/packages/marko/tags-html.d.ts#L13).


## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
