### PR TITLE
feat: add `server` and `client` statements

### DIFF
--- a/packages/compiler/src/babel-types/generator/patch.js
+++ b/packages/compiler/src/babel-types/generator/patch.js
@@ -49,7 +49,7 @@ Object.assign(Printer.prototype, {
       this.token("\n");
     }
 
-    this.token(`${node.static ? "static" : "$"} `);
+    this.token(`${node.static ? node.location ?? "static" : "$"} `);
 
     if (
       node.body.length === 1 &&

--- a/packages/compiler/src/babel-types/generator/patch.js
+++ b/packages/compiler/src/babel-types/generator/patch.js
@@ -49,7 +49,7 @@ Object.assign(Printer.prototype, {
       this.token("\n");
     }
 
-    this.token(`${node.static ? node.location ?? "static" : "$"} `);
+    this.token(`${node.static ? node.target ?? "static" : "$"} `);
 
     if (
       node.body.length === 1 &&

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -76,7 +76,7 @@ const MarkoDefinitions = {
 
   MarkoScriptlet: {
     aliases: ["Marko", "Statement"],
-    builder: ["body", "static", "location"],
+    builder: ["body", "static", "target"],
     visitor: ["body"],
     fields: {
       body: {
@@ -86,7 +86,7 @@ const MarkoDefinitions = {
         validate: assertValueType("boolean"),
         default: false,
       },
-      location: {
+      target: {
         validate: assertValueType("string"),
         optional: true,
       },

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -76,7 +76,7 @@ const MarkoDefinitions = {
 
   MarkoScriptlet: {
     aliases: ["Marko", "Statement"],
-    builder: ["body", "static"],
+    builder: ["body", "static", "location"],
     visitor: ["body"],
     fields: {
       body: {
@@ -85,6 +85,10 @@ const MarkoDefinitions = {
       static: {
         validate: assertValueType("boolean"),
         default: false,
+      },
+      location: {
+        validate: assertValueType("string"),
+        optional: true,
       },
     },
   },

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,8 @@
+# Render undefined
+```html
+<div>
+  <span>
+    2
+  </span>
+</div>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/csr.expected.md
@@ -1,0 +1,13 @@
+# Render undefined
+```html
+<div>
+  <span>
+    2
+  </span>
+</div>
+```
+
+# Mutations
+```
+inserted div0
+```

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/dom.expected/template.js
@@ -1,0 +1,10 @@
+const client_x = 2;
+const x = typeof server_x === "undefined" ? client_x : server_x;
+import { data as _data, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
+const _setup = _scope => {
+  _data(_scope["#text/0"], x);
+};
+export const template = "<div><span> </span></div>";
+export const walks = /* next(2), get, out(2) */"E m";
+export const setup = _setup;
+export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(template, walks, setup), "packages/translator-tags/src/__tests__/fixtures/server-client/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/html.expected/template.js
@@ -1,0 +1,8 @@
+const server_x = 1;
+const x = typeof server_x === "undefined" ? client_x : server_x;
+import { escapeXML as _escapeXML, write as _write, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/html";
+const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
+  const _scope0_id = _nextScopeId();
+  _write(`<div><span>${_escapeXML(x)}</span></div>`);
+});
+export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/server-client/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,8 @@
+# Render "End"
+```html
+<div>
+  <span>
+    1
+  </span>
+</div>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/ssr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/ssr.expected.md
@@ -1,0 +1,27 @@
+# Write
+  <div><span>1</span></div>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <span>
+        1
+      </span>
+    </div>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/div0
+inserted #document/html0/body1/div0/span0
+inserted #document/html0/body1/div0/span0/#text0
+```

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/template.marko
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/template.marko
@@ -1,0 +1,8 @@
+server const server_x = 1;
+client const client_x = 2;
+static const x = typeof server_x === "undefined" ? client_x : server_x;
+<div>
+  <span>
+    ${x}
+  </span>
+</div>

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/test.ts
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/test.ts
@@ -1,0 +1,1 @@
+export const skip_resume = true;

--- a/packages/translator-tags/src/core/client.ts
+++ b/packages/translator-tags/src/core/client.ts
@@ -1,0 +1,31 @@
+import { parseStatements } from "@marko/babel-utils";
+import { types as t } from "@marko/compiler";
+export default {
+  parse(tag: t.NodePath<t.MarkoTag>) {
+    const {
+      node,
+      hub: { file },
+    } = tag;
+    const rawValue = node.rawValue!;
+    const code = rawValue.replace(/^client\s*/, "").trim();
+    const start = node.name.start! + (rawValue.length - code.length);
+    let body = parseStatements(file, code, start, start + code.length);
+    if (body.length === 1 && t.isBlockStatement(body[0])) {
+      body = body[0].body;
+    }
+
+    tag.replaceWith(t.markoScriptlet(body, true, "client"));
+  },
+  parseOptions: {
+    statement: true,
+    rawOpenTag: true,
+  },
+  autocomplete: [
+    {
+      displayText: "client <statement>",
+      description:
+        "A JavaScript statement which is only evaluated once your template is loaded on the client.",
+      descriptionMoreURL: "https://markojs.com/docs/syntax/#client-javascript",
+    },
+  ],
+};

--- a/packages/translator-tags/src/core/index.ts
+++ b/packages/translator-tags/src/core/index.ts
@@ -1,6 +1,7 @@
 import { taglibId } from "../util/is-core-tag";
 import FlushHereAndAfter from "./__flush_here_and_after__";
 import AttrsTag from "./attrs";
+import ClientTag from "./client";
 import ElseTag from "./condition/else";
 import ElseIfTag from "./condition/else-if";
 import IfTag from "./condition/if";
@@ -19,6 +20,7 @@ import LifecycleTag from "./lifecycle";
 import LogTag from "./log";
 import NoopTag from "./noop";
 import ReturnTag from "./return";
+import ServerTag from "./server";
 import StaticTag from "./static";
 import StyleTag from "./style";
 
@@ -47,5 +49,7 @@ export default {
   "<init-widgets>": NoopTag,
   "<init-components>": NoopTag,
   "<static>": StaticTag,
+  "<server>": ServerTag,
+  "<client>": ClientTag,
   "<__flush_here_and_after__>": FlushHereAndAfter,
 };

--- a/packages/translator-tags/src/core/server.ts
+++ b/packages/translator-tags/src/core/server.ts
@@ -1,0 +1,31 @@
+import { parseStatements } from "@marko/babel-utils";
+import { types as t } from "@marko/compiler";
+export default {
+  parse(tag: t.NodePath<t.MarkoTag>) {
+    const {
+      node,
+      hub: { file },
+    } = tag;
+    const rawValue = node.rawValue!;
+    const code = rawValue.replace(/^server\s*/, "").trim();
+    const start = node.name.start! + (rawValue.length - code.length);
+    let body = parseStatements(file, code, start, start + code.length);
+    if (body.length === 1 && t.isBlockStatement(body[0])) {
+      body = body[0].body;
+    }
+
+    tag.replaceWith(t.markoScriptlet(body, true, "server"));
+  },
+  parseOptions: {
+    statement: true,
+    rawOpenTag: true,
+  },
+  autocomplete: [
+    {
+      displayText: "server <statement>",
+      description:
+        "A JavaScript statement which is only evaluated once your template is loaded on the server.",
+      descriptionMoreURL: "https://markojs.com/docs/syntax/#server-javascript",
+    },
+  ],
+};

--- a/packages/translator-tags/src/visitors/program/html.ts
+++ b/packages/translator-tags/src/visitors/program/html.ts
@@ -28,7 +28,11 @@ export default {
           renderContent.push(child.node);
           child.remove();
         } else if (child.isMarkoScriptlet()) {
-          child.replaceWithMultiple(child.node.body);
+          if (child.node.location && child.node.location !== "server") {
+            child.remove();
+          } else {
+            child.replaceWithMultiple(child.node.body);
+          }
         }
       }
 

--- a/packages/translator-tags/src/visitors/program/html.ts
+++ b/packages/translator-tags/src/visitors/program/html.ts
@@ -28,7 +28,7 @@ export default {
           renderContent.push(child.node);
           child.remove();
         } else if (child.isMarkoScriptlet()) {
-          if (child.node.location && child.node.location !== "server") {
+          if (child.node.target && child.node.target !== "server") {
             child.remove();
           } else {
             child.replaceWithMultiple(child.node.body);

--- a/packages/translator-tags/src/visitors/scriptlet.ts
+++ b/packages/translator-tags/src/visitors/scriptlet.ts
@@ -15,7 +15,7 @@ export default {
         if (node.static) return; // handled in program exit for html currently.
         scriptlet.replaceWithMultiple(node.body);
       } else {
-        if (node.location && node.location !== "client") {
+        if (node.target && node.target !== "client") {
           scriptlet.remove();
         } else if (node.static) {
           scriptlet.replaceWithMultiple(node.body);

--- a/packages/translator-tags/src/visitors/scriptlet.ts
+++ b/packages/translator-tags/src/visitors/scriptlet.ts
@@ -15,7 +15,9 @@ export default {
         if (node.static) return; // handled in program exit for html currently.
         scriptlet.replaceWithMultiple(node.body);
       } else {
-        if (node.static) {
+        if (node.location && node.location !== "client") {
+          scriptlet.remove();
+        } else if (node.static) {
           scriptlet.replaceWithMultiple(node.body);
         } else {
           addStatement(


### PR DESCRIPTION
## Description

- Add `server` and `client` top-level statements, which act the same as `static` but are restricted to their target.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
