### PR TITLE
fix: code coverage in for-of loops

### DIFF
--- a/.changeset/slow-insects-sparkle.md
+++ b/.changeset/slow-insects-sparkle.md
@@ -1,0 +1,6 @@
+---
+"@marko/translator-default": patch
+"marko": patch
+---
+
+For-of loop code coverage improvement

--- a/packages/marko/src/runtime/helpers/of-fallback.js
+++ b/packages/marko/src/runtime/helpers/of-fallback.js
@@ -1,0 +1,4 @@
+var arr = [];
+module.exports = function (v) {
+  return v || arr;
+};

--- a/packages/translator-default/src/index.js
+++ b/packages/translator-default/src/index.js
@@ -497,6 +497,7 @@ export function getRuntimeEntryFiles(output, optimize) {
     `${base}runtime/components/attach-detach.js`,
     `${base}runtime/helpers/assign.js`,
     `${base}runtime/helpers/class-value.js`,
+    `${base}runtime/helpers/of-fallback.js`,
     `${base}runtime/helpers/dynamic-tag.js`,
     `${base}runtime/helpers/attr-tag.js`,
     `${base}runtime/helpers/merge.js`,

--- a/packages/translator-default/src/taglib/core/translate-for.js
+++ b/packages/translator-default/src/taglib/core/translate-for.js
@@ -1,4 +1,4 @@
-import { assertAllowedAttributes } from "@marko/babel-utils";
+import { assertAllowedAttributes, importDefault } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 
 export function exit(path) {
@@ -44,10 +44,13 @@ export function exit(path) {
       block,
     );
   } else if (ofAttr) {
-    let ofAttrValue = t.logicalExpression(
-      "||",
-      ofAttr.value,
-      t.arrayExpression([]),
+    let ofAttrValue = t.callExpression(
+      importDefault(
+        path.hub.file,
+        "marko/src/runtime/helpers/of-fallback.js",
+        "of_fallback",
+      ),
+      [ofAttr.value],
     );
     allowedAttributes.push("of");
 

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/cjs-expected.js
@@ -4,6 +4,7 @@ exports.__esModule = true;
 exports.default = void 0;
 var _index = require("marko/src/runtime/html/index.js");
 var _attrTag = require("marko/src/runtime/helpers/attr-tag.js");
+var _ofFallback = _interopRequireDefault(require("marko/src/runtime/helpers/of-fallback.js"));
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
@@ -16,7 +17,7 @@ const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
   (0, _renderTag.default)(_index2.default, (0, _attrTag.i)(() => {
     (0, _attrTag.a)("list", (0, _attrTag.i)(() => {
-      for (const color of input.colors || []) {
+      for (const color of (0, _ofFallback.default)(input.colors)) {
         if (x) {
           (0, _attrTag.r)("items", {
             "style": {
@@ -55,9 +56,9 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
         });
       }
     }));
-    for (const col of input.table || []) {
+    for (const col of (0, _ofFallback.default)(input.table)) {
       (0, _attrTag.r)("cols", (0, _attrTag.i)(() => {
-        for (const row of col || []) {
+        for (const row of (0, _ofFallback.default)(col)) {
           (0, _attrTag.r)("rows", {
             "row": row,
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/html-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -11,7 +12,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "style": {
@@ -50,9 +51,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         });
       }
     }));
-    for (const col of input.table || []) {
+    for (const col of _of_fallback(input.table)) {
       _marko_repeated_attr_tag("cols", _marko_render_input(() => {
-        for (const row of col || []) {
+        for (const row of _of_fallback(col)) {
           _marko_repeated_attr_tag("rows", {
             "row": row,
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/htmlProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "LOwmoBub",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -11,7 +12,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "style": {
@@ -50,9 +51,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         });
       }
     }));
-    for (const col of input.table || []) {
+    for (const col of _of_fallback(input.table)) {
       _marko_repeated_attr_tag("cols", _marko_render_input(() => {
-        for (const row of col || []) {
+        for (const row of _of_fallback(col)) {
           _marko_repeated_attr_tag("rows", {
             "row": row,
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdom-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
@@ -12,7 +13,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "style": {
@@ -51,9 +52,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         });
       }
     }));
-    for (const col of input.table || []) {
+    for (const col of _of_fallback(input.table)) {
       _marko_repeated_attr_tag("cols", _marko_render_input(() => {
-        for (const row of col || []) {
+        for (const row of _of_fallback(col)) {
           _marko_repeated_attr_tag("rows", {
             "row": row,
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-dynamic/snapshots/vdomProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "LOwmoBub",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
@@ -12,7 +13,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "style": {
@@ -51,9 +52,9 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
         });
       }
     }));
-    for (const col of input.table || []) {
+    for (const col of _of_fallback(input.table)) {
       _marko_repeated_attr_tag("cols", _marko_render_input(() => {
-        for (const row of col || []) {
+        for (const row of _of_fallback(col)) {
           _marko_repeated_attr_tag("rows", {
             "row": row,
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/cjs-expected.js
@@ -4,6 +4,7 @@ exports.__esModule = true;
 exports.default = void 0;
 var _index = require("marko/src/runtime/html/index.js");
 var _attrTag = require("marko/src/runtime/helpers/attr-tag.js");
+var _ofFallback = _interopRequireDefault(require("marko/src/runtime/helpers/of-fallback.js"));
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
 var _index2 = _interopRequireDefault(require("./components/hello/index.marko"));
 var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
@@ -16,7 +17,7 @@ const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
   (0, _renderTag.default)(_index2.default, (0, _attrTag.i)(() => {
     (0, _attrTag.a)("list", (0, _attrTag.i)(() => {
-      for (const color of input.colors || []) {
+      for (const color of (0, _ofFallback.default)(input.colors)) {
         if (x) {
           (0, _attrTag.r)("items", {
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/html-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
@@ -11,7 +12,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/htmlProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "ktPbis$k",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
@@ -11,7 +12,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdom-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/at-tags-
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/src/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
@@ -12,7 +13,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/at-tags-repeated-longhand/snapshots/vdomProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "ktPbis$k",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { r as _marko_repeated_attr_tag, a as _marko_repeatable_attr_tag, i as _marko_render_input } from "marko/dist/runtime/helpers/attr-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _hello from "./components/hello/index.marko";
 import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
@@ -12,7 +13,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_hello, _marko_render_input(() => {
     _marko_repeatable_attr_tag("list", _marko_render_input(() => {
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         if (x) {
           _marko_repeated_attr_tag("items", {
             "renderBody": out => {

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/cjs-expected.js
@@ -4,6 +4,7 @@ exports.__esModule = true;
 exports.default = void 0;
 var _index = require("marko/src/runtime/html/index.js");
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
+var _ofFallback = _interopRequireDefault(require("marko/src/runtime/helpers/of-fallback.js"));
 var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
@@ -13,7 +14,7 @@ var _default = exports.default = _marko_template;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
   let _i = 0;
-  for (const val of arr || []) {
+  for (const val of (0, _ofFallback.default)(arr)) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.w("<div>");
@@ -45,7 +46,7 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<div></div>");
   }
   let _i2 = 0;
-  for (const val of arr || []) {
+  for (const val of (0, _ofFallback.default)(arr)) {
     let i = _i2++;
     const _keyValue = `@${i}`,
       _keyScope4 = `[${_keyValue}]`;

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/html-expected.js
@@ -3,12 +3,13 @@ const _marko_componentType = "packages/translator-default/test/fixtures/for-tag/
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   let _i = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.w("<div>");
@@ -40,7 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<div></div>");
   }
   let _i2 = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i2++;
     const _keyValue = `@${i}`,
       _keyScope4 = `[${_keyValue}]`;

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/htmlProduction-expected.js
@@ -3,12 +3,13 @@ const _marko_componentType = "lMveozAf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   let _i = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.w(`<div>${_marko_escapeXml(i)}: ${_marko_escapeXml(val)}</div><div></div><div></div>`);
@@ -24,7 +25,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w(`<div>${_marko_escapeXml(i)}</div><div></div><div></div>`);
   }
   let _i2 = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i2++;
     const _keyValue = `@${i}`,
       _keyScope4 = `[${_keyValue}]`;

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/vdom-expected.js
@@ -2,13 +2,14 @@ import { t as _t } from "marko/src/runtime/vdom/index.js";
 const _marko_componentType = "packages/translator-default/test/fixtures/for-tag/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   let _i = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.be("div", null, "0" + _keyScope, _component, null, 0);
@@ -40,7 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "8" + _keyScope3, _component, 0, 0);
   }
   let _i2 = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i2++;
     const _keyValue = `@${i}`,
       _keyScope4 = `[${_keyValue}]`;

--- a/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/for-tag/snapshots/vdomProduction-expected.js
@@ -2,13 +2,14 @@ import { t as _t } from "marko/dist/runtime/vdom/index.js";
 const _marko_componentType = "lMveozAf",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   let _i = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i++;
     const _keyScope = `[${i}]`;
     out.be("div", null, "0" + _keyScope, _component, null, 0);
@@ -40,7 +41,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.e("div", null, "8" + _keyScope3, _component, 0, 0);
   }
   let _i2 = 0;
-  for (const val of arr || []) {
+  for (const val of _of_fallback(arr)) {
     let i = _i2++;
     const _keyValue = `@${i}`,
       _keyScope4 = `[${_keyValue}]`;

--- a/packages/translator-default/test/fixtures/macros/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/cjs-expected.js
@@ -5,6 +5,7 @@ exports.default = void 0;
 var _index = require("marko/src/runtime/html/index.js");
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
 var _dynamicTag = _interopRequireDefault(require("marko/src/runtime/helpers/dynamic-tag.js"));
+var _ofFallback = _interopRequireDefault(require("marko/src/runtime/helpers/of-fallback.js"));
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 const _marko_componentType = "packages/translator-default/test/fixtures/macros/template.marko",
@@ -20,7 +21,7 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
       out.w("<ul>");
       {
         let _keyValue = 0;
-        for (const child of node.children || []) {
+        for (const child of (0, _ofFallback.default)(node.children)) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
           (0, _dynamicTag.default)(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);

--- a/packages/translator-default/test/fixtures/macros/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/html-expected.js
@@ -4,6 +4,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/macros/t
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
@@ -15,7 +16,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w("<ul>");
       {
         let _keyValue = 0;
-        for (const child of node.children || []) {
+        for (const child of _of_fallback(node.children)) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);

--- a/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/htmlProduction-expected.js
@@ -4,6 +4,7 @@ const _marko_componentType = "$$jmXzyi",
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
@@ -13,7 +14,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.w("<ul>");
       {
         let _keyValue = 0;
-        for (const child of node.children || []) {
+        for (const child of _of_fallback(node.children)) {
           const _keyScope = `[${_keyValue++}]`;
           out.w("<li>");
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);

--- a/packages/translator-default/test/fixtures/macros/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/vdom-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/macros/t
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
@@ -16,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.be("ul", null, "1", _component, null, 0);
       {
         let _keyValue = 0;
-        for (const child of node.children || []) {
+        for (const child of _of_fallback(node.children)) {
           const _keyScope = `[${_keyValue++}]`;
           out.be("li", null, "2" + _keyScope, _component, null, 0);
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);

--- a/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/macros/snapshots/vdomProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "$$jmXzyi",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_dynamic_tag from "marko/dist/runtime/helpers/dynamic-tag.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
@@ -16,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
       out.be("ul", null, "1", _component, null, 0);
       {
         let _keyValue = 0;
-        for (const child of node.children || []) {
+        for (const child of _of_fallback(node.children)) {
           const _keyScope = `[${_keyValue++}]`;
           out.be("li", null, "2" + _keyScope, _component, null, 0);
           _marko_dynamic_tag(out, _renderTree, () => child, null, null, null, _componentDef, "3" + _keyScope);

--- a/packages/translator-default/test/fixtures/simple/snapshots/cjs-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/cjs-expected.js
@@ -4,6 +4,7 @@ exports.__esModule = true;
 exports.default = void 0;
 var _index = require("marko/src/runtime/html/index.js");
 var _escapeXml = require("marko/src/runtime/html/helpers/escape-xml.js");
+var _ofFallback = _interopRequireDefault(require("marko/src/runtime/helpers/of-fallback.js"));
 var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 const _marko_componentType = "packages/translator-default/test/fixtures/simple/template.marko",
@@ -18,7 +19,7 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
     out.w("<ul>");
     {
       let _keyValue = 0;
-      for (const color of input.colors || []) {
+      for (const color of (0, _ofFallback.default)(input.colors)) {
         const _keyScope = `[${_keyValue++}]`;
         out.w("<li>");
         out.w((0, _escapeXml.x)(color));

--- a/packages/translator-default/test/fixtures/simple/snapshots/html-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/html-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "packages/translator-default/test/fixtures/simple/t
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
@@ -13,7 +14,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<ul>");
     {
       let _keyValue = 0;
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         const _keyScope = `[${_keyValue++}]`;
         out.w("<li>");
         out.w(_marko_escapeXml(color));

--- a/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/htmlProduction-expected.js
@@ -3,6 +3,7 @@ const _marko_componentType = "VuvBWhNc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xml.js";
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
@@ -11,7 +12,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.w("<ul>");
     {
       let _keyValue = 0;
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         const _keyScope = `[${_keyValue++}]`;
         out.w(`<li>${_marko_escapeXml(color)}</li>`);
       }

--- a/packages/translator-default/test/fixtures/simple/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/vdom-expected.js
@@ -2,6 +2,7 @@ import { t as _t } from "marko/src/runtime/vdom/index.js";
 const _marko_componentType = "packages/translator-default/test/fixtures/simple/template.marko",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+import _of_fallback from "marko/src/runtime/helpers/of-fallback.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
@@ -14,7 +15,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.be("ul", null, "0", _component, null, 0);
     {
       let _keyValue = 0;
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         const _keyScope = `[${_keyValue++}]`;
         out.be("li", null, "1" + _keyScope, _component, null, 0);
         out.t(color, _component);

--- a/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/simple/snapshots/vdomProduction-expected.js
@@ -2,6 +2,7 @@ import { t as _t } from "marko/dist/runtime/vdom/index.js";
 const _marko_componentType = "VuvBWhNc",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
+import _of_fallback from "marko/dist/runtime/helpers/of-fallback.js";
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";
 const _marko_node = _marko_constElement("div", null, 1).t("No colors!");
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
@@ -16,7 +17,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     out.be("ul", null, "0", _component, null, 0);
     {
       let _keyValue = 0;
-      for (const color of input.colors || []) {
+      for (const color of _of_fallback(input.colors)) {
         const _keyScope = `[${_keyValue++}]`;
         out.be("li", null, "1" + _keyScope, _component, null, 0);
         out.t(color, _component);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Istanbul treats logical expressions in a way that results in uncovered lines in for-of loops as they were implemented.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
