### PR TITLE
fix: issue diffing unescaped html that contains comments

### DIFF
--- a/.changeset/wise-dogs-jam.md
+++ b/.changeset/wise-dogs-jam.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"marko": patch
+"@marko/compiler": patch
+---
+
+Fix issue with comment nodes in unescaped html by bringing back virtual comment nodes.

--- a/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
+++ b/packages/marko/src/runtime/vdom/AsyncVDOMBuilder.js
@@ -4,6 +4,7 @@ var attrsHelper = require("./helpers/attrs");
 var morphdom = require("./morphdom");
 var vdom = require("./vdom");
 var VElement = vdom.___VElement;
+var VComment = vdom.___VComment;
 var VDocumentFragment = vdom.___VDocumentFragment;
 var VText = vdom.___VText;
 var VComponent = vdom.___VComponent;
@@ -131,6 +132,10 @@ var proto = (AsyncVDOMBuilder.prototype = {
 
     this.___parent.___appendChild(new VText(text, ownerComponent));
     return this;
+  },
+
+  comment: function (comment, ownerComponent) {
+    return this.node(new VComment(comment, ownerComponent));
   },
 
   html: function (html, ownerComponent) {

--- a/packages/marko/src/runtime/vdom/VComment.js
+++ b/packages/marko/src/runtime/vdom/VComment.js
@@ -1,0 +1,24 @@
+var VNode = require("./VNode");
+var inherit = require("raptor-util/inherit");
+
+function VComment(value, ownerComponent) {
+  this.___VNode(-1 /* no children */, ownerComponent);
+  this.___nodeValue = value;
+}
+
+VComment.prototype = {
+  ___nodeType: 8,
+
+  ___actualize: function (doc) {
+    var nodeValue = this.___nodeValue;
+    return doc.createComment(nodeValue);
+  },
+
+  ___cloneNode: function () {
+    return new VComment(this.___nodeValue);
+  },
+};
+
+inherit(VComment, VNode);
+
+module.exports = VComment;

--- a/packages/marko/src/runtime/vdom/vdom.js
+++ b/packages/marko/src/runtime/vdom/vdom.js
@@ -1,4 +1,5 @@
 var parseHTML = require("./parse-html");
+var VComment = require("./VComment");
 var VComponent = require("./VComponent");
 var VDocumentFragment = require("./VDocumentFragment");
 var VElement = require("./VElement");
@@ -22,6 +23,8 @@ function virtualize(node, ownerComponent) {
       return VElement.___virtualize(node, virtualizeChildNodes, ownerComponent);
     case 3:
       return new VText(node.nodeValue, ownerComponent);
+    case 8:
+      return new VComment(node.nodeValue, ownerComponent);
     case 11:
       var vdomDocFragment = new VDocumentFragment();
       virtualizeChildNodes(node, vdomDocFragment, ownerComponent);
@@ -36,9 +39,11 @@ function virtualizeHTML(html, ownerComponent) {
 
   var vdomFragment = new VDocumentFragment();
   var curChild = parseHTML(html);
+  var virtualized;
 
   while (curChild) {
-    vdomFragment.___appendChild(virtualize(curChild, ownerComponent));
+    virtualized = virtualize(curChild, ownerComponent);
+    if (virtualized) vdomFragment.___appendChild(virtualized);
     curChild = curChild.nextSibling;
   }
 
@@ -73,6 +78,7 @@ Node_prototype.___appendDocumentFragment = function () {
   return this.___appendChild(new VDocumentFragment());
 };
 
+exports.___VComment = VComment;
 exports.___VDocumentFragment = VDocumentFragment;
 exports.___VElement = VElement;
 exports.___VText = VText;

--- a/packages/marko/test/components-browser/fixtures/component-unescaped-html/test.js
+++ b/packages/marko/test/components-browser/fixtures/component-unescaped-html/test.js
@@ -21,4 +21,12 @@ module.exports = function (helpers) {
   expect(component.el.childNodes.length).to.equal(1);
   expect(component.el.firstChild.nodeName).to.equal("SELECT");
   expect(component.el.firstChild.selectedIndex).to.equal(1);
+
+  component.state.html =
+    '<!-- A comment -->';
+  component.update();
+
+  expect(component.el.childNodes.length).to.equal(1);
+  expect(component.el.firstChild.nodeType).to.equal(Node.COMMENT_NODE);
+  expect(component.el.firstChild.data).to.equal(" A comment ");
 };

--- a/packages/translator-default/test/fixtures/comments/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/vdom-expected.js
@@ -7,7 +7,10 @@ import { r as _marko_registerComponent } from "marko/src/runtime/components/regi
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.e("div", null, "0", _component, 0, 0);
+  out.be("div", null, "0", _component, null, 0);
+  out.comment("abc", _component);
+  out.comment("[if lt IE 9]><script src=\"...\"></script><![endif]", _component);
+  out.ee();
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/comments/snapshots/vdomProduction-expected.js
@@ -7,7 +7,10 @@ import { r as _marko_registerComponent } from "marko/dist/runtime/components/reg
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.e("div", null, "0", _component, 0, 0);
+  out.be("div", null, "0", _component, null, 0);
+  out.comment("abc", _component);
+  out.comment("[if lt IE 9]><script src=\"...\"></script><![endif]", _component);
+  out.ee();
 }, {
   t: _marko_componentType,
   i: true

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/vdom-expected.js
@@ -6,7 +6,9 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
-_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.comment("test", _component);
+}, {
   t: _marko_componentType,
   i: true,
   d: true

--- a/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/html-comment/snapshots/vdomProduction-expected.js
@@ -6,7 +6,9 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
 _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
-_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {}, {
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.comment("test", _component);
+}, {
   t: _marko_componentType,
   i: true
 }, _marko_component);

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdom-expected.js
@@ -117,6 +117,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     "id": "a"
   }), "18", _component, null, 4);
   out.t(a, _component);
+  out.comment("abc", _component);
   out.e("div", {
     "c": "1"
   }, "19", _component, 0, 0);

--- a/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
+++ b/packages/translator-default/test/fixtures/sanity-check/snapshots/vdomProduction-expected.js
@@ -134,6 +134,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
     "id": "a"
   }), "18", _component, null, 4);
   out.t(a, _component);
+  out.comment("abc", _component);
   out.n(_marko_node7, _component);
   out.n(_marko_node8, _component);
   if (x === a) {


### PR DESCRIPTION
## Description

Fixes a regression where unescaped html that contained a comment node was throwing an exception while diffing.
This was caused by https://github.com/marko-js/marko/pull/1519 which assumed the comment nodes were no longer used (bad assumption).

Besides support for diffing unescaped html with comments, now any nodes which cannot be virtualized are skipped.

This PR also fixes the `<html-comment>` tag syntax to properly output vdom nodes.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
