### PR TITLE
feat: event handler implicit components

### DIFF
--- a/.changeset/shaggy-teachers-pay.md
+++ b/.changeset/shaggy-teachers-pay.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": minor
+"@marko/compiler": minor
+"marko": minor
+---
+
+Using event handlers now causes a template to become an implicit component or split component (depending on if a string event handler is used).

--- a/packages/marko/src/runtime/helpers/empty-component.js
+++ b/packages/marko/src/runtime/helpers/empty-component.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/components/app-button-component/index.marko
+++ b/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/components/app-button-component/index.marko
@@ -1,0 +1,4 @@
+<button id=input.id onClick(() => {
+    component.emit("click");
+})>Click me</button>
+

--- a/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/components/app-button-split/index.marko
+++ b/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/components/app-button-split/index.marko
@@ -1,0 +1,2 @@
+$ if (typeof window === "object") throw new Error("Should be server only");
+<button id=input.id onClick("emit", "click")>Click me</button>

--- a/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/template.component-browser.js
+++ b/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/template.component-browser.js
@@ -1,0 +1,9 @@
+module.exports = {
+  onMount() {
+    window.testComponent = this;
+    this.clicks = 0;
+  },
+  trackClick() {
+    this.clicks++;
+  }
+}

--- a/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/template.marko
+++ b/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/template.marko
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+html lang="en"
+    head
+        meta charset="UTF-8"
+        title -- Marko Components Tests
+    body
+
+        div id="test"
+        div id="mocha"
+        div id="testsTarget"
+
+        app-button-split id="a" onClick("trackClick")
+        app-button-component id="b" onClick("trackClick")

--- a/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/tests.js
+++ b/packages/marko/test/components-pages/fixtures/component-implicit-event-handlers/tests.js
@@ -1,0 +1,9 @@
+var expect = require("chai").expect;
+
+it("should have initialized both components", function () {
+  var component = window.testComponent;
+  expect(component.clicks).to.equal(0);
+  document.getElementById("a").click();
+  expect(component.clicks).to.equal(1);
+  document.getElementById("b").click();
+});

--- a/packages/translator-default/src/tag/native-tag[html]/index.js
+++ b/packages/translator-default/src/tag/native-tag[html]/index.js
@@ -92,6 +92,7 @@ export default function (path, isNullable) {
   if (isHTML) {
     if (
       (!meta.hasStatefulTagParams &&
+        !meta.hasFunctionEventHandlers &&
         (meta.hasComponentBrowser || !meta.hasComponent)) ||
       isPreserved(path)
     ) {

--- a/packages/translator-default/src/util/get-component-files.js
+++ b/packages/translator-default/src/util/get-component-files.js
@@ -1,7 +1,7 @@
 import path from "path";
 import { escapeRegExp } from "./escape-regexp";
 
-const COMPONENT_FILES_KEY = Symbol();
+const COMPONENT_FILES_KEY = "___marko_component_files___";
 
 export default function getComponentFiles({ hub: { file } }) {
   const meta = file.metadata.marko;

--- a/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/hydrate-expected.js
+++ b/packages/translator-default/test/fixtures/error-duplicate-event-handlers/snapshots/hydrate-expected.js
@@ -1,0 +1,4 @@
+import { register, init } from "marko/src/runtime/components/index.js";
+import component_0 from "marko/src/runtime/helpers/empty-component.js";
+register("packages/translator-default/test/fixtures/error-duplicate-event-handlers/template.marko", component_0);
+init();

--- a/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/hydrate-expected.js
+++ b/packages/translator-default/test/fixtures/error-event-handler-missing-args/snapshots/hydrate-expected.js
@@ -1,0 +1,3 @@
+import { init } from "marko/src/runtime/components/index.js";
+import "./template.marko";
+init();

--- a/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/hydrate-expected.js
+++ b/packages/translator-default/test/fixtures/error-event-handler-value/snapshots/hydrate-expected.js
@@ -1,0 +1,4 @@
+import { register, init } from "marko/src/runtime/components/index.js";
+import component_0 from "marko/src/runtime/helpers/empty-component.js";
+register("packages/translator-default/test/fixtures/error-event-handler-value/template.marko", component_0);
+init();

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/cjs-expected.js
@@ -27,6 +27,6 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   (0, _renderTag.default)(_customTag2.default, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,
-  i: true,
+  s: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/html-expected.js
@@ -22,6 +22,6 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,
-  i: true,
+  s: true,
   d: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
@@ -20,5 +20,5 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,
-  i: true
+  s: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/hydrate-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/hydrate-expected.js
@@ -1,0 +1,4 @@
+import { register, init } from "marko/src/runtime/components/index.js";
+import component_0 from "marko/src/runtime/helpers/empty-component.js";
+register("packages/translator-default/test/fixtures/event-handlers/template.marko", component_0);
+init();

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/vdom-expected.js
@@ -6,7 +6,8 @@ import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
-_marko_registerComponent(_marko_componentType, () => _marko_template);
+import _marko_split_component from "marko/src/runtime/helpers/empty-component.js";
+_marko_registerComponent(_marko_componentType, () => _marko_split_component);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.e("div", null, "0", _component, 0, 0, {
@@ -25,7 +26,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,
-  i: true,
+  s: true,
   d: true
 }, _marko_component);
 import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
@@ -6,7 +6,8 @@ import _customTag from "./components/custom-tag.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
-_marko_registerComponent(_marko_componentType, () => _marko_template);
+import _marko_split_component from "marko/dist/runtime/helpers/empty-component.js";
+_marko_registerComponent(_marko_componentType, () => _marko_split_component);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.e("div", null, "0", _component, 0, 0, {
@@ -25,7 +26,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   _marko_tag(_customTag, {}, out, _componentDef, "5", [["camelcasedEvent", "handle", false]]);
 }, {
   t: _marko_componentType,
-  i: true
+  s: true
 }, _marko_component);
 import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
 _marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);


### PR DESCRIPTION
## Description

This PR makes it so that if you have a template with event handlers and no `class`, `component.js` or `component-browser.js` that it will implicitly create one for you.

If the event handlers are all string literals it will inline a noop split component (`component-browser.js`) which means that having a top level template that just forwards events will work out of the box without manually creating an empty `component-browser.js` file. Eg the following will just work even as a top level template.

```marko
<button onClick("emit", "click")/>
```

If the event handler is not a string, then the template will implicitly become a client side component. Which means examples like this work out of the box without wrapping it in a component.
```marko
static function handleClick() {
  // ...
}

<button onClick(handleClick)/>
```

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
