### PR TITLE
Add open graph attributes to type defs

### DIFF
--- a/.changeset/curly-cameras-move.md
+++ b/.changeset/curly-cameras-move.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Add open graph attributes to type defs

--- a/packages/marko/tags-html.d.ts
+++ b/packages/marko/tags-html.d.ts
@@ -1513,7 +1513,7 @@ declare global {
          * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name
          */
         name?: AttrString;
-  
+
         /** @see https://ogp.me/ */
         property?: AttrString;
       }

--- a/packages/marko/tags-html.d.ts
+++ b/packages/marko/tags-html.d.ts
@@ -854,6 +854,8 @@ declare global {
       interface Head extends HTMLAttributes<HTMLHeadElement> {
         /** @deprecated */
         profile?: AttrString;
+        /** @see https://ogp.me/ */
+        prefix?: AttrString;
       }
       interface Header extends HTMLAttributes<HTMLElement> {}
       interface HGroup extends HTMLAttributes<HTMLElement> {}
@@ -876,6 +878,8 @@ declare global {
         manifest?: AttrString;
         /** @deprecated */
         version?: AttrString;
+        /** @see https://ogp.me/ */
+        prefix?: AttrString;
       }
       interface I extends HTMLAttributes<HTMLElement> {}
       interface IFrame extends HTMLAttributes<HTMLIFrameElement> {
@@ -1509,6 +1513,9 @@ declare global {
          * @see https://html.spec.whatwg.org/multipage/semantics.html#attr-meta-name
          */
         name?: AttrString;
+  
+        /** @see https://ogp.me/ */
+        property?: AttrString;
       }
       interface Meter extends HTMLAttributes<HTMLMeterElement> {
         /**


### PR DESCRIPTION
## Description

Add open graph attributes to type defs

- Adds `prefix` to `<html>` and `<head>`
- Adds `property` to `<meta>`


