### PR TITLE
fix: hydration native tag no-update issue

### DIFF
--- a/.changeset/grumpy-shirts-cross.md
+++ b/.changeset/grumpy-shirts-cross.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix issue where native tags with `no-update` were not having their key serialized from the server causing a hydration diffing issue in some cases.


### PR DESCRIPTION
## Description

Fixes an issue where native tags would fail to hydrate in some cases if there was a diffing mismatch because they did not have their server key serialized.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
