### PR TITLE
fix: add frame property to compile errors

### DIFF
--- a/.changeset/nine-kids-divide.md
+++ b/.changeset/nine-kids-divide.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"marko": patch
+---
+
+Add frame property to compile errors

--- a/packages/compiler/src/util/build-code-frame.js
+++ b/packages/compiler/src/util/build-code-frame.js
@@ -34,6 +34,12 @@ class CompileError extends Error {
         writable: true,
         configurable: true,
       },
+      frame: {
+        value: prettyMessage,
+        enumerable: false,
+        writable: true,
+        configurable: true,
+      },
       // Ignore some mutations from Babel.
       code: {
         enumerable: false,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adds a `frame` property to CompileError errors

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
