### PR TITLE
fix: optimize vdom key issue

### DIFF
--- a/.changeset/warm-plums-look.md
+++ b/.changeset/warm-plums-look.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Fix issue where element keys could be different because of hoisted const elements not always being keyed. This could cause a hydration issue since the server and client compilations would not agree on the keys.

--- a/packages/translator-default/src/util/optimize-vdom-create.js
+++ b/packages/translator-default/src/util/optimize-vdom-create.js
@@ -8,7 +8,7 @@ import {
 import { types as t } from "@marko/compiler";
 import { decode } from "he";
 import translateAttributes from "../tag/native-tag[vdom]/attributes";
-import { hasUserKey } from "./key-manager";
+import { getKeyManager, hasUserKey } from "./key-manager";
 import write from "./vdom-out-write";
 
 const skipDirectives = new Set([
@@ -40,6 +40,7 @@ const mergeStaticCreateVisitor = {
     );
   },
   MarkoTag(path, state) {
+    getKeyManager(path).resolveKey(path);
     state.currentRoot = t.callExpression(
       t.memberExpression(state.currentRoot, t.identifier("e")),
       getConstElementArgs(path),

--- a/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
@@ -11,7 +11,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.be("html", null, "0", _component, null, 0);
   out.n(_marko_node, _component);
-  out.be("body", null, "2", _component, null, 0);
+  out.be("body", null, "3", _component, null, 0);
   out.t("The content of the document......", _component);
   out.ee();
   out.ee();

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
@@ -11,7 +11,7 @@ _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.n(_marko_node, _component);
-  out.be("div", null, "1", _component, null, 0);
+  out.be("div", null, "7", _component, null, 0);
   scriptletA();
   scriptletB();
   out.t("Hello ", _component);


### PR DESCRIPTION
Fix issue where element keys could be different because of hoisted const elements not always being keyed. This could cause a hydration issue since the server and client compilations would not agree on the keys.

Resolves #2216 

> Note:
> Ideally we refactor this so that this keying is all figured out in the analyze stage so that it's actually impossible for there to be a server/client compilation disagreement. 