### PR TITLE
perf: improve html body content escaping

### DIFF
--- a/.changeset/serious-phones-burn.md
+++ b/.changeset/serious-phones-burn.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Improve the html content escape helpers. The existing implementations no longer maintain an edge in newer versions of node and the regexp based versions are faster.

--- a/packages/marko/src/runtime/html/helpers/escape-script-placeholder.js
+++ b/packages/marko/src/runtime/html/helpers/escape-script-placeholder.js
@@ -1,4 +1,8 @@
 "use strict";
+const unsafeCharsReg = /<\/script/g;
+const replaceMatch = () => "\\x3C/script";
+const escape = (str) =>
+  unsafeCharsReg.test(str) ? str.replace(unsafeCharsReg, replaceMatch) : str;
 
 /**
  * Escapes the '</' sequence in the body of a <script> body to avoid the `<script>` being
@@ -15,9 +19,10 @@
  * prematurely ended and a new script tag could then be started that could then execute
  * arbitrary code.
  */
-var escapeEndingScriptTagRegExp = /<\/script/g;
-module.exports = function escapeScriptHelper(val) {
-  return typeof val === "string"
-    ? val.replace(escapeEndingScriptTagRegExp, "\\u003C/script")
-    : val + "";
+module.exports = function escapeScriptHelper(value) {
+  if (value == null) {
+    return "";
+  }
+
+  return escape(value + "");
 };

--- a/packages/marko/src/runtime/html/helpers/escape-style-placeholder.js
+++ b/packages/marko/src/runtime/html/helpers/escape-style-placeholder.js
@@ -1,4 +1,8 @@
 "use strict";
+const unsafeCharsReg = /<\/style/g;
+const replaceMatch = () => "\\3C/style";
+const escape = (str) =>
+  unsafeCharsReg.test(str) ? str.replace(unsafeCharsReg, replaceMatch) : str;
 
 /**
  * Escapes the '</' sequence in the body of a <style> body to avoid the `<style>` being
@@ -13,9 +17,10 @@
  * prematurely ended and a script tag could then be started that could then execute
  * arbitrary code.
  */
-var escapeEndingStyleTagRegExp = /<\/style/g;
-module.exports = function escapeScriptHelper(val) {
-  return typeof val === "string"
-    ? val.replace(escapeEndingStyleTagRegExp, "\\003C/style")
-    : val + "";
+module.exports = function escapeScriptHelper(value) {
+  if (value == null) {
+    return "";
+  }
+
+  return escape(value + "");
 };

--- a/packages/marko/src/runtime/html/helpers/escape-xml.js
+++ b/packages/marko/src/runtime/html/helpers/escape-xml.js
@@ -1,4 +1,10 @@
 "use strict";
+const unsafeCharsRegExp = /[<&]/g;
+const replaceMatch = (c) => (c === "&" ? "&amp;" : "&lt;");
+const escape = (str) =>
+  unsafeCharsRegExp.test(str)
+    ? str.replace(unsafeCharsRegExp, replaceMatch)
+    : str;
 
 module.exports.x = function (value) {
   if (value == null) {
@@ -9,37 +15,7 @@ module.exports.x = function (value) {
     return value.toHTML();
   }
 
-  return escapeXML(value + "");
+  return escape(value + "");
 };
 
-exports.___escapeXML = escapeXML;
-
-function escapeXML(str) {
-  var len = str.length;
-  var result = "";
-  var lastPos = 0;
-  var i = 0;
-  var replacement;
-
-  for (; i < len; i++) {
-    switch (str[i]) {
-      case "<":
-        replacement = "&lt;";
-        break;
-      case "&":
-        replacement = "&amp;";
-        break;
-      default:
-        continue;
-    }
-
-    result += str.slice(lastPos, i) + replacement;
-    lastPos = i + 1;
-  }
-
-  if (lastPos) {
-    return result + str.slice(lastPos);
-  }
-
-  return str;
-}
+exports.___escapeXML = escape;

--- a/packages/marko/test/render/fixtures/escape-script/expected.html
+++ b/packages/marko/test/render/fixtures/escape-script/expected.html
@@ -1,3 +1,3 @@
 <script>
-    var foo = {"name":"Evil \u003C/script>"};
+    var foo = {"name":"Evil \x3C/script>"};
 </script><pre>{"name":"Evil &lt;/script>"}</pre>

--- a/packages/marko/test/render/fixtures/escape-style/expected.html
+++ b/packages/marko/test/render/fixtures/escape-style/expected.html
@@ -1,5 +1,5 @@
 <style>
     #foo {
-        background-color:\003C/style><script>alert("evil");</script>;
+        background-color:\3C/style><script>alert("evil");</script>;
     }
 </style>

--- a/packages/marko/test/render/fixtures/script-tag-entities/expected.html
+++ b/packages/marko/test/render/fixtures/script-tag-entities/expected.html
@@ -1,1 +1,1 @@
-<script>console.log('<div>Hello <script>evil\u003C/script></div>');</script>
+<script>console.log('<div>Hello <script>evil\x3C/script></div>');</script>

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/cjs-expected.js
@@ -19,12 +19,12 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w("Hello world <a/>");
   out.w("<script>");
   out.w("\n    ");
-  out.w("Hello <b> \\u003C/script>");
+  out.w("Hello <b> \\x3C/script>");
   out.w("\n  ");
   out.w("</script>");
   out.w("<style>");
   out.w("\n    ");
-  out.w("Hello <b> \\003C/style>");
+  out.w("Hello <b> \\3C/style>");
   out.w("\n  ");
   out.w("</style>");
   out.w("</div>");

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/html-expected.js
@@ -14,12 +14,12 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w("Hello world <a/>");
   out.w("<script>");
   out.w("\n    ");
-  out.w("Hello <b> \\u003C/script>");
+  out.w("Hello <b> \\x3C/script>");
   out.w("\n  ");
   out.w("</script>");
   out.w("<style>");
   out.w("\n    ");
-  out.w("Hello <b> \\003C/style>");
+  out.w("Hello <b> \\3C/style>");
   out.w("\n  ");
   out.w("</style>");
   out.w("</div>");

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
@@ -7,7 +7,7 @@ import _marko_to_string from "marko/dist/runtime/helpers/to-string.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.w(`<div>${_marko_escapeXml(input.x)}Hello world &lt;a/>${_marko_to_string(input.x)}Hello world <a/><script>\n    Hello <b> \\u003C/script>\n  </script><style>\n    Hello <b> \\003C/style>\n  </style></div>`);
+  out.w(`<div>${_marko_escapeXml(input.x)}Hello world &lt;a/>${_marko_to_string(input.x)}Hello world <a/><script>\n    Hello <b> \\x3C/script>\n  </script><style>\n    Hello <b> \\3C/style>\n  </style></div>`);
 }, {
   t: _marko_componentType,
   i: true


### PR DESCRIPTION
## Description

After some recent benchmarking it turns out the current escape utilities for html body content are no longer faster than their regexp counter parts.

This PR updates the implementations to use regexps for escaping instead of manual iteration.

Note: In most cases doing a `.test` call before doing a `.replace` is faster, even though it's technically a bit slower for the cases where we actually escape something.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
