### PR TITLE
fix: precommit script tracks size snapshots

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npm exec -- lint-staged && npm run build && npm run build:sizes && git add .sizes.json
+npm exec -- lint-staged && npm run build && npm run build:sizes && git add .sizes.json && git add .sizes

--- a/.sizes.json
+++ b/.sizes.json
@@ -30,7 +30,7 @@
       "name": "counter 💧",
       "user": {
         "min": 219,
-        "brotli": 158
+        "brotli": 160
       },
       "runtime": {
         "min": 2297,
@@ -38,14 +38,14 @@
       },
       "total": {
         "min": 2516,
-        "brotli": 1244
+        "brotli": 1246
       }
     },
     {
       "name": "comments",
       "user": {
         "min": 1071,
-        "brotli": 598
+        "brotli": 588
       },
       "runtime": {
         "min": 7435,
@@ -53,22 +53,22 @@
       },
       "total": {
         "min": 8506,
-        "brotli": 3662
+        "brotli": 3652
       }
     },
     {
       "name": "comments 💧",
       "user": {
-        "min": 939,
-        "brotli": 545
+        "min": 934,
+        "brotli": 544
       },
       "runtime": {
         "min": 7927,
         "brotli": 3302
       },
       "total": {
-        "min": 8866,
-        "brotli": 3847
+        "min": 8861,
+        "brotli": 3846
       }
     }
   ]

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -11,11 +11,11 @@ import {
   f as m,
   g as d,
   q as e,
-  h as v,
-  j as r,
+  h as r,
+  j as v,
   o as $,
-  k as b,
-  m as f,
+  k as f,
+  m as b,
   n as p,
 } from "./runtime-BUIbQm-R.js";
 const h = o(2, (s) => {
@@ -24,90 +24,90 @@ const h = o(2, (s) => {
     } = s;
     H(s[0], { comments: n.comments, path: a });
   }),
-  g = a(8, null, void 0, h),
-  j = a(6, null, void 0, h),
-  k = s(
-    "0GfEvKAi",
+  k = a(8, null, void 0, h),
+  K = a(6, null, void 0, h),
+  T = s(
+    "QURHKITf",
     n(
-      `${K}`,
-      `/${P}&`,
+      `${I}`,
+      `/${J}&`,
       (s) => {
-        w(s[0]);
+        N(s[0]);
       },
-      [j, g],
+      [K, k],
     ),
   ),
-  D = o(2, (s) => {
+  _ = o(2, (s) => {
     const {
       _: { 2: n },
       7: a,
     } = s;
-    X(s, `${n.path || "c"}-${a}`);
+    U(s, `${n.path || "c"}-${a}`);
   }),
-  E = v(4),
-  G = r("mXX1vryl", (s) =>
+  j = r(4),
+  E = v("ZcKJNKFe", (s) =>
     $(
       s[2],
       "click",
       ((s) => {
         const { 9: n } = s;
         return function () {
-          b(s, V, !n);
+          f(s, F, !n);
         };
       })(s),
     ),
   ),
-  V = t(9, (s, n) => {
-    m(s[0], "hidden", !n), d(s[3], n ? "[-]" : "[+]"), e(s, G);
+  F = t(9, (s, n) => {
+    m(s[0], "hidden", !n), d(s[3], n ? "[-]" : "[+]"), e(s, E);
   }),
-  X = t(8, (s, n) => m(s[0], "id", n), u(g, 4)),
-  _ = t(7, null, D),
-  q = t(
+  U = t(8, (s, n) => m(s[0], "id", n), u(k, 4)),
+  Z = t(7, null, _),
+  g = t(
     6,
     (s, n) => {
-      d(s[1], n.text), E(s, n.comments ? k : null);
+      d(s[1], n.text), j(s, n.comments ? T : null);
     },
-    l([E, u(j, 4)]),
+    l([j, u(K, 4)]),
   ),
-  x = t(
+  q = t(
     5,
     (s, n) => {
-      q(s, n[0]), _(s, n[1]);
+      g(s, n[0]), Z(s, n[1]);
     },
-    l([q, _]),
+    l([g, Z]),
   ),
-  y = a(2, null, void 0, D),
-  A = i(
+  x = a(2, null, void 0, _),
+  D = i(
     0,
     s(
-      "HrV8uGg1",
+      "$F_EaYZk",
       n(
         "<li><span> </span><button> </button><!></li>",
         " E l D l%",
         (s) => {
-          V(s, !0);
+          F(s, !0);
         },
-        [y],
+        [x],
         void 0,
-        x,
+        q,
       ),
     ),
   ),
-  H = t(2, (s, n) => A(s, [n.comments]), l([A, c(y, 0)])),
-  K = "<ul></ul>",
-  P = " b",
-  w = function () {},
-  z = t(2, (s, n) => H(s[0], n), p(0, H));
-f(
+  H = t(2, (s, n) => D(s, [n.comments]), l([D, c(x, 0)])),
+  I = "<ul></ul>",
+  J = " b",
+  N = function () {},
+  Q = t(2, (s, n) => H(s[0], n), p(0, H));
+b(
   n(
-    `${K}`,
-    `/${P}&`,
+    `${I}`,
+    `/${J}&`,
     (s) => {
-      w(s[0]);
+      N(s[0]);
     },
     void 0,
     void 0,
-    t(1, (s, n) => z(s, n[0]), z),
+    t(1, (s, n) => Q(s, n[0]), Q),
   ),
-  "cb6DVPga",
+  "rUbTinTf",
 ).mount();

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -17,7 +17,7 @@ import {
   k as b,
   m as f,
   n as p,
-} from "./runtime-Cw1kg4Iu.js";
+} from "./runtime-BUIbQm-R.js";
 const h = o(2, (s) => {
     const {
       _: { 6: n, 8: a },
@@ -58,23 +58,23 @@ const h = o(2, (s) => {
     ),
   ),
   V = t(9, (s, n) => {
-    u(s[0], "hidden", !n), d(s[3], n ? "[-]" : "[+]"), e(s, G);
+    m(s[0], "hidden", !n), d(s[3], n ? "[-]" : "[+]"), e(s, G);
   }),
-  X = t(8, (s, n) => u(s[0], "id", n), c(g, 4)),
+  X = t(8, (s, n) => m(s[0], "id", n), u(g, 4)),
   _ = t(7, null, D),
   q = t(
     6,
     (s, n) => {
       d(s[1], n.text), E(s, n.comments ? k : null);
     },
-    m([E, c(j, 4)]),
+    l([E, u(j, 4)]),
   ),
   x = t(
     5,
     (s, n) => {
       q(s, n[0]), _(s, n[1]);
     },
-    m([q, _]),
+    l([q, _]),
   ),
   y = a(2, null, void 0, D),
   A = i(
@@ -93,7 +93,7 @@ const h = o(2, (s) => {
       ),
     ),
   ),
-  H = t(2, (s, n) => A(s, [n.comments]), l(y, 0)),
+  H = t(2, (s, n) => A(s, [n.comments]), l([A, c(y, 0)])),
   K = "<ul></ul>",
   P = " b",
   w = function () {},

--- a/.sizes/comments.ssr/entry.js
+++ b/.sizes/comments.ssr/entry.js
@@ -3,97 +3,97 @@ import {
   c as n,
   a,
   b as t,
-  o as l,
-  v as o,
-  d as i,
-  e as c,
+  o,
+  v as l,
+  d as c,
+  e as i,
   i as u,
   f as m,
   q as e,
   g as d,
   h as r,
-  j as v,
-  k as f,
-  l as p,
-  m as b,
+  j as f,
+  k as p,
+  l as v,
+  m as $,
 } from "./runtime-C35w6ZnD.js";
-const h = m(2, (s) => {
+const b = m(2, (s) => {
     const {
       _: { 6: n, 8: a },
     } = s;
-    H(s[0], { comments: n.comments, path: a });
+    I(s[0], { comments: n.comments, path: a });
   }),
-  $ = t(8, null, void 0, h),
-  g = t(6, null, void 0, h),
-  j = s(
-    "0GfEvKAi",
+  h = t(8, null, void 0, b),
+  k = t(6, null, void 0, b),
+  K = s(
+    "QURHKITf",
     n(
-      `${K}`,
-      `/${V}&`,
+      `${J}`,
+      `/${N}&`,
       (s) => {
-        w(s[0]);
+        Q(s[0]);
       },
-      [g, $],
+      [k, h],
     ),
   ),
-  k = m(2, (s) => {
+  _ = m(2, (s) => {
     const {
       _: { 2: n },
       7: a,
     } = s;
-    _(s, `${n.path || "c"}-${a}`);
+    Z(s, `${n.path || "c"}-${a}`);
   }),
-  E = r(4),
-  G = a("mXX1vryl", (s) =>
-    l(
+  j = r(4),
+  E = a("ZcKJNKFe", (s) =>
+    o(
       s[2],
       "click",
       ((s) => {
         const { 9: n } = s;
         return function () {
-          e(s, X, !n);
+          e(s, F, !n);
         };
       })(s),
     ),
   ),
-  X = o(9, (s, n) => {
-    i(s[0], "hidden", !n), c(s[3], n ? "[-]" : "[+]"), f(s, G);
+  F = l(9, (s, n) => {
+    c(s[0], "hidden", !n), i(s[3], n ? "[-]" : "[+]"), p(s, E);
   }),
-  _ = o(8, (s, n) => i(s[0], "id", n), d($, 4)),
-  q = o(7, null, k),
-  x = o(
+  Z = l(8, (s, n) => c(s[0], "id", n), d(h, 4)),
+  g = l(7, null, _),
+  q = l(
     6,
     (s, n) => {
-      c(s[1], n.text), E(s, n.comments ? j : null);
+      i(s[1], n.text), j(s, n.comments ? K : null);
     },
-    u([E, d(g, 4)]),
+    u([j, d(k, 4)]),
   ),
-  y = o(
+  x = l(
     5,
     (s, n) => {
-      x(s, n[0]), q(s, n[1]);
+      q(s, n[0]), g(s, n[1]);
     },
-    u([x, q]),
+    u([q, g]),
   ),
-  A = t(2, null, void 0, k),
-  D = p(
+  D = t(2, null, void 0, _),
+  H = v(
     0,
     s(
-      "HrV8uGg1",
+      "$F_EaYZk",
       n(
         "<li><span> </span><button> </button><!></li>",
         " E l D l%",
         (s) => {
-          X(s, !0);
+          F(s, !0);
         },
-        [A],
+        [D],
         void 0,
-        y,
+        x,
       ),
     ),
   ),
-  H = o(2, (s, n) => D(s, [n.comments]), u([D, v(A, 0)])),
-  K = "<ul></ul>",
-  V = " b",
-  w = function () {};
-b();
+  I = l(2, (s, n) => H(s, [n.comments]), u([H, f(D, 0)])),
+  J = "<ul></ul>",
+  N = " b",
+  Q = function () {};
+$();

--- a/.sizes/comments.ssr/entry.js
+++ b/.sizes/comments.ssr/entry.js
@@ -16,7 +16,7 @@ import {
   k as f,
   l as p,
   m as b,
-} from "./runtime-BDGaykzf.js";
+} from "./runtime-C35w6ZnD.js";
 const h = m(2, (s) => {
     const {
       _: { 6: n, 8: a },
@@ -92,7 +92,7 @@ const h = m(2, (s) => {
       ),
     ),
   ),
-  H = o(2, (s, n) => D(s, [n.comments]), v(A, 0)),
+  H = o(2, (s, n) => D(s, [n.comments]), u([D, v(A, 0)])),
   K = "<ul></ul>",
   V = " b",
   w = function () {};

--- a/.sizes/counter.csr/entry.js
+++ b/.sizes/counter.csr/entry.js
@@ -1,31 +1,31 @@
 import {
-  c as t,
-  a as s,
+  c as s,
+  a as t,
   v as a,
   d as n,
   q as o,
   r as c,
   o as i,
-  b as m,
+  b as r,
 } from "./runtime-C853KoX8.js";
-const r = c("eSP3qy+t", (t) =>
+const u = c("XBSGKvBc", (s) =>
     i(
-      t[0],
+      s[0],
       "click",
-      ((t) => {
-        const { 2: s } = t;
+      ((s) => {
+        const { 2: t } = s;
         return function () {
-          m(t, u, s + 1);
+          r(s, m, t + 1);
         };
-      })(t),
+      })(s),
     ),
   ),
-  u = a(2, (t, s) => {
-    n(t[1], s), o(t, r);
+  m = a(2, (s, t) => {
+    n(s[1], t), o(s, u);
   });
-t(
-  s("<div><button> </button></div>", "D D m", (t) => {
-    u(t, 0);
+s(
+  t("<div><button> </button></div>", "D D m", (s) => {
+    m(s, 0);
   }),
-  "QIqKtmwZ",
+  "tPaZsVqd",
 ).mount();

--- a/.sizes/counter.ssr/entry.js
+++ b/.sizes/counter.ssr/entry.js
@@ -1,25 +1,25 @@
 import {
   r as s,
   o as a,
-  q as t,
+  q as c,
   v as n,
   d as o,
   a as r,
-  i as c,
+  i as t,
 } from "./runtime-BOMPXhWq.js";
-const i = s("eSP3qy+t", (s) =>
+const i = s("XBSGKvBc", (s) =>
     a(
       s[0],
       "click",
       ((s) => {
         const { 2: a } = s;
         return function () {
-          t(s, e, a + 1);
+          c(s, m, a + 1);
         };
       })(s),
     ),
   ),
-  e = n(2, (s, a) => {
+  m = n(2, (s, a) => {
     o(s[1], a), r(s, i);
   });
-c();
+t();

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -548,9 +548,9 @@ function Ne(e, t, r) {
   return (s, d) => {
     if (d === I) return;
     if (d === O || d === q) {
-      for (let e of s[o]) {
-        f?.(e, d);
-        for (let t of l) t(e, d);
+      for (let t of s[o] ?? s[e + "("].values()) {
+        f?.(t, d);
+        for (let e of l) e(t, d);
       }
       return;
     }

--- a/packages/babel-utils/index.d.ts
+++ b/packages/babel-utils/index.d.ts
@@ -317,6 +317,7 @@ export function getTagDefForTagName(
 export function getTemplateId(
   optimize: boolean | Config,
   request: string,
+  child?: string,
 ): string;
 export function resolveTagImport(
   path: t.NodePath<any>,

--- a/packages/compiler/config.d.ts
+++ b/packages/compiler/config.d.ts
@@ -24,7 +24,7 @@ declare const Config: {
   hydrateIncludeImports?: RegExp | ((request: string) => boolean);
   hydrateInit?: boolean;
   optimize?: boolean;
-  optimizedRegistryIds?: Map<string, string>;
+  optimizeKnownTemplates?: string[];
   cache?: Map<unknown, unknown>;
   hot?: boolean;
   /** @deprecated */

--- a/packages/compiler/src/config.js
+++ b/packages/compiler/src/config.js
@@ -114,11 +114,11 @@ const config = {
   optimize: undefined,
 
   /**
-   * If `optimize` is enabled you can provide a Map which the compiler will
-   * use to store shorter registry/template id's in. This can only be used
-   * if the same `optimizedRegistryIds` are used for both server and client compilations.
+   * If `optimize` is enabled you can provide an array of template paths which the compiler will
+   * use to generate shorter registry/template ids using incrementing ids. This can only be used
+   * if the same `optimizeKnownTemplates` are used for both server and client compilations.
    */
-  optimizedRegistryIds: undefined,
+  optimizeKnownTemplates: undefined,
 
   /**
    * This option should be set if `hydrate` output is specified.

--- a/packages/marko/docs/compiler.md
+++ b/packages/marko/docs/compiler.md
@@ -206,12 +206,12 @@ Default: [environment based](https://github.com/marko-js/marko/blob/0f212897d2d3
 
 Enables production mode optimizations.
 
-#### `optimizedRegistryIds`
+#### `optimizeKnownTemplates`
 
-Type: `Map<string, string>`<br>
+Type: `string[]`<br>
 Default: `undefined`
 
-If `optimize` is enabled you can provide a Map which the compiler will use to store shorter registry/template id's in. This can only be used if the same `optimizedRegistryIds` are used for both server and client compilations.
+If `optimize` is enabled you can provide an array of template paths which the compiler will use to generate shorter registry/template ids using incrementing ids. This can only be used if the same `optimizeKnownTemplates` are used for both server and client compilations.
 
 #### `resolveVirtualDependency`
 

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "cY5vQoUJ",
+const _marko_componentType = "kxPbdNSf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tag-inside-if-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "cY5vQoUJ",
+const _marko_componentType = "kxPbdNSf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "EC7Wpjet",
+const _marko_componentType = "sUNz$TS",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-and-static/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "EC7Wpjet",
+const _marko_componentType = "sUNz$TS",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "V8pzyNwe",
+const _marko_componentType = "NFoDYqBe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-tag-parent/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "V8pzyNwe",
+const _marko_componentType = "NFoDYqBe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "OLo+Dwkn",
+const _marko_componentType = "mPcXYlXc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic-with-params/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "OLo+Dwkn",
+const _marko_componentType = "mPcXYlXc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "GuHig6zQ",
+const _marko_componentType = "LOwmoBub",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "GuHig6zQ",
+const _marko_componentType = "LOwmoBub",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "1bkLHbaD",
+const _marko_componentType = "ktPbis$k",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "1bkLHbaD",
+const _marko_componentType = "ktPbis$k",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "9N4Yuzi+",
+const _marko_componentType = "jRyKrJEm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-with-key/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "9N4Yuzi+",
+const _marko_componentType = "jRyKrJEm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "hNiObgtw",
+const _marko_componentType = "dYgc$jSg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/at-tags/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "hNiObgtw",
+const _marko_componentType = "dYgc$jSg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "CtqnD7TI",
+const _marko_componentType = "SKefyeE",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-boolean/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "CtqnD7TI",
+const _marko_componentType = "SKefyeE",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "TKoJdMQb",
+const _marko_componentType = "LmLeMzYd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/attr-class/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-class/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "TKoJdMQb",
+const _marko_componentType = "LmLeMzYd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "SA1M0lYk",
+const _marko_componentType = "WJodxLLd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/attr-escape/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-escape/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "SA1M0lYk",
+const _marko_componentType = "WJodxLLd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "9WNpCPpT",
+const _marko_componentType = "hTUpofGm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-falsey/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "9WNpCPpT",
+const _marko_componentType = "hTUpofGm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "8v5gGoOT",
+const _marko_componentType = "rALlVyzm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-shorthand/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "8v5gGoOT",
+const _marko_componentType = "rALlVyzm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "+mnrnsox",
+const _marko_componentType = "JctBubUm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";

--- a/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-method-with-return/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "+mnrnsox",
+const _marko_componentType = "JctBubUm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./components/test.marko";

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "m2haKSSA",
+const _marko_componentType = "YjySFM$h",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-scoped/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "m2haKSSA",
+const _marko_componentType = "YjySFM$h",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "Up7A+MWi",
+const _marko_componentType = "M$jre_me",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/dist/runtime/helpers/style-value.js";

--- a/packages/translator-default/test/fixtures/attr-style/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-style/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "Up7A+MWi",
+const _marko_componentType = "M$jre_me",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_style_merge from "marko/dist/runtime/helpers/style-value.js";

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "vJZypcf5",
+const _marko_componentType = "jF_vuKKj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/attr-template-literal-escape/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "vJZypcf5",
+const _marko_componentType = "jF_vuKKj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "8BXCo81d",
+const _marko_componentType = "NJnnEvrm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/await-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/await-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "8BXCo81d",
+const _marko_componentType = "NJnnEvrm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "MoYb8VAR",
+const _marko_componentType = "_KZJAbGc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";

--- a/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/camel-case-attr-name-override/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "MoYb8VAR",
+const _marko_componentType = "_KZJAbGc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag/index.marko";

--- a/packages/translator-default/test/fixtures/cdata/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "EazLsc5m",
+const _marko_componentType = "wEhGo_W",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/cdata/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/cdata/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "EazLsc5m",
+const _marko_componentType = "wEhGo_W",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "ErZDLFTk",
+const _marko_componentType = "kWrkzUZ",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./component.js";

--- a/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component-index/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "ErZDLFTk",
+const _marko_componentType = "kWrkzUZ",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "cQ4BiZgz",
+const _marko_componentType = "ZWiI$rRf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";

--- a/packages/translator-default/test/fixtures/class-external-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-external-component/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "cQ4BiZgz",
+const _marko_componentType = "ZWiI$rRf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "rmgp0gbX",
+const _marko_componentType = "rkyWcuZi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline-class-props-without-on-create/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "rmgp0gbX",
+const _marko_componentType = "rkyWcuZi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "F7GLatBK",
+const _marko_componentType = "KuiZaKlb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/class-inline/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/class-inline/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "F7GLatBK",
+const _marko_componentType = "KuiZaKlb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/comments/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "7oQXz9rS",
+const _marko_componentType = "v$mWNcnm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "7oQXz9rS",
+const _marko_componentType = "v$mWNcnm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "O83mlmop",
+const _marko_componentType = "oWdNwOdd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-element-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "O83mlmop",
+const _marko_componentType = "oWdNwOdd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "aA/l93YC",
+const _marko_componentType = "MpcNgwsf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-child-analyze/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "aA/l93YC",
+const _marko_componentType = "MpcNgwsf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "ZqQwXW7R",
+const _marko_componentType = "xBzKAzof",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "ZqQwXW7R",
+const _marko_componentType = "xBzKAzof",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTagData from "./custom-tag-data-tag.js";

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "hPPGxVRm",
+const _marko_componentType = "YostVzSg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-migration/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "hPPGxVRm",
+const _marko_componentType = "YostVzSg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _new from "./new.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "D4iHvcrp",
+const _marko_componentType = "UYhnOcR",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-parameters/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "D4iHvcrp",
+const _marko_componentType = "UYhnOcR",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "c9tNjqrV",
+const _marko_componentType = "RBmkrfZf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-render-body/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "c9tNjqrV",
+const _marko_componentType = "RBmkrfZf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testBodyFunction from "./tags/test-body-function/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "WET+Vfy4",
+const _marko_componentType = "lAveFICe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";

--- a/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-separate-assets/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "WET+Vfy4",
+const _marko_componentType = "lAveFICe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "s2zGW8TX",
+const _marko_componentType = "rQojdplj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-template/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "s2zGW8TX",
+const _marko_componentType = "rQojdplj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./hello.marko";

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "5fhDZgMT",
+const _marko_componentType = "ruCJLtRl",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag-transform/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "5fhDZgMT",
+const _marko_componentType = "ruCJLtRl",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "gHRccTPG",
+const _marko_componentType = "A_B_NaGg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";

--- a/packages/translator-default/test/fixtures/custom-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/custom-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "gHRccTPG",
+const _marko_componentType = "A_B_NaGg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _testHello from "./tags/test-hello/renderer.js";

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "qc7Y7xBI",
+const _marko_componentType = "wpPUPHMi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-marko-implicit-component/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "qc7Y7xBI",
+const _marko_componentType = "wpPUPHMi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "Pet223we",
+const _marko_componentType = "_geBbHjd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-migration/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "Pet223we",
+const _marko_componentType = "_geBbHjd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _test from "./test.marko";

--- a/packages/translator-default/test/fixtures/data-reassigned/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-reassigned/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "aUDwECFR",
+const _marko_componentType = "tHBGyMvf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/data-reassigned/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/data-reassigned/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "aUDwECFR",
+const _marko_componentType = "tHBGyMvf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/declaration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "p0+/pj8a",
+const _marko_componentType = "Xew$hMFi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/declaration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declaration/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "p0+/pj8a",
+const _marko_componentType = "Xew$hMFi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/declared-class-member/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declared-class-member/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "xmfoovwT",
+const _marko_componentType = "NHNFQVjk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 class MyClass {

--- a/packages/translator-default/test/fixtures/declared-class-member/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/declared-class-member/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "xmfoovwT",
+const _marko_componentType = "NHNFQVjk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 class MyClass {

--- a/packages/translator-default/test/fixtures/doctype/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "VJrYycFN",
+const _marko_componentType = "sdGygAse",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _initComponents from "marko/dist/core-tags/components/init-components-tag.js";

--- a/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/doctype/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "VJrYycFN",
+const _marko_componentType = "sdGygAse",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "FiPq+pCl",
+const _marko_componentType = "oWpiEthb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";

--- a/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-name/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "FiPq+pCl",
+const _marko_componentType = "oWpiEthb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import tagA from "./components/tag-a/index.marko";

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "W5oFh28/",
+const _marko_componentType = "RWaFoVLe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/dynamic-tag-string-literal/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "W5oFh28/",
+const _marko_componentType = "RWaFoVLe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "GzjO/FF7",
+const _marko_componentType = "_fXseyvb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/else-tag-with-whitespace-and-comments/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "GzjO/FF7",
+const _marko_componentType = "_fXseyvb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/entities/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "Q2oCYb3A",
+const _marko_componentType = "SwfhrTyd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/entities/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/entities/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "Q2oCYb3A",
+const _marko_componentType = "SwfhrTyd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/error-at-tags-repeated-not-allowed/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-at-tags-repeated-not-allowed/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "QmMQupx3",
+const _marko_componentType = "DhEjG_vd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/error-at-tags-repeated-not-allowed/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-at-tags-repeated-not-allowed/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "QmMQupx3",
+const _marko_componentType = "DhEjG_vd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";

--- a/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-at-tags-top-level/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "DvY2Lw0O",
+const _marko_componentType = "crOdlzP",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "QPcOe9nt",
+const _marko_componentType = "wSGKQcsd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-body-only-if-no-condition/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "QPcOe9nt",
+const _marko_componentType = "wSGKQcsd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "/7Yakras",
+const _marko_componentType = "WvTnmMgn",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-class-with-name/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "/7Yakras",
+const _marko_componentType = "WvTnmMgn",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "vPxaLPFT",
+const _marko_componentType = "RjLyZPLj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";

--- a/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/error-repeated-closing-dynamic-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "vPxaLPFT",
+const _marko_componentType = "RjLyZPLj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "7zxvsBE8",
+const _marko_componentType = "ZKWzBcpm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/event-handlers/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "7zxvsBE8",
+const _marko_componentType = "ZKWzBcpm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _customTag from "./components/custom-tag.marko";

--- a/packages/translator-default/test/fixtures/exports/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "NPJMtzPP",
+const _marko_componentType = "UjIIdOMc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 export const x = 1;

--- a/packages/translator-default/test/fixtures/exports/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/exports/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "NPJMtzPP",
+const _marko_componentType = "UjIIdOMc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 export const x = 1;

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "avg1eu47",
+const _marko_componentType = "lMveozAf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "avg1eu47",
+const _marko_componentType = "lMveozAf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "kCnjd+Lm",
+const _marko_componentType = "EkpPQDvh",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/hello-dynamic/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "kCnjd+Lm",
+const _marko_componentType = "EkpPQDvh",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "3DMKav/3",
+const _marko_componentType = "dqZSxpql",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "3DMKav/3",
+const _marko_componentType = "dqZSxpql",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "PF20NQ88",
+const _marko_componentType = "JsvAAqfd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/html-entity/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-entity/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "PF20NQ88",
+const _marko_componentType = "JsvAAqfd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "y0rlhGQ3",
+const _marko_componentType = "HBWuhxxk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/if-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/if-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "y0rlhGQ3",
+const _marko_componentType = "HBWuhxxk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "9FdWS4tF",
+const _marko_componentType = "SspwDkDm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";

--- a/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-hydrate-include/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "9FdWS4tF",
+const _marko_componentType = "SspwDkDm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "xrPYS1qL",
+const _marko_componentType = "OkpTjMkk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";

--- a/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag-conflict/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "xrPYS1qL",
+const _marko_componentType = "OkpTjMkk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { asset as test } from "./test1/asset";

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "aVPzDB9L",
+const _marko_componentType = "URzQEXvf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";

--- a/packages/translator-default/test/fixtures/import-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/import-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "aVPzDB9L",
+const _marko_componentType = "URzQEXvf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import bar, { f as foo } from "./bar";

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "R6eF4gGA",
+const _marko_componentType = "yYFbYFKd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macro-non-root/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "R6eF4gGA",
+const _marko_componentType = "yYFbYFKd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "pLQ9rpQM",
+const _marko_componentType = "$$jmXzyi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "pLQ9rpQM",
+const _marko_componentType = "$$jmXzyi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "+Vkh85NW",
+const _marko_componentType = "XmJQWdRm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_merge_attrs from "marko/dist/runtime/html/helpers/merge-attrs.js";

--- a/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/native-tag-spread-attrs/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "+Vkh85NW",
+const _marko_componentType = "XmJQWdRm",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_merge_attrs from "marko/dist/runtime/vdom/helpers/merge-attrs.js";

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "qUg9ApxN",
+const _marko_componentType = "ANctejLi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";

--- a/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-directives/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "qUg9ApxN",
+const _marko_componentType = "ANctejLi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _hello from "./components/hello/index.marko";

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "r46whWwu",
+const _marko_componentType = "UWBVmEaj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier-multiple/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "r46whWwu",
+const _marko_componentType = "UWBVmEaj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "az9GXCCR",
+const _marko_componentType = "txzFRmBf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/no-update-modifier/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "az9GXCCR",
+const _marko_componentType = "txzFRmBf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "jxXJawbJ",
+const _marko_componentType = "wDexuEsh",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/placeholders/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/placeholders/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "jxXJawbJ",
+const _marko_componentType = "wDexuEsh",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "AWlOZ9B/",
+const _marko_componentType = "XZVjmXd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/prevent-override-component-def/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "AWlOZ9B/",
+const _marko_componentType = "XZVjmXd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "iJY8a2Ko",
+const _marko_componentType = "QcHqTDah",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/root-migration/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-migration/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "iJY8a2Ko",
+const _marko_componentType = "QcHqTDah",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "dqltXdhn",
+const _marko_componentType = "ssIUhVeg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/root-transform/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/root-transform/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "dqltXdhn",
+const _marko_componentType = "ssIUhVeg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "OLFRWJ/R",
+const _marko_componentType = "RXRiNgXc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "OLFRWJ/R",
+const _marko_componentType = "RXRiNgXc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import a from "b";

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "g3aimRge",
+const _marko_componentType = "bUT_ctOg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/scriptlet-line-block/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "g3aimRge",
+const _marko_componentType = "bUT_ctOg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "WqUsRyBC",
+const _marko_componentType = "UprVgmJe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-classname/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "WqUsRyBC",
+const _marko_componentType = "UprVgmJe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "wUxkdMJU",
+const _marko_componentType = "dFcmvNXj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/shorthand-id/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "wUxkdMJU",
+const _marko_componentType = "dFcmvNXj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "YUZPhHIa",
+const _marko_componentType = "RrOqqG_e",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";

--- a/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple-attrs-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "YUZPhHIa",
+const _marko_componentType = "RrOqqG_e",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "NRekT+g6",
+const _marko_componentType = "VuvBWhNc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "NRekT+g6",
+const _marko_componentType = "VuvBWhNc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "Wgq3cfjm",
+const _marko_componentType = "UCeRSDHe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_component from "./template.component.js";

--- a/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component-with-component/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "Wgq3cfjm",
+const _marko_componentType = "UCeRSDHe",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/split-component/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "tgVjO8nX",
+const _marko_componentType = "FDyCGzsj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/split-component/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/split-component/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "tgVjO8nX",
+const _marko_componentType = "FDyCGzsj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "zKxreLgp",
+const _marko_componentType = "gePURnBk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;

--- a/packages/translator-default/test/fixtures/static-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/static-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "zKxreLgp",
+const _marko_componentType = "gePURnBk",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 var foo = 123;

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "iTWeM9Hv",
+const _marko_componentType = "wYLVapch",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-empty/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "iTWeM9Hv",
+const _marko_componentType = "wYLVapch",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "ZsW3uNOB",
+const _marko_componentType = "EVqifTof",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/style-block-with-styles/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "ZsW3uNOB",
+const _marko_componentType = "EVqifTof",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "LOy6P2CY",
+const _marko_componentType = "hBySBBqc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/svg-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/svg-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "LOy6P2CY",
+const _marko_componentType = "hBySBBqc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "s8GmyX5C",
+const _marko_componentType = "GEeKKkmj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-block-scoping/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "s8GmyX5C",
+const _marko_componentType = "GEeKKkmj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "d4MwwGDt",
+const _marko_componentType = "KzLAymhg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";

--- a/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/tag-with-default-attr/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "d4MwwGDt",
+const _marko_componentType = "KzLAymhg",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "or1T1BHP",
+const _marko_componentType = "agEGWbti",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/textarea-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "or1T1BHP",
+const _marko_componentType = "agEGWbti",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "L6x2qKS4",
+const _marko_componentType = "JGEoYgyc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/top-level-text/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/top-level-text/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "L6x2qKS4",
+const _marko_componentType = "JGEoYgyc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "vnqwugCu",
+const _marko_componentType = "KtvGzXPj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "vnqwugCu",
+const _marko_componentType = "KtvGzXPj",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_class_merge from "marko/dist/runtime/helpers/class-value.js";

--- a/packages/translator-default/test/fixtures/typescript-generic-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-generic-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "H1mF9+h2",
+const _marko_componentType = "XDMeUVGb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _typeArg from "./components/type-arg.marko";

--- a/packages/translator-default/test/fixtures/typescript-generic-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/typescript-generic-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "H1mF9+h2",
+const _marko_componentType = "XDMeUVGb",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _typeArg from "./components/type-arg.marko";

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "R2kcOR51",
+const _marko_componentType = "FY_LxXJd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/while-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/while-tag/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "R2kcOR51",
+const _marko_componentType = "FY_LxXJd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/htmlProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/html/index.js";
-const _marko_componentType = "TRrwGTtp",
+const _marko_componentType = "IaJpMLZd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";

--- a/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/white-space-test/snapshots/vdomProduction-expected.js
@@ -1,5 +1,5 @@
 import { t as _t } from "marko/dist/runtime/vdom/index.js";
-const _marko_componentType = "TRrwGTtp",
+const _marko_componentType = "IaJpMLZd",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";

--- a/packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.hydrate.js
@@ -1,16 +1,16 @@
-// size: 301 (min) 184 (brotli)
+// size: 302 (min) 185 (brotli)
 
 import {
   register as n,
   on as o,
   queueSource as t,
-  value as c,
+  value as a,
   attr as e,
   data as i,
   queueEffect as r,
-  init as a,
+  init as c,
 } from "@marko/runtime-tags/dom";
-const m = n("c", (n) =>
+const m = n("a1", (n) =>
     o(
       n[1],
       "click",
@@ -22,7 +22,7 @@ const m = n("c", (n) =>
       })(n),
     ),
   ),
-  s = c(3, (n, o) => {
+  s = a(3, (n, o) => {
     e(n[0], "disabled", o), i(n[2], o ? "enable" : "disable"), r(n, m);
   });
-a();
+c();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
@@ -1,33 +1,33 @@
-// size: 381 (min) 219 (brotli)
+// size: 383 (min) 220 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  data as n,
+  value as n,
+  data as c,
   queueEffect as r,
   queueSource as m,
   intersections as i,
   inChild as s,
-  init as u,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const a = c(5, (o, t) => n(o[1], t)),
-  d = o("d", (o) => {
-    const { 4: c } = o;
-    t(o[0], "click", c);
+const u = n(5, (o, t) => c(o[1], t)),
+  e = o("a0", (o) => {
+    const { 4: n } = o;
+    t(o[0], "click", n);
   }),
-  e = c(4, (o, t) => r(o, d)),
-  f = o("c", (o) => {
+  f = n(4, (o, t) => r(o, e)),
+  k = o("b0", (o) => {
     const { 1: t } = o;
     return function () {
-      m(o, k, t + 1);
+      m(o, b, t + 1);
     };
   }),
-  k = c(
+  b = n(
     1,
     (o, t) => {
-      a(o[0], t), e(o[0], f(o));
+      u(o[0], t), f(o[0], k(o));
     },
-    i([s(0, a), s(0, e)]),
+    i([s(0, u), s(0, f)]),
   );
-u();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,33 +1,33 @@
-// size: 381 (min) 222 (brotli)
+// size: 383 (min) 217 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  queueEffect as n,
+  value as n,
+  queueEffect as c,
   data as r,
   queueSource as m,
   intersections as i,
   inChild as s,
-  init as u,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const a = o("d", (o) => {
-    const { 5: c } = o;
-    t(o[0], "click", c);
+const u = o("a0", (o) => {
+    const { 5: n } = o;
+    t(o[0], "click", n);
   }),
-  d = c(5, (o, t) => n(o, a)),
-  e = c(4, (o, t) => r(o[1], t)),
-  f = o("c", (o) => {
+  e = n(5, (o, t) => c(o, u)),
+  f = n(4, (o, t) => r(o[1], t)),
+  k = o("b0", (o) => {
     const { 1: t } = o;
     return function () {
-      m(o, k, t + 1);
+      m(o, b, t + 1);
     };
   }),
-  k = c(
+  b = n(
     1,
     (o, t) => {
-      e(o[0], t), d(o[0], f(o));
+      f(o[0], t), e(o[0], k(o));
     },
-    i([s(0, e), s(0, d)]),
+    i([s(0, f), s(0, e)]),
   );
-u();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
@@ -1,39 +1,39 @@
-// size: 444 (min) 244 (brotli)
+// size: 446 (min) 245 (brotli)
 
 import {
   register as t,
   on as o,
-  value as c,
-  queueEffect as n,
+  value as n,
+  queueEffect as c,
   data as r,
   queueSource as m,
   intersections as e,
   inChild as i,
   init as s,
 } from "@marko/runtime-tags/dom";
-const u = c(7, (t, o) => {
+const a = n(7, (t, o) => {
     r(t[1], o),
       ((t, o) => {
         r(t[2], o);
       })(t, o);
   }),
-  a = c(6, (t, o) => u(t, o.text)),
-  d = t("d", (t) => {
-    const { 5: c } = t;
-    o(t[0], "click", c);
+  u = n(6, (t, o) => a(t, o.text)),
+  f = t("a0", (t) => {
+    const { 5: n } = t;
+    o(t[0], "click", n);
   }),
-  f = c(5, (t, o) => n(t, d)),
-  k = t("c", (t) => {
+  k = n(5, (t, o) => c(t, f)),
+  x = t("b0", (t) => {
     const { 1: o } = t;
     return function () {
-      m(t, x, o + 1);
+      m(t, b, o + 1);
     };
   }),
-  x = c(
+  b = n(
     1,
     (t, o) => {
-      a(t[0], { text: o }), f(t[0], k(t));
+      u(t[0], { text: o }), k(t[0], x(t));
     },
-    e([i(0, a), i(0, f)]),
+    e([i(0, u), i(0, k)]),
   );
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,38 +1,38 @@
-// size: 409 (min) 229 (brotli)
+// size: 411 (min) 233 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  data as n,
+  value as n,
+  data as c,
   queueEffect as r,
   queueSource as m,
   intersections as i,
   inChild as s,
-  init as u,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const a = c(6, (o, t) => {
-    n(o[1], t),
+const u = n(6, (o, t) => {
+    c(o[1], t),
       ((o, t) => {
-        n(o[2], t);
+        c(o[2], t);
       })(o, t);
   }),
-  d = o("d", (o) => {
-    const { 5: c } = o;
-    t(o[0], "click", c);
+  e = o("a0", (o) => {
+    const { 5: n } = o;
+    t(o[0], "click", n);
   }),
-  e = c(5, (o, t) => r(o, d)),
-  f = o("c", (o) => {
+  f = n(5, (o, t) => r(o, e)),
+  k = o("b0", (o) => {
     const { 1: t } = o;
     return function () {
-      m(o, k, t + 1);
+      m(o, b, t + 1);
     };
   }),
-  k = c(
+  b = n(
     1,
     (o, t) => {
-      a(o[0], t), e(o[0], f(o));
+      u(o[0], t), f(o[0], k(o));
     },
-    i([s(0, a), s(0, e)]),
+    i([s(0, u), s(0, f)]),
   );
-u();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
@@ -1,33 +1,33 @@
-// size: 381 (min) 219 (brotli)
+// size: 383 (min) 220 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  data as n,
+  value as n,
+  data as c,
   queueEffect as r,
   queueSource as m,
   intersections as i,
   inChild as s,
-  init as u,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const a = c(5, (o, t) => n(o[1], t)),
-  d = o("d", (o) => {
-    const { 4: c } = o;
-    t(o[0], "click", c);
+const u = n(5, (o, t) => c(o[1], t)),
+  e = o("a0", (o) => {
+    const { 4: n } = o;
+    t(o[0], "click", n);
   }),
-  e = c(4, (o, t) => r(o, d)),
-  f = o("c", (o) => {
+  f = n(4, (o, t) => r(o, e)),
+  k = o("b0", (o) => {
     const { 1: t } = o;
     return function () {
-      m(o, k, t + 1);
+      m(o, b, t + 1);
     };
   }),
-  k = c(
+  b = n(
     1,
     (o, t) => {
-      a(o[0], t), e(o[0], f(o));
+      u(o[0], t), f(o[0], k(o));
     },
-    i([s(0, a), s(0, e)]),
+    i([s(0, u), s(0, f)]),
   );
-u();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
@@ -1,40 +1,40 @@
-// size: 515 (min) 275 (brotli)
+// size: 519 (min) 274 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  queueEffect as n,
+  value as n,
+  queueEffect as c,
   queueSource as r,
   registerSubscriber as i,
   dynamicClosure as m,
   data as s,
-  registerRenderer as d,
-  createRenderer as e,
-  intersections as f,
-  inChild as u,
-  dynamicSubscribers as a,
-  init as k,
+  registerRenderer as a,
+  createRenderer as b,
+  intersections as u,
+  inChild as d,
+  dynamicSubscribers as e,
+  init as f,
 } from "@marko/runtime-tags/dom";
-const g = o("f", (o) => {
-    const { 4: c } = o;
-    t(o[0], "click", c);
+const k = o("a0", (o) => {
+    const { 4: n } = o;
+    t(o[0], "click", n);
   }),
-  l = c(4, (o, t) => n(o, g)),
-  p = o("c", (o) => {
+  g = n(4, (o, t) => c(o, k)),
+  l = o("b0", (o) => {
     const { 1: t } = o;
     return function () {
-      r(o, v, t + 1);
+      r(o, p, t + 1);
     };
   });
-d(
-  "e",
-  e(" ", " ", void 0, [
+a(
+  "b2",
+  b(" ", " ", void 0, [
     i(
-      "d",
+      "b1",
       m(1, (o, t) => s(o[0], t)),
     ),
   ]),
 );
-const v = c(1, (o, t) => l(o[0], p(o)), f([u(0, l), a(1)]));
-k();
+const p = n(1, (o, t) => g(o[0], l(o)), u([d(0, g), e(1)]));
+f();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 252 (min) 160 (brotli)
+// size: 253 (min) 160 (brotli)
 
 import {
   register as o,
@@ -9,19 +9,19 @@ import {
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("d", (o) =>
+const a = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          n(o, u, t + 1);
+          n(o, s, t + 1);
         };
       })(o),
     ),
   ),
-  u = r(2, (o, t) => {
-    c(o[1], t), m(o, s);
+  s = r(2, (o, t) => {
+    c(o[1], t), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 546 (min) 285 (brotli)
+// size: 549 (min) 294 (brotli)
 
 import {
   registerRenderer as n,
@@ -8,16 +8,16 @@ import {
   value as i,
   queueEffect as r,
   inConditionalScope as u,
-  closure as e,
+  closure as a,
   data as m,
   queueSource as s,
-  conditional as f,
+  conditional as e,
   init as l,
 } from "@marko/runtime-tags/dom";
-const d = e(4, (n, o) => m(n[0], o)),
-  k = n("d", o("The count is <!>", "b%", void 0, [d])),
-  a = f(2),
-  b = t("e", (n) =>
+const f = a(4, (n, o) => m(n[0], o)),
+  k = n("a2", o("The count is <!>", "b%", void 0, [f])),
+  d = e(2),
+  b = t("a3", (n) =>
     c(
       n[0],
       "click",
@@ -29,8 +29,8 @@ const d = e(4, (n, o) => m(n[0], o)),
       })(n),
     ),
   ),
-  g = i(4, (n, o) => r(n, b), u(d, 2)),
-  h = t("f", (n) =>
+  g = i(4, (n, o) => r(n, b), u(f, 2)),
+  h = t("a4", (n) =>
     c(
       n[1],
       "click",
@@ -45,8 +45,8 @@ const d = e(4, (n, o) => m(n[0], o)),
   p = i(
     3,
     (n, o) => {
-      r(n, h), a(n, o ? k : null);
+      r(n, h), d(n, o ? k : null);
     },
-    a,
+    d,
   );
 l();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 544 (min) 289 (brotli)
+// size: 547 (min) 292 (brotli)
 
 import {
   registerRenderer as n,
@@ -6,38 +6,38 @@ import {
   register as t,
   on as c,
   value as r,
-  queueEffect as i,
-  inConditionalScope as s,
-  closure as u,
-  data as m,
-  queueSource as a,
-  conditional as e,
-  init as f,
+  queueEffect as a,
+  inConditionalScope as i,
+  closure as s,
+  data as u,
+  queueSource as m,
+  conditional as l,
+  init as e,
 } from "@marko/runtime-tags/dom";
-const l = u(4, (n, o) => m(n[0], o)),
-  d = n("d", o("<span> </span>", "D ", void 0, [l])),
-  k = e(2),
-  p = t("e", (n) =>
+const f = s(4, (n, o) => u(n[0], o)),
+  k = n("a2", o("<span> </span>", "D ", void 0, [f])),
+  p = l(2),
+  d = t("a3", (n) =>
     c(
       n[0],
       "click",
       ((n) => {
         const { 4: o } = n;
         return function () {
-          a(n, g, o + 1);
+          m(n, g, o + 1);
         };
       })(n),
     ),
   ),
-  g = r(4, (n, o) => i(n, p), s(l, 2)),
-  v = t("f", (n) =>
+  g = r(4, (n, o) => a(n, d), i(f, 2)),
+  v = t("a4", (n) =>
     c(
       n[1],
       "click",
       ((n) => {
         const { 3: o } = n;
         return function () {
-          a(n, D, !o);
+          m(n, D, !o);
         };
       })(n),
     ),
@@ -45,8 +45,8 @@ const l = u(4, (n, o) => m(n[0], o)),
   D = r(
     3,
     (n, o) => {
-      i(n, v), k(n, o ? d : null);
+      a(n, v), p(n, o ? k : null);
     },
-    k,
+    p,
   );
-f();
+e();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 446 (min) 225 (brotli)
+// size: 448 (min) 227 (brotli)
 
 import {
   register as n,
@@ -12,39 +12,39 @@ import {
 } from "@marko/runtime-tags/dom";
 const u = m(2, (n) => {
     const { 4: t, 5: c } = n;
-    e(n, t * c);
+    a(n, t * c);
   }),
-  e = o(6, (n, t) => r(n[3], t)),
-  f = n("d", (n) =>
+  a = o(6, (n, t) => r(n[3], t)),
+  e = n("a2", (n) =>
     t(
       n[0],
       "click",
       ((n) => {
         const { 5: t } = n;
         return function () {
-          c(n, k, t + 1);
+          c(n, f, t + 1);
         };
       })(n),
     ),
   ),
-  k = o(
+  f = o(
     5,
     (n, t) => {
-      r(n[1], t), i(n, f);
+      r(n[1], t), i(n, e);
     },
     u,
   ),
-  a = n("e", (n) =>
+  k = n("a3", (n) =>
     t(
       n[2],
       "click",
       ((n) => {
         const { 4: t } = n;
         return function () {
-          c(n, d, t + 1);
+          c(n, l, t + 1);
         };
       })(n),
     ),
   ),
-  d = o(4, (n, t) => i(n, a), u);
+  l = o(4, (n, t) => i(n, k), u);
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 252 (min) 160 (brotli)
+// size: 253 (min) 160 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
-  data as r,
+  queueSource as n,
+  value as r,
+  data as c,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("c", (o) =>
+const a = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          c(o, u, t + 1);
+          n(o, s, t + 1);
         };
       })(o),
     ),
   ),
-  u = n(2, (o, t) => {
-    r(o[1], t), m(o, s);
+  s = r(2, (o, t) => {
+    c(o[1], t), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 124 (min) 96 (brotli)
+// size: 125 (min) 109 (brotli)
 
 import {
   register as o,
   createRenderer as m,
   dynamicTagAttrs as r,
 } from "@marko/runtime-tags/dom";
-r(0, o("b", m("Hello World", "")));
+r(0, o("a0", m("Hello World", "")));

--- a/packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 111 (min) 80 (brotli)
+// size: 112 (min) 83 (brotli)
 
 import { register as m, init as o } from "@marko/runtime-tags/dom";
-m("c", (m) => (document.body.className = "no-deps")), o();
+m("a1", (m) => (document.body.className = "no-deps")), o();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.hydrate.js
@@ -1,31 +1,31 @@
-// size: 403 (min) 242 (brotli)
+// size: 405 (min) 239 (brotli)
 
 import {
   registerRenderer as l,
   createRenderer as n,
   value as o,
   inConditionalScope as t,
-  register as c,
-  on as i,
-  closure as m,
-  data as u,
-  queueSource as r,
-  conditional as d,
-  init as a,
+  register as i,
+  on as m,
+  closure as u,
+  data as a,
+  queueSource as c,
+  conditional as r,
+  init as d,
 } from "@marko/runtime-tags/dom";
-const e = m(2, (l, n) => u(l[0], n.text)),
-  f = l("c", n(" ", " ", void 0, [e])),
-  k = d(1),
+const e = u(2, (l, n) => a(l[0], n.text)),
+  f = l("a1", n(" ", " ", void 0, [e])),
+  k = r(1),
   s = o(3, (l, n) => k(l, n ? f : null), k),
   g = o(2, null, t(e, 1));
-c("d", (l) =>
-  i(
+i("a2", (l) =>
+  m(
     l[0],
     "click",
     ((l) =>
       function () {
-        r(l, g, null), r(l, s, !1);
+        c(l, g, null), c(l, s, !1);
       })(l),
   ),
 ),
-  a();
+  d();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 252 (min) 160 (brotli)
+// size: 253 (min) 160 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
-  data as r,
+  queueSource as n,
+  value as r,
+  data as c,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("c", (o) =>
+const a = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          c(o, u, t + 1);
+          n(o, s, t + 1);
         };
       })(o),
     ),
   ),
-  u = n(2, (o, t) => {
-    r(o[1], t), m(o, s);
+  s = r(2, (o, t) => {
+    c(o[1], t), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 331 (min) 202 (brotli)
+// size: 332 (min) 206 (brotli)
 
 import {
   register as n,
@@ -8,9 +8,9 @@ import {
   data as c,
   intersection as m,
   queueEffect as i,
-  init as s,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const u = n("d", (n) =>
+const s = n("a2", (n) =>
     o(
       n[0],
       "click",
@@ -19,7 +19,7 @@ const u = n("d", (n) =>
         return function () {
           t(
             n,
-            a,
+            u,
             o.map(
               ((n) => {
                 const { 3: o } = n;
@@ -31,11 +31,11 @@ const u = n("d", (n) =>
       })(n),
     ),
   ),
-  a = r(
+  u = r(
     2,
     (n, o) => c(n[1], o.join("")),
     m(2, (n) => {
-      i(n, u);
+      i(n, s);
     }),
   );
-s();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.hydrate.js
@@ -1,21 +1,21 @@
-// size: 200 (min) 131 (brotli)
+// size: 201 (min) 134 (brotli)
 
 import {
   register as o,
-  on as c,
-  queueSource as m,
-  value as t,
+  on as m,
+  queueSource as t,
+  value as c,
   data as i,
   init as n,
 } from "@marko/runtime-tags/dom";
-const r = t(2, (o, c) => i(o[1], c));
-o("c", (o) =>
-  c(
+const r = c(2, (o, m) => i(o[1], m));
+o("a1", (o) =>
+  m(
     o[0],
     "click",
     ((o) =>
       function () {
-        m(o, r, 1);
+        t(o, r, 1);
       })(o),
   ),
 ),

--- a/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.hydrate.js
@@ -1,19 +1,19 @@
-// size: 250 (min) 177 (brotli)
+// size: 252 (min) 165 (brotli)
 
 import {
   registerSubscriber as o,
   dynamicClosure as m,
   data as r,
-  registerRenderer as d,
+  registerRenderer as b,
   createRenderer as i,
   value as t,
   dynamicSubscribers as a,
 } from "@marko/runtime-tags/dom";
-d(
-  "d",
+b(
+  "b1",
   i("<h1>Hello <!></h1>", "Db%", void 0, [
     o(
-      "c",
+      "b0",
       m(3, (o, m) => r(o[0], m)),
     ),
   ]),

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 442 (min) 255 (brotli)
+// size: 445 (min) 252 (brotli)
 
 import {
   register as t,
@@ -7,14 +7,14 @@ import {
   dynamicClosure as c,
   data as r,
   queueEffect as u,
-  registerRenderer as i,
-  createRenderer as m,
-  value as s,
-  dynamicSubscribers as d,
-  queueSource as e,
-  init as f,
+  registerRenderer as b,
+  createRenderer as i,
+  value as m,
+  dynamicSubscribers as s,
+  queueSource as l,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const l = t("d", (t) =>
+const d = t("b1", (t) =>
   o(
     t[0],
     "click",
@@ -23,21 +23,21 @@ const l = t("d", (t) =>
         _: { 1: o },
       } = t;
       return function () {
-        e(t._, a, o + 1);
+        l(t._, e, o + 1);
       };
     })(t),
   ),
 );
-i(
-  "f",
-  m("<button> </button>", " D ", void 0, [
+b(
+  "b3",
+  i("<button> </button>", " D ", void 0, [
     n(
-      "e",
+      "b2",
       c(1, (t, o) => {
-        r(t[1], o), u(t, l);
+        r(t[1], o), u(t, d);
       }),
     ),
   ]),
 );
-const a = s(1, null, d(1));
-f();
+const e = m(1, null, s(1));
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 468 (min) 267 (brotli)
+// size: 471 (min) 273 (brotli)
 
 import {
   register as t,
@@ -7,15 +7,15 @@ import {
   dynamicClosure as c,
   data as r,
   queueEffect as u,
-  registerRenderer as i,
-  createRenderer as m,
-  dynamicTagAttrs as s,
-  value as d,
-  dynamicSubscribers as e,
-  queueSource as l,
-  init as a,
+  registerRenderer as b,
+  createRenderer as i,
+  dynamicTagAttrs as m,
+  value as s,
+  dynamicSubscribers as l,
+  queueSource as a,
+  init as d,
 } from "@marko/runtime-tags/dom";
-const b = t("c", (t) =>
+const e = t("b1", (t) =>
   o(
     t[0],
     "click",
@@ -24,24 +24,24 @@ const b = t("c", (t) =>
         _: { 1: o },
       } = t;
       return function () {
-        l(t._, f, o + 1);
+        a(t._, f, o + 1);
       };
     })(t),
   ),
 );
-s(
+m(
   0,
-  i(
-    "e",
-    m("<button> </button>", " D ", void 0, [
+  b(
+    "b3",
+    i("<button> </button>", " D ", void 0, [
       n(
-        "d",
+        "b2",
         c(1, (t, o) => {
-          r(t[1], o), u(t, b);
+          r(t[1], o), u(t, e);
         }),
       ),
     ]),
   ),
 );
-const f = d(1, null, e(1));
-a();
+const f = s(1, null, l(1));
+d();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 384 (min) 225 (brotli)
+// size: 385 (min) 226 (brotli)
 
 import {
   register as t,
@@ -18,7 +18,7 @@ const r = e(2, (t) => {
   } = t;
   i(t[0], "data-selected", n === o), i(t[0], "data-multiple", o % n == 0);
 });
-t("c", (t) =>
+t("a1", (t) =>
   n(
     t[0],
     "click",

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 584 (min) 325 (brotli)
+// size: 587 (min) 326 (brotli)
 
 import {
   registerRenderer as t,
   createRenderer as o,
   register as n,
-  on as c,
+  on as a,
   value as i,
-  intersections as s,
-  inConditionalScope as e,
+  intersections as c,
+  inConditionalScope as s,
   closure as m,
   data as r,
   queueSource as u,
-  queueEffect as a,
-  conditional as d,
-  init as b,
+  queueEffect as e,
+  conditional as b,
+  init as d,
 } from "@marko/runtime-tags/dom";
 const k = m(1, (t, o) => r(t[0], o)),
   p = t(
-    "c",
+    "a1",
     o("<span>The button was clicked <!> times.</span>", "Db%", void 0, [k]),
   ),
-  f = n("d", (t) =>
-    c(
+  f = n("a2", (t) =>
+    a(
       t[0],
       "click",
       ((t) => {
@@ -35,9 +35,9 @@ const k = m(1, (t, o) => r(t[0], o)),
     ),
   ),
   l = m(1, (t, o) => {
-    r(t[1], o), a(t, f);
+    r(t[1], o), e(t, f);
   }),
-  v = t("e", o("<button> </button>", " D ", void 0, [l])),
-  D = d(0),
-  _ = i(1, (t, o) => D(t, o < 3 ? v : p), s([D, e(l, 0), e(k, 0)]));
-b();
+  v = t("a3", o("<button> </button>", " D ", void 0, [l])),
+  D = b(0),
+  _ = i(1, (t, o) => D(t, o < 3 ? v : p), c([D, s(l, 0), s(k, 0)]));
+d();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 561 (min) 307 (brotli)
+// size: 564 (min) 305 (brotli)
 
 import {
   register as o,
@@ -9,22 +9,22 @@ import {
   queueEffect as r,
   data as s,
   intersection as u,
-  loopOf as d,
-  init as e,
+  loopOf as a,
+  init as l,
 } from "@marko/runtime-tags/dom";
-const l = t(2, (o, n) => s(o[0], n)),
-  m = o(
-    "d",
+const m = t(2, (o, n) => s(o[0], n)),
+  d = o(
+    "a2",
     n(
       " ",
       " ",
       void 0,
       void 0,
       void 0,
-      t(1, (o, n) => l(o, n[0])),
+      t(1, (o, n) => m(o, n[0])),
     ),
   ),
-  f = o("e", (o) =>
+  e = o("a3", (o) =>
     c(
       o[1],
       "click",
@@ -37,11 +37,11 @@ const l = t(2, (o, n) => s(o[0], n)),
       })(o),
     ),
   ),
-  k = u(2, (o) => {
-    r(o, f);
+  f = u(2, (o) => {
+    r(o, e);
   }),
-  v = d(0, m),
-  a = o("f", (o) =>
+  k = a(0, d),
+  v = o("a4", (o) =>
     c(
       o[2],
       "click",
@@ -56,9 +56,9 @@ const l = t(2, (o, n) => s(o[0], n)),
   g = t(
     4,
     (o, n) => {
-      r(o, a), v(o, [n]);
+      r(o, v), k(o, [n]);
     },
-    k,
+    f,
   ),
-  p = t(3, null, k);
-e();
+  p = t(3, null, f);
+l();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 567 (min) 313 (brotli)
+// size: 570 (min) 291 (brotli)
 
 import {
   register as n,
@@ -9,14 +9,14 @@ import {
   queueEffect as r,
   attr as e,
   data as u,
-  loopOf as d,
-  init as f,
+  loopOf as a,
+  init as d,
 } from "@marko/runtime-tags/dom";
 const m = t(2, (n, o) => u(n[0], o)),
-  s = d(
+  s = a(
     0,
     n(
-      "e",
+      "a3",
       o(
         "<li> </li>",
         "D ",
@@ -27,20 +27,20 @@ const m = t(2, (n, o) => u(n[0], o)),
       ),
     ),
   ),
-  l = n("f", (n) =>
+  f = n("a4", (n) =>
     i(
       n[2],
       "click",
       ((n) => {
         const { 4: o } = n;
         return function () {
-          c(n, v, [].concat(o).reverse());
+          c(n, l, [].concat(o).reverse());
         };
       })(n),
     ),
   ),
-  v = t(4, (n, o) => {
-    r(n, l),
+  l = t(4, (n, o) => {
+    r(n, f),
       s(n, [
         o,
         function (n) {
@@ -48,7 +48,7 @@ const m = t(2, (n, o) => u(n[0], o)),
         },
       ]);
   }),
-  a = n("g", (n) =>
+  v = n("a5", (n) =>
     i(
       n[1],
       "click",
@@ -61,6 +61,6 @@ const m = t(2, (n, o) => u(n[0], o)),
     ),
   ),
   k = t(3, (n, o) => {
-    e(n[0], "hidden", !o), r(n, a);
+    e(n[0], "hidden", !o), r(n, v);
   });
-f();
+d();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.hydrate.js
@@ -1,30 +1,30 @@
-// size: 313 (min) 192 (brotli)
+// size: 315 (min) 199 (brotli)
 
 import {
   register as o,
   createRenderer as n,
   on as t,
-  queueSource as c,
-  value as r,
+  queueSource as r,
+  value as c,
   queueEffect as l,
   conditional as m,
-  init as i,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const u = o("c", n("Hello!", "")),
-  e = m(0),
-  s = o("d", (o) =>
+const i = o("a1", n("Hello!", "")),
+  u = m(0),
+  e = o("a2", (o) =>
     t(
       o[1],
       "click",
       ((o) => {
         const { 2: n } = o;
         return function () {
-          c(o, a, !n);
+          r(o, s, !n);
         };
       })(o),
     ),
   ),
-  a = r(2, (o, n) => {
-    l(o, s), e(o, n ? u : null);
+  s = c(2, (o, n) => {
+    l(o, e), u(o, n ? i : null);
   });
-i();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 252 (min) 160 (brotli)
+// size: 253 (min) 160 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
-  data as r,
+  queueSource as n,
+  value as r,
+  data as c,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("c", (o) =>
+const a = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          c(o, u, t + 1);
+          n(o, s, t + 1);
         };
       })(o),
     ),
   ),
-  u = n(2, (o, t) => {
-    r(o[1], t), m(o, s);
+  s = r(2, (o, t) => {
+    c(o[1], t), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
@@ -1,31 +1,31 @@
-// size: 463 (min) 278 (brotli)
+// size: 465 (min) 291 (brotli)
 
 import {
   registerRenderer as n,
   createRenderer as o,
   value as t,
-  inConditionalScope as c,
+  inConditionalScope as a,
   register as r,
-  on as i,
-  closure as l,
-  data as m,
-  queueSource as s,
-  queueEffect as u,
-  conditional as a,
-  init as d,
+  on as c,
+  closure as i,
+  data as l,
+  queueSource as m,
+  queueEffect as s,
+  conditional as u,
+  init as e,
 } from "@marko/runtime-tags/dom";
-const e = l(3, (n, o) => m(n[0], o)),
-  p = n("c", o("<span> </span>", "D ", void 0, [e])),
-  f = a(1),
-  k = t(3, null, c(e, 1)),
-  b = r("d", (n) =>
-    i(
+const p = i(3, (n, o) => l(n[0], o)),
+  d = n("a1", o("<span> </span>", "D ", void 0, [p])),
+  f = u(1),
+  k = t(3, null, a(p, 1)),
+  b = r("a2", (n) =>
+    c(
       n[0],
       "click",
       ((n) => {
         const { 2: o } = n;
         return function () {
-          s(n, k, "bye"), s(n, g, !o);
+          m(n, k, "bye"), m(n, g, !o);
         };
       })(n),
     ),
@@ -33,8 +33,8 @@ const e = l(3, (n, o) => m(n[0], o)),
   g = t(
     2,
     (n, o) => {
-      u(n, b), f(n, o ? p : null);
+      s(n, b), f(n, o ? d : null);
     },
     f,
   );
-d();
+e();

--- a/packages/translator-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 328 (min) 196 (brotli)
+// size: 329 (min) 201 (brotli)
 
 import {
   register as n,
@@ -10,7 +10,7 @@ import {
   queueEffect as m,
   init as u,
 } from "@marko/runtime-tags/dom";
-const i = n("c", (n) =>
+const i = n("a1", (n) =>
     o(
       n[0],
       "click",

--- a/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.hydrate.js
@@ -1,55 +1,55 @@
-// size: 647 (min) 348 (brotli)
+// size: 651 (min) 366 (brotli)
 
 import {
   register as o,
   attrsEvents as r,
   value as n,
-  attrs as d,
-  queueEffect as e,
-  conditional as t,
-  queueSource as c,
-  registerSubscriber as i,
-  dynamicClosure as m,
-  data as f,
-  registerRenderer as s,
-  createRenderer as u,
-  bindRenderer as a,
-  intersections as k,
-  inChild as y,
-  dynamicSubscribers as B,
-  init as g,
+  attrs as t,
+  queueEffect as d,
+  conditional as e,
+  queueSource as i,
+  registerSubscriber as m,
+  dynamicClosure as c,
+  data as a,
+  registerRenderer as b,
+  createRenderer as s,
+  bindRenderer as u,
+  intersections as f,
+  inChild as k,
+  dynamicSubscribers as y,
+  init as B,
 } from "@marko/runtime-tags/dom";
-const l = t(1),
-  p = o("f", (o) => r(o, 0)),
-  v = n(4, (o, r) => l(o, r), l),
-  C = n(
+const g = e(1),
+  l = o("a0", (o) => r(o, 0)),
+  p = n(4, (o, r) => g(o, r), g),
+  v = n(
     3,
     (o, r) => {
       ((o, r) => {
-        d(o, 0, r), e(o, p);
+        t(o, 0, r), d(o, l);
       })(o, r),
-        v(o, r.renderBody);
+        p(o, r.renderBody);
     },
-    v,
+    p,
   ),
-  b = o("c", (o) => {
+  C = o("b0", (o) => {
     const { 1: r } = o;
     return function () {
-      c(o, j, r + 1);
+      i(o, j, r + 1);
     };
   }),
-  h = s(
-    "e",
-    u(" ", " ", void 0, [
-      i(
-        "d",
-        m(1, (o, r) => f(o[0], r)),
+  h = b(
+    "b2",
+    s(" ", " ", void 0, [
+      m(
+        "b1",
+        c(1, (o, r) => a(o[0], r)),
       ),
     ]),
   ),
   j = n(
     1,
-    (o, r) => C(o[0], { onClick: b(o), renderBody: a(o, h) }),
-    k([y(0, C), B(1)]),
+    (o, r) => v(o[0], { onClick: C(o), renderBody: u(o, h) }),
+    f([k(0, v), y(1)]),
   );
-g();
+B();

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 345 (min) 213 (brotli)
+// size: 346 (min) 213 (brotli)
 
 import {
   value as n,
@@ -16,22 +16,22 @@ const l = o(2, (n) => {
     t(n[0], o);
   }),
   a = n(3, null, l),
-  d = c("d", (n) =>
+  e = c("b1", (n) =>
     r(
       n[1],
       "click",
       ((n) => {
         const { 2: o } = n;
         return function () {
-          s(n, e, o + 1);
+          s(n, f, o + 1);
         };
       })(n),
     ),
   ),
-  e = n(
+  f = n(
     2,
     (n, o) => {
-      m(n, d), a(n[0], o);
+      m(n, e), a(n[0], o);
     },
     i(0, a),
   );

--- a/packages/translator-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 339 (min) 191 (brotli)
+// size: 340 (min) 193 (brotli)
 
 import {
   register as c,
@@ -9,19 +9,19 @@ import {
   intersection as m,
   init as r,
 } from "@marko/runtime-tags/dom";
-const f = m(2, (c) => {
+const a = m(2, (c) => {
     const { 5: o, 6: n } = c;
     i(c[4], o + n);
   }),
-  k = t(6, (c, o) => i(c[3], o), f),
-  s = t(5, (c, o) => i(c[1], o), f);
-c("d", (c) => {
+  f = t(6, (c, o) => i(c[3], o), a),
+  k = t(5, (c, o) => i(c[1], o), a);
+c("a2", (c) => {
   o(
     c[0],
     "click",
     ((c) =>
       function () {
-        n(c, s, 10);
+        n(c, k, 10);
       })(c),
   ),
     o(
@@ -29,7 +29,7 @@ c("d", (c) => {
       "click",
       ((c) =>
         function () {
-          n(c, k, 5);
+          n(c, f, 5);
         })(c),
     );
 }),

--- a/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 191 (min) 137 (brotli)
+// size: 192 (min) 138 (brotli)
 
 import {
   register as o,
@@ -8,7 +8,7 @@ import {
 } from "@marko/runtime-tags/dom";
 const r = m(2, (o, i) => d(o[0], i));
 o(
-  "b",
+  "a0",
   i(
     "<!>, ",
     "%",

--- a/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 345 (min) 195 (brotli)
+// size: 347 (min) 194 (brotli)
 
 import {
   register as o,
@@ -8,7 +8,7 @@ import {
 } from "@marko/runtime-tags/dom";
 const m = d(2, (o, i) => v(o[0], i));
 o(
-  "b",
+  "a0",
   i(
     "<p> </p>",
     "D ",
@@ -21,7 +21,7 @@ o(
 const p = d(4, (o, i) => v(o[1], i)),
   t = d(3, (o, i) => v(o[0], i));
 o(
-  "c",
+  "a1",
   i(
     "<p><!>: <!></p>",
     "D%c%",

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 111 (min) 80 (brotli)
+// size: 112 (min) 89 (brotli)
 
 import { register as o, createRenderer as t } from "@marko/runtime-tags/dom";
-o("c", t("This is the body content", ""));
+o("b0", t("This is the body content", ""));

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 114 (min) 91 (brotli)
+// size: 115 (min) 104 (brotli)
 
 import {
   registerBoundSignal as m,
@@ -6,6 +6,6 @@ import {
   data as r,
 } from "@marko/runtime-tags/dom";
 m(
-  "c",
+  "b0",
   o(2, (m, o) => r(m[1], o)),
 );

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 114 (min) 91 (brotli)
+// size: 115 (min) 104 (brotli)
 
 import {
   registerBoundSignal as m,
@@ -6,6 +6,6 @@ import {
   data as r,
 } from "@marko/runtime-tags/dom";
 m(
-  "c",
+  "b0",
   o(2, (m, o) => r(m[1], o)),
 );

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 335 (min) 198 (brotli)
+// size: 337 (min) 199 (brotli)
 
 import {
   register as o,
@@ -8,30 +8,30 @@ import {
   data as c,
   queueEffect as m,
   tagVarSignal as i,
-  registerBoundSignal as e,
+  registerBoundSignal as a,
   init as s,
 } from "@marko/runtime-tags/dom";
-const u = o("e", (o) =>
+const u = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          n(o, a, t + 1);
+          n(o, e, t + 1);
         };
       })(o),
     ),
   ),
-  a = r(
+  e = r(
     2,
     (o, t) => {
       c(o[1], t), m(o, u), i(o, t);
     },
     i,
   );
-e(
-  "d",
+a(
+  "b0",
   r(2, (o, t) => c(o[1], t)),
 ),
   s();

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.hydrate.js
@@ -1,28 +1,28 @@
-// size: 315 (min) 197 (brotli)
+// size: 316 (min) 197 (brotli)
 
 import {
   register as o,
   on as r,
   queueSource as t,
   value as n,
-  data as c,
-  queueEffect as i,
+  data as i,
+  queueEffect as c,
   init as m,
 } from "@marko/runtime-tags/dom";
-const f = n(4, (o, r) => c(o[0], JSON.stringify(r))),
-  s = o("c", (o) =>
+const a = n(4, (o, r) => i(o[0], JSON.stringify(r))),
+  f = o("a1", (o) =>
     r(
       o[1],
       "click",
       ((o) => {
         const { 3: r } = o;
         return function () {
-          t(o, a, r + 1);
+          t(o, s, r + 1);
         };
       })(o),
     ),
   ),
-  a = n(3, (o, r) => {
-    c(o[2], r), i(o, s), f(o, { foo: 1, bar: r + 1 });
+  s = n(3, (o, r) => {
+    i(o[2], r), c(o, f), a(o, { foo: 1, bar: r + 1 });
   });
 m();

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 481 (min) 290 (brotli)
+// size: 483 (min) 285 (brotli)
 
 import {
   register as o,
@@ -6,40 +6,40 @@ import {
   createRenderer as n,
   dynamicTagAttrs as i,
   queueSource as c,
-  value as d,
-  data as m,
-  queueEffect as r,
-  init as u,
+  value as m,
+  data as r,
+  queueEffect as a,
+  init as d,
 } from "@marko/runtime-tags/dom";
-const e = o("c", (o) =>
+const u = o("a1", (o) =>
     t(
       o[2],
       "click",
       ((o) => {
         const { 7: t } = o;
         return function () {
-          c(o, l, t + 1);
+          c(o, e, t + 1);
         };
       })(o),
     ),
   ),
-  l = d(7, (o, t) => {
-    m(o[1], t), m(o[3], t), r(o, e);
+  e = m(7, (o, t) => {
+    r(o[1], t), r(o[3], t), a(o, u);
   }),
-  v = d(6, (o, t) => m(o[0], t)),
-  a = d(5, (o, t) => v(o, t.name));
+  l = m(6, (o, t) => r(o[0], t)),
+  v = m(5, (o, t) => l(o, t.name));
 o(
-  "d",
+  "a2",
   n(
     "<div>Hello <!> <!></div><button> </button>",
     "Db%c%l D ",
     (o) => {
-      l(o, 1);
+      e(o, 1);
     },
     void 0,
     void 0,
-    d(4, (o, t) => a(o, t[0])),
+    m(4, (o, t) => v(o, t[0])),
   ),
 ),
   i(0),
-  u();
+  d();

--- a/packages/translator-tags/src/__tests__/fixtures/do-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/do-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 198 (min) 136 (brotli)
+// size: 199 (min) 148 (brotli)
 
 import {
   register as o,
@@ -8,5 +8,5 @@ import {
   init as i,
 } from "@marko/runtime-tags/dom";
 import s from "./test-log";
-const e = m(3, (o, t) => r(o[0], t));
-o("e", (o) => t(o, e, JSON.stringify(s))), i();
+const a = m(3, (o, t) => r(o[0], t));
+o("a3", (o) => t(o, a, JSON.stringify(s))), i();

--- a/packages/translator-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.hydrate.js
@@ -1,36 +1,36 @@
-// size: 360 (min) 225 (brotli)
+// size: 362 (min) 222 (brotli)
 
 import {
   register as n,
   createRenderer as o,
-  on as t,
-  data as c,
+  on as a,
+  data as t,
   queueSource as r,
-  value as a,
+  value as c,
   queueEffect as l,
   conditional as m,
   init as s,
 } from "@marko/runtime-tags/dom";
 const i = n(
-    "c",
+    "a1",
     o("<span> </span>", "D ", (n) => {
-      c(n[0], n.$global.x);
+      t(n[0], n.$global.x);
     }),
   ),
   u = m(0),
-  p = n("d", (n) =>
-    t(
+  p = n("a2", (n) =>
+    a(
       n[1],
       "click",
       ((n) => {
         const { 2: o } = n;
         return function () {
-          r(n, d, !o);
+          r(n, e, !o);
         };
       })(n),
     ),
   ),
-  d = a(2, (n, o) => {
+  e = c(2, (n, o) => {
     l(n, p), u(n, o ? i : null);
   });
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 464 (min) 247 (brotli)
+// size: 468 (min) 247 (brotli)
 
 import {
   registerSubscriber as c,
@@ -6,15 +6,15 @@ import {
   data as n,
   registerRenderer as t,
   createRenderer as m,
-  value as i,
-  dynamicSubscribers as r,
-  register as f,
+  value as b,
+  dynamicSubscribers as i,
+  register as r,
   on as l,
   queueSource as s,
   init as u,
 } from "@marko/runtime-tags/dom";
 c(
-  "d",
+  "b1",
   o(
     4,
     (c, o) => n(c[2], o),
@@ -22,11 +22,11 @@ c(
   ),
 );
 const a = c(
-  "e",
+  "b2",
   o(4, (c, o) => n(c[2], o)),
 );
 t(
-  "f",
+  "b3",
   m(
     "<!> <!> <!>",
     "%c%c%",
@@ -36,15 +36,15 @@ t(
     [o(3, (c, o) => n(c[1], o)), a],
   ),
 );
-const d = i(4, null, r(4));
-r(3);
-f("g", (c) =>
+const f = b(4, null, i(4));
+i(3);
+r("b4", (c) =>
   l(
     c[0],
     "click",
     ((c) =>
       function () {
-        s(c, d, 4);
+        s(c, f, 4);
       })(c),
   ),
 ),

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.hydrate.js
@@ -1,29 +1,29 @@
-// size: 266 (min) 171 (brotli)
+// size: 267 (min) 171 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as r,
+  queueSource as r,
+  value as c,
   data as m,
   queueEffect as n,
   init as s,
 } from "@marko/runtime-tags/dom";
-const i = o("c", (o) => {
-    const { 2: r } = o;
+const a = o("a1", (o) => {
+    const { 2: c } = o;
     t(
       o[0],
       "click",
-      r <= 1 &&
+      c <= 1 &&
         ((o) => {
           const { 2: t } = o;
           return () => {
-            c(o, a, t + 1);
+            r(o, i, t + 1);
           };
         })(o),
     );
   }),
-  a = r(2, (o, t) => {
-    m(o[1], t), n(o, i);
+  i = c(2, (o, t) => {
+    m(o[1], t), n(o, a);
   });
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 439 (min) 273 (brotli)
+// size: 441 (min) 261 (brotli)
 
 import {
   register as n,
@@ -6,23 +6,23 @@ import {
   dynamicTagAttrs as t,
   on as c,
   queueSource as s,
-  value as r,
-  queueEffect as a,
+  value as a,
+  queueEffect as r,
   conditional as i,
   intersection as m,
-  init as d,
+  init as l,
 } from "@marko/runtime-tags/dom";
-const l = n("c", o("body content", "")),
-  u = t(0, l),
+const u = n("a1", o("body content", "")),
+  d = t(0, u),
   e = i(
     0,
     null,
     m(2, (n) => {
       const { 3: o } = n;
-      u(n, () => ({ class: o }));
+      d(n, () => ({ class: o }));
     }),
   ),
-  p = n("d", (n) =>
+  p = n("a2", (n) =>
     c(
       n[1],
       "click",
@@ -34,11 +34,11 @@ const l = n("c", o("body content", "")),
       })(n),
     ),
   ),
-  f = r(
+  f = a(
     2,
     (n, o) => {
-      a(n, p), e(n, o || l);
+      r(n, p), e(n, o || u);
     },
     e,
   );
-d();
+l();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 269 (min) 179 (brotli)
+// size: 270 (min) 180 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
-  classAttr as r,
+  queueSource as n,
+  value as r,
+  classAttr as c,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("c", (o) =>
+const a = o("a1", (o) =>
     t(
       o[1],
       "click",
       ((o) => {
         const { 2: t } = o;
         return function () {
-          c(o, u, "A" === t ? "B" : "A");
+          n(o, s, "A" === t ? "B" : "A");
         };
       })(o),
     ),
   ),
-  u = n(2, (o, t) => {
-    r(o[0], t), m(o, s);
+  s = r(2, (o, t) => {
+    c(o[0], t), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.hydrate.js
@@ -1,50 +1,50 @@
-// size: 545 (min) 332 (brotli)
+// size: 546 (min) 321 (brotli)
 
 import {
   createTemplate as i,
-  createRenderer as d,
-  value as o,
+  createRenderer as o,
+  value as d,
   data as n,
-  dynamicTagAttrs as c,
-  register as t,
+  dynamicTagAttrs as t,
+  register as c,
   on as r,
   queueSource as m,
   queueEffect as v,
-  conditional as s,
-  init as a,
+  conditional as a,
+  init as s,
 } from "@marko/runtime-tags/dom";
-const u = o(3, (i, d) => n(i[0], d)),
-  f = o(2, (i, d) => u(i, d.id));
-var e = i(
-  d(
+const u = d(3, (i, o) => n(i[0], o)),
+  f = d(2, (i, o) => u(i, o.id));
+var b = i(
+  o(
     "<div>Id is <!></div>",
     "Db%l",
     function () {},
     void 0,
     void 0,
-    o(1, (i, d) => f(i, d[0])),
+    d(1, (i, o) => f(i, o[0])),
   ),
-  "d",
+  "a",
 );
-const k = c(1),
-  l = s(1, (i) => k(i, () => ({ id: "dynamic" })), k),
-  b = t("c", (i) =>
+const e = t(1),
+  k = a(1, (i) => e(i, () => ({ id: "dynamic" })), e),
+  l = c("b1", (i) =>
     r(
       i[0],
       "click",
       ((i) => {
-        const { 2: d } = i;
+        const { 2: o } = i;
         return function () {
-          m(i, g, d === e ? "div" : e);
+          m(i, g, o === b ? "div" : b);
         };
       })(i),
     ),
   ),
-  g = o(
+  g = d(
     2,
-    (i, d) => {
-      v(i, b), l(i, d);
+    (i, o) => {
+      v(i, l), k(i, o);
     },
-    l,
+    k,
   );
-a();
+s();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
@@ -1,15 +1,15 @@
-// size: 752 (min) 369 (brotli)
+// size: 753 (min) 345 (brotli)
 
 import {
   createTemplate as i,
   createRenderer as o,
   value as n,
   data as v,
-  dynamicTagAttrs as d,
-  register as t,
-  on as c,
-  queueSource as l,
-  queueEffect as a,
+  dynamicTagAttrs as t,
+  register as c,
+  on as d,
+  queueSource as a,
+  queueEffect as l,
   conditional as u,
   intersection as r,
   init as s,
@@ -25,7 +25,7 @@ var f = i(
     void 0,
     n(1, (i, o) => m(i, o[0])),
   ),
-  "d",
+  "a",
 );
 const h = n(3, (i, o) => v(i[0], o)),
   b = n(2, (i, o) => h(i, o.value));
@@ -38,9 +38,9 @@ var k = i(
     void 0,
     n(1, (i, o) => b(i, o[0])),
   ),
-  "e",
+  "b",
 );
-const C = d(0),
+const C = t(0),
   D = u(
     0,
     null,
@@ -49,14 +49,14 @@ const C = d(0),
       C(i, () => ({ value: o }));
     }),
   ),
-  g = t("c", (i) =>
-    c(
+  g = c("c1", (i) =>
+    d(
       i[1],
       "click",
       ((i) => {
         const { 2: o } = i;
         return function () {
-          l(i, p, o === f ? k : f);
+          a(i, p, o === f ? k : f);
         };
       })(i),
     ),
@@ -64,7 +64,7 @@ const C = d(0),
   p = n(
     2,
     (i, o) => {
-      a(i, g), D(i, o);
+      l(i, g), D(i, o);
     },
     D,
   );

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 380 (min) 239 (brotli)
+// size: 382 (min) 234 (brotli)
 
 import {
   register as n,
   createRenderer as o,
   dynamicTagAttrs as t,
-  on as c,
-  queueSource as r,
+  on as r,
+  queueSource as c,
   value as i,
   queueEffect as m,
-  conditional as d,
+  conditional as a,
   init as u,
 } from "@marko/runtime-tags/dom";
-const e = n("c", o("Body Content", "")),
-  l = t(0, e),
-  s = d(0, (n) => l(n, () => ({})), l),
-  a = n("d", (n) =>
-    c(
+const d = n("a1", o("Body Content", "")),
+  e = t(0, d),
+  l = a(0, (n) => e(n, () => ({})), e),
+  s = n("a2", (n) =>
+    r(
       n[1],
       "click",
       ((n) => {
         const { 2: o } = n;
         return function () {
-          r(n, f, o ? null : "div");
+          c(n, f, o ? null : "div");
         };
       })(n),
     ),
@@ -29,8 +29,8 @@ const e = n("c", o("Body Content", "")),
   f = i(
     2,
     (n, o) => {
-      m(n, a), s(n, o || e);
+      m(n, s), l(n, o || d);
     },
-    s,
+    l,
   );
 u();

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 569 (min) 306 (brotli)
+// size: 572 (min) 302 (brotli)
 
 import {
   register as n,
@@ -9,36 +9,36 @@ import {
   queueEffect as r,
   createRenderer as u,
   dynamicTagAttrs as s,
-  conditional as m,
-  init as a,
+  conditional as a,
+  init as m,
 } from "@marko/runtime-tags/dom";
-const e = n("g", (n) =>
+const b = n("a1", (n) =>
     t(
       n[0],
       "click",
       ((n) => {
         const { 2: t } = n;
         return function () {
-          o(n, f, t + 1);
+          o(n, d, t + 1);
         };
       })(n),
     ),
   ),
-  f = c(2, (n, t) => {
-    i(n[1], t), r(n, e);
+  d = c(2, (n, t) => {
+    i(n[1], t), r(n, b);
   }),
-  d = (n) => {
-    f(n, 0);
+  e = (n) => {
+    d(n, 0);
   },
-  k = n(
-    "e",
+  f = n(
+    "b1",
     u("<button id=count> </button>", "/ D l&", (n) => {
-      d(n[0]);
+      e(n[0]);
     }),
   ),
-  l = s(0, k),
-  p = m(0, (n) => l(n, () => ({})), l),
-  b = n("f", (n) =>
+  k = s(0, f),
+  l = a(0, (n) => k(n, () => ({})), k),
+  p = n("b2", (n) =>
     t(
       n[1],
       "click",
@@ -53,8 +53,8 @@ const e = n("g", (n) =>
   g = c(
     2,
     (n, t) => {
-      r(n, b), p(n, t || k);
+      r(n, p), l(n, t || f);
     },
-    p,
+    l,
   );
-a();
+m();

--- a/packages/translator-tags/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 293 (min) 169 (brotli)
+// size: 294 (min) 170 (brotli)
 
 import {
   register as t,
@@ -8,7 +8,7 @@ import {
   queueEffect as c,
   init as m,
 } from "@marko/runtime-tags/dom";
-const r = t("d", (t) => {
+const r = t("a2", (t) => {
     const { 1: e } = t;
     (document.getElementById("button").textContent = e),
       n(

--- a/packages/translator-tags/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 137 (min) 96 (brotli)
+// size: 138 (min) 96 (brotli)
 
 import { register as t, init as e } from "@marko/runtime-tags/dom";
-t("c", (t) => {
+t("a1", (t) => {
   const { 0: e } = t;
   document.getElementById("ref").textContent = e;
 }),

--- a/packages/translator-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 613 (min) 312 (brotli)
+// size: 615 (min) 307 (brotli)
 
 import {
   register as i,
@@ -7,19 +7,19 @@ import {
   value as n,
   queueSource as o,
   queueEffect as r,
-  loopOf as e,
-  data as d,
-  init as a,
+  loopOf as a,
+  data as e,
+  init as d,
 } from "@marko/runtime-tags/dom";
-const s = n(5, (i, c) => d(i[1], c)),
-  m = n(4, (i, c) => d(i[0], c)),
+const s = n(5, (i, c) => e(i[1], c)),
+  m = n(4, (i, c) => e(i[0], c)),
   v = n(3, (i, c) => {
     m(i, c.name), s(i, c.description);
   }),
-  u = e(
+  u = a(
     0,
     i(
-      "d",
+      "a2",
       c(
         "<div><!>: <!></div>",
         "D%c%",
@@ -30,7 +30,7 @@ const s = n(5, (i, c) => d(i[1], c)),
       ),
     ),
   ),
-  p = i("e", (i) => {
+  p = i("a3", (i) => {
     t(
       i[1],
       "click",
@@ -58,4 +58,4 @@ const s = n(5, (i, c) => d(i[1], c)),
   f = n(3, (i, c) => {
     r(i, p), u(i, [c]);
   });
-a();
+d();

--- a/packages/translator-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,23 +1,23 @@
-// size: 508 (min) 300 (brotli)
+// size: 510 (min) 307 (brotli)
 
 import {
   register as o,
   on as t,
   registerRenderer as n,
-  createRenderer as c,
-  value as i,
-  intersections as r,
+  createRenderer as i,
+  value as r,
+  intersections as c,
   inLoopScope as m,
   queueSource as u,
-  closure as d,
-  queueEffect as s,
-  loopTo as a,
+  closure as a,
+  queueEffect as d,
+  loopTo as s,
   data as b,
   init as e,
 } from "@marko/runtime-tags/dom";
-const f = i(3, (o, t) => b(o[1], t)),
-  k = i(2, (o, t) => f(o, t[0])),
-  v = o("c", (o) =>
+const f = r(3, (o, t) => b(o[1], t)),
+  k = r(2, (o, t) => f(o, t[0])),
+  v = o("a1", (o) =>
     t(
       o[0],
       "click",
@@ -31,7 +31,7 @@ const f = i(3, (o, t) => b(o[1], t)),
       })(o),
     ),
   ),
-  _ = d(1, (o, t) => s(o, v)),
-  g = a(0, n("d", c("<button> </button>", " D ", void 0, [_], void 0, k))),
-  l = i(1, (o, t) => g(o, [t, 0, 1]), r([g, m(_, 0)]));
+  _ = a(1, (o, t) => d(o, v)),
+  g = s(0, n("a2", i("<button> </button>", " D ", void 0, [_], void 0, k))),
+  l = r(1, (o, t) => g(o, [t, 0, 1]), c([g, m(_, 0)]));
 e();

--- a/packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 246 (min) 163 (brotli)
+// size: 247 (min) 165 (brotli)
 
 import {
   register as o,
@@ -9,7 +9,7 @@ import {
 const v = d(4, (o, i) => m(o[0], i)),
   r = d(3, (o, i) => m(o[1], i));
 o(
-  "b",
+  "a0",
   i(
     "<div><!>: <!></div>",
     "D%c%",

--- a/packages/translator-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,27 +1,27 @@
-// size: 283 (min) 185 (brotli)
+// size: 284 (min) 184 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
-  data as r,
+  queueSource as n,
+  value as r,
+  data as c,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = o("c", (o) =>
+const a = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 3: t } = o;
         return function () {
-          c(o, u, t + 1);
+          n(o, s, t + 1);
         };
       })(o),
     ),
   ),
-  u = n(3, (o, t) => {
-    r(o[1], t), r(o[2], `${t} + ${t} = ${t + t}`), m(o, s);
+  s = r(3, (o, t) => {
+    c(o[1], t), c(o[2], `${t} + ${t} = ${t + t}`), m(o, a);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/template.hydrate.js
@@ -1,22 +1,22 @@
-// size: 285 (min) 170 (brotli)
+// size: 288 (min) 180 (brotli)
 
 import {
   register as m,
   queueSource as t,
-  value as e,
-  tagVarSignal as a,
+  value as a,
+  tagVarSignal as e,
   registerBoundSignal as o,
   data as r,
   init as n,
 } from "@marko/runtime-tags/dom";
-const d = e(1, (m, t) => a(m, t), a);
-m("f", (m) => t(m, d, m[0].parentElement.tagName)),
+const b = a(1, (m, t) => e(m, t), e);
+m("a1", (m) => t(m, b, m[0].parentElement.tagName)),
   o(
-    "d",
-    e(5, (m, t) => r(m[3], t)),
+    "b0",
+    a(5, (m, t) => r(m[3], t)),
   ),
   o(
-    "e",
-    e(4, (m, t) => r(m[1], t)),
+    "b1",
+    a(4, (m, t) => r(m[1], t)),
   ),
   n();

--- a/packages/translator-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.hydrate.js
@@ -1,30 +1,30 @@
-// size: 309 (min) 191 (brotli)
+// size: 311 (min) 198 (brotli)
 
 import {
   register as n,
   createRenderer as o,
   on as t,
-  queueSource as c,
-  value as r,
+  queueSource as r,
+  value as c,
   queueEffect as i,
   conditional as m,
-  init as u,
+  init as a,
 } from "@marko/runtime-tags/dom";
-const l = n("c", o("hi", "")),
-  s = m(1),
-  a = n("d", (n) =>
+const u = n("a1", o("hi", "")),
+  l = m(1),
+  s = n("a2", (n) =>
     t(
       n[0],
       "click",
       ((n) => {
         const { 2: o } = n;
         return function () {
-          c(n, d, !o);
+          r(n, e, !o);
         };
       })(n),
     ),
   ),
-  d = r(2, (n, o) => {
-    i(n, a), s(n, o ? l : null);
+  e = c(2, (n, o) => {
+    i(n, s), l(n, o ? u : null);
   });
-u();
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 164 (min) 93 (brotli)
+// size: 169 (min) 95 (brotli)
 
-import { register as o, createRenderer as m } from "@marko/runtime-tags/dom";
-o("b", m("C", "")),
-  o("c", m("B", "")),
-  o("d", m("A", "")),
-  o("e", m("World", "")),
-  o("f", m("Hello", ""));
+import { register as a, createRenderer as o } from "@marko/runtime-tags/dom";
+a("a0", o("C", "")),
+  a("a1", o("B", "")),
+  a("a2", o("A", "")),
+  a("a3", o("World", "")),
+  a("a4", o("Hello", ""));

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.hydrate.js
@@ -1,26 +1,26 @@
-// size: 269 (min) 178 (brotli)
+// size: 270 (min) 179 (brotli)
 
 import {
   register as o,
   on as r,
   initValue as t,
-  queueSource as c,
-  value as m,
+  queueSource as m,
+  value as c,
   data as n,
-  queueEffect as i,
-  init as s,
+  queueEffect as a,
+  init as i,
 } from "@marko/runtime-tags/dom";
-const a = o("c", (o) =>
+const s = o("a1", (o) =>
     r(
       o[0],
       "click",
       ((o) => {
         const { 6: r } = o;
-        return () => (c(o, e, r + 1), r);
+        return () => (m(o, e, r + 1), r);
       })(o),
     ),
   ),
-  e = m(6, (o, r) => {
-    n(o[2], r), i(o, a);
+  e = c(6, (o, r) => {
+    n(o[2], r), a(o, s);
   });
-t(6, e), s();
+t(6, e), i();

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.hydrate.js
@@ -1,19 +1,19 @@
-// size: 234 (min) 155 (brotli)
+// size: 235 (min) 156 (brotli)
 
 import {
   register as o,
   queueSource as m,
   value as t,
   data as r,
-  queueEffect as c,
+  queueEffect as a,
   init as n,
 } from "@marko/runtime-tags/dom";
 const s = t(3, (o, m) => r(o[1], m)),
-  a = o("c", (o) => {
+  c = o("a1", (o) => {
     const { 2: t } = o;
     m(o, s, t), m(o, i, 2);
   }),
   i = t(2, (o, m) => {
-    r(o[0], m), c(o, a);
+    r(o[0], m), a(o, c);
   });
 n();

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,24 +1,24 @@
-// size: 433 (min) 244 (brotli)
+// size: 434 (min) 244 (brotli)
 
 import {
   register as o,
   on as t,
-  value as c,
-  data as r,
+  value as r,
+  data as c,
   queueEffect as m,
   intersections as n,
   queueSource as s,
-  intersection as i,
-  init as a,
+  intersection as a,
+  init as i,
 } from "@marko/runtime-tags/dom";
-const e = i(2, (o) => {
-    const { 6: t, 7: c } = o;
-    k(o, t + c);
+const e = a(2, (o) => {
+    const { 6: t, 7: r } = o;
+    k(o, t + r);
   }),
-  k = c(8, (o, t) => r(o[4], t)),
-  u = c(7, (o, t) => r(o[3], t), e),
-  d = c(6, (o, t) => r(o[2], t), e),
-  f = o("c", (o) =>
+  k = r(8, (o, t) => c(o[4], t)),
+  u = r(7, (o, t) => c(o[3], t), e),
+  d = r(6, (o, t) => c(o[2], t), e),
+  f = o("a1", (o) =>
     t(
       o[0],
       "click",
@@ -28,11 +28,11 @@ const e = i(2, (o) => {
       })(o),
     ),
   ),
-  g = c(
+  g = r(
     5,
     (o, t) => {
-      r(o[1], t), m(o, f), d(o, t + 1), u(o, t + 2);
+      c(o[1], t), m(o, f), d(o, t + 1), u(o, t + 2);
     },
     n([d, u]),
   );
-a();
+i();

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,28 +1,28 @@
-// size: 314 (min) 199 (brotli)
+// size: 315 (min) 201 (brotli)
 
 import {
   register as o,
   on as r,
   queueSource as t,
-  value as c,
-  data as m,
+  value as m,
+  data as c,
   intersection as n,
-  queueEffect as i,
-  init as s,
+  queueEffect as a,
+  init as i,
 } from "@marko/runtime-tags/dom";
-const a = o("c", (o) =>
+const s = o("a1", (o) =>
     r(
       o[0],
       "click",
       ((o) => {
-        const { 3: r, 4: c } = o;
-        return () => t(o, u, t(o, k, r + c));
+        const { 3: r, 4: m } = o;
+        return () => t(o, u, t(o, k, r + m));
       })(o),
     ),
   ),
   e = n(2, (o) => {
-    i(o, a);
+    a(o, s);
   }),
-  k = c(4, (o, r) => m(o[2], r), e),
-  u = c(3, (o, r) => m(o[1], r), e);
-s();
+  k = m(4, (o, r) => c(o[2], r), e),
+  u = m(3, (o, r) => c(o[1], r), e);
+i();

--- a/packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 168 (min) 117 (brotli)
+// size: 169 (min) 117 (brotli)
 
 import {
   register as m,
@@ -7,5 +7,5 @@ import {
   data as n,
   init as r,
 } from "@marko/runtime-tags/dom";
-const i = t(1, (m, o) => n(m[0], o));
-m("c", (m) => o(m, i, "Client Only")), r();
+const a = t(1, (m, o) => n(m[0], o));
+m("a1", (m) => o(m, a, "Client Only")), r();

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.hydrate.js
@@ -1,30 +1,30 @@
-// size: 465 (min) 230 (brotli)
+// size: 468 (min) 231 (brotli)
 
 import {
   register as t,
   queueSource as n,
   value as o,
-  data as c,
-  lifecycle as r,
+  data as r,
+  lifecycle as c,
   on as u,
   queueEffect as i,
   init as s,
 } from "@marko/runtime-tags/dom";
-const e = t("b", (t) => {
+const a = t("a0", (t) => {
     const { 3: n } = t;
     return function () {
       this.cur = n;
     };
   }),
-  m = t("c", (t) => {
+  e = t("a1", (t) => {
     const { 3: o } = t;
     return function () {
-      n(t, f, this.cur), (this.cur = o);
+      n(t, m, this.cur), (this.cur = o);
     };
   }),
-  f = o(4, (t, n) => c(t[1], n)),
-  a = t("e", (t) => {
-    r(t, 4, { onMount: e(t), onUpdate: m(t) }),
+  m = o(4, (t, n) => r(t[1], n)),
+  f = t("a3", (t) => {
+    c(t, 4, { onMount: a(t), onUpdate: e(t) }),
       u(
         t[2],
         "click",
@@ -37,6 +37,6 @@ const e = t("b", (t) => {
       );
   }),
   h = o(3, (t, n) => {
-    c(t[0], n), i(t, a);
+    r(t[0], n), i(t, f);
   });
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 453 (min) 237 (brotli)
+// size: 456 (min) 240 (brotli)
 
 import {
   register as t,
@@ -10,31 +10,31 @@ import {
   init as u,
 } from "@marko/runtime-tags/dom";
 const i = t(
-    "b",
+    "a0",
     (t) =>
       function () {
         this.onUpdate();
       },
   ),
-  s = t("c", (t) => {
+  a = t("a1", (t) => {
     const { 1: n } = t;
     return function () {
       (document.getElementById("ref").textContent = `x=${n}, was=${this.cur}`),
         (this.cur = n);
     };
   }),
-  m = t("e", (t) => {
-    n(t, 3, { onMount: i(t), onUpdate: s(t) }),
+  s = t("a3", (t) => {
+    n(t, 3, { onMount: i(t), onUpdate: a(t) }),
       o(
         t[0],
         "click",
         ((t) => {
           const { 1: n } = t;
           return function () {
-            e(t, a, n + 1);
+            e(t, m, n + 1);
           };
         })(t),
       );
   }),
-  a = c(1, (t, n) => r(t, m));
+  m = c(1, (t, n) => r(t, s));
 u();

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,38 +1,38 @@
-// size: 488 (min) 216 (brotli)
+// size: 491 (min) 216 (brotli)
 
 import {
   register as t,
   lifecycle as n,
   on as e,
   queueSource as o,
-  value as c,
-  queueEffect as r,
+  value as r,
+  queueEffect as c,
   init as u,
 } from "@marko/runtime-tags/dom";
-const m = t("b", (t) => {
+const m = t("a0", (t) => {
     const { 1: n } = t;
     return function () {
       document.getElementById("ref").textContent = "Mount " + n;
     };
   }),
-  d = t("c", (t) => {
+  a = t("a1", (t) => {
     const { 1: n } = t;
     return function () {
       document.getElementById("ref").textContent = "Update " + n;
     };
   }),
-  f = t("e", (t) => {
-    n(t, 3, { onMount: m(t), onUpdate: d(t) }),
+  d = t("a3", (t) => {
+    n(t, 3, { onMount: m(t), onUpdate: a(t) }),
       e(
         t[0],
         "click",
         ((t) => {
           const { 1: n } = t;
           return function () {
-            o(t, i, n + 1);
+            o(t, f, n + 1);
           };
         })(t),
       );
   }),
-  i = c(1, (t, n) => r(t, f));
+  f = r(1, (t, n) => c(t, d));
 u();

--- a/packages/translator-tags/src/__tests__/fixtures/log-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/log-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 198 (min) 137 (brotli)
+// size: 199 (min) 148 (brotli)
 
 import {
   register as o,
@@ -8,5 +8,5 @@ import {
   init as i,
 } from "@marko/runtime-tags/dom";
 import s from "./test-log";
-const f = m(2, (o, t) => r(o[0], t));
-o("c", (o) => t(o, f, JSON.stringify(s))), i();
+const a = m(2, (o, t) => r(o[0], t));
+o("a1", (o) => t(o, a, JSON.stringify(s))), i();

--- a/packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 192 (min) 129 (brotli)
+// size: 193 (min) 130 (brotli)
 
 import {
   register as o,
@@ -8,7 +8,7 @@ import {
 } from "@marko/runtime-tags/dom";
 const d = i(2, (o, t) => m(o[0], t.text));
 o(
-  "c",
+  "a1",
   t(
     " ",
     " ",

--- a/packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 192 (min) 129 (brotli)
+// size: 193 (min) 130 (brotli)
 
 import {
   register as o,
@@ -8,7 +8,7 @@ import {
 } from "@marko/runtime-tags/dom";
 const d = i(2, (o, t) => m(o[0], t.text));
 o(
-  "c",
+  "a1",
   t(
     " ",
     " ",

--- a/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 102 (min) 81 (brotli)
+// size: 103 (min) 82 (brotli)
 
 import { register as t, init as o } from "@marko/runtime-tags/dom";
-t("c", (t) => (t[0].textContent = "hello")), o();
+t("a1", (t) => (t[0].textContent = "hello")), o();

--- a/packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.hydrate.js
@@ -1,30 +1,30 @@
-// size: 332 (min) 196 (brotli)
+// size: 333 (min) 199 (brotli)
 
 import {
   register as o,
   on as t,
-  queueSource as c,
-  value as n,
+  queueSource as n,
+  value as c,
   data as r,
   queueEffect as m,
   init as i,
 } from "@marko/runtime-tags/dom";
-const s = n(6, (o, t) => r(o[3], t)),
-  u = n(5, (o, t) => r(o[2], t)),
-  a = o("c", (o) =>
+const s = c(6, (o, t) => r(o[3], t)),
+  a = c(5, (o, t) => r(o[2], t)),
+  u = o("a1", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 4: t } = o;
         return function () {
-          const n = c(o, u, (c(o, e, t + 1), t));
-          c(o, s, n);
+          const c = n(o, a, (n(o, e, t + 1), t));
+          n(o, s, c);
         };
       })(o),
     ),
   ),
-  e = n(4, (o, t) => {
-    r(o[1], t), m(o, a);
+  e = c(4, (o, t) => {
+    r(o[1], t), m(o, u);
   });
 i();

--- a/packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 413 (min) 189 (brotli)
+// size: 414 (min) 190 (brotli)
 
 import {
   register as n,
@@ -9,7 +9,7 @@ import {
   queueEffect as i,
   init as u,
 } from "@marko/runtime-tags/dom";
-const m = n("d", (n) => {
+const m = n("a2", (n) => {
     c(
       n[0],
       "click",

--- a/packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 192 (min) 129 (brotli)
+// size: 193 (min) 130 (brotli)
 
 import {
   register as o,
@@ -8,7 +8,7 @@ import {
 } from "@marko/runtime-tags/dom";
 const d = i(2, (o, t) => m(o[0], t.text));
 o(
-  "c",
+  "a1",
   t(
     " ",
     " ",

--- a/packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,34 +1,34 @@
-// size: 332 (min) 191 (brotli)
+// size: 333 (min) 192 (brotli)
 
 import {
   register as o,
   on as t,
   queueSource as n,
   value as r,
-  queueEffect as c,
-  data as m,
-  init as a,
+  queueEffect as a,
+  data as c,
+  init as m,
 } from "@marko/runtime-tags/dom";
 const i = r(5, (o, t) => {
-    m(o[1], t),
+    c(o[1], t),
       ((o, t) => {
-        m(o[2], t);
+        c(o[2], t);
       })(o, t);
   }),
   s = r(4, (o, t) => i(o, t.a)),
-  u = o("d", (o) =>
+  u = o("a2", (o) =>
     t(
       o[0],
       "click",
       ((o) => {
         const { 3: t } = o;
         return function () {
-          n(o, d, t + 1);
+          n(o, e, t + 1);
         };
       })(o),
     ),
   ),
-  d = r(3, (o, t) => {
-    c(o, u), s(o, { a: t });
+  e = r(3, (o, t) => {
+    a(o, u), s(o, { a: t });
   });
-a();
+m();

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 483 (min) 288 (brotli)
+// size: 484 (min) 290 (brotli)
 
 import {
   register as r,
@@ -15,7 +15,7 @@ const l = o(9, (r, a) => t(r[5], JSON.stringify(a))),
   m = o(7, (r, a) => t(r[2], a)),
   b = o(6, (r, a) => t(r[1], a)),
   f = (r, a) => {};
-r("d", (r) =>
+r("a2", (r) =>
   a(
     r[0],
     "click",

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.hydrate.js
@@ -1,15 +1,15 @@
-// size: 271 (min) 181 (brotli)
+// size: 272 (min) 180 (brotli)
 
 import {
   registerRenderer as o,
-  createRenderer as m,
-  value as a,
+  createRenderer as a,
+  value as m,
   intersections as n,
   inConditionalScope as r,
   closure as s,
   data as t,
   conditional as i,
 } from "@marko/runtime-tags/dom";
-const p = s(3, (o, m) => t(o[0], m)),
-  d = (o("b", m("<span> </span>", "D ", void 0, [p])), i(0));
+const p = s(3, (o, a) => t(o[0], a)),
+  d = (o("a0", a("<span> </span>", "D ", void 0, [p])), i(0));
 n([d, r(p, 0)]);

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
@@ -1,23 +1,23 @@
-// size: 875 (min) 402 (brotli)
+// size: 881 (min) 402 (brotli)
 
 import {
   register as n,
   on as t,
   registerSubscriber as o,
   dynamicClosure as u,
-  data as i,
-  queueEffect as c,
+  data as c,
+  queueEffect as i,
   registerRenderer as l,
   createRenderer as r,
-  value as _,
-  dynamicSubscribers as d,
-  inConditionalScope as e,
+  value as a,
+  dynamicSubscribers as _,
+  inConditionalScope as d,
   queueSource as b,
-  closure as f,
+  closure as e,
   conditional as m,
   init as s,
 } from "@marko/runtime-tags/dom";
-const k = n("e", (n) =>
+const f = n("a3", (n) =>
     t(
       n[0],
       "click",
@@ -28,28 +28,28 @@ const k = n("e", (n) =>
           },
         } = n;
         return function () {
-          b(n._._, p, t + 1);
+          b(n._._, j, t + 1);
         };
       })(n),
     ),
   ),
-  v = l(
-    "g",
+  k = l(
+    "a5",
     r("<button id=count> </button>", " D ", void 0, [
       o(
-        "f",
+        "a4",
         u(
           4,
           (n, t) => {
-            i(n[1], t), c(n, k);
+            c(n[1], t), i(n, f);
           },
           (n) => n._._,
         ),
       ),
     ]),
   ),
-  a = m(1),
-  g = n("h", (n) =>
+  v = m(1),
+  D = n("a6", (n) =>
     t(
       n[0],
       "click",
@@ -63,19 +63,19 @@ const k = n("e", (n) =>
       })(n),
     ),
   ),
-  D = f(
+  g = e(
     3,
     (n, t) => {
-      c(n, g), a(n, t ? v : null);
+      i(n, D), v(n, t ? k : null);
     },
     void 0,
-    a,
+    v,
   ),
-  h = l("i", r("<button id=inner></button><!><!>", " b%D", void 0, [D])),
-  j = m(1),
-  p = _(4, null, d(4)),
-  q = _(3, null, e(D, 1)),
-  w = n("j", (n) =>
+  p = l("a7", r("<button id=inner></button><!><!>", " b%D", void 0, [g])),
+  h = m(1),
+  j = a(4, null, _(4)),
+  q = a(3, null, d(g, 1)),
+  w = n("a8", (n) =>
     t(
       n[0],
       "click",
@@ -87,11 +87,11 @@ const k = n("e", (n) =>
       })(n),
     ),
   ),
-  x = _(
+  x = a(
     2,
     (n, t) => {
-      c(n, w), j(n, t ? h : null);
+      i(n, w), h(n, t ? p : null);
     },
-    j,
+    h,
   );
 s();

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.hydrate.js
@@ -1,51 +1,51 @@
-// size: 665 (min) 315 (brotli)
+// size: 670 (min) 316 (brotli)
 
 import {
-  registerSubscriber as n,
-  dynamicClosure as l,
-  data as o,
-  registerRenderer as d,
+  registerSubscriber as a,
+  dynamicClosure as n,
+  data as l,
+  registerRenderer as o,
   createRenderer as i,
-  value as a,
+  value as d,
   intersections as s,
   inConditionalScope as u,
   dynamicSubscribers as m,
   closure as p,
   conditional as v,
 } from "@marko/runtime-tags/dom";
-const r = d(
-    "c",
+const r = o(
+    "a1",
     i("<span> </span>", "D ", void 0, [
-      n(
-        "b",
-        l(
+      a(
+        "a0",
+        n(
           5,
-          (n, l) => o(n[0], l),
-          (n) => n._._,
+          (a, n) => l(a[0], n),
+          (a) => a._._,
         ),
       ),
     ]),
   ),
-  t = d(
-    "e",
+  t = o(
+    "a3",
     i("<span> </span>", "D ", void 0, [
-      n(
-        "d",
-        l(
+      a(
+        "a2",
+        n(
           4,
-          (n, l) => o(n[0], l),
-          (n) => n._._,
+          (a, n) => l(a[0], n),
+          (a) => a._._,
         ),
       ),
     ]),
   ),
   D = v(1),
   _ = v(0),
-  b = p(5, (n, l) => D(n, l ? r : null), void 0, D),
-  c = p(4, (n, l) => _(n, l ? t : null), void 0, _),
-  e = d("f", i("<!><!><!><!>", "D%b%D", void 0, [c, b])),
+  b = p(5, (a, n) => D(a, n ? r : null), void 0, D),
+  c = p(4, (a, n) => _(a, n ? t : null), void 0, _),
+  e = o("a4", i("<!><!><!><!>", "D%b%D", void 0, [c, b])),
   f = v(0),
-  g = a(5, null, s([u(b, 0), m(5)])),
-  k = a(4, null, s([u(c, 0), m(4)])),
-  h = a(3, (n, l) => f(n, l ? e : null), f);
+  g = d(5, null, s([u(b, 0), m(5)])),
+  k = d(4, null, s([u(c, 0), m(4)])),
+  h = d(3, (a, n) => f(a, n ? e : null), f);
 s([h, k, g]);

--- a/packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/dom.expected/template.hydrate.js
@@ -1,12 +1,12 @@
-// size: 129 (min) 99 (brotli)
+// size: 131 (min) 101 (brotli)
 
 import {
   register as m,
-  attrsEvents as o,
-  init as r,
+  attrsEvents as a,
+  init as o,
 } from "@marko/runtime-tags/dom";
-m("b", (m) => {
-  o(m, 1), o(m, 2);
+m("a0", (m) => {
+  a(m, 1), a(m, 2);
 }),
-  m("c", (m) => o(m, 0)),
-  r();
+  m("a1", (m) => a(m, 0)),
+  o();

--- a/packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.hydrate.js
@@ -1,21 +1,21 @@
-// size: 273 (min) 181 (brotli)
+// size: 274 (min) 181 (brotli)
 
 import {
   register as o,
-  queueSource as r,
-  getAbortSignal as t,
-  value as a,
+  queueSource as a,
+  getAbortSignal as r,
+  value as t,
   data as m,
   init as e,
 } from "@marko/runtime-tags/dom";
-const n = a(5, (o, r) => m(o[1], r)),
-  s = a(4, (o, r) => m(o[0], r));
-o("d", (o) => {
-  const { 3: a } = o;
-  r(o, s, a.value + 1),
-    (t(o, 0).onabort = (
+const n = t(5, (o, a) => m(o[1], a)),
+  s = t(4, (o, a) => m(o[0], a));
+o("a2", (o) => {
+  const { 3: t } = o;
+  a(o, s, t.value + 1),
+    (r(o, 0).onabort = (
       (o) => () =>
-        r(o, n, previousValue)
+        a(o, n, previousValue)
     )(o));
 }),
   e();

--- a/packages/translator-tags/src/util/signals.ts
+++ b/packages/translator-tags/src/util/signals.ts
@@ -633,7 +633,8 @@ export function getResumeRegisterId(
   }
   return getTemplateId(
     markoOpts,
-    `${filename}_${section.id}${name}${type ? "/" + type : ""}`,
+    filename as string,
+    `${section.id}${name}${type ? "/" + type : ""}`,
   );
 }
 

--- a/packages/translator-tags/src/visitors/function.ts
+++ b/packages/translator-tags/src/visitors/function.ts
@@ -53,7 +53,8 @@ export default {
 
     extra.registerId = getTemplateId(
       markoOpts,
-      `${filename}_${section.id}/${name + id}`,
+      filename as string,
+      `${section.id}/${name + id}`,
     );
   },
 };

--- a/packages/translator-tags/src/visitors/program/dom.ts
+++ b/packages/translator-tags/src/visitors/program/dom.ts
@@ -1,4 +1,3 @@
-import { getTemplateId } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import { bindingHasDownstreamExpressions } from "../../util/binding-has-downstream-expressions";
 import { callRuntime } from "../../util/runtime";
@@ -116,10 +115,6 @@ export default {
         );
       }
 
-      const {
-        markoOpts,
-        opts: { filename },
-      } = program.hub.file;
       program.node.body.push(
         t.exportDefaultDeclaration(
           callRuntime(
@@ -133,7 +128,7 @@ export default {
               undefined,
               programParamsSignal?.identifier,
             ),
-            t.stringLiteral(getTemplateId(markoOpts, `${filename}`)),
+            t.stringLiteral(program.hub.file.metadata.marko.id),
           ),
         ),
       );

--- a/packages/translator-tags/src/visitors/program/html.ts
+++ b/packages/translator-tags/src/visitors/program/html.ts
@@ -1,4 +1,3 @@
-import { getTemplateId } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 import { returnId } from "../../core/return";
 import isStatic from "../../util/is-static";
@@ -37,10 +36,6 @@ export default {
       }
 
       const rendererId = program.scope.generateUidIdentifier("renderer");
-      const {
-        markoOpts,
-        opts: { filename },
-      } = program.hub.file;
       program.pushContainer("body", [
         t.variableDeclaration("const", [
           t.variableDeclarator(
@@ -59,7 +54,7 @@ export default {
           callRuntime(
             "createTemplate",
             rendererId,
-            t.stringLiteral(getTemplateId(markoOpts, `${filename}`)),
+            t.stringLiteral(program.hub.file.metadata.marko.id),
           ),
         ),
       ]);

--- a/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/dynamic-tag.ts
@@ -1,6 +1,5 @@
 import {
   assertAttributesOrArgs,
-  getTemplateId,
   importDefault,
   importNamed,
   loadFileForTag,
@@ -126,12 +125,7 @@ export default {
             t.expressionStatement(
               t.callExpression(serialized5to6, [
                 t.identifier((tagExpression as t.Identifier).name),
-                t.stringLiteral(
-                  getTemplateId(
-                    markoOpts,
-                    loadFileForTag(tag)!.metadata.marko.id,
-                  ),
-                ),
+                t.stringLiteral(loadFileForTag(tag)!.metadata.marko.id),
               ]),
             ),
           );
@@ -141,12 +135,7 @@ export default {
             t.expressionStatement(
               callRuntime(
                 "register",
-                t.stringLiteral(
-                  getTemplateId(
-                    markoOpts,
-                    loadFileForTag(tag)!.metadata.marko.id,
-                  ),
-                ),
+                t.stringLiteral(loadFileForTag(tag)!.metadata.marko.id),
                 t.identifier((tagExpression as t.Identifier).name),
               ),
             ),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- updates the precommit script to `git add` the `.sizes` directory
- switches from `optimizeRegistryIds` to `optimizeKnownTemplates` to ensure templates are given ids in a deterministic order

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
