### PR TITLE
fix: avoid normalizing nullish values for script/style interpolation

### DIFF
--- a/.changeset/rotten-months-cheat.md
+++ b/.changeset/rotten-months-cheat.md
@@ -1,0 +1,9 @@
+---
+"marko": patch
+---
+
+Fix regression where interpolating null/undefined in a script/style tag was being replaced with an empty string instead of toString'd and added.
+
+Eg `<script>${undefined}</>` was changed to render nothing, when previously it output `undefined` as a string inside the script.
+
+Note this behavior should not be relied on and will change in the next major of Marko to normalize the interpolated value to an empty string for nullish values.

--- a/packages/marko/src/runtime/html/helpers/escape-script-placeholder.js
+++ b/packages/marko/src/runtime/html/helpers/escape-script-placeholder.js
@@ -20,9 +20,5 @@ const escape = (str) =>
  * arbitrary code.
  */
 module.exports = function escapeScriptHelper(value) {
-  if (value == null) {
-    return "";
-  }
-
   return escape(value + "");
 };

--- a/packages/marko/src/runtime/html/helpers/escape-style-placeholder.js
+++ b/packages/marko/src/runtime/html/helpers/escape-style-placeholder.js
@@ -18,9 +18,5 @@ const escape = (str) =>
  * arbitrary code.
  */
 module.exports = function escapeScriptHelper(value) {
-  if (value == null) {
-    return "";
-  }
-
   return escape(value + "");
 };


### PR DESCRIPTION
## Description

Fix regression where interpolating null/undefined in a script/style tag was being replaced with an empty string instead of toString'd and added.

Eg `<script>${undefined}</>` was changed to render nothing, when previously it output `undefined` as a string inside the script.

Note this behavior should not be relied on and will change in the next major of Marko to normalize the interpolated value to an empty string for nullish values.
