### PR TITLE
test(translator): check for shadowing `data` with a tag destructure

### DIFF
--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/cjs-expected.js
@@ -1,0 +1,35 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+var _index = require("marko/src/runtime/html/index.js");
+var _attrTag = require("marko/src/runtime/helpers/attr-tag.js");
+var _renderer = _interopRequireDefault(require("marko/src/core-tags/core/await/renderer.js"));
+var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
+var _renderer2 = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = exports.default = _marko_template;
+const _marko_component = {};
+_marko_template._ = (0, _renderer2.default)(function (input, out, _componentDef, _component, state, $global) {
+  (0, _renderTag.default)(_renderer.default, (0, _attrTag.i)(() => {
+    (0, _attrTag.a)("then", {
+      "renderBody": (out, {
+        data
+      }) => {
+        console.log(data);
+      }
+    });
+  }, {
+    "_provider": Promise.resolve({
+      data: true
+    }),
+    "_name": "Promise.resolve({\n  data: true\n})"
+  }), out, _componentDef, "0");
+  console.log(input);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/generated-expected.diagnostics.txt
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/generated-expected.diagnostics.txt
@@ -1,0 +1,1 @@
+deprecation[fixable](7:15-7:19): The 'data' variable is deprecated. Use 'input' instead.

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/generated-expected.marko
@@ -1,0 +1,10 @@
+<await(Promise.resolve({
+  data: true
+}))>
+  <@then|{
+    data
+  }|>
+    $ console.log(data);
+  </@then>
+</await>
+$ console.log(input);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/html-expected.js
@@ -1,0 +1,30 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _await from "marko/src/core-tags/core/await/renderer.js";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_await, _marko_render_input(() => {
+    _marko_repeatable_attr_tag("then", {
+      "renderBody": (out, {
+        data
+      }) => {
+        console.log(data);
+      }
+    });
+  }, {
+    "_provider": Promise.resolve({
+      data: true
+    }),
+    "_name": "Promise.resolve({\n  data: true\n})"
+  }), out, _componentDef, "0");
+  console.log(input);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/htmlProduction-expected.js
@@ -1,0 +1,29 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "TP6I2Ph",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _await from "marko/dist/core-tags/core/await/renderer.js";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_await, _marko_render_input(() => {
+    _marko_repeatable_attr_tag("then", {
+      "renderBody": (out, {
+        data
+      }) => {
+        console.log(data);
+      }
+    });
+  }, {
+    "_provider": Promise.resolve({
+      data: true
+    }),
+    "_name": "Promise.resolve({\n  data: true\n})"
+  }), out, _componentDef, "0");
+  console.log(input);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/vdom-expected.js
@@ -1,0 +1,34 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _await from "marko/src/core-tags/core/await/renderer.js";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_await, _marko_render_input(() => {
+    _marko_repeatable_attr_tag("then", {
+      "renderBody": (out, {
+        data
+      }) => {
+        console.log(data);
+      }
+    });
+  }, {
+    "_provider": Promise.resolve({
+      data: true
+    }),
+    "_name": "Promise.resolve({\n  data: true\n})"
+  }), out, _componentDef, "0");
+  console.log(input);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/snapshots/vdomProduction-expected.js
@@ -1,0 +1,33 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "TP6I2Ph",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import { a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _await from "marko/dist/core-tags/core/await/renderer.js";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_await, _marko_render_input(() => {
+    _marko_repeatable_attr_tag("then", {
+      "renderBody": (out, {
+        data
+      }) => {
+        console.log(data);
+      }
+    });
+  }, {
+    "_provider": Promise.resolve({
+      data: true
+    }),
+    "_name": "Promise.resolve({\n  data: true\n})"
+  }), out, _componentDef, "0");
+  console.log(input);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/data-structure/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/data-structure/template.marko
@@ -1,0 +1,7 @@
+<await(Promise.resolve({data: true}))>
+ <@then|{data}|>
+  $ console.log(data)
+ </@then>
+</await>
+
+$ console.log(data);


### PR DESCRIPTION
- Maybe resolves #2254 

## Description

- Added test for shadowing with a destructure
- The shadowing issue mentioned in the issue is not replicated by Marko's test suite
- With minimal testing, it seems this is not replicable. I will look further to attempt replication.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
