### PR TITLE
feat: for loop by attribute support property string + fixes

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 13988,
-        "brotli": 5409
+        "min": 14050,
+        "brotli": 5416
       }
     },
     {
@@ -45,30 +45,30 @@
       "name": "comments",
       "user": {
         "min": 1071,
-        "brotli": 588
+        "brotli": 587
       },
       "runtime": {
-        "min": 7435,
-        "brotli": 3064
+        "min": 7497,
+        "brotli": 3098
       },
       "total": {
-        "min": 8506,
-        "brotli": 3652
+        "min": 8568,
+        "brotli": 3685
       }
     },
     {
       "name": "comments 💧",
       "user": {
         "min": 934,
-        "brotli": 544
+        "brotli": 547
       },
       "runtime": {
-        "min": 7927,
-        "brotli": 3302
+        "min": 7989,
+        "brotli": 3291
       },
       "total": {
-        "min": 8861,
-        "brotli": 3846
+        "min": 8923,
+        "brotli": 3838
       }
     }
   ]

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -17,7 +17,7 @@ import {
   k as f,
   m as b,
   n as p,
-} from "./runtime-BUIbQm-R.js";
+} from "./runtime-DPiBbhgy.js";
 const h = o(2, (s) => {
     const {
       _: { 6: n, 8: a },

--- a/.sizes/comments.ssr/entry.js
+++ b/.sizes/comments.ssr/entry.js
@@ -16,7 +16,7 @@ import {
   k as p,
   l as v,
   m as $,
-} from "./runtime-C35w6ZnD.js";
+} from "./runtime-GYBoSX4a.js";
 const b = m(2, (s) => {
     const {
       _: { 6: n, 8: a },

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -105,17 +105,17 @@ function b(e, t) {
   );
 }
 var v = new Map(),
-  m = new WeakMap(),
-  y = { capture: !0 };
+  y = new WeakMap(),
+  m = { capture: !0 };
 function w(e, t, n) {
   let r = v.get(t);
   r || v.set(t, (r = new WeakMap())),
     r.has(e) ||
       (function (e, t) {
         let n = e.getRootNode(),
-          r = m.get(n);
-        r || m.set(n, (r = new Set())),
-          r.has(t) || (r.add(t), n.addEventListener(t, N, y));
+          r = y.get(n);
+        r || y.set(n, (r = new Set())),
+          r.has(t) || (r.add(t), n.addEventListener(t, N, m));
       })(e, t),
     r.set(e, n || void 0);
 }
@@ -537,12 +537,13 @@ function he(e, t, n) {
 var pe = new Map([[Symbol(), n(void 0)]]),
   be = [n(void 0)],
   ve = new Map(),
-  me = [];
-function ye(e, t) {
+  ye = [];
+function me(e, t) {
   return Se(e, t, (e, t) => {
     let [n, r = xe] = e,
       o = 0;
-    for (let e of n) t(r(e, o), [e, o, n]), o++;
+    if ("string" == typeof r) for (let e of n) t(e[r], [e, o, n]), o++;
+    else for (let e of n) t(r(e, o), [e, o, n]), o++;
   });
 }
 function we(e, t) {
@@ -582,13 +583,13 @@ function Se(e, t, r) {
       p,
       b,
       v = s[e],
-      m = 8 === v.nodeType || 3 === v.nodeType,
-      y = s[e + "("] || (m ? pe : ve),
-      w = s[e + "!"] || Array.from(y.values()),
+      y = 8 === v.nodeType || 3 === v.nodeType,
+      m = s[e + "("] || (y ? pe : ve),
+      w = s[e + "!"] || Array.from(m.values()),
       N = !0;
     if (
       (r(d, (e, n) => {
-        let r = y.get(e),
+        let r = m.get(e),
           o = O;
         if ((r || ((r = oe(t, s.$global, s)), (o = q)), f && f(r, n), l))
           for (let e of l) e(r, o);
@@ -596,14 +597,14 @@ function Se(e, t, r) {
       }),
       !g)
     )
-      if (m) (g = pe), (h = be), n(v);
+      if (y) (g = pe), (h = be), n(v);
       else {
         if (t.r) for (let e = 0; e < w.length; e++) i(w[e]);
-        (v.textContent = ""), (g = ve), (h = me), (N = !1);
+        (v.textContent = ""), (g = ve), (h = ye), (N = !1);
       }
     if (N) {
-      if (m) {
-        y === pe && n(v);
+      if (y) {
+        m === pe && n(v);
         let e = w[w.length - 1];
         (p = e.b.nextSibling), (b = e.a.parentNode);
       } else (p = null), (b = v);
@@ -619,17 +620,17 @@ function Se(e, t, r) {
           p = t.length - 1,
           b = n.length - 1,
           v = t[g],
-          m = n[h],
-          y = t[p],
+          y = n[h],
+          m = t[p],
           w = n[b];
         e: {
-          for (; v === m; ) {
+          for (; v === y; ) {
             if ((++g, ++h, g > p || h > b)) break e;
-            (v = t[g]), (m = n[h]);
+            (v = t[g]), (y = n[h]);
           }
-          for (; y === w; ) {
+          for (; m === w; ) {
             if ((--p, --b, g > p || h > b)) break e;
-            (y = t[p]), (w = n[b]);
+            (m = t[p]), (w = n[b]);
           }
         }
         if (g > p) {
@@ -645,15 +646,15 @@ function Se(e, t, r) {
           } while (g <= p);
         else {
           let v = p - g + 1,
-            m = b - h + 1,
-            y = t,
-            w = new Array(m);
-          for (o = 0; o < m; ++o) w[o] = -1;
+            y = b - h + 1,
+            m = t,
+            w = new Array(y);
+          for (o = 0; o < y; ++o) w[o] = -1;
           let N = 0,
             S = 0,
             C = new Map();
           for (l = h; l <= b; ++l) C.set(n[l], l);
-          for (o = g; o <= p && S < m; ++o)
+          for (o = g; o <= p && S < y; ++o)
             (s = t[o]),
               (l = C.get(s)),
               void 0 !== l &&
@@ -661,12 +662,12 @@ function Se(e, t, r) {
                 ++S,
                 (d = n[l]),
                 (w[l - h] = o),
-                (y[o] = null));
+                (m[o] = null));
           if (v === t.length && 0 === S) {
-            for (; h < m; ++h) a(n[h], e, r);
+            for (; h < y; ++h) a(n[h], e, r);
             for (; g < v; ++g) u(t[g]);
           } else {
-            for (o = v - S; o > 0; ) (s = y[g++]), null !== s && (u(s), o--);
+            for (o = v - S; o > 0; ) (s = m[g++]), null !== s && (u(s), o--);
             if (N === c) {
               let t = (function (e) {
                 let t,
@@ -690,15 +691,15 @@ function Se(e, t, r) {
                   (o[t] = n), (n = r[n]);
                 return o;
               })(w);
-              for (l = t.length - 1, i = n.length, o = m - 1; o >= 0; --o)
+              for (l = t.length - 1, i = n.length, o = y - 1; o >= 0; --o)
                 -1 === w[o] || l < 0 || o !== t[l]
                   ? ((N = o + h),
                     (d = n[N++]),
                     (f = N < i ? n[N].a : r),
                     a(d, e, f))
                   : --l;
-            } else if (S !== m)
-              for (i = n.length, o = m - 1; o >= 0; --o)
+            } else if (S !== y)
+              for (i = n.length, o = y - 1; o >= 0; --o)
                 -1 === w[o] &&
                   ((N = o + h),
                   (d = n[N++]),
@@ -995,7 +996,7 @@ export {
   Y as intersections,
   j as lifecycle,
   we as loopIn,
-  ye as loopOf,
+  me as loopOf,
   Ne as loopTo,
   Q as nextTagId,
   w as on,

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -190,9 +190,16 @@ export function loopOf(nodeAccessor: Accessor, renderer: Renderer) {
     const [all, by = bySecondArg] = value as typeof value &
       [all: unknown[], by?: (item: unknown, index: number) => unknown];
     let i = 0;
-    for (const item of all) {
-      cb(by(item, i), [item, i, all]);
-      i++;
+    if (typeof by === "string") {
+      for (const item of all) {
+        cb((item as Record<string, unknown>)[by], [item, i, all]);
+        i++;
+      }
+    } else {
+      for (const item of all) {
+        cb(by(item, i), [item, i, all]);
+        i++;
+      }
     }
   });
 }
@@ -201,6 +208,9 @@ export function loopIn(nodeAccessor: Accessor, renderer: Renderer) {
   return loop(nodeAccessor, renderer, (value, cb) => {
     const [all, by = byFirstArg] = value as typeof value &
       [all: Record<string, unknown>, by?: (key: string, v: unknown) => unknown];
+    if (MARKO_DEBUG && typeof by === "string") {
+      throw "<for in> does not support a string as the `by` attribute. Use a function that returns the key.";
+    }
     for (const key in all) {
       const v = all[key];
       cb(by(key, v), [key, v, all]);
@@ -216,6 +226,9 @@ export function loopTo(nodeAccessor: Accessor, renderer: Renderer) {
       step: number,
       by?: (v: number) => unknown,
     ];
+    if (MARKO_DEBUG && typeof by === "string") {
+      throw "<for from...to> does not support a string as the `by` attribute. Use a function that returns the key.";
+    }
     const steps = (to - from) / step;
     for (let i = 0; i <= steps; i++) {
       const v = from + i * step;

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/csr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,48 @@
+# Render {}
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  secondthirdfirst
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  thirdfirstsecond
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/csr.expected.md
@@ -1,0 +1,71 @@
+# Render {}
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+# Mutations
+```
+inserted div0
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  secondthirdfirst
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+# Mutations
+```
+removed div0/#text2 before div0/#text0
+inserted div0/#text2
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  thirdfirstsecond
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+# Mutations
+```
+removed div0/#text2 before div0/#text0
+inserted div0/#text2
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+# Mutations
+```
+removed div0/#text2 before div0/#text0
+inserted div0/#text2
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,45 @@
+// size: 431 (min) 251 (brotli)
+
+import {
+  register as o,
+  createRenderer as i,
+  on as t,
+  value as c,
+  queueSource as n,
+  queueEffect as r,
+  loopOf as d,
+  data as m,
+  init as a,
+} from "@marko/runtime-tags/dom";
+const e = c(3, (o, i) => m(o[0], i)),
+  s = c(2, (o, i) => e(o, i.text)),
+  u = d(
+    0,
+    o(
+      "a1",
+      i(
+        " ",
+        " ",
+        void 0,
+        void 0,
+        void 0,
+        c(1, (o, i) => s(o, i[0])),
+      ),
+    ),
+  ),
+  v = o("a2", (o) =>
+    t(
+      o[1],
+      "click",
+      ((o) => {
+        const { 2: i } = o;
+        return function () {
+          n(o, f, [...i.slice(1), i[0]]);
+        };
+      })(o),
+    ),
+  ),
+  f = c(2, (o, i) => {
+    r(o, v), u(o, [i, "id"]);
+  });
+a();

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/dom.expected/template.js
@@ -1,0 +1,35 @@
+import { data as _data, on as _on, queueSource as _queueSource, createRenderer as _createRenderer, value as _value, register as _register, loopOf as _loopOf, queueEffect as _queueEffect, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
+const _text$forBody = /* @__PURE__ */_value("text", (_scope, text) => _data(_scope["#text/0"], text));
+const _pattern_$forBody = /* @__PURE__ */_value("_pattern_", (_scope, _pattern_) => _text$forBody(_scope, _pattern_.text));
+const _params_2$forBody = /* @__PURE__ */_value("_params_2", (_scope, _params_2) => _pattern_$forBody(_scope, _params_2[0]));
+const _forBody = _register("packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_1_renderer", /* @__PURE__ */_createRenderer(" ", /* get */" ", void 0, void 0, void 0, _params_2$forBody));
+const _for = /* @__PURE__ */_loopOf("#text/0", _forBody);
+const _onClick = _scope => {
+  const {
+    items
+  } = _scope;
+  return function () {
+    _queueSource(_scope, _items, [...items.slice(1), items[0]]);
+  };
+};
+const _items_effect = _register("packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items", _scope => _on(_scope["#button/1"], "click", _onClick(_scope)));
+const _items = /* @__PURE__ */_value("items", (_scope, items) => {
+  _queueEffect(_scope, _items_effect);
+  _for(_scope, [items, "id"]);
+});
+const _setup = _scope => {
+  _items(_scope, [{
+    id: 0,
+    text: "first"
+  }, {
+    id: 1,
+    text: "second"
+  }, {
+    id: 2,
+    text: "third"
+  }]);
+};
+export const _template_ = "<div><!><button>Rotate</button></div>";
+export const _walks_ = /* next(1), replace, over(1), get, out(1) */"D%b l";
+export const _setup_ = _setup;
+export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/html.expected/template.js
@@ -1,0 +1,37 @@
+import { write as _write, escapeXML as _escapeXML, markResumeNode as _markResumeNode, markResumeControlSingleNodeEnd as _markResumeControlSingleNodeEnd, writeScope as _writeScope, nextScopeId as _nextScopeId, getScopeById as _getScopeById, maybeFlush as _maybeFlush, writeEffect as _writeEffect, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/html";
+const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
+  const _scope0_id = _nextScopeId();
+  const items = [{
+    id: 0,
+    text: "first"
+  }, {
+    id: 1,
+    text: "second"
+  }, {
+    id: 2,
+    text: "third"
+  }];
+  _write("<div>");
+  const _forScopeIds = [],
+    _scope1_ = new Map();
+  let _i2 = 0;
+  for (const _v of items) {
+    const _scope1_id = _nextScopeId();
+    let _i = _i2++;
+    const {
+      text
+    } = _v;
+    _forScopeIds.push(_scope1_id);
+    _write(`${_escapeXML(text)}${_markResumeNode(_scope1_id, "#text/0")}`);
+    _writeScope(_scope1_id, {});
+    _scope1_.set(_v["id"], _getScopeById(_scope1_id));
+    _maybeFlush();
+  }
+  _write(`${_markResumeControlSingleNodeEnd(_scope0_id, "#text/0", _forScopeIds)}<button>Rotate</button>${_markResumeNode(_scope0_id, "#button/1")}</div>`);
+  _writeEffect(_scope0_id, "packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items");
+  _writeScope(_scope0_id, {
+    "items": items,
+    "#text/0(": _scope1_.size ? _scope1_ : undefined
+  });
+});
+export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/resume-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,48 @@
+# Render {}
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  secondthirdfirst
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  thirdfirstsecond
+  <button>
+    Rotate
+  </button>
+</div>
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/resume.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/resume.expected.md
@@ -1,0 +1,126 @@
+# Render {}
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      first
+      <!--M*1 #text/0-->
+      second
+      <!--M*2 #text/0-->
+      third
+      <!--M*3 #text/0-->
+      <!--M|0 #text/0 1,2,3-->
+      <button>
+        Rotate
+      </button>
+      <!--M*0 #button/1-->
+    </div>
+    <script>
+      (M$h=[]).push(_=&gt;(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M*1 #text/0-->
+      second
+      <!--M*2 #text/0-->
+      thirdfirst
+      <!--M*3 #text/0-->
+      <!--M|0 #text/0 1,2,3-->
+      <button>
+        Rotate
+      </button>
+      <!--M*0 #button/1-->
+    </div>
+    <script>
+      (M$h=[]).push(_=&gt;(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+removed #document/html0/body1/div0/#text4 before #document/html0/body1/div0/#comment0
+inserted #document/html0/body1/div0/#text4
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M*1 #text/0-->
+      <!--M*2 #text/0-->
+      thirdfirstsecond
+      <!--M*3 #text/0-->
+      <!--M|0 #text/0 1,2,3-->
+      <button>
+        Rotate
+      </button>
+      <!--M*0 #button/1-->
+    </div>
+    <script>
+      (M$h=[]).push(_=&gt;(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+removed #document/html0/body1/div0/#text4 after #document/html0/body1/div0/#comment0
+inserted #document/html0/body1/div0/#text4
+```
+
+
+# Render 
+container.querySelector("button").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M*1 #text/0-->
+      <!--M*2 #text/0-->
+      firstsecondthird
+      <!--M*3 #text/0-->
+      <!--M|0 #text/0 1,2,3-->
+      <button>
+        Rotate
+      </button>
+      <!--M*0 #button/1-->
+    </div>
+    <script>
+      (M$h=[]).push(_=&gt;(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+removed #document/html0/body1/div0/#text4 after #document/html0/body1/div0/#comment1
+inserted #document/html0/body1/div0/#text4
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,9 @@
+# Render "End"
+```html
+<div>
+  firstsecondthird
+  <button>
+    Rotate
+  </button>
+</div>
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/ssr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/__snapshots__/ssr.expected.md
@@ -1,0 +1,48 @@
+# Write
+  <div>first<!M*1 #text/0>second<!M*2 #text/0>third<!M*3 #text/0><!M|0 #text/0 1,2,3><button>Rotate</button><!M*0 #button/1></div><script>(M$h=[]).push(_=>(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])</script>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      first
+      <!--M*1 #text/0-->
+      second
+      <!--M*2 #text/0-->
+      third
+      <!--M*3 #text/0-->
+      <!--M|0 #text/0 1,2,3-->
+      <button>
+        Rotate
+      </button>
+      <!--M*0 #button/1-->
+    </div>
+    <script>
+      (M$h=[]).push(_=&gt;(_.e={0:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#text/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},1:_.b,2:_.c,3:_.d}),[0,"packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko_0_items",])
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/div0
+inserted #document/html0/body1/div0/#text0
+inserted #document/html0/body1/div0/#comment1
+inserted #document/html0/body1/div0/#text2
+inserted #document/html0/body1/div0/#comment3
+inserted #document/html0/body1/div0/#text4
+inserted #document/html0/body1/div0/#comment5
+inserted #document/html0/body1/div0/#comment6
+inserted #document/html0/body1/div0/button7
+inserted #document/html0/body1/div0/button7/#text0
+inserted #document/html0/body1/div0/#comment8
+inserted #document/html0/body1/script1
+inserted #document/html0/body1/script1/#text0
+```

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/template.marko
@@ -1,0 +1,7 @@
+<div>
+  <let/items=[{ id:0, text: "first"}, { id:1, text: "second"}, { id:2, text: "third"}]/>
+
+  <for|{ text }| of=items by="id">${text}</for>
+
+  <button onClick() { items = [...items.slice(1), items[0]]; }>Rotate</button>
+</div>

--- a/packages/translator-tags/src/__tests__/fixtures/for-by-string/test.ts
+++ b/packages/translator-tags/src/__tests__/fixtures/for-by-string/test.ts
@@ -1,0 +1,5 @@
+export const steps = [{}, click, click, click];
+
+function click(container: Element) {
+  (container.querySelector("button") as HTMLButtonElement).click();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- feat: support string for `by` attribute: `<for|x| of=y by="id">`
- fix: support function `by` for non `of` loops on server

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
