### PR TITLE
Fix dynamic tag with attribute tags and the `ignoreUnrecognizedTags` compiler option.

### DIFF
--- a/.changeset/shaggy-plants-smell.md
+++ b/.changeset/shaggy-plants-smell.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Fix issue with the "ignoreUnrecognizedTags" compiler option being used with dynamic tags that have attribute tags.

--- a/.changeset/wise-sloths-prove.md
+++ b/.changeset/wise-sloths-prove.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Removes the debug mode dom manipulation warning since chrome dropped the api's that allowed us to get useful stack traces.

--- a/packages/marko/src/node_modules/@internal/components-util/index-browser.js
+++ b/packages/marko/src/node_modules/@internal/components-util/index-browser.js
@@ -140,33 +140,6 @@ function addComponentRootToKeyedElements(
   }
 }
 
-// eslint-disable-next-line no-constant-condition
-if ("MARKO_DEBUG") {
-  var warnNodeRemoved = function (event) {
-    var fragment = event.target.fragment;
-    if (fragment) {
-      var baseError = new Error(
-        "Fragment boundary marker removed.  This will cause an error when the fragment is updated."
-      );
-      fragment.___markersRemovedError = function (message) {
-        var error = new Error(message + " Boundary markers missing.");
-
-        baseError.stack = baseError.stack.replace(/.*warnNodeRemoved.*\n/, "");
-
-         
-        console.warn(baseError);
-        return error;
-      };
-    }
-  };
-  exports.___startDOMManipulationWarning = function (host) {
-    host.addEventListener("DOMNodeRemoved", warnNodeRemoved);
-  };
-  exports.___stopDOMManipulationWarning = function (host) {
-    host.removeEventListener("DOMNodeRemoved", warnNodeRemoved);
-  };
-}
-
 exports.___runtimeId = runtimeId;
 exports.___componentLookup = componentLookup;
 exports.___getComponentForEl = getComponentForEl;

--- a/packages/marko/src/runtime/vdom/morphdom/index.js
+++ b/packages/marko/src/runtime/vdom/morphdom/index.js
@@ -708,11 +708,6 @@ function morphdom(fromNode, toNode, host, componentsContext) {
     }
   } // END: morphEl(...)
 
-  // eslint-disable-next-line no-constant-condition
-  if ("MARKO_DEBUG") {
-    componentsUtil.___stopDOMManipulationWarning(host);
-  }
-
   morphChildren(fromNode, toNode, toNode.___component);
 
   detachedNodes.forEach(function (node) {
@@ -736,11 +731,6 @@ function morphdom(fromNode, toNode, host, componentsContext) {
       }
     }
   });
-
-  // eslint-disable-next-line no-constant-condition
-  if ("MARKO_DEBUG") {
-    componentsUtil.___startDOMManipulationWarning(host);
-  }
 }
 
 module.exports = morphdom;

--- a/packages/translator-default/src/tag/index.js
+++ b/packages/translator-default/src/tag/index.js
@@ -46,7 +46,11 @@ export default {
     }
 
     if (!isAttributeTag(path)) {
-      if (path.hub.file.markoOpts.ignoreUnrecognizedTags && !tagDef) {
+      if (
+        path.hub.file.markoOpts.ignoreUnrecognizedTags &&
+        !tagDef &&
+        !isDynamicTag(path)
+      ) {
         findAttributeTags(path).forEach(function replaceAttrTagName(child) {
           child.set(
             "name",


### PR DESCRIPTION
## Description

* Fix issue with the "ignoreUnrecognizedTags" compiler option being used with dynamic tags that have attribute tags.
* Removes the debug mode dom manipulation warning since chrome dropped the api's that allowed us to get useful stack traces.
