### PR TITLE
fix: issues related to hydrating no-update native tags

### DIFF
--- a/.changeset/six-terms-smile.md
+++ b/.changeset/six-terms-smile.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"marko": patch
+"@marko/translator-default": patch
+---
+
+Fix issues related to hydrating sections under a native tag with the `no-update` directive.

--- a/packages/marko/src/node_modules/@internal/components-registry/index-browser.js
+++ b/packages/marko/src/node_modules/@internal/components-registry/index-browser.js
@@ -12,6 +12,7 @@ var req = require("@internal/require");
 var componentLookup = componentsUtil.___componentLookup;
 var addComponentRootToKeyedElements =
   componentsUtil.___addComponentRootToKeyedElements;
+var keysByDOMNode = domData.___keyByDOMNode;
 var keyedElementsByComponentId = domData.___ssrKeyedElementsByComponentId;
 var componentsByDOMNode = domData.___componentByDOMNode;
 var serverComponentRootNodes = {};
@@ -233,6 +234,8 @@ function indexServerComponentBoundaries(node, runtimeId, stack) {
             keyedElementsByComponentId[ownerId] ||
             (keyedElementsByComponentId[ownerId] = {});
         }
+
+        keysByDOMNode.set(node, markoKey);
         keyedElements[markoKey] = node;
       }
       if (markoProps) {

--- a/packages/marko/src/node_modules/@internal/preserve-tag/index-browser.js
+++ b/packages/marko/src/node_modules/@internal/preserve-tag/index-browser.js
@@ -19,7 +19,8 @@ module.exports = function render(input, out) {
 
   var isPreserved =
     shouldPreserve &&
-    (isHydrate || referenceComponent.___keyedElements[checkKey]);
+    ((isComponent && isHydrate) ||
+      referenceComponent.___keyedElements[checkKey]);
 
   if (isComponent) {
     out.bf(key, ownerComponent, shouldPreserve);

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -596,9 +596,9 @@ function morphdom(fromNode, toNode, host, componentsContext) {
                 curFromNodeType === TEXT_NODE &&
                 toNextSibling.___nodeType === TEXT_NODE &&
                 curFromNodeValue.startsWith(curToNodeValue) &&
-                toNextSibling.___nodeValue.startsWith(
-                  curFromNodeValue.slice(curToNodeValue.length),
-                )
+                curFromNodeValue
+                  .slice(curToNodeValue.length)
+                  .startsWith(toNextSibling.___nodeValue)
               ) {
                 // In hydrate mode we can use splitText to more efficiently handle
                 // adjacent text vdom nodes that were merged.


### PR DESCRIPTION
## Description

Fixes #2198.

Note that there is quite a lot going on there and there are 3 main fixes in this PR on top of #2210 which was a partial fix.

In #2210 it ensured that native tags with `no-update` got their key serialized via the `data-marko-key` attribute to help with diffing.

However there are two places keys need to be stored and `data-marko-key` only set one of them. (The first place is essentially for `getEl` and the second is used in morphdom for diffing).
https://github.com/marko-js/marko/compare/no-update-directives-hydrate-fixes-04-16-24?expand=1#diff-172d13e48a87ce821ebe7c0b2d56ab3aad1fc85092dc196a360200a400236825R238 ensures the key is there when we go to diff.

Next issue is that after #2192 had an incorrect check to see if we should split the text node. With the check that was there if you had more than two adjacent split text nodes it would no longer split properly (the check was inverted). https://github.com/marko-js/marko/compare/no-update-directives-hydrate-fixes-04-16-24?expand=1#diff-ad4fe05b8d2ad0abd2165affcfc2fcf2b4550b970aca5013b00a4f24b2079f22R599-R601

Finally there's an underlying issue that all of the above surfaced which is the error displayed in #2198.
Essentially the check for wether or not we should preserve (no-update) a node was essentially just `true` during hydrate.

This meant that Marko could not recover from hydration mismatches when there was a `no-update` on the native tag.
However now that we properly serialize the key and have things in the correct lookups we can use that to check if the node actually existed in the server output before deciding if we should tell the vdom to try and preserve it (this should make the error in #2198 impossible to hit even if therre's a hydrate mismatch).

