### PR TITLE
fix: upgrade babel/it-fails, fix VComment

### DIFF
--- a/.changeset/early-ways-relax.md
+++ b/.changeset/early-ways-relax.md
@@ -1,7 +1,5 @@
 ---
 "marko": patch
-"@marko/translator-interop-class-tags": patch
-"@marko/translator-tags": patch
 ---
 
 fix: upgrade babel/it-fails, fix VComment

--- a/.changeset/early-ways-relax.md
+++ b/.changeset/early-ways-relax.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/translator-interop-class-tags": patch
+"@marko/translator-tags": patch
+---
+
+fix: upgrade babel/it-fails, fix VComment

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "express": "^4.19.2",
         "globals": "^15.9.0",
         "husky": "^9.1.4",
-        "it-fails": "^1.0.7",
+        "it-fails": "^1.0.8",
         "jsdom": "^24.1.1",
         "jsdom-context-require": "^5.2.3",
         "kleur": "^4.1.5",
@@ -76,9 +76,9 @@
       }
     },
     "node_modules/@babel/cli": {
-      "version": "7.24.8",
-      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.24.8.tgz",
-      "integrity": "sha512-isdp+G6DpRyKc+3Gqxy2rjzgF7Zj9K0mzLNnxz+E/fgeag8qT3vVulX4gY9dGO1q0y+0lUv6V3a+uhUzMzrwXg==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.25.6.tgz",
+      "integrity": "sha512-Z+Doemr4VtvSD2SNHTrkiFZ1LX+JI6tyRXAAOb4N9khIuPyoEPmTPJarPm8ljJV1D6bnMQjyHMWTT9NeKbQuXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -99,7 +99,7 @@
       },
       "optionalDependencies": {
         "@nicolo-ribaudo/chokidar-2": "2.1.8-no-fsevents.3",
-        "chokidar": "^3.4.0"
+        "chokidar": "^3.6.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -119,9 +119,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.2.tgz",
-      "integrity": "sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.25.4.tgz",
+      "integrity": "sha512-+LGRog6RAsCJrrrg/IO6LGmpphNe5DiK30dGjCoxxeGv49B10/3XYGxPsAwrDlMFcFEvdAUavDT8r9k/hSyQqQ==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -158,12 +158,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.0.tgz",
-      "integrity": "sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.25.6.tgz",
+      "integrity": "sha512-VPC82gr1seXOpkjAAKoLhP50vx4vGNlF4msF64dSFq1P8RfB+QAuJWGHPXXPc8QyfVWwwB/TNNU4+ayZmHNbZw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.0",
+        "@babel/types": "^7.25.6",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^2.5.1"
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.0.tgz",
-      "integrity": "sha512-GYM6BxeQsETc9mnct+nIIpf63SAyzvyYN7UB/IlTyd+MBg06afFGp0mIeUqGyWgS2mxad6vqbMrHVlaL3m70sQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.25.4.tgz",
+      "integrity": "sha512-ro/bFs3/84MDgDmMwbcHgDa8/E6J3QKNTk4xJJnVeFtGE+tL0K26E3pNxhYz2b67fJpt7Aphw5XcploKXuCvCQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
@@ -225,7 +225,7 @@
         "@babel/helper-optimise-call-expression": "^7.24.7",
         "@babel/helper-replace-supers": "^7.25.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.24.7",
-        "@babel/traverse": "^7.25.0",
+        "@babel/traverse": "^7.25.4",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -439,13 +439,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.0.tgz",
-      "integrity": "sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.25.6.tgz",
+      "integrity": "sha512-Xg0tn4HcfTijTwfDwYlvVCl43V6h4KyVVX2aEm4qdO/PC6L2YvzLHFdmxhoeSA3eslcE6+ZVXHgWwopXYLNq4Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.0"
+        "@babel/types": "^7.25.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -467,12 +467,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.3.tgz",
-      "integrity": "sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.6.tgz",
+      "integrity": "sha512-trGdfBdbD0l1ZPmcJ83eNxB9rbEax4ALFTF7fN386TMYbeCQbyme5cOEXQhbGXKebwGaB/J52w1mrklMcbgy6Q==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.25.2"
+        "@babel/types": "^7.25.6"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -647,13 +647,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-assertions": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.24.7.tgz",
-      "integrity": "sha512-Ec3NRUMoi8gskrkBe3fNmEQfxDvY8bgfQpz6jlk/41kX9eUjvpyqWU7PBP/pLAvMaSQjbMNKJmvX57jP+M6bPg==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.25.6.tgz",
+      "integrity": "sha512-aABl0jHw9bZ2karQ/uUD6XP4u0SG22SJrOHFoL6XB1R7dTovOP4TzTlsxOYC5yQ1pdscVK2JTUnF6QL3ARoAiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -663,13 +663,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.24.7.tgz",
-      "integrity": "sha512-hbX+lKKeUMGihnK8nvKqmXBInriT3GVjzXKFriV3YC6APGxMbP8RZNFwy91+hocLXq90Mta+HshoB31802bb8A==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.25.6.tgz",
+      "integrity": "sha512-sXaDXaJN9SNLymBdlWFA+bjzBhFD617ZaFiY13dGt7TVslVvVgA6fkZOP7Ki3IGElC45lwHdOTrCtKZGVAWeLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -831,12 +831,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.24.7.tgz",
-      "integrity": "sha512-c/+fVeJBB0FeKsFvwytYiUD+LBvhHjGSI0g446PRGdSVGZLRNArBUno2PETbAly3tpiNAQR5XaZ+JslxkotsbA==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.4.tgz",
+      "integrity": "sha512-uMOCoHVU52BsSWxPOMVv5qKRdeSlPuImUCB2dlPuBSU+W2/ROE7/Zg8F2Kepbk+8yBa68LlRKxO+xgEVWorsDg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -879,16 +879,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.0.tgz",
-      "integrity": "sha512-uaIi2FdqzjpAMvVqvB51S42oC2JEVgh0LDsGfZVDysWE8LrJtQC2jvKmOqEYThKyB7bDEb7BP1GYWDm7tABA0Q==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.25.4.tgz",
+      "integrity": "sha512-jz8cV2XDDTqjKPwVPJBIjORVEmSGYhdRa8e5k5+vN+uwcjSrSxUaebBRa4ko1jqNF2uxyg8G6XYk30Jv285xzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-remap-async-to-generator": "^7.25.0",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
-        "@babel/traverse": "^7.25.0"
+        "@babel/traverse": "^7.25.4"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -948,14 +948,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-class-properties": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.24.7.tgz",
-      "integrity": "sha512-vKbfawVYayKcSeSR5YYzzyXvsDFWU2mD8U5TFeXtbCPLFUqe7GyCgvO6XDHzje862ODrOwy6WCPmKeWHbCFJ4w==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.25.4.tgz",
+      "integrity": "sha512-nZeZHyCWPfjkdU5pA/uHiTaDAFUEqkpzf1YoQT2NeSynCGYq9rxfyI3XpQbfx/a0hSnFH6TGlEXvae5Vi7GD8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-create-class-features-plugin": "^7.25.4",
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -983,17 +983,17 @@
       }
     },
     "node_modules/@babel/plugin-transform-classes": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.0.tgz",
-      "integrity": "sha512-xyi6qjr/fYU304fiRwFbekzkqVJZ6A7hOjWZd+89FVcBqPV3S9Wuozz82xdpLspckeaafntbzglaW4pqpzvtSw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.25.4.tgz",
+      "integrity": "sha512-oexUfaQle2pF/b6E0dwsxQtAol9TLSO88kQvym6HHBWFliV2lGdrPieX+WgMRLSJDVzdYywk7jXbLPuO2KLTLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.24.7",
-        "@babel/helper-compilation-targets": "^7.24.8",
+        "@babel/helper-compilation-targets": "^7.25.2",
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-replace-supers": "^7.25.0",
-        "@babel/traverse": "^7.25.0",
+        "@babel/traverse": "^7.25.4",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1473,14 +1473,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-private-methods": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.24.7.tgz",
-      "integrity": "sha512-COTCOkG2hn4JKGEKBADkA8WNb35TGkkRbI5iT845dB+NyqgO8Hn+ajPbSnIQznneJTa3d30scb6iz/DhH8GsJQ==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.25.4.tgz",
+      "integrity": "sha512-ao8BG7E2b/URaUQGqN3Tlsg+M3KlHY6rJ1O1gXAEUnZoyNQnvKyH87Kfg+FoxSeyWUB8ISZZsC91C44ZuBFytw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-class-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-create-class-features-plugin": "^7.25.4",
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1558,16 +1558,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.24.7.tgz",
-      "integrity": "sha512-YqXjrk4C+a1kZjewqt+Mmu2UuV1s07y8kqcUf4qYLnoqemhR4gRQikhdAhSVJioMjVTu6Mo6pAbaypEA3jY6fw==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.25.4.tgz",
+      "integrity": "sha512-8hsyG+KUYGY0coX6KUCDancA0Vw225KJ2HJO0yCNr1vq5r+lJTleDaJf0K7iOhjw4SWhu03TMBzYTJ9krmzULQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7",
+        "@babel/helper-plugin-utils": "^7.24.8",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.1",
+        "babel-plugin-polyfill-corejs3": "^0.10.6",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
         "semver": "^6.3.1"
       },
@@ -1729,14 +1729,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-unicode-sets-regex": {
-      "version": "7.24.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.24.7.tgz",
-      "integrity": "sha512-2G8aAvF4wy1w/AGZkemprdGMRg5o6zPNhbHVImRz3lss55TYCBd6xStN19rt8XJHq20sqV0JbyWjOWwQRwV/wg==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.25.4.tgz",
+      "integrity": "sha512-qesBxiWkgN1Q+31xUE9RcMk79eOXXDCv6tfyGMRSs4RGlioSg2WVyQAm07k726cSE56pa+Kb0y9epX2qaXzTvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-create-regexp-features-plugin": "^7.24.7",
-        "@babel/helper-plugin-utils": "^7.24.7"
+        "@babel/helper-create-regexp-features-plugin": "^7.25.2",
+        "@babel/helper-plugin-utils": "^7.24.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1746,13 +1746,13 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.3.tgz",
-      "integrity": "sha512-QsYW7UeAaXvLPX9tdVliMJE7MD7M6MLYVTovRTIwhoYQVFHR1rM4wO8wqAezYi3/BpSD+NzVCZ69R6smWiIi8g==",
+      "version": "7.25.4",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.4.tgz",
+      "integrity": "sha512-W9Gyo+KmcxjGahtt3t9fb14vFRWvPpu5pT6GBlovAK6BTBcxgjfVMSQCfJl4oi35ODrxP6xx2Wr8LNST57Mraw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.25.2",
+        "@babel/compat-data": "^7.25.4",
         "@babel/helper-compilation-targets": "^7.25.2",
         "@babel/helper-plugin-utils": "^7.24.8",
         "@babel/helper-validator-option": "^7.24.8",
@@ -1781,13 +1781,13 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.24.7",
-        "@babel/plugin-transform-async-generator-functions": "^7.25.0",
+        "@babel/plugin-transform-async-generator-functions": "^7.25.4",
         "@babel/plugin-transform-async-to-generator": "^7.24.7",
         "@babel/plugin-transform-block-scoped-functions": "^7.24.7",
         "@babel/plugin-transform-block-scoping": "^7.25.0",
-        "@babel/plugin-transform-class-properties": "^7.24.7",
+        "@babel/plugin-transform-class-properties": "^7.25.4",
         "@babel/plugin-transform-class-static-block": "^7.24.7",
-        "@babel/plugin-transform-classes": "^7.25.0",
+        "@babel/plugin-transform-classes": "^7.25.4",
         "@babel/plugin-transform-computed-properties": "^7.24.7",
         "@babel/plugin-transform-destructuring": "^7.24.8",
         "@babel/plugin-transform-dotall-regex": "^7.24.7",
@@ -1815,7 +1815,7 @@
         "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
         "@babel/plugin-transform-optional-chaining": "^7.24.8",
         "@babel/plugin-transform-parameters": "^7.24.7",
-        "@babel/plugin-transform-private-methods": "^7.24.7",
+        "@babel/plugin-transform-private-methods": "^7.25.4",
         "@babel/plugin-transform-private-property-in-object": "^7.24.7",
         "@babel/plugin-transform-property-literals": "^7.24.7",
         "@babel/plugin-transform-regenerator": "^7.24.7",
@@ -1828,10 +1828,10 @@
         "@babel/plugin-transform-unicode-escapes": "^7.24.7",
         "@babel/plugin-transform-unicode-property-regex": "^7.24.7",
         "@babel/plugin-transform-unicode-regex": "^7.24.7",
-        "@babel/plugin-transform-unicode-sets-regex": "^7.24.7",
+        "@babel/plugin-transform-unicode-sets-regex": "^7.25.4",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
         "babel-plugin-polyfill-corejs2": "^0.4.10",
-        "babel-plugin-polyfill-corejs3": "^0.10.4",
+        "babel-plugin-polyfill-corejs3": "^0.10.6",
         "babel-plugin-polyfill-regenerator": "^0.6.1",
         "core-js-compat": "^3.37.1",
         "semver": "^6.3.1"
@@ -1906,9 +1906,9 @@
       "license": "MIT"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.0.tgz",
-      "integrity": "sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.25.6.tgz",
+      "integrity": "sha512-VBj9MYyDb9tuLq7yzqjgzt6Q+IBQLrGZfdjOekyEirZPHxXWoTSGUTMrpsfi58Up73d13NfYLv8HT9vmznjzhQ==",
       "license": "MIT",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
@@ -1932,16 +1932,16 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.25.3",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.3.tgz",
-      "integrity": "sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.25.6.tgz",
+      "integrity": "sha512-9Vrcx5ZW6UwK5tvqsj0nGpp/XzqthkT0dqIc9g1AdtygFToNtTF67XzYS//dm+SAK9cp3B9R4ZO/46p63SCjlQ==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.24.7",
-        "@babel/generator": "^7.25.0",
-        "@babel/parser": "^7.25.3",
+        "@babel/generator": "^7.25.6",
+        "@babel/parser": "^7.25.6",
         "@babel/template": "^7.25.0",
-        "@babel/types": "^7.25.2",
+        "@babel/types": "^7.25.6",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -1959,9 +1959,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.25.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.2.tgz",
-      "integrity": "sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==",
+      "version": "7.25.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.25.6.tgz",
+      "integrity": "sha512-/l42B1qxpG6RdfYf343Uw1vmDjeNhneUXtzhojE7pDgfpEypmRhI6j1kr17XCVv4Cgl9HdAiQY2x0GwKm7rWCw==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.24.8",
@@ -1980,17 +1980,16 @@
       "license": "MIT"
     },
     "node_modules/@changesets/apply-release-plan": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.4.tgz",
-      "integrity": "sha512-HLFwhKWayKinWAul0Vj+76jVx1Pc2v55MGPVjZ924Y/ROeSsBMFutv9heHmCUj48lJyRfOTJG5+ar+29FUky/A==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/@changesets/apply-release-plan/-/apply-release-plan-7.0.5.tgz",
+      "integrity": "sha512-1cWCk+ZshEkSVEZrm2fSj1Gz8sYvxgUL4Q78+1ZZqeqfuevPTPk033/yUZ3df8BKMohkqqHfzj0HOOrG0KtXTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/config": "^3.0.2",
+        "@changesets/config": "^3.0.3",
         "@changesets/get-version-range-type": "^0.4.0",
-        "@changesets/git": "^3.0.0",
-        "@changesets/should-skip-package": "^0.1.0",
+        "@changesets/git": "^3.0.1",
+        "@changesets/should-skip-package": "^0.1.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
         "detect-indent": "^6.0.0",
@@ -2032,16 +2031,15 @@
       }
     },
     "node_modules/@changesets/assemble-release-plan": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.3.tgz",
-      "integrity": "sha512-bLNh9/Lgl1VwkjWZTq8JmRqH+hj7/Yzfz0jsQ/zJJ+FTmVqmqPj3szeKOri8O/hEM8JmHW019vh2gTO9iq5Cuw==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/assemble-release-plan/-/assemble-release-plan-6.0.4.tgz",
+      "integrity": "sha512-nqICnvmrwWj4w2x0fOhVj2QEGdlUuwVAwESrUo5HLzWMI1rE5SWfsr9ln+rDqWB6RQ2ZyaMZHUcU7/IRaUJS+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/should-skip-package": "^0.1.0",
+        "@changesets/get-dependents-graph": "^2.1.2",
+        "@changesets/should-skip-package": "^0.1.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
         "semver": "^7.5.3"
@@ -2083,40 +2081,38 @@
       }
     },
     "node_modules/@changesets/cli": {
-      "version": "2.27.7",
-      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.7.tgz",
-      "integrity": "sha512-6lr8JltiiXPIjDeYg4iM2MeePP6VN/JkmqBsVA5XRiy01hGS3y629LtSDvKcycj/w/5Eur1rEwby/MjcYS+e2A==",
+      "version": "2.27.8",
+      "resolved": "https://registry.npmjs.org/@changesets/cli/-/cli-2.27.8.tgz",
+      "integrity": "sha512-gZNyh+LdSsI82wBSHLQ3QN5J30P4uHKJ4fXgoGwQxfXwYFTJzDdvIJasZn8rYQtmKhyQuiBj4SSnLuKlxKWq4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/apply-release-plan": "^7.0.4",
-        "@changesets/assemble-release-plan": "^6.0.3",
+        "@changesets/apply-release-plan": "^7.0.5",
+        "@changesets/assemble-release-plan": "^6.0.4",
         "@changesets/changelog-git": "^0.2.0",
-        "@changesets/config": "^3.0.2",
+        "@changesets/config": "^3.0.3",
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/get-release-plan": "^4.0.3",
-        "@changesets/git": "^3.0.0",
-        "@changesets/logger": "^0.1.0",
-        "@changesets/pre": "^2.0.0",
-        "@changesets/read": "^0.6.0",
-        "@changesets/should-skip-package": "^0.1.0",
+        "@changesets/get-dependents-graph": "^2.1.2",
+        "@changesets/get-release-plan": "^4.0.4",
+        "@changesets/git": "^3.0.1",
+        "@changesets/logger": "^0.1.1",
+        "@changesets/pre": "^2.0.1",
+        "@changesets/read": "^0.6.1",
+        "@changesets/should-skip-package": "^0.1.1",
         "@changesets/types": "^6.0.0",
-        "@changesets/write": "^0.3.1",
+        "@changesets/write": "^0.3.2",
         "@manypkg/get-packages": "^1.1.3",
         "@types/semver": "^7.5.0",
         "ansi-colors": "^4.1.3",
-        "chalk": "^2.1.0",
         "ci-info": "^3.7.0",
         "enquirer": "^2.3.0",
         "external-editor": "^3.1.0",
         "fs-extra": "^7.0.1",
-        "human-id": "^1.0.2",
         "mri": "^1.2.0",
         "outdent": "^0.5.0",
         "p-limit": "^2.2.0",
-        "preferred-pm": "^3.0.0",
+        "package-manager-detector": "^0.2.0",
+        "picocolors": "^1.1.0",
         "resolve-from": "^5.0.0",
         "semver": "^7.5.3",
         "spawndamnit": "^2.0.0",
@@ -2140,15 +2136,15 @@
       }
     },
     "node_modules/@changesets/config": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.2.tgz",
-      "integrity": "sha512-cdEhS4t8woKCX2M8AotcV2BOWnBp09sqICxKapgLHf9m5KdENpWjyrFNMjkLqGJtUys9U+w93OxWT0czorVDfw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@changesets/config/-/config-3.0.3.tgz",
+      "integrity": "sha512-vqgQZMyIcuIpw9nqFIpTSNyc/wgm/Lu1zKN5vECy74u95Qx/Wa9g27HdgO4NkVAaq+BGA8wUc/qvbvVNs93n6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@changesets/errors": "^0.2.0",
-        "@changesets/get-dependents-graph": "^2.1.1",
-        "@changesets/logger": "^0.1.0",
+        "@changesets/get-dependents-graph": "^2.1.2",
+        "@changesets/logger": "^0.1.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
         "fs-extra": "^7.0.1",
@@ -2166,16 +2162,15 @@
       }
     },
     "node_modules/@changesets/get-dependents-graph": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.1.tgz",
-      "integrity": "sha512-LRFjjvigBSzfnPU2n/AhFsuWR5DK++1x47aq6qZ8dzYsPtS/I5mNhIGAS68IAxh1xjO9BTtz55FwefhANZ+FCA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@changesets/get-dependents-graph/-/get-dependents-graph-2.1.2.tgz",
+      "integrity": "sha512-sgcHRkiBY9i4zWYBwlVyAjEM9sAzs4wYVwJUdnbDLnVG3QwAaia1Mk5P8M7kraTOZN+vBET7n8KyB0YXCbFRLQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
-        "chalk": "^2.1.0",
-        "fs-extra": "^7.0.1",
+        "picocolors": "^1.1.0",
         "semver": "^7.5.3"
       }
     },
@@ -2204,17 +2199,16 @@
       }
     },
     "node_modules/@changesets/get-release-plan": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.3.tgz",
-      "integrity": "sha512-6PLgvOIwTSdJPTtpdcr3sLtGatT+Jr22+cQwEBJBy6wP0rjB4yJ9lv583J9fVpn1bfQlBkDa8JxbS2g/n9lIyA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@changesets/get-release-plan/-/get-release-plan-4.0.4.tgz",
+      "integrity": "sha512-SicG/S67JmPTrdcc9Vpu0wSQt7IiuN0dc8iR5VScnnTVPfIaLvKmEGRvIaF0kcn8u5ZqLbormZNTO77bCEvyWw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/assemble-release-plan": "^6.0.3",
-        "@changesets/config": "^3.0.2",
-        "@changesets/pre": "^2.0.0",
-        "@changesets/read": "^0.6.0",
+        "@changesets/assemble-release-plan": "^6.0.4",
+        "@changesets/config": "^3.0.3",
+        "@changesets/pre": "^2.0.1",
+        "@changesets/read": "^0.6.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3"
       }
@@ -2227,15 +2221,13 @@
       "license": "MIT"
     },
     "node_modules/@changesets/git": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.0.tgz",
-      "integrity": "sha512-vvhnZDHe2eiBNRFHEgMiGd2CT+164dfYyrJDhwwxTVD/OW0FUD6G7+4DIx1dNwkwjHyzisxGAU96q0sVNBns0w==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@changesets/git/-/git-3.0.1.tgz",
+      "integrity": "sha512-pdgHcYBLCPcLd82aRcuO0kxCDbw/yISlOtkmwmE8Odo1L6hSiZrBOsRl84eYG7DRCab/iHnOkWqExqc4wxk2LQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.2.0",
-        "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
         "is-subdir": "^1.1.1",
         "micromatch": "^4.0.2",
@@ -2243,13 +2235,13 @@
       }
     },
     "node_modules/@changesets/logger": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.0.tgz",
-      "integrity": "sha512-pBrJm4CQm9VqFVwWnSqKEfsS2ESnwqwH+xR7jETxIErZcfd1u2zBSqrHbRHR7xjhSgep9x2PSKFKY//FAshA3g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/logger/-/logger-0.1.1.tgz",
+      "integrity": "sha512-OQtR36ZlnuTxKqoW4Sv6x5YIhOmClRd5pWsjZsddYxpWs517R0HkyiefQPIytCVh4ZcC5x9XaG8KTdd5iRQUfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "chalk": "^2.1.0"
+        "picocolors": "^1.1.0"
       }
     },
     "node_modules/@changesets/parse": {
@@ -2264,13 +2256,12 @@
       }
     },
     "node_modules/@changesets/pre": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.0.tgz",
-      "integrity": "sha512-HLTNYX/A4jZxc+Sq8D1AMBsv+1qD6rmmJtjsCJa/9MSRybdxh0mjbTvE6JYZQ/ZiQ0mMlDOlGPXTm9KLTU3jyw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@changesets/pre/-/pre-2.0.1.tgz",
+      "integrity": "sha512-vvBJ/If4jKM4tPz9JdY2kGOgWmCowUYOi5Ycv8dyLnEE8FgpYYUo1mgJZxcdtGGP3aG8rAQulGLyyXGSLkIMTQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
         "@changesets/errors": "^0.2.0",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3",
@@ -2278,30 +2269,28 @@
       }
     },
     "node_modules/@changesets/read": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.0.tgz",
-      "integrity": "sha512-ZypqX8+/im1Fm98K4YcZtmLKgjs1kDQ5zHpc2U1qdtNBmZZfo/IBiG162RoP0CUF05tvp2y4IspH11PLnPxuuw==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@changesets/read/-/read-0.6.1.tgz",
+      "integrity": "sha512-jYMbyXQk3nwP25nRzQQGa1nKLY0KfoOV7VLgwucI0bUO8t8ZLCr6LZmgjXsiKuRDc+5A6doKPr9w2d+FEJ55zQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
-        "@changesets/git": "^3.0.0",
-        "@changesets/logger": "^0.1.0",
+        "@changesets/git": "^3.0.1",
+        "@changesets/logger": "^0.1.1",
         "@changesets/parse": "^0.4.0",
         "@changesets/types": "^6.0.0",
-        "chalk": "^2.1.0",
         "fs-extra": "^7.0.1",
-        "p-filter": "^2.1.0"
+        "p-filter": "^2.1.0",
+        "picocolors": "^1.1.0"
       }
     },
     "node_modules/@changesets/should-skip-package": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.0.tgz",
-      "integrity": "sha512-FxG6Mhjw7yFStlSM7Z0Gmg3RiyQ98d/9VpQAZ3Fzr59dCOM9G6ZdYbjiSAt0XtFr9JR5U2tBaJWPjrkGGc618g==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@changesets/should-skip-package/-/should-skip-package-0.1.1.tgz",
+      "integrity": "sha512-H9LjLbF6mMHLtJIc/eHR9Na+MifJ3VxtgP/Y+XLn4BF7tDTEN1HNYtH6QMcjP1uxp9sjaFYmW8xqloaCi/ckTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
         "@changesets/types": "^6.0.0",
         "@manypkg/get-packages": "^1.1.3"
       }
@@ -2314,13 +2303,12 @@
       "license": "MIT"
     },
     "node_modules/@changesets/write": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.1.tgz",
-      "integrity": "sha512-SyGtMXzH3qFqlHKcvFY2eX+6b0NGiFcNav8AFsYwy5l8hejOeoeTDemu5Yjmke2V5jpzY+pBvM0vCCQ3gdZpfw==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@changesets/write/-/write-0.3.2.tgz",
+      "integrity": "sha512-kDxDrPNpUgsjDbWBvUo27PzKX4gqeKOlhibaOXDJA6kuBisGqNHv/HwGJrAu8U/dSf8ZEFIeHIPtvSlZI1kULw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.20.1",
         "@changesets/types": "^6.0.0",
         "fs-extra": "^7.0.1",
         "human-id": "^1.0.2",
@@ -2344,16 +2332,16 @@
       }
     },
     "node_modules/@ebay/browserslist-config": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-2.9.0.tgz",
-      "integrity": "sha512-556YqdQ0/DMBL0dZz/U1IU14hTnWinSv81uCc0xJO2bSxokxXcZ4/xK4+h4xwL3s6zIpAwKEINiwPoT82MtbWQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@ebay/browserslist-config/-/browserslist-config-2.10.0.tgz",
+      "integrity": "sha512-+piGZ54TkYZEDxUB01NQlsULJIEsfxjQ5Pnyc9iK4xU5opecnmY1i7t3yhfj2JUanC00jN+QYXXF7dztgqCseQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.0.tgz",
-      "integrity": "sha512-3sG8Zwa5fMcA9bgqB8AfWPQ+HFke6uD3h1s3RIwUNK8EG7a4buxvuFTs3j1IMs2NXAk9F30C/FF4vxRgQCcmoQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.23.1.tgz",
+      "integrity": "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==",
       "cpu": [
         "ppc64"
       ],
@@ -2368,9 +2356,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.0.tgz",
-      "integrity": "sha512-+KuOHTKKyIKgEEqKbGTK8W7mPp+hKinbMBeEnNzjJGyFcWsfrXjSTNluJHCY1RqhxFurdD8uNXQDei7qDlR6+g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.23.1.tgz",
+      "integrity": "sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==",
       "cpu": [
         "arm"
       ],
@@ -2385,9 +2373,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.0.tgz",
-      "integrity": "sha512-EuHFUYkAVfU4qBdyivULuu03FhJO4IJN9PGuABGrFy4vUuzk91P2d+npxHcFdpUnfYKy0PuV+n6bKIpHOB3prQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.23.1.tgz",
+      "integrity": "sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==",
       "cpu": [
         "arm64"
       ],
@@ -2402,9 +2390,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.0.tgz",
-      "integrity": "sha512-WRrmKidLoKDl56LsbBMhzTTBxrsVwTKdNbKDalbEZr0tcsBgCLbEtoNthOW6PX942YiYq8HzEnb4yWQMLQuipQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.23.1.tgz",
+      "integrity": "sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==",
       "cpu": [
         "x64"
       ],
@@ -2419,9 +2407,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.0.tgz",
-      "integrity": "sha512-YLntie/IdS31H54Ogdn+v50NuoWF5BDkEUFpiOChVa9UnKpftgwzZRrI4J132ETIi+D8n6xh9IviFV3eXdxfow==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.23.1.tgz",
+      "integrity": "sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==",
       "cpu": [
         "arm64"
       ],
@@ -2436,9 +2424,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.0.tgz",
-      "integrity": "sha512-IMQ6eme4AfznElesHUPDZ+teuGwoRmVuuixu7sv92ZkdQcPbsNHzutd+rAfaBKo8YK3IrBEi9SLLKWJdEvJniQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.23.1.tgz",
+      "integrity": "sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==",
       "cpu": [
         "x64"
       ],
@@ -2453,9 +2441,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-0muYWCng5vqaxobq6LB3YNtevDFSAZGlgtLoAc81PjUfiFz36n4KMpwhtAd4he8ToSI3TGyuhyx5xmiWNYZFyw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==",
       "cpu": [
         "arm64"
       ],
@@ -2470,9 +2458,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.0.tgz",
-      "integrity": "sha512-XKDVu8IsD0/q3foBzsXGt/KjD/yTKBCIwOHE1XwiXmrRwrX6Hbnd5Eqn/WvDekddK21tfszBSrE/WMaZh+1buQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.23.1.tgz",
+      "integrity": "sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==",
       "cpu": [
         "x64"
       ],
@@ -2487,9 +2475,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.0.tgz",
-      "integrity": "sha512-SEELSTEtOFu5LPykzA395Mc+54RMg1EUgXP+iw2SJ72+ooMwVsgfuwXo5Fn0wXNgWZsTVHwY2cg4Vi/bOD88qw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.23.1.tgz",
+      "integrity": "sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==",
       "cpu": [
         "arm"
       ],
@@ -2504,9 +2492,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.0.tgz",
-      "integrity": "sha512-j1t5iG8jE7BhonbsEg5d9qOYcVZv/Rv6tghaXM/Ug9xahM0nX/H2gfu6X6z11QRTMT6+aywOMA8TDkhPo8aCGw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.23.1.tgz",
+      "integrity": "sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==",
       "cpu": [
         "arm64"
       ],
@@ -2521,9 +2509,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.0.tgz",
-      "integrity": "sha512-P7O5Tkh2NbgIm2R6x1zGJJsnacDzTFcRWZyTTMgFdVit6E98LTxO+v8LCCLWRvPrjdzXHx9FEOA8oAZPyApWUA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.23.1.tgz",
+      "integrity": "sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==",
       "cpu": [
         "ia32"
       ],
@@ -2538,9 +2526,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.0.tgz",
-      "integrity": "sha512-InQwepswq6urikQiIC/kkx412fqUZudBO4SYKu0N+tGhXRWUqAx+Q+341tFV6QdBifpjYgUndV1hhMq3WeJi7A==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.23.1.tgz",
+      "integrity": "sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==",
       "cpu": [
         "loong64"
       ],
@@ -2555,9 +2543,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.0.tgz",
-      "integrity": "sha512-J9rflLtqdYrxHv2FqXE2i1ELgNjT+JFURt/uDMoPQLcjWQA5wDKgQA4t/dTqGa88ZVECKaD0TctwsUfHbVoi4w==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.23.1.tgz",
+      "integrity": "sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==",
       "cpu": [
         "mips64el"
       ],
@@ -2572,9 +2560,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.0.tgz",
-      "integrity": "sha512-cShCXtEOVc5GxU0fM+dsFD10qZ5UpcQ8AM22bYj0u/yaAykWnqXJDpd77ublcX6vdDsWLuweeuSNZk4yUxZwtw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.23.1.tgz",
+      "integrity": "sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==",
       "cpu": [
         "ppc64"
       ],
@@ -2589,9 +2577,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.0.tgz",
-      "integrity": "sha512-HEtaN7Y5UB4tZPeQmgz/UhzoEyYftbMXrBCUjINGjh3uil+rB/QzzpMshz3cNUxqXN7Vr93zzVtpIDL99t9aRw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.23.1.tgz",
+      "integrity": "sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==",
       "cpu": [
         "riscv64"
       ],
@@ -2606,9 +2594,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.0.tgz",
-      "integrity": "sha512-WDi3+NVAuyjg/Wxi+o5KPqRbZY0QhI9TjrEEm+8dmpY9Xir8+HE/HNx2JoLckhKbFopW0RdO2D72w8trZOV+Wg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.23.1.tgz",
+      "integrity": "sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==",
       "cpu": [
         "s390x"
       ],
@@ -2623,9 +2611,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.0.tgz",
-      "integrity": "sha512-a3pMQhUEJkITgAw6e0bWA+F+vFtCciMjW/LPtoj99MhVt+Mfb6bbL9hu2wmTZgNd994qTAEw+U/r6k3qHWWaOQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.23.1.tgz",
+      "integrity": "sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==",
       "cpu": [
         "x64"
       ],
@@ -2640,9 +2628,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-cRK+YDem7lFTs2Q5nEv/HHc4LnrfBCbH5+JHu6wm2eP+d8OZNoSMYgPZJq78vqQ9g+9+nMuIsAO7skzphRXHyw==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==",
       "cpu": [
         "x64"
       ],
@@ -2657,9 +2645,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.0.tgz",
-      "integrity": "sha512-suXjq53gERueVWu0OKxzWqk7NxiUWSUlrxoZK7usiF50C6ipColGR5qie2496iKGYNLhDZkPxBI3erbnYkU0rQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.23.1.tgz",
+      "integrity": "sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==",
       "cpu": [
         "arm64"
       ],
@@ -2674,9 +2662,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.0.tgz",
-      "integrity": "sha512-6p3nHpby0DM/v15IFKMjAaayFhqnXV52aEmv1whZHX56pdkK+MEaLoQWj+H42ssFarP1PcomVhbsR4pkz09qBg==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.23.1.tgz",
+      "integrity": "sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==",
       "cpu": [
         "x64"
       ],
@@ -2691,9 +2679,9 @@
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.0.tgz",
-      "integrity": "sha512-BFelBGfrBwk6LVrmFzCq1u1dZbG4zy/Kp93w2+y83Q5UGYF1d8sCzeLI9NXjKyujjBBniQa8R8PzLFAUrSM9OA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.23.1.tgz",
+      "integrity": "sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==",
       "cpu": [
         "x64"
       ],
@@ -2708,9 +2696,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.0.tgz",
-      "integrity": "sha512-lY6AC8p4Cnb7xYHuIxQ6iYPe6MfO2CC43XXKo9nBXDb35krYt7KGhQnOkRGar5psxYkircpCqfbNDB4uJbS2jQ==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.23.1.tgz",
+      "integrity": "sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==",
       "cpu": [
         "arm64"
       ],
@@ -2725,9 +2713,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.0.tgz",
-      "integrity": "sha512-7L1bHlOTcO4ByvI7OXVI5pNN6HSu6pUQq9yodga8izeuB1KcT2UkHaH6118QJwopExPn0rMHIseCTx1CRo/uNA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.23.1.tgz",
+      "integrity": "sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==",
       "cpu": [
         "ia32"
       ],
@@ -2742,9 +2730,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.0.tgz",
-      "integrity": "sha512-Arm+WgUFLUATuoxCJcahGuk6Yj9Pzxd6l11Zb/2aAuv5kWWvvfhLFo2fni4uSK5vzlUdCGZ/BdV5tH8klj8p8g==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.23.1.tgz",
+      "integrity": "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==",
       "cpu": [
         "x64"
       ],
@@ -2788,9 +2776,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.0.tgz",
-      "integrity": "sha512-G/M/tIiMrTAxEWRfLfQJMmGNX28IxBg4PBz8XqQhqUHLFI6TL2htpIB1iQCj144V5ee/JaKyT9/WZ0MGZWfA7A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.11.1.tgz",
+      "integrity": "sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2798,9 +2786,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.17.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.17.1.tgz",
-      "integrity": "sha512-BlYOpej8AQ8Ev9xVqroV7a02JK3SkBAaN9GfMMH9W6Ch8FlQlkjGw4Ir7+FgYwfirivAf4t+GtzuAxqfukmISA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
+      "integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -2808,6 +2796,16 @@
         "debug": "^4.3.1",
         "minimatch": "^3.1.2"
       },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.6.0.tgz",
+      "integrity": "sha512-8I2Q8ykA4J0x0o7cg67FPVnehcqWTBehu/lmY+bolPFHGjh49YzGBMXTvpqVgEbBdvNCSxj6iFgiIyHzf03lzg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -2870,9 +2868,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.8.0.tgz",
-      "integrity": "sha512-MfluB7EUfxXtv3i/++oh89uzAr4PDI4nn201hsp+qaXqsjAWzinlZEHEfPgAX4doIlKvPG/i0A9dpKxOLII8yA==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.11.1.tgz",
+      "integrity": "sha512-/qu+TWz8WwPWc7/HcIJKi+c+MOm46GdVaSlTTQcaqaL53+GsoA6MxWp5PtTx48qbSP7ylM1Kn7nhvkugfJvRSA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2885,6 +2883,19 @@
       "integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
+      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "levn": "^0.4.1"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -2936,9 +2947,9 @@
       }
     },
     "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3319,9 +3330,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.20.0.tgz",
-      "integrity": "sha512-TSpWzflCc4VGAUJZlPpgAJE1+V60MePDQnBd7PPkpuEmOy8i87aL6tinFGKBFKuEDikYpig72QzdT3QPYIi+oA==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.22.5.tgz",
+      "integrity": "sha512-SU5cvamg0Eyu/F+kLeMXS7GoahL+OoizlclVFX3l5Ql6yNlywJJ0OuqTzUx0v+aHhPHEB/56CT06GQrRrGNYww==",
       "cpu": [
         "arm"
       ],
@@ -3333,9 +3344,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.20.0.tgz",
-      "integrity": "sha512-u00Ro/nok7oGzVuh/FMYfNoGqxU5CPWz1mxV85S2w9LxHR8OoMQBuSk+3BKVIDYgkpeOET5yXkx90OYFc+ytpQ==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.22.5.tgz",
+      "integrity": "sha512-S4pit5BP6E5R5C8S6tgU/drvgjtYW76FBuG6+ibG3tMvlD1h9LHVF9KmlmaUBQ8Obou7hEyS+0w+IR/VtxwNMQ==",
       "cpu": [
         "arm64"
       ],
@@ -3347,9 +3358,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.20.0.tgz",
-      "integrity": "sha512-uFVfvzvsdGtlSLuL0ZlvPJvl6ZmrH4CBwLGEFPe7hUmf7htGAN+aXo43R/V6LATyxlKVC/m6UsLb7jbG+LG39Q==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.22.5.tgz",
+      "integrity": "sha512-250ZGg4ipTL0TGvLlfACkIxS9+KLtIbn7BCZjsZj88zSg2Lvu3Xdw6dhAhfe/FjjXPVNCtcSp+WZjVsD3a/Zlw==",
       "cpu": [
         "arm64"
       ],
@@ -3361,9 +3372,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.20.0.tgz",
-      "integrity": "sha512-xbrMDdlev53vNXexEa6l0LffojxhqDTBeL+VUxuuIXys4x6xyvbKq5XqTXBCEUA8ty8iEJblHvFaWRJTk/icAQ==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.22.5.tgz",
+      "integrity": "sha512-D8brJEFg5D+QxFcW6jYANu+Rr9SlKtTenmsX5hOSzNYVrK5oLAEMTUgKWYJP+wdKyCdeSwnapLsn+OVRFycuQg==",
       "cpu": [
         "x64"
       ],
@@ -3375,9 +3386,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.20.0.tgz",
-      "integrity": "sha512-jMYvxZwGmoHFBTbr12Xc6wOdc2xA5tF5F2q6t7Rcfab68TT0n+r7dgawD4qhPEvasDsVpQi+MgDzj2faOLsZjA==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.22.5.tgz",
+      "integrity": "sha512-PNqXYmdNFyWNg0ma5LdY8wP+eQfdvyaBAojAXgO7/gs0Q/6TQJVXAXe8gwW9URjbS0YAammur0fynYGiWsKlXw==",
       "cpu": [
         "arm"
       ],
@@ -3389,9 +3400,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.20.0.tgz",
-      "integrity": "sha512-1asSTl4HKuIHIB1GcdFHNNZhxAYEdqML/MW4QmPS4G0ivbEcBr1JKlFLKsIRqjSwOBkdItn3/ZDlyvZ/N6KPlw==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.22.5.tgz",
+      "integrity": "sha512-kSSCZOKz3HqlrEuwKd9TYv7vxPYD77vHSUvM2y0YaTGnFc8AdI5TTQRrM1yIp3tXCKrSL9A7JLoILjtad5t8pQ==",
       "cpu": [
         "arm"
       ],
@@ -3403,9 +3414,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.20.0.tgz",
-      "integrity": "sha512-COBb8Bkx56KldOYJfMf6wKeYJrtJ9vEgBRAOkfw6Ens0tnmzPqvlpjZiLgkhg6cA3DGzCmLmmd319pmHvKWWlQ==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.22.5.tgz",
+      "integrity": "sha512-oTXQeJHRbOnwRnRffb6bmqmUugz0glXaPyspp4gbQOPVApdpRrY/j7KP3lr7M8kTfQTyrBUzFjj5EuHAhqH4/w==",
       "cpu": [
         "arm64"
       ],
@@ -3417,9 +3428,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.20.0.tgz",
-      "integrity": "sha512-+it+mBSyMslVQa8wSPvBx53fYuZK/oLTu5RJoXogjk6x7Q7sz1GNRsXWjn6SwyJm8E/oMjNVwPhmNdIjwP135Q==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.22.5.tgz",
+      "integrity": "sha512-qnOTIIs6tIGFKCHdhYitgC2XQ2X25InIbZFor5wh+mALH84qnFHvc+vmWUpyX97B0hNvwNUL4B+MB8vJvH65Fw==",
       "cpu": [
         "arm64"
       ],
@@ -3431,9 +3442,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.20.0.tgz",
-      "integrity": "sha512-yAMvqhPfGKsAxHN8I4+jE0CpLWD8cv4z7CK7BMmhjDuz606Q2tFKkWRY8bHR9JQXYcoLfopo5TTqzxgPUjUMfw==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.22.5.tgz",
+      "integrity": "sha512-TMYu+DUdNlgBXING13rHSfUc3Ky5nLPbWs4bFnT+R6Vu3OvXkTkixvvBKk8uO4MT5Ab6lC3U7x8S8El2q5o56w==",
       "cpu": [
         "ppc64"
       ],
@@ -3445,9 +3456,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.20.0.tgz",
-      "integrity": "sha512-qmuxFpfmi/2SUkAw95TtNq/w/I7Gpjurx609OOOV7U4vhvUhBcftcmXwl3rqAek+ADBwSjIC4IVNLiszoj3dPA==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.22.5.tgz",
+      "integrity": "sha512-PTQq1Kz22ZRvuhr3uURH+U/Q/a0pbxJoICGSprNLAoBEkyD3Sh9qP5I0Asn0y0wejXQBbsVMRZRxlbGFD9OK4A==",
       "cpu": [
         "riscv64"
       ],
@@ -3459,9 +3470,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.20.0.tgz",
-      "integrity": "sha512-I0BtGXddHSHjV1mqTNkgUZLnS3WtsqebAXv11D5BZE/gfw5KoyXSAXVqyJximQXNvNzUo4GKlCK/dIwXlz+jlg==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.22.5.tgz",
+      "integrity": "sha512-bR5nCojtpuMss6TDEmf/jnBnzlo+6n1UhgwqUvRoe4VIotC7FG1IKkyJbwsT7JDsF2jxR+NTnuOwiGv0hLyDoQ==",
       "cpu": [
         "s390x"
       ],
@@ -3473,9 +3484,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.20.0.tgz",
-      "integrity": "sha512-y+eoL2I3iphUg9tN9GB6ku1FA8kOfmF4oUEWhztDJ4KXJy1agk/9+pejOuZkNFhRwHAOxMsBPLbXPd6mJiCwew==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.22.5.tgz",
+      "integrity": "sha512-N0jPPhHjGShcB9/XXZQWuWBKZQnC1F36Ce3sDqWpujsGjDz/CQtOL9LgTrJ+rJC8MJeesMWrMWVLKKNR/tMOCA==",
       "cpu": [
         "x64"
       ],
@@ -3487,9 +3498,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.20.0.tgz",
-      "integrity": "sha512-hM3nhW40kBNYUkZb/r9k2FKK+/MnKglX7UYd4ZUy5DJs8/sMsIbqWK2piZtVGE3kcXVNj3B2IrUYROJMMCikNg==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.22.5.tgz",
+      "integrity": "sha512-uBa2e28ohzNNwjr6Uxm4XyaA1M/8aTgfF2T7UIlElLaeXkgpmIJ2EitVNQxjO9xLLLy60YqAgKn/AqSpCUkE9g==",
       "cpu": [
         "x64"
       ],
@@ -3501,9 +3512,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.20.0.tgz",
-      "integrity": "sha512-psegMvP+Ik/Bg7QRJbv8w8PAytPA7Uo8fpFjXyCRHWm6Nt42L+JtoqH8eDQ5hRP7/XW2UiIriy1Z46jf0Oa1kA==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.22.5.tgz",
+      "integrity": "sha512-RXT8S1HP8AFN/Kr3tg4fuYrNxZ/pZf1HemC5Tsddc6HzgGnJm0+Lh5rAHJkDuW3StI0ynNXukidROMXYl6ew8w==",
       "cpu": [
         "arm64"
       ],
@@ -3515,9 +3526,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.20.0.tgz",
-      "integrity": "sha512-GabekH3w4lgAJpVxkk7hUzUf2hICSQO0a/BLFA11/RMxQT92MabKAqyubzDZmMOC/hcJNlc+rrypzNzYl4Dx7A==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.22.5.tgz",
+      "integrity": "sha512-ElTYOh50InL8kzyUD6XsnPit7jYCKrphmddKAe1/Ytt74apOxDq5YEcbsiKs0fR3vff3jEneMM+3I7jbqaMyBg==",
       "cpu": [
         "ia32"
       ],
@@ -3529,9 +3540,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.20.0.tgz",
-      "integrity": "sha512-aJ1EJSuTdGnM6qbVC4B5DSmozPTqIag9fSzXRNNo+humQLG89XpPgdt16Ia56ORD7s+H8Pmyx44uczDQ0yDzpg==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.22.5.tgz",
+      "integrity": "sha512-+lvL/4mQxSV8MukpkKyyvfwhH266COcWlXE/1qxwN08ajovta3459zrjLghYMgDerlzNwLAcFpvU+WWE5y6nAQ==",
       "cpu": [
         "x64"
       ],
@@ -3577,9 +3588,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
-      "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true,
       "license": "MIT"
     },
@@ -3602,21 +3613,28 @@
         "parse5": "^7.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mocha": {
-      "version": "10.0.7",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.7.tgz",
-      "integrity": "sha512-GN8yJ1mNTcFcah/wKEFIJckJx9iJLoMSzWcfRRuxz/Jk+U6KQNnml+etbtxFK8lPjzOw3zp4Ha/kjSst9fsHYw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.8.tgz",
+      "integrity": "sha512-HfMcUmy9hTMJh66VNcmeC9iVErIZJli2bszuXc6julh5YGuRb/W5OnkHjwLNYdFlMis0sY3If5SEAp+PktdJjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.1.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.1.0.tgz",
-      "integrity": "sha512-AOmuRF0R2/5j1knA3c6G3HOk523Ga+l+ZXltX8SF1+5oqcXijjfTd8fY3XRZqSihEu9XhtQnKYLmkFaoxgsJHw==",
+      "version": "22.7.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.4.tgz",
+      "integrity": "sha512-y+NPi1rFzDs1NdQHHToqeiX2TIS79SWEAw9GYhkkx8bD0ChpfqC+n2j5OXOCpzfojBEBt6DnEnnG9MY0zk1XLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.13.0"
+        "undici-types": "~6.19.2"
       }
     },
     "node_modules/@types/semver": {
@@ -3634,17 +3652,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.0.1.tgz",
-      "integrity": "sha512-5g3Y7GDFsJAnY4Yhvk8sZtFfV6YNF2caLzjrRPUBzewjPCaj0yokePB4LJSobyCzGMzjZZYFbwuzbfDHlimXbQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.7.0.tgz",
+      "integrity": "sha512-RIHOoznhA3CCfSTFiB6kBGLQtB/sox+pJ6jeFu6FxJvqL8qRxq/FfGO/UhsGgQM9oGdXkV4xUgli+dt26biB6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.0.1",
-        "@typescript-eslint/type-utils": "8.0.1",
-        "@typescript-eslint/utils": "8.0.1",
-        "@typescript-eslint/visitor-keys": "8.0.1",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/type-utils": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -3668,16 +3686,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.0.1.tgz",
-      "integrity": "sha512-5IgYJ9EO/12pOUwiBKFkpU7rS3IU21mtXzB81TNwq2xEybcmAZrE9qwDtsb5uQd9aVO9o0fdabFyAmKveXyujg==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.7.0.tgz",
+      "integrity": "sha512-lN0btVpj2unxHlNYLI//BQ7nzbMJYBVQX5+pbNXvGYazdlgYonMn4AhhHifQ+J4fGRYA/m1DjaQjx+fDetqBOQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.0.1",
-        "@typescript-eslint/types": "8.0.1",
-        "@typescript-eslint/typescript-estree": "8.0.1",
-        "@typescript-eslint/visitor-keys": "8.0.1",
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -3697,14 +3715,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.0.1.tgz",
-      "integrity": "sha512-NpixInP5dm7uukMiRyiHjRKkom5RIFA4dfiHvalanD2cF0CLUuQqxfg8PtEUo9yqJI2bBhF+pcSafqnG3UBnRQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.7.0.tgz",
+      "integrity": "sha512-87rC0k3ZlDOuz82zzXRtQ7Akv3GKhHs0ti4YcbAJtaomllXoSO8hi7Ix3ccEvCd824dy9aIX+j3d2UMAfCtVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.0.1",
-        "@typescript-eslint/visitor-keys": "8.0.1"
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3715,14 +3733,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.0.1.tgz",
-      "integrity": "sha512-+/UT25MWvXeDX9YaHv1IS6KI1fiuTto43WprE7pgSMswHbn1Jm9GEM4Txp+X74ifOWV8emu2AWcbLhpJAvD5Ng==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.7.0.tgz",
+      "integrity": "sha512-tl0N0Mj3hMSkEYhLkjREp54OSb/FI6qyCzfiiclvJvOqre6hsZTGSnHtmFLDU8TIM62G7ygEa1bI08lcuRwEnQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.0.1",
-        "@typescript-eslint/utils": "8.0.1",
+        "@typescript-eslint/typescript-estree": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^1.3.0"
       },
@@ -3740,9 +3758,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.0.1.tgz",
-      "integrity": "sha512-PpqTVT3yCA/bIgJ12czBuE3iBlM3g4inRSC5J0QOdQFAn07TYrYEQBBKgXH1lQpglup+Zy6c1fxuwTk4MTNKIw==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.7.0.tgz",
+      "integrity": "sha512-LLt4BLHFwSfASHSF2K29SZ+ZCsbQOM+LuarPjRUuHm+Qd09hSe3GCeaQbcCr+Mik+0QFRmep/FyZBO6fJ64U3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3754,16 +3772,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.0.1.tgz",
-      "integrity": "sha512-8V9hriRvZQXPWU3bbiUV4Epo7EvgM6RTs+sUmxp5G//dBGy402S7Fx0W0QkB2fb4obCF8SInoUzvTYtc3bkb5w==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.7.0.tgz",
+      "integrity": "sha512-MC8nmcGHsmfAKxwnluTQpNqceniT8SteVwd2voYlmiSWGOtjvGXdPl17dYu2797GVscK30Z04WRM28CrKS9WOg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "@typescript-eslint/types": "8.0.1",
-        "@typescript-eslint/visitor-keys": "8.0.1",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/visitor-keys": "8.7.0",
         "debug": "^4.3.4",
-        "globby": "^11.1.0",
+        "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
         "minimatch": "^9.0.4",
         "semver": "^7.6.0",
@@ -3822,16 +3840,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.0.1.tgz",
-      "integrity": "sha512-CBFR0G0sCt0+fzfnKaciu9IBsKvEKYwN9UZ+eeogK1fYHg4Qxk1yf/wLQkLXlq8wbU2dFlgAesxt8Gi76E8RTA==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.7.0.tgz",
+      "integrity": "sha512-ZbdUdwsl2X/s3CiyAu3gOlfQzpbuG3nTWKPoIvAu1pu5r8viiJvv2NPN2AqArL35NCYtw/lrPPfM4gxrMLNLPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.0.1",
-        "@typescript-eslint/types": "8.0.1",
-        "@typescript-eslint/typescript-estree": "8.0.1"
+        "@typescript-eslint/scope-manager": "8.7.0",
+        "@typescript-eslint/types": "8.7.0",
+        "@typescript-eslint/typescript-estree": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3845,13 +3863,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.0.1.tgz",
-      "integrity": "sha512-W5E+o0UfUcK5EgchLZsyVWqARmsM7v54/qEq6PY3YI5arkgmCzHiuk0zKSJJbm71V0xdRna4BGomkCTXz2/LkQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.7.0.tgz",
+      "integrity": "sha512-b1tx0orFCCh/THWPQa2ZwWzvOeyzzp36vkJYOpVg0u8UVOIsfVrnuC9FqAw9gRKn+rG2VmWQ/zDJZzkxUnj/XQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.0.1",
+        "@typescript-eslint/types": "8.7.0",
         "eslint-visitor-keys": "^3.4.3"
       },
       "engines": {
@@ -4166,9 +4184,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.2.tgz",
-      "integrity": "sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==",
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4180,7 +4198,7 @@
         "http-errors": "2.0.0",
         "iconv-lite": "0.4.24",
         "on-finished": "2.4.1",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "raw-body": "2.5.2",
         "type-is": "~1.6.18",
         "unpipe": "1.0.0"
@@ -4245,9 +4263,9 @@
       "license": "ISC"
     },
     "node_modules/browserslist": {
-      "version": "4.23.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.3.tgz",
-      "integrity": "sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==",
+      "version": "4.24.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
+      "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4264,8 +4282,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001646",
-        "electron-to-chromium": "^1.5.4",
+        "caniuse-lite": "^1.0.30001663",
+        "electron-to-chromium": "^1.5.28",
         "node-releases": "^2.0.18",
         "update-browserslist-db": "^1.1.0"
       },
@@ -4458,9 +4476,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001651",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001651.tgz",
-      "integrity": "sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==",
+      "version": "1.0.30001664",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001664.tgz",
+      "integrity": "sha512-AmE7k4dXiNKQipgn7a2xg558IRqPN3jMQY/rOsbxDhrd0tyChwbITBfiwtnqz8bi2M5mIWbxAYBvk7W7QBUS2g==",
       "funding": [
         {
           "type": "opencollective",
@@ -4773,9 +4791,9 @@
       "license": "MIT"
     },
     "node_modules/complain": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/complain/-/complain-1.6.0.tgz",
-      "integrity": "sha512-9oBfSEfxveaNmo2eSp/vEPkaBVxUhiJTZVgGYayzBchSAXQM6CK1PAQeV5ICShnSgfT+biYzrN7egKwwX+HkCw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/complain/-/complain-1.6.1.tgz",
+      "integrity": "sha512-WsiVAbAPcPSwyC5k8g/PLceaW0MXJUw61KqBd9uiyDOSuDIC6Ho/EbyhdFjeV6wq44R2g/b8IFpvV/1ZyXiqUQ==",
       "license": "MIT",
       "dependencies": {
         "error-stack-parser": "^2.0.1"
@@ -4845,9 +4863,9 @@
       "license": "MIT"
     },
     "node_modules/core-js-compat": {
-      "version": "3.38.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.0.tgz",
-      "integrity": "sha512-75LAicdLa4OJVwFxFbQR3NdnZjNgX6ILpVcVzcC4T2smerB5lELMrJQQQoWV6TiuC/vlaFqgU2tKQx9w5s0e0A==",
+      "version": "3.38.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.38.1.tgz",
+      "integrity": "sha512-JRH6gfXxGmrzF3tZ57lFx97YARxCXPaMzPo6jELZhv88pBH5VXpQ+y0znKGlFnzuaihqhLbefxSJxWJMPtfDzw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4893,24 +4911,17 @@
       }
     },
     "node_modules/cssstyle": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
-      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.1.0.tgz",
+      "integrity": "sha512-h66W1URKpBS5YMI/V8PyXvTMFT8SupJ1IzoIV8IeBC/ji8WVmrO8dGlTi+2dh6whmdk6BiKJLD/ZBkhWbcg6nA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "rrweb-cssom": "^0.6.0"
+        "rrweb-cssom": "^0.7.1"
       },
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/cssstyle/node_modules/rrweb-cssom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
-      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/csstype": {
       "version": "3.1.3",
@@ -4940,12 +4951,12 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -5188,22 +5199,22 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.5.tgz",
-      "integrity": "sha512-QR7/A7ZkMS8tZuoftC/jfqNkZLQO779SSW3YuZHP4eXpj3EffGLFcB/Xu9AAZQzLccTiCV+EmUo3ha4mQ9wnlA==",
+      "version": "1.5.29",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.29.tgz",
+      "integrity": "sha512-PF8n2AlIhCKXQ+gTpiJi0VhcHDb69kYX4MtCiivctc2QD3XuNZ/XIOlbGzt7WAjjEev0TtaH6Cu3arZExm5DOw==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
-      "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
+      "integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5277,9 +5288,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.0.tgz",
-      "integrity": "sha512-1lvV17H2bMYda/WaFb2jLPeHU3zml2k4/yagNMG8Q/YtfMjCwEUZa2eXXMgZTVSL5q1n4H7sQ0X6CdJDqqeCFA==",
+      "version": "0.23.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.23.1.tgz",
+      "integrity": "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5290,36 +5301,36 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.23.0",
-        "@esbuild/android-arm": "0.23.0",
-        "@esbuild/android-arm64": "0.23.0",
-        "@esbuild/android-x64": "0.23.0",
-        "@esbuild/darwin-arm64": "0.23.0",
-        "@esbuild/darwin-x64": "0.23.0",
-        "@esbuild/freebsd-arm64": "0.23.0",
-        "@esbuild/freebsd-x64": "0.23.0",
-        "@esbuild/linux-arm": "0.23.0",
-        "@esbuild/linux-arm64": "0.23.0",
-        "@esbuild/linux-ia32": "0.23.0",
-        "@esbuild/linux-loong64": "0.23.0",
-        "@esbuild/linux-mips64el": "0.23.0",
-        "@esbuild/linux-ppc64": "0.23.0",
-        "@esbuild/linux-riscv64": "0.23.0",
-        "@esbuild/linux-s390x": "0.23.0",
-        "@esbuild/linux-x64": "0.23.0",
-        "@esbuild/netbsd-x64": "0.23.0",
-        "@esbuild/openbsd-arm64": "0.23.0",
-        "@esbuild/openbsd-x64": "0.23.0",
-        "@esbuild/sunos-x64": "0.23.0",
-        "@esbuild/win32-arm64": "0.23.0",
-        "@esbuild/win32-ia32": "0.23.0",
-        "@esbuild/win32-x64": "0.23.0"
+        "@esbuild/aix-ppc64": "0.23.1",
+        "@esbuild/android-arm": "0.23.1",
+        "@esbuild/android-arm64": "0.23.1",
+        "@esbuild/android-x64": "0.23.1",
+        "@esbuild/darwin-arm64": "0.23.1",
+        "@esbuild/darwin-x64": "0.23.1",
+        "@esbuild/freebsd-arm64": "0.23.1",
+        "@esbuild/freebsd-x64": "0.23.1",
+        "@esbuild/linux-arm": "0.23.1",
+        "@esbuild/linux-arm64": "0.23.1",
+        "@esbuild/linux-ia32": "0.23.1",
+        "@esbuild/linux-loong64": "0.23.1",
+        "@esbuild/linux-mips64el": "0.23.1",
+        "@esbuild/linux-ppc64": "0.23.1",
+        "@esbuild/linux-riscv64": "0.23.1",
+        "@esbuild/linux-s390x": "0.23.1",
+        "@esbuild/linux-x64": "0.23.1",
+        "@esbuild/netbsd-x64": "0.23.1",
+        "@esbuild/openbsd-arm64": "0.23.1",
+        "@esbuild/openbsd-x64": "0.23.1",
+        "@esbuild/sunos-x64": "0.23.1",
+        "@esbuild/win32-arm64": "0.23.1",
+        "@esbuild/win32-ia32": "0.23.1",
+        "@esbuild/win32-x64": "0.23.1"
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -5342,20 +5353,24 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.8.0.tgz",
-      "integrity": "sha512-K8qnZ/QJzT2dLKdZJVX6W4XOwBzutMYmt0lqUS+JdXgd+HTYFlonFgkJ8s44d/zMPPCnOOk0kMWCApCPhiOy9A==",
+      "version": "9.11.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.11.1.tgz",
+      "integrity": "sha512-MobhYKIoAO1s1e4VUrgx1l1Sk2JBR/Gqjjgw8+mfgoLE2xwsHur4gdfTxyTgShrhvdVFTaJSgMiQBl1jv/AWxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
-        "@eslint/config-array": "^0.17.1",
+        "@eslint/config-array": "^0.18.0",
+        "@eslint/core": "^0.6.0",
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "9.8.0",
+        "@eslint/js": "9.11.1",
+        "@eslint/plugin-kit": "^0.2.0",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.3.0",
         "@nodelib/fs.walk": "^1.2.8",
+        "@types/estree": "^1.0.6",
+        "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -5375,7 +5390,6 @@
         "is-glob": "^4.0.0",
         "is-path-inside": "^3.0.3",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
@@ -5391,6 +5405,14 @@
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-formatter-unix": {
@@ -5414,9 +5436,9 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.0.2.tgz",
-      "integrity": "sha512-6E4xmrTw5wtxnLA5wYL3WDfhZ/1bUBGOXV0zQvVRDOtrR8D0p6W7fs3JweNYhwRYeGvd/1CKX2se0/2s7Q/nJA==",
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.1.0.tgz",
+      "integrity": "sha512-14dSvlhaVhKKsa9Fx1l8A17s7ah7Ef7wCakJ10LYk6+GYmP9yDti2oq2SEwcyndt6knfcZyhyxwY3i9yL78EQw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5431,9 +5453,9 @@
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
-      "integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.1.0.tgz",
+      "integrity": "sha512-Q7lok0mqMUSf5a/AdAZkA5a/gHcO6snwQClVNNvFKCAVlxXucdU8pKydU5ZVZjBx5xr37vGbFFWtLQYreLzrZg==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -5611,15 +5633,15 @@
       }
     },
     "node_modules/espree": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.1.0.tgz",
-      "integrity": "sha512-M1M6CpiE6ffoigIOWYO9UDP8TMUw9kqb21tf+08IgDYjCsOvCuDt4jQcZmoYxx+w7zlKw9/N0KXfto+I8/FrXA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.2.0.tgz",
+      "integrity": "sha512-upbkBJbckcCNBDBDXEbuhjbP68n+scUd3k/U2EkyM9nw+I/jPiL4cLF/Al06CF96wRltFda16sxDFrxsI1v0/g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.12.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.0.0"
+        "eslint-visitor-keys": "^4.1.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5783,38 +5805,38 @@
       }
     },
     "node_modules/express": {
-      "version": "4.19.2",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.19.2.tgz",
-      "integrity": "sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==",
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.0.tgz",
+      "integrity": "sha512-VqcNGcj/Id5ZT1LZ/cfihi3ttTn+NJmkli2eZADigjq29qTlWi/hAQ43t/VLPq8+UX06FCEx3ByOYet6ZFblng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "1.20.2",
+        "body-parser": "1.20.3",
         "content-disposition": "0.5.4",
         "content-type": "~1.0.4",
         "cookie": "0.6.0",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "2.0.0",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "etag": "~1.8.1",
-        "finalhandler": "1.2.0",
+        "finalhandler": "1.3.1",
         "fresh": "0.5.2",
         "http-errors": "2.0.0",
-        "merge-descriptors": "1.0.1",
+        "merge-descriptors": "1.0.3",
         "methods": "~1.1.2",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
-        "path-to-regexp": "0.1.7",
+        "path-to-regexp": "0.1.10",
         "proxy-addr": "~2.0.7",
-        "qs": "6.11.0",
+        "qs": "6.13.0",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
-        "send": "0.18.0",
-        "serve-static": "1.15.0",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
         "setprototypeof": "1.2.0",
         "statuses": "2.0.1",
         "type-is": "~1.6.18",
@@ -5903,9 +5925,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.1.tgz",
-      "integrity": "sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.2.tgz",
+      "integrity": "sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==",
       "dev": true,
       "license": "MIT"
     },
@@ -5946,14 +5968,14 @@
       }
     },
     "node_modules/finalhandler": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.2.0.tgz",
-      "integrity": "sha512-5uXcUVftlQMFnWC9qu/svkWv3GTd2PfUhK/3PLkYNAe7FbqJMt3515HaxE6eRL74GdsriiwujiawdaB1BpEISg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "on-finished": "2.4.1",
         "parseurl": "~1.3.3",
@@ -6005,30 +6027,6 @@
       "dependencies": {
         "locate-path": "^5.0.0",
         "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/find-yarn-workspace-root2": {
-      "version": "1.2.16",
-      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz",
-      "integrity": "sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "micromatch": "^4.0.2",
-        "pkg-dir": "^4.2.0"
-      }
-    },
-    "node_modules/find-yarn-workspace-root2/node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
@@ -6563,9 +6561,9 @@
       }
     },
     "node_modules/husky": {
-      "version": "9.1.4",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.4.tgz",
-      "integrity": "sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==",
+      "version": "9.1.6",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.6.tgz",
+      "integrity": "sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -6592,9 +6590,9 @@
       }
     },
     "node_modules/ignore": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
-      "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6681,9 +6679,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.0.tgz",
-      "integrity": "sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
+      "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6943,9 +6941,9 @@
       }
     },
     "node_modules/it-fails": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/it-fails/-/it-fails-1.0.7.tgz",
-      "integrity": "sha512-LQPmjUBLy3tVZJxWgcpScwL2rd/BZxLkWxZGWG+UVnJ4HDZmrjc0HW+RBNTzsXer5Zsj/f0WxTaIaHpm7NNjNg==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/it-fails/-/it-fails-1.0.8.tgz",
+      "integrity": "sha512-ESGoV6kOX6QfDHouMOw15/KYhprCTR//ks8+BbdqnKPlpniRLIM+jmA9SFq2pUrShyZvhhTbAvTCeWddmIpCEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6993,9 +6991,9 @@
       }
     },
     "node_modules/jsdom": {
-      "version": "24.1.1",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.1.tgz",
-      "integrity": "sha512-5O1wWV99Jhq4DV7rCLIoZ/UIhyQeDR7wHVyZAHAshbrvZsLs+Xzz7gtwnlJTJDjleiTKh54F4dXrX70vJQTyJQ==",
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7034,9 +7032,9 @@
       }
     },
     "node_modules/jsdom-context-require": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-5.2.3.tgz",
-      "integrity": "sha512-lzm7LCeJpouFBgOoYAz0RZ0/Jyei9+f3bzrvHuBat+YsIqSKFFhSYv6/pGwnUjYSkHpA+7MMvpnCUcOWbSQ/MA==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/jsdom-context-require/-/jsdom-context-require-5.2.4.tgz",
+      "integrity": "sha512-pWy8HGDGyHZJQ1wVT32oBqjMpoS7CjMEBbdDaL3O3E4sOgMAIZ1Ybq1fHArIf2mRkbFj3fA4T8tt11eHa0WySw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7044,7 +7042,7 @@
         "resolve.exports": "^2.0.2"
       },
       "peerDependencies": {
-        "jsdom": "11 - 24"
+        "jsdom": "11 - 25"
       }
     },
     "node_modules/jsesc": {
@@ -7177,9 +7175,9 @@
       }
     },
     "node_modules/lint-staged": {
-      "version": "15.2.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.8.tgz",
-      "integrity": "sha512-PUWFf2zQzsd9EFU+kM1d7UP+AZDbKFKuj+9JNVTBkhUFhbg4MAt6WfyMMwBfM4lYqd4D2Jwac5iuTu9rVj4zCQ==",
+      "version": "15.2.10",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-15.2.10.tgz",
+      "integrity": "sha512-5dY5t743e1byO19P9I4b3x8HJwalIznL5E1FWYnU6OWw33KxNBSLAc6Cy7F2PsFEO8FKnLwjwm5hx7aMF0jzZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7189,7 +7187,7 @@
         "execa": "~8.0.1",
         "lilconfig": "~3.1.2",
         "listr2": "~8.2.4",
-        "micromatch": "~4.0.7",
+        "micromatch": "~4.0.8",
         "pidtree": "~0.6.0",
         "string-argv": "~0.3.2",
         "yaml": "~2.5.0"
@@ -7249,22 +7247,6 @@
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/load-yaml-file": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/load-yaml-file/-/load-yaml-file-0.2.0.tgz",
-      "integrity": "sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.1.5",
-        "js-yaml": "^3.13.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/locate-path": {
@@ -7422,9 +7404,9 @@
       }
     },
     "node_modules/log-update/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7563,11 +7545,14 @@
       }
     },
     "node_modules/merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -7597,9 +7582,9 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.7.tgz",
-      "integrity": "sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7696,9 +7681,9 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.7.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.0.tgz",
-      "integrity": "sha512-v8/rBWr2VO5YkspYINnvu81inSz2y3ODJrhO175/Exzor1RcEZZkizgE2A+w/CAXXoESS8Kys5E62dOHGHzULA==",
+      "version": "10.7.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.7.3.tgz",
+      "integrity": "sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7948,13 +7933,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/mocha/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/mocha/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -8076,9 +8054,9 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
     "node_modules/natural-compare": {
@@ -8346,11 +8324,18 @@
       }
     },
     "node_modules/package-json-from-dist": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
-      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-manager-detector": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-0.2.0.tgz",
+      "integrity": "sha512-E385OSk9qDcXhcM9LNSe4sdhx8a9mAPrZ4sMLW+tmxl5ZuGtPUcdFu+MPP2jbgiWAZ6Pfe5soGFMd+0Db5Vrog==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -8463,9 +8448,9 @@
       "license": "ISC"
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.10.tgz",
+      "integrity": "sha512-7lf7qcQidTku0Gu3YDPc8DJ1q7OOucfa/BSsIwjuh56VU7katFvuM8hULfkwB3Fns/rsVF7PwPKVw1sl5KQS9w==",
       "dev": true,
       "license": "MIT"
     },
@@ -8490,9 +8475,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.0.tgz",
+      "integrity": "sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -8604,87 +8589,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/preferred-pm": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/preferred-pm/-/preferred-pm-3.1.4.tgz",
-      "integrity": "sha512-lEHd+yEm22jXdCphDrkvIJQU66EuLojPPtvZkpKIkiD+l0DMThF/niqZKJSoU8Vl7iuvtmzyMhir9LdVy5WMnA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^5.0.0",
-        "find-yarn-workspace-root2": "1.2.16",
-        "path-exists": "^4.0.0",
-        "which-pm": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/preferred-pm/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -8712,13 +8616,13 @@
       }
     },
     "node_modules/prettier-plugin-packagejson": {
-      "version": "2.5.1",
-      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.1.tgz",
-      "integrity": "sha512-6i4PW1KxEA+VrokYNGeI/q8qQX3u5DNBc7eLr9GX4OrvWr9DMls1lhbuNopkKG7Li9rTNxerWnYQyjxoUO4ROA==",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-packagejson/-/prettier-plugin-packagejson-2.5.2.tgz",
+      "integrity": "sha512-w+TmoLv2pIa+siplW1cCj2ujEXQQS6z7wmWLOiLQK/2QVl7Wy6xh/ZUpqQw8tbKMXDodmSW4GONxlA33xpdNOg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "sort-package-json": "2.10.0",
+        "sort-package-json": "2.10.1",
         "synckit": "0.9.1"
       },
       "peerDependencies": {
@@ -8797,13 +8701,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
-      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.0.4"
+        "side-channel": "^1.0.6"
       },
       "engines": {
         "node": ">=0.6"
@@ -8953,9 +8857,9 @@
       "license": "MIT"
     },
     "node_modules/regenerate-unicode-properties": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.1.1.tgz",
-      "integrity": "sha512-X007RyZLsCJVVrjgEFVpLUTZwyOZk3oiL75ZcuYjlIWd6rNJtOjkBwQc5AsRrpbKVkxN6sklw/k/9m2jJYOf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-10.2.0.tgz",
+      "integrity": "sha512-DqHn3DwbmmPVzeKj9woBadqmXxLvQoQIwu7nopMc72ztvxVmVk2SBhSnx67zuye5TP+lJsb/TBQsjLKhnDf3MA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9143,13 +9047,13 @@
       "license": "MIT"
     },
     "node_modules/rollup": {
-      "version": "4.20.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.20.0.tgz",
-      "integrity": "sha512-6rbWBChcnSGzIlXeIdNIZTopKYad8ZG8ajhl78lGRLsI2rX8IkaotQhVas2Ma+GPxJav19wrSzvRvuiv0YKzWw==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.22.5.tgz",
+      "integrity": "sha512-WoinX7GeQOFMGznEcWA1WrTQCd/tpEbMkc3nuMs9BT0CPjMdSjPMTVClwWd4pgSQwJdP65SK9mTCNvItlr5o7w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.5"
+        "@types/estree": "1.0.6"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -9159,22 +9063,22 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.20.0",
-        "@rollup/rollup-android-arm64": "4.20.0",
-        "@rollup/rollup-darwin-arm64": "4.20.0",
-        "@rollup/rollup-darwin-x64": "4.20.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.20.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.20.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.20.0",
-        "@rollup/rollup-linux-arm64-musl": "4.20.0",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.20.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.20.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.20.0",
-        "@rollup/rollup-linux-x64-gnu": "4.20.0",
-        "@rollup/rollup-linux-x64-musl": "4.20.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.20.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.20.0",
-        "@rollup/rollup-win32-x64-msvc": "4.20.0",
+        "@rollup/rollup-android-arm-eabi": "4.22.5",
+        "@rollup/rollup-android-arm64": "4.22.5",
+        "@rollup/rollup-darwin-arm64": "4.22.5",
+        "@rollup/rollup-darwin-x64": "4.22.5",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.22.5",
+        "@rollup/rollup-linux-arm-musleabihf": "4.22.5",
+        "@rollup/rollup-linux-arm64-gnu": "4.22.5",
+        "@rollup/rollup-linux-arm64-musl": "4.22.5",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.22.5",
+        "@rollup/rollup-linux-riscv64-gnu": "4.22.5",
+        "@rollup/rollup-linux-s390x-gnu": "4.22.5",
+        "@rollup/rollup-linux-x64-gnu": "4.22.5",
+        "@rollup/rollup-linux-x64-musl": "4.22.5",
+        "@rollup/rollup-win32-arm64-msvc": "4.22.5",
+        "@rollup/rollup-win32-ia32-msvc": "4.22.5",
+        "@rollup/rollup-win32-x64-msvc": "4.22.5",
         "fsevents": "~2.3.2"
       }
     },
@@ -9269,9 +9173,9 @@
       }
     },
     "node_modules/send": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.18.0.tgz",
-      "integrity": "sha512-qqWzuOjSFOuqPjFe4NOsMLafToQQwBSOEpS+FwEt3A2V3vKubTquT3vmLTQpFgMXp8AlFWFuP1qKaJZOtPpVXg==",
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9310,12 +9214,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/send/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.2",
@@ -9328,16 +9235,16 @@
       }
     },
     "node_modules/serve-static": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.15.0.tgz",
-      "integrity": "sha512-XGuRDNjXUijsUL0vl6nSD7cwURuzEgglbOaFuZM9g3kwDXOWVTck0jLzjPzGD+TazWbboZYu52/9/XPdUgne9g==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "~1.0.2",
+        "encodeurl": "~2.0.0",
         "escape-html": "~1.0.3",
         "parseurl": "~1.3.3",
-        "send": "0.18.0"
+        "send": "0.19.0"
       },
       "engines": {
         "node": ">= 0.8.0"
@@ -9491,9 +9398,9 @@
       "license": "MIT"
     },
     "node_modules/sort-package-json": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.10.0.tgz",
-      "integrity": "sha512-MYecfvObMwJjjJskhxYfuOADkXp1ZMMnCFC8yhp+9HDsk7HhR336hd7eiBs96lTXfiqmUNI+WQCeCMRBhl251g==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-2.10.1.tgz",
+      "integrity": "sha512-d76wfhgUuGypKqY72Unm5LFnMpACbdxXsLPcL27pOsSrmVqH3PztFp1uq+Z22suk15h7vXmTesuh2aEjdCqb5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9764,9 +9671,9 @@
       }
     },
     "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10045,9 +9952,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.31.5",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.31.5.tgz",
-      "integrity": "sha512-YPmas0L0rE1UyLL/llTWA0SiDOqIcAQYLeUj7cJYzXHlRTAnMSg9pPe4VJ5PlKvTrPQsdVFuiRiwyeNlYgwh2Q==",
+      "version": "5.34.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.34.0.tgz",
+      "integrity": "sha512-y5NUX+U9HhVsK/zihZwoq4r9dICLyV2jXGOriDAVOeKhq3LKVjgJbGO90FisozXLlJfvjHqgckGmJFBb9KYoWQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10265,9 +10172,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
       "dev": true,
       "license": "0BSD"
     },
@@ -10309,9 +10216,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.5.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
-      "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.2.tgz",
+      "integrity": "sha512-NW8ByodCSNCwZeghjN3o+JX5OFH0Ojg6sadjEKY4huZ52TqbJTJnDo5+Tw98lSy63NZvi4n+ez5m2u5d4PkZyw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -10323,15 +10230,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.0.1.tgz",
-      "integrity": "sha512-V3Y+MdfhawxEjE16dWpb7/IOgeXnLwAEEkS7v8oDqNcR1oYlqWhGH/iHqHdKVdpWme1VPZ0SoywXAkCqawj2eQ==",
+      "version": "8.7.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.7.0.tgz",
+      "integrity": "sha512-nEHbEYJyHwsuf7c3V3RS7Saq+1+la3i0ieR3qP0yjqWSzVmh8Drp47uOl9LjbPANac4S7EFSqvcYIKXUUwIfIQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.0.1",
-        "@typescript-eslint/parser": "8.0.1",
-        "@typescript-eslint/utils": "8.0.1"
+        "@typescript-eslint/eslint-plugin": "8.7.0",
+        "@typescript-eslint/parser": "8.7.0",
+        "@typescript-eslint/utils": "8.7.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -10347,16 +10254,16 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.13.0.tgz",
-      "integrity": "sha512-xtFJHudx8S2DSoujjMd1WeWvn7KKWFRESZTMeL1RptAYERu29D6jphMjjY+vn96jvN3kVPDNxU/E13VTaXj6jg==",
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.0.tgz",
-      "integrity": "sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-2.0.1.tgz",
+      "integrity": "sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10378,9 +10285,9 @@
       }
     },
     "node_modules/unicode-match-property-value-ecmascript": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.1.0.tgz",
-      "integrity": "sha512-qxkjQt6qjg/mYscYMC0XKRn3Rh0wFPlfxB0xkt9CfyTvpX1Ra0+rAmdX2QyAobptSEvuy4RtpPRui6XkV+8wjA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-2.2.0.tgz",
+      "integrity": "sha512-4IehN3V/+kkr5YeSSDDQG8QLqO26XpL2XP3GQtqwlT/QYSECAwFztxVHjlbh0+gjJ3XmNLS0zDsbgs9jWKExLg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10418,9 +10325,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.0.tgz",
-      "integrity": "sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.1.tgz",
+      "integrity": "sha512-R8UzCaa9Az+38REPiJ1tXlImTJXlVfgHZsglwBD/k6nj76ctsH1E3q4doGrukiLQd3sGQYu56r5+lo5r94l29A==",
       "funding": [
         {
           "type": "opencollective",
@@ -10437,8 +10344,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.0"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -10605,20 +10512,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/which-pm": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/which-pm/-/which-pm-2.2.0.tgz",
-      "integrity": "sha512-MOiaDbA5ZZgUjkeMWM5EkJp4loW5ZRoa5bc3/aeMox/PJelMhE6t7S/mLuiY43DBupyxH+S0U1bTui9kWUlmsw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "load-yaml-file": "^0.2.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8.15"
-      }
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10742,9 +10635,9 @@
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
-      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
+      "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10846,9 +10739,9 @@
       "license": "ISC"
     },
     "node_modules/yaml": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.0.tgz",
-      "integrity": "sha512-2wWLbGbYDiSqqIKoPjar3MPgB94ErzCtrNE1FdqGuaO0pi2JGjmE8aW8TDZwzU7vuxcGRdL/4gPQwQ7hD5AMSw==",
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -10973,6 +10866,8 @@
     },
     "packages/babel-utils/node_modules/jsesc": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11016,6 +10911,8 @@
     },
     "packages/compiler/node_modules/jsesc": {
       "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.0.2.tgz",
+      "integrity": "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g==",
       "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
@@ -11049,6 +10946,8 @@
     },
     "packages/marko/node_modules/brace-expansion": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -11056,6 +10955,8 @@
     },
     "packages/marko/node_modules/minimatch": {
       "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.1.tgz",
+      "integrity": "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "express": "^4.19.2",
     "globals": "^15.9.0",
     "husky": "^9.1.4",
-    "it-fails": "^1.0.7",
+    "it-fails": "^1.0.8",
     "jsdom": "^24.1.1",
     "jsdom-context-require": "^5.2.3",
     "kleur": "^4.1.5",

--- a/packages/marko/src/runtime/vdom/VComment.js
+++ b/packages/marko/src/runtime/vdom/VComment.js
@@ -9,9 +9,9 @@ function VComment(value, ownerComponent) {
 VComment.prototype = {
   ___nodeType: 8,
 
-  ___actualize: function (doc) {
+  ___actualize: function (host) {
     var nodeValue = this.___nodeValue;
-    return doc.createComment(nodeValue);
+    return (host.ownerDocument || host).createComment(nodeValue);
   },
 
   ___cloneNode: function () {

--- a/packages/marko/test/render/fixtures/html-comment-tag-dynamic/vdom-expected.html
+++ b/packages/marko/test/render/fixtures/html-comment-tag-dynamic/vdom-expected.html
@@ -1,0 +1,1 @@
+<!--"This is a <custom-tag>test</custom-tag>"-->

--- a/packages/marko/test/render/fixtures/html-comment-tag/vdom-expected.html
+++ b/packages/marko/test/render/fixtures/html-comment-tag/vdom-expected.html
@@ -1,0 +1,1 @@
+<!--"This is a comment"-->

--- a/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -36,4 +36,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 10);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/components/custom-tag.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/explicit/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/explicit/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<h1>Hello world</h1>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/explicit/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/explicit/template.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/dom.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/dom.expected/components/tags-counter.js
@@ -19,4 +19,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/components/tags-counter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/components/tags-counter.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTagName(_scope, _classCounter);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/template.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/dom.expected/template.js
@@ -16,4 +16,4 @@ export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTagName(_scope, _classCounter);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/template.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -20,4 +20,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/components/tags-layout.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/components/tags-layout.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
@@ -27,4 +27,4 @@ export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTagName(_scope, _classLayout || _classLayoutBody);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/template.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const count = 0;
   const _dynamicScope = _peekNextScope();
-  _dynamicTagInput(_dynamicScope, _classLayout, {}, _register( /* @__PURE__ */_createRenderer(() => {
+  _dynamicTagInput(_dynamicScope, _classLayout, {}, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write(`<button id=tags>${_escapeXML(count)}${_markResumeNode(_scope1_id, "#text/1")}</button>${_markResumeNode(_scope1_id, "#button/0")}`);
     _writeEffect(_scope1_id, "packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/template.marko_1_count/subscriber");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -27,4 +27,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/components/tags-layout.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/components/tags-layout.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
@@ -42,4 +42,4 @@ export function _setup_(_scope) {
   _multiplier(_scope, 1);
   _dynamicTagName(_scope, _classLayout || _classLayoutBody);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/template.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const multiplier = 1;
   const _dynamicScope = _peekNextScope();
-  _dynamicTagInput(_dynamicScope, _classLayout, {}, _register( /* @__PURE__ */_createRenderer((baseCount, message) => {
+  _dynamicTagInput(_dynamicScope, _classLayout, {}, _register(/* @__PURE__ */_createRenderer((baseCount, message) => {
     const _scope1_id = _nextScopeId();
     _write(`<h1>${_escapeXML(message)}${_markResumeNode(_scope1_id, "#text/0")}</h1><button id=tags>${_escapeXML(multiplier)}${_markResumeNode(_scope1_id, "#text/2")} * <!>${_escapeXML(baseCount)}${_markResumeNode(_scope1_id, "#text/3")} = <!>${_escapeXML(multiplier * baseCount)}${_markResumeNode(_scope1_id, "#text/4")}</button>${_markResumeNode(_scope1_id, "#button/1")}`);
     _writeEffect(_scope1_id, "packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/template.marko_1_multiplier/subscriber");

--- a/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/let/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-interop/src/__tests__/fixtures/let/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ export function _setup_(_scope) {
   _clickCount(_scope, 0);
   _lastClickCount(_scope, undefined);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.expected/template.js
@@ -12,7 +12,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
     const _scope2_id = _nextScopeId();
     _thing = {
       x: 1,
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Hello");
       }), "packages/translator-tags/src/__tests__/fixtures/at-tag-inside-if-tag/template.marko_3_renderer")
     };

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/html.expected/template.js
@@ -8,17 +8,17 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   _dynamicTagInput(_dynamicScope, x, {
     header: {
       class: "my-header",
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Header content");
       }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/template.marko_2_renderer")
     },
     footer: {
       class: "my-footer",
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Footer content");
       }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/template.marko_3_renderer")
     }
-  }, _register( /* @__PURE__ */_createRenderer(() => {
+  }, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write("Body content");
   }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/template.marko_1_renderer"));

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.expected/template.js
@@ -11,7 +11,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   if (x) {
     const _scope2_id = _nextScopeId();
     _item = {
-      renderBody: _register( /* @__PURE__ */_createRenderer(y => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(y => {
         _write(`${_escapeXML(y)}`);
       }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_3_renderer")
     };

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.expected/template.js
@@ -14,7 +14,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
         style: {
           color
         },
-        renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+        renderBody: _register(/* @__PURE__ */_createRenderer(() => {
           _write("foo");
         }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_6_renderer")
       });
@@ -29,7 +29,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
         style: {
           color
         },
-        renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+        renderBody: _register(/* @__PURE__ */_createRenderer(() => {
           _write("bar");
         }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_7_renderer")
       });
@@ -57,7 +57,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
       let _i = _i2++;
       _row.push({
         row: row,
-        renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+        renderBody: _register(/* @__PURE__ */_createRenderer(() => {
           _write(`${_escapeXML(row)}${_markResumeNode(_scope11_id, "#text/0")}`);
         }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_11_renderer", _scope10_id)
       });
@@ -78,7 +78,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
     outside: true,
     row: {
       row: -1,
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Outside");
       }), "packages/translator-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_13_renderer")
     }

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected/components/hello/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected/components/hello/index.js
@@ -5,4 +5,4 @@ import { conditional as _conditional, value as _value, createRenderer as _create
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.foo), _dynamicTagName);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/at-tags/components/hello/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/at-tags/components/hello/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.expected/template.js
@@ -13,4 +13,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _helloBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/at-tags/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/at-tags/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/at-tags/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _childScope = _peekNextScope();
   _hello._({
     foo: {
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Foo!");
       }), "packages/translator-tags/src/__tests__/fixtures/at-tags/template.marko_2_renderer")
     }

--- a/packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ const _disabled = /* @__PURE__ */_value("disabled", (_scope, disabled) => {
 export function _setup_(_scope) {
   _disabled(_scope, true);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-boolean-dynamic/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-boolean/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-boolean/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<input checked>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-boolean/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-boolean/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/components/custom-tag.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-class/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-class/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -47,4 +47,4 @@ export function _setup_(_scope) {
   _customTag(_scope["#childScope/1"]);
   _customTag(_scope["#childScope/2"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-class/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-class/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.expected/template.js
@@ -32,11 +32,11 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
         b: c,
         d
       }],
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Hello");
       }), "packages/translator-tags/src/__tests__/fixtures/attr-class/template.marko_2_renderer")
     }
-  }, _register( /* @__PURE__ */_createRenderer(() => {
+  }, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/attr-class/template.marko_1_c/subscriber");
     _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/attr-class/template.marko_1_d/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
@@ -9,4 +9,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _attr(_scope["#div/0"], "nested", `a ${input.foo + ` nested ${input.bar}`} b`);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-escape/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-escape/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-falsey/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-falsey/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<div d=0 y=1></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-falsey/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-falsey/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/components/custom-tag.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-style/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/attr-style/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.expected/template.js
@@ -30,4 +30,4 @@ export function _setup_(_scope) {
   _customTag(_scope["#childScope/2"]);
   _customTag(_scope["#childScope/3"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-style/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-style/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.expected/template.js
@@ -34,7 +34,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
       style: {
         color: "green"
       },
-      renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+      renderBody: _register(/* @__PURE__ */_createRenderer(() => {
         _write("Hello");
       }), "packages/translator-tags/src/__tests__/fixtures/attr-style/template.marko_2_renderer")
     }

--- a/packages/translator-tags/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.expected/template.js
@@ -4,4 +4,4 @@ export const _setup_ = () => {};
 import { attr as _attr, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _attr(_scope["#div/0"], "foo", `Hello ${input.name}`));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-template-literal-escape/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/attr-template-literal-escape/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-chain/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-chain/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _y(_scope, x * 2));
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-chain/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-chain/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/components/my-button.js
@@ -15,4 +15,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _text_(_scope, input.text);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-attrs/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/components/my-button.js
@@ -15,4 +15,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-alias/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/components/my-button.js
@@ -22,4 +22,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _pattern__(_scope, input.value);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ export function _setup_(_scope) {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/components/my-button.js
@@ -21,4 +21,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _text_(_scope, input.text);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/components/my-button.js
@@ -15,4 +15,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _text_(_scope, input.text);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-input/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _myButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-input/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/components/my-button.js
@@ -16,4 +16,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _renderBody_(_scope, input.renderBody);
 }, _renderBody_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/components/my-button.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _clickCount(_scope, 0);
   _myButton_renderBody(_scope["#childScope/0"], /* @__PURE__ */_bindRenderer(_scope, _myButtonBody));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
@@ -8,7 +8,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
     onClick: _register(function () {
       clickCount++;
     }, "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/template.marko_0/onClick", _scope0_id),
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`${_escapeXML(clickCount)}${_markResumeNode(_scope1_id, "#text/0")}`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/basic-component-renderBody/template.marko_1_clickCount/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/components/counter.js
@@ -17,4 +17,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component/components/counter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component/components/counter.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ export function _setup_(_scope) {
   _counter(_scope["#childScope/0"]);
 }
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-component/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ export function _setup_(_scope) {
   _show(_scope, true);
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ export function _setup_(_scope) {
   _show(_scope, true);
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-conditional-counter/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ export function _setup_(_scope) {
   _b(_scope, 0);
   _if(_scope, true ? _ifBody : null);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-converge-in-if/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-converge-in-if/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
@@ -23,4 +23,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter-const-event-handler/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter-const-event-handler/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
@@ -36,4 +36,4 @@ export function _setup_(_scope) {
   _count(_scope, 0);
   _multiplier(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter-multiplier/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-counter/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.expected/template.js
@@ -10,4 +10,4 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/0", _scope => _tagNam
 export const _tagName_ = /* @__PURE__ */_value("tagName", (_scope, tagName) => _dynamicTagName(_scope, tagName || _tagNameBody), _dynamicTagName);
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _tagName_(_scope, input.tagName), _tagName_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/html.expected/template.js
@@ -7,7 +7,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _dynamicScope = _peekNextScope();
   _dynamicTagInput(_dynamicScope, tagName, {
     class: ["a", "b"]
-  }, _register( /* @__PURE__ */_createRenderer(() => {
+  }, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write("Hello World");
   }), "packages/translator-tags/src/__tests__/fixtures/basic-dynamic-native-tag/template.marko_1_renderer"));

--- a/packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ const _setup__effect = _register("packages/translator-tags/src/__tests__/fixture
 export function _setup_(_scope) {
   _queueEffect(_scope, _setup__effect);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-effect-no-deps/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ export function _setup_(_scope) {
   });
   _show(_scope, true);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-execution-order/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-execution-order/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-export/__snapshots__/dom.expected/template.js
@@ -6,4 +6,4 @@ import { data as _data, value as _value, createRenderer as _createRenderer, crea
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _data(_scope["#text/0"], value));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-export/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-export/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-flush-here/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-flush-here/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<h1>Hello World</h1><script>\n    console.log('Hello 
 export const _walks_ = /* over(2) */"c";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-flush-here/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-flush-here/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-fn-with-block/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -30,4 +30,4 @@ export function _setup_(_scope) {
   _a(_scope, [0]);
   _b(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/dom.expected/template.js
@@ -9,4 +9,4 @@ export function _setup_(_scope) {
   _queueEffect(_scope, _setup__effect);
   _data(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-handler-refless/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/components/comments.js
@@ -63,4 +63,4 @@ const _forBody = _registerRenderer("packages/translator-tags/src/__tests__/fixtu
 const _for = /* @__PURE__ */_loopOf("#ul/0", _forBody);
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, [input.comments]), _intersections([_for, _inLoopScope(_input$forBody, "#ul/0")]));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/components/comments.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _comments(_scope["#childScope/0"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/components/layout.js
@@ -6,4 +6,4 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _renderBody_ = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody), _dynamicTagName);
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _renderBody_(_scope, input.renderBody), _renderBody_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-layout/components/layout.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-layout/components/layout.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export function _setup_(_scope) {
   _layout(_scope["#childScope/0"]);
   _layout_renderBody(_scope["#childScope/0"], /* @__PURE__ */_bindRenderer(_scope, _layoutBody));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-layout/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-layout/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-layout/__snapshots__/html.expected/template.js
@@ -7,7 +7,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   } = input;
   const _childScope = _peekNextScope();
   _layout._({
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`<h1>Hello <!>${_escapeXML(name)}${_markResumeNode(_scope1_id, "#text/0")}</h1>`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/basic-layout/template.marko_1_name/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ import { conditional as _conditional, value as _value, createRenderer as _create
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), _dynamicTagName);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
@@ -26,4 +26,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _childBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const count = 0;
   const _childScope = _peekNextScope();
   _child._({
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`<button>${_escapeXML(count)}${_markResumeNode(_scope1_id, "#text/1")}</button>${_markResumeNode(_scope1_id, "#button/0")}`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/template.marko_1_count/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ import { conditional as _conditional, value as _value, createRenderer as _create
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), _dynamicTagName);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -25,4 +25,4 @@ export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTagName(_scope, false || Child || _falseChildBody);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const count = 0;
   const _dynamicScope = _peekNextScope();
-  _dynamicTagInput(_dynamicScope, false || Child, {}, _register( /* @__PURE__ */_createRenderer(() => {
+  _dynamicTagInput(_dynamicScope, false || Child, {}, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write(`<button>${_escapeXML(count)}${_markResumeNode(_scope1_id, "#text/1")}</button>${_markResumeNode(_scope1_id, "#button/0")}`);
     _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/template.marko_1_count/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -33,4 +33,4 @@ export function _setup_(_scope) {
   _selected(_scope, 0);
   _for(_scope, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-for/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -24,4 +24,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-nested-scope-if/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -43,4 +43,4 @@ export function _setup_(_scope) {
   _id(_scope, 0);
   _items(_scope, []);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-push-pop-list/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-scriptlet/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ export function _setup_(_scope) {
   _data(_scope["#text/1"], doubleCount);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-scriptlet/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-scriptlet/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -37,4 +37,4 @@ export function _setup_(_scope) {
   _open(_scope, true);
   _list(_scope, [1, 2, 3]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-shared-node-ref/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-static/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-static/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ import { data as _data, createRenderer as _createRenderer, createTemplate as _cr
 export function _setup_(_scope) {
   _data(_scope["#text/0"], x);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-static/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-static/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ const _show = /* @__PURE__ */_value("show", (_scope, show) => {
 export function _setup_(_scope) {
   _show(_scope, true);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-toggle-show/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ export function _setup_(_scope) {
   _unused_2(_scope, 456);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/basic-unused-ref/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -23,4 +23,4 @@ export function _setup_(_scope) {
   _show(_scope, true);
   _message(_scope, "hi");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/batched-updates-cleanup/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
@@ -26,4 +26,4 @@ export function _setup_(_scope) {
   _a(_scope, 0);
   _b(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/batched-updates/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/batched-updates/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/components/FancyButton.js
+++ b/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/components/FancyButton.js
@@ -14,4 +14,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _renderBody_(_scope, input.renderBody);
 }, _renderBody_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/body-content/components/FancyButton.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/body-content/components/FancyButton.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ export function _setup_(_scope) {
   _FancyButton(_scope["#childScope/0"]);
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/body-content/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/body-content/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/body-content/__snapshots__/html.expected/template.js
@@ -8,7 +8,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
     onClick: _register(function () {
       clickCount++;
     }, "packages/translator-tags/src/__tests__/fixtures/body-content/template.marko_0/onClick", _scope0_id),
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`${_escapeXML(clickCount)}${_markResumeNode(_scope1_id, "#text/0")}`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/body-content/template.marko_1_clickCount/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<div>Here is a CDATA section:  with all kinds of unes
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/cdata/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/cdata/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/comments/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/comments/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<div><!--abc--><!--[if lt IE 9]><script src=\"...\"><
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/comments/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/comments/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/components/counter.js
@@ -23,4 +23,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/components/counter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/components/counter.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/template.js
@@ -9,4 +9,4 @@ export function _setup_(_scope) {
     format: formatNumber
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-import-value/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/components/display-intersection.js
@@ -15,4 +15,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _dummy(_scope, {});
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/components/display-intersection.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/components/display-intersection.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ export function _setup_(_scope) {
   _displayIntersection(_scope["#childScope/0"]);
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-intersection/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/components/counter.js
@@ -23,4 +23,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/components/counter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/components/counter.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ export function _setup_(_scope) {
     format: formatNumber2
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/component-attrs-static-code/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/dom.expected/template.js
@@ -13,4 +13,4 @@ export function _setup_(_scope) {
     y: 2
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/const-tag-destructure/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/const-tag-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/const-tag/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/const-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/const-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/dom.expected/template.js
@@ -23,4 +23,4 @@ export function _setup_(_scope) {
   _a(_scope, 0);
   _b(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/counter-intersection/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/counter-intersection/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ const _forBody = _register("packages/translator-tags/src/__tests__/fixtures/crea
 const _for = /* @__PURE__ */_loopTo("#div/0", _forBody);
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _for(_scope, [input.to, input.from, input.step]));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _for2(_scope, [input.children]);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/__snapshots__/dom.expected/components/custom-tag.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-args-error/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-args-error/__snapshots__/dom.expected/components/custom-tag.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-args-error/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-args-error/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/components/hello/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/components/hello/index.js
@@ -2,4 +2,4 @@ export const _template_ = "Hello";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/components/hello/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/components/hello/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/components/message.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/components/message.js
@@ -2,4 +2,4 @@ export const _template_ = "Frank";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/components/message.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/components/message.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "Hello Frank";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-child-analyze/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ import { data as _data, value as _value2, createRenderer as _createRenderer, cre
 const _value = /* @__PURE__ */_value2("value", (_scope, value) => _data(_scope["#text/0"], value));
 export const _input_ = /* @__PURE__ */_value2("input", (_scope, input) => _value(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value2("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.expected/template.js
@@ -13,4 +13,4 @@ export function _setup_(_scope) {
     value: 3
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-default-value/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -36,4 +36,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 10);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/template.js
@@ -15,4 +15,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _customTagBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const _childScope = _peekNextScope();
   _customTag._({
-    renderBody: _register( /* @__PURE__ */_createRenderer((count, count2) => {
+    renderBody: _register(/* @__PURE__ */_createRenderer((count, count2) => {
       const _scope1_id = _nextScopeId();
       _write(`<div>Counts: <!>${_escapeXML(count)}${_markResumeNode(_scope1_id, "#text/0")},<!>${_escapeXML(count2)}${_markResumeNode(_scope1_id, "#text/1")}</div>`);
     }), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/template.marko_1_renderer")

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/components/custom-tag.js
@@ -31,4 +31,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _customTagBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _childScope = _peekNextScope();
   _customTag._({
     name: "hello",
-    renderBody: _register( /* @__PURE__ */_createRenderer(({
+    renderBody: _register(/* @__PURE__ */_createRenderer(({
       count,
       name
     }) => {

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/components/custom-tag.js
@@ -27,4 +27,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _customTagBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const _childScope = _peekNextScope();
   _customTag._({
-    renderBody: _register( /* @__PURE__ */_createRenderer(count => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(count => {
       const _scope1_id = _nextScopeId();
       _write(`<div>Count: <!>${_escapeXML(count)}${_markResumeNode(_scope1_id, "#text/0")}</div>`);
     }), "packages/translator-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/template.marko_1_renderer")

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/components/child/index.js
@@ -6,4 +6,4 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _renderBody_ = /* @__PURE__ */_value("renderBody", (_scope, renderBody) => _dynamicTagName(_scope, renderBody), _dynamicTagName);
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _renderBody_(_scope, input.renderBody), _renderBody_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/components/child/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/components/child/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
   _child_renderBody(_scope["#childScope/0"], /* @__PURE__ */_bindRenderer(_scope, _childBody));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _childScope = _peekNextScope();
   _child._({
     name: "World",
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write("This is the body content");
     }), "packages/translator-tags/src/__tests__/fixtures/custom-tag-render-body/template.marko_1_renderer")

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-separate-assets/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-separate-assets/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-separate-assets/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-separate-assets/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/hello.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/hello.js
@@ -4,4 +4,4 @@ export const _setup_ = () => {};
 import { data as _data, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _data(_scope["#text/0"], input.name));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-template/hello.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/custom-tag-template/hello.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ export function _setup_(_scope) {
     name: "Frank"
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-template/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-template/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _tagVarSignal(_scope, x + 3
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _setTagVar(_scope, "#childScope/0", _data);
   _child(_scope["#childScope/0"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-expression/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/components/child.js
@@ -14,4 +14,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 2);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _setTagVar(_scope, "#childScope/0", _data);
   _child(_scope["#childScope/0"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var-multiple/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/components/child.js
@@ -18,4 +18,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => {
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _setTagVar(_scope, "#childScope/0", _data);
   _child(_scope["#childScope/0"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/custom-tag-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/debug-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/debug-tag/__snapshots__/dom.expected/template.js
@@ -12,4 +12,4 @@ export function _setup_(_scope) {
   _x(_scope, 0);
   _y(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/debug-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/debug-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/declaration/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/declaration/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<!><contact-info><name>Hello World</name></contact-in
 export const _walks_ = /* over(1) */"Db";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/declaration/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/declaration/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/components/child.js
@@ -10,4 +10,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _dynamicTagName(_scope, input.thing.renderBody);
 }, _dynamicTagName);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.js
@@ -26,4 +26,4 @@ export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
   _selected(_scope, false);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const selected = false;
   const myThing = {
     selected: selected,
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write("<span>The thing</span>");
     }), "packages/translator-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/template.marko_1_renderer")

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => {
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-object/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-object/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
@@ -38,4 +38,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _defineBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const x = 1;
   const myTag = {
-    renderBody: _register( /* @__PURE__ */_createRenderer((a, b, c) => {
+    renderBody: _register(/* @__PURE__ */_createRenderer((a, b, c) => {
       const _scope1_id = _nextScopeId();
       _write(`<div>${_escapeXML(a)}${_markResumeNode(_scope1_id, "#text/0")}|<!>${_escapeXML(b)}${_markResumeNode(_scope1_id, "#text/1")}|<!>${_escapeXML(c)}${_markResumeNode(_scope1_id, "#text/2")}</div>`);
     }), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-args/template.marko_1_renderer")

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
@@ -35,4 +35,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _defineBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const x = 1;
   const myTag = {
-    renderBody: _register( /* @__PURE__ */_createRenderer(({
+    renderBody: _register(/* @__PURE__ */_createRenderer(({
       number
     }) => {
       const _scope1_id = _nextScopeId();

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.js
@@ -24,4 +24,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _defineBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const x = 1;
   const myTag = {
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`<div>${_escapeXML(x)}${_markResumeNode(_scope1_id, "#text/0")}</div>`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/define-tag-render-closure/template.marko_1_x/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.js
@@ -32,4 +32,4 @@ export function _setup_(_scope) {
     renderBody: /* @__PURE__ */_bindRenderer(_scope, _defineBody)
   });
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/define-tag-render/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import { escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _w
 const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const myTag = {
-    renderBody: _register( /* @__PURE__ */_createRenderer(({
+    renderBody: _register(/* @__PURE__ */_createRenderer(({
       name
     }) => {
       const _scope1_id = _nextScopeId();

--- a/packages/translator-tags/src/__tests__/fixtures/do-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/do-tag/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ export function _setup_(_scope) {
   _str(_scope, "rendered");
   _logOutput(_scope, JSON.stringify(log));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/do-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/do-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/doctype/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/doctype/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<!><html><head><title>Title of the document</title></
 export const _walks_ = /* over(1) */"Db";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/doctype/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/doctype/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ const _show = /* @__PURE__ */_value("show", (_scope, show) => {
 export function _setup_(_scope) {
   _show(_scope, false);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dollar-global-client/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dollar-global-client/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/components/custom-tag.js
@@ -5,4 +5,4 @@ import { conditional as _conditional, value as _value, createRenderer as _create
 const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _dynamicTagName(_scope, input.renderBody), _dynamicTagName);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-closures/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-closures/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.js
@@ -36,4 +36,4 @@ export function _setup_(_scope) {
   });
   _if(_scope, Math.random() ? _ifBody : null);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-closures/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-closures/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/html.expected/template.js
@@ -8,7 +8,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   _write(`<button></button>${_markResumeNode(_scope0_id, "#button/0")}`);
   const _childScope = _peekNextScope();
   _customTag._({
-    renderBody: _register( /* @__PURE__ */_createRenderer(() => {
+    renderBody: _register(/* @__PURE__ */_createRenderer(() => {
       const _scope1_id = _nextScopeId();
       _write(`${_escapeXML(a)} ${_escapeXML(b)} <!>${_escapeXML(c)}${_markResumeNode(_scope1_id, "#text/2")}`);
       _writeEffect(_scope1_id, "packages/translator-tags/src/__tests__/fixtures/dynamic-closures/template.marko_1_c/subscriber");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-event-handlers/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -30,4 +30,4 @@ export function _setup_(_scope) {
   _tagName(_scope, "span");
   _className(_scope, "A");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/html.expected/template.js
@@ -6,7 +6,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _dynamicScope = _peekNextScope();
   _dynamicTagInput(_dynamicScope, tagName, {
     class: className
-  }, _register( /* @__PURE__ */_createRenderer(() => {
+  }, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write("body content");
   }), "packages/translator-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/template.marko_1_renderer"));

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/components/custom-tag.js
@@ -7,4 +7,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _tagVarSignal(_scope, input);
 }, _tagVarSignal);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
@@ -29,4 +29,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -4,4 +4,4 @@ export const _setup_ = () => {};
 import { data as _data, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _data(_scope["#text/0"], input));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
@@ -28,4 +28,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-args/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ const _className = /* @__PURE__ */_value("className", (_scope, className) => {
 export function _setup_(_scope) {
   _className(_scope, "A");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ import { data as _data, value as _value, createRenderer as _createRenderer, crea
 export const _id_ = /* @__PURE__ */_value("id", (_scope, id) => _data(_scope["#text/0"], id));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _id_(_scope, input.id));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
 export function _setup_(_scope) {
   _tagName(_scope, child);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-native/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child1.js
@@ -5,4 +5,4 @@ import { data as _data, value as _value, createRenderer as _createRenderer, crea
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _data(_scope["#text/0"], value));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/components/child1.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/components/child1.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/components/child2.js
@@ -5,4 +5,4 @@ import { data as _data, value as _value, createRenderer as _createRenderer, crea
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _data(_scope["#text/0"], value));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/components/child2.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/components/child2.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ export function _setup_(_scope) {
   _tagName(_scope, child1);
   _val(_scope, 3);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/components/tag-a/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/components/tag-a/index.js
@@ -2,4 +2,4 @@ export const _template_ = "";
 export const _walks_ = "";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/components/tag-a/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/components/tag-a/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/components/tag-b/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/components/tag-b/index.js
@@ -2,4 +2,4 @@ export const _template_ = "";
 export const _walks_ = "";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/components/tag-b/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/components/tag-b/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/template.js
@@ -111,4 +111,4 @@ export function _setup_(_scope) {
   _tag(_scope["#childScope/7"]);
   _tagConstA(_scope, "a");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/html.expected/template.js
@@ -55,7 +55,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   });
   const _tagName4 = showTagA && tagA;
   const _childScope2 = _peekNextScope();
-  const _renderBody = _register( /* @__PURE__ */_createRenderer(() => {
+  const _renderBody = _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write("Body content");
   }), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-name/template.marko_1_renderer");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-native/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-native/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<!><p class=par>paragraph</p><!>";
 export const _walks_ = /* over(1) */"DbD";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-native/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-native/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/components/custom-tag.js
@@ -6,4 +6,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _tagVarSignal(_scope, "hello from other");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/components/custom-tag.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/components/custom-tag.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
@@ -28,4 +28,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _dynamicTagName(_scope, tags[0]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-single-arg/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => {
 export function _setup_(_scope) {
   _x(_scope, null);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const x = null;
   const _dynamicScope = _peekNextScope();
-  _dynamicTagInput(_dynamicScope, x, {}, _register( /* @__PURE__ */_createRenderer(() => {
+  _dynamicTagInput(_dynamicScope, x, {}, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     _write("Body Content");
   }), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/template.marko_1_renderer"));

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/components/child/index.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/components/child/index.js
@@ -4,4 +4,4 @@ import { tagVarSignal as _tagVarSignal, createRenderer as _createRenderer, creat
 export function _setup_(_scope) {
   _tagVarSignal(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/components/child/index.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/components/child/index.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/template.js
@@ -15,4 +15,4 @@ export function _setup_(_scope) {
   _setTagVar(_scope, "#childScope/1", _data2);
   _child(_scope["#childScope/1"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/components/counter.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/components/counter.js
@@ -17,4 +17,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/components/counter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/components/counter.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
@@ -24,4 +24,4 @@ const _tagName = /* @__PURE__ */_value("tagName", (_scope, tagName) => {
 export function _setup_(_scope) {
   _tagName(_scope, "div");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
   const _scope0_id = _nextScopeId();
   const tagName = "div";
   const _dynamicScope = _peekNextScope();
-  _dynamicTagInput(_dynamicScope, tagName, {}, _register( /* @__PURE__ */_createRenderer(() => {
+  _dynamicTagInput(_dynamicScope, tagName, {}, _register(/* @__PURE__ */_createRenderer(() => {
     const _scope1_id = _nextScopeId();
     const _childScope = _peekNextScope();
     _counter._({});

--- a/packages/translator-tags/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/effect-counter/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ const _clickCount = /* @__PURE__ */_value("clickCount", (_scope, clickCount) => 
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-counter/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-counter/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/effect-serialize-promise/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/effect-serialize-promise/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ const _promise = /* @__PURE__ */_value("promise", (_scope, promise) => _queueEff
 export function _setup_(_scope) {
   _promise(_scope, Promise.resolve("hello"));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-serialize-promise/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-serialize-promise/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/effect-tag/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueEffect(_scope, _x_eff
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/effect-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/entities/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/entities/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "Hello John &amp; Suzy Invalid Entity: &b ; Valid Nume
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/entities/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/entities/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export function _setup_(_scope) {
   });
   _fullName(_scope, user.fullName = `${user.firstName} ${user.middleName} ${user.lastName}`);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/error-const-mutation/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/error-const-mutation/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
@@ -45,4 +45,4 @@ export function _setup_(_scope) {
     description: "HTML Reimagined"
   }]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-destructure/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ const _num = /* @__PURE__ */_value("num", (_scope, num) => _for(_scope, [num, 0,
 export function _setup_(_scope) {
   _num(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-event-handler/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-event-handler/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-tag-siblings/__snapshots__/dom.expected/template.js
@@ -16,4 +16,4 @@ const _arrA = /* @__PURE__ */_value("arrA", (_scope, arrA) => {
 export function _setup_(_scope) {
   _arrA(_scope, [1, 2, 3]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag-siblings/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag-siblings/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/dom.expected/template.js
@@ -23,4 +23,4 @@ export function _setup_(_scope) {
   _arrA(_scope, [1, 2, 3]);
   _arrB(_scope, [1, 2, 3]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag-with-state/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/for-tag/__snapshots__/dom.expected/template.js
@@ -108,4 +108,4 @@ export function _setup_(_scope) {
   _for9(_scope, [10, 0, 1]);
   _for10(_scope, [10, 0, 1]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/for-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _html(_scope, input.missing, "#text/2");
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/hello-dynamic/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/hello-dynamic/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.js
@@ -18,4 +18,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-counter/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-counter/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/components/parent-el.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/components/parent-el.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _queueEffect(_scope, _setup__effect);
   _tagName(_scope, undefined);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-var/components/parent-el.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-var/components/parent-el.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.expected/template.js
@@ -10,4 +10,4 @@ export function _setup_(_scope) {
   _setTagVar(_scope, "#childScope/2", _spanName);
   _parentEl(_scope["#childScope/2"]);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-comment-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/html-entity/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/html-entity/__snapshots__/dom.expected/template.js
@@ -2,4 +2,4 @@ export const _template_ = "<div>&lt;div&gt;</div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-entity/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/html-entity/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/id-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/id-tag/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _x(_scope, _nextTagId(_scope));
   _y(_scope, _nextTagId(_scope));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/id-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/id-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.js
@@ -19,4 +19,4 @@ const _show = /* @__PURE__ */_value("show", (_scope, show) => {
 export function _setup_(_scope) {
   _show(_scope, false);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/if-default-false/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/if-default-false/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
@@ -16,4 +16,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _if3(_scope, input.x ? _ifBody3 : input.y ? _elseIfBody : _elseBody);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/if-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/if-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-conflict/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-conflict/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _data(_scope["#text/0"], asset1);
   _data(_scope["#text/1"], asset2);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-conflict/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-conflict/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.expected/components/baz.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.expected/components/baz.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/components/baz.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/components/baz.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _bazComp(_scope["#childScope/1"]);
 }
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-shorthand/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/components/baz.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/components/baz.js
@@ -2,4 +2,4 @@ export const _template_ = "<div>baz</div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/components/baz.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/components/baz.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/components/foo.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/components/foo.js
@@ -2,4 +2,4 @@ export const _template_ = "<div>foo</div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/components/foo.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/components/foo.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _dynamicTagName(_scope, x =
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag-ternary/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected/components/baz.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected/components/baz.js
@@ -2,4 +2,4 @@ export const _template_ = "<div></div>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag/components/baz.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag/components/baz.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export function _setup_(_scope) {
   _bazComp(_scope["#childScope/2"]);
   _data(_scope["#text/3"], c);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/import-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/input-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/input-destructure/__snapshots__/dom.expected/template.js
@@ -9,4 +9,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _b_(_scope, input.b);
 });
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/input-destructure/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/input-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/components/child.js
@@ -51,4 +51,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   (_scope["_otherState_change"] ? _otherState : _otherState_init)(_scope, input["value"]);
 }, _intersections([_state_change, _state, _otherState_change, _otherState]));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.js
@@ -16,4 +16,4 @@ export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
   _source(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-child/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
@@ -33,4 +33,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _handler(_scope, _(_scope));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-id/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-id/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/__snapshots__/dom.expected/template.js
@@ -37,4 +37,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _yChange(_scope, _(_scope));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y_change(_scope, _valueChange(_scope));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-static/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-static/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
@@ -20,4 +20,4 @@ export const _a_ = /* @__PURE__ */_value("a", (_scope, a) => {
 });
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _a_(_scope, input.a));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/let-tag-derived/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/let-tag-derived/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
@@ -17,4 +17,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-set-in-effect/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
@@ -27,4 +27,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => {
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag-with-intersection/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _queueEffect(_scope, _setup__effect);
   _x(_scope, undefined);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/let-undefined-until-dom/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
@@ -42,4 +42,4 @@ export function _setup_(_scope) {
   _x(_scope, 0);
   _prev(_scope, false);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-assignment/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -58,4 +58,4 @@ export function _setup_(_scope) {
   _x(_scope, 0);
   _show(_scope, true);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-conditional/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueEffect(_scope, _x_eff
 export function _setup_(_scope) {
   _x(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag-this/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -36,4 +36,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _queueEffect(_scope, _x_eff
 export function _setup_(_scope) {
   _x(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/lifecycle-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/log-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/log-tag/__snapshots__/dom.expected/template.js
@@ -13,4 +13,4 @@ export function _setup_(_scope) {
   _tagVar(_scope, "tag var");
   _output(_scope, JSON.stringify(testLog));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/log-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/log-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/migrate-input/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/migrate-input/__snapshots__/dom.expected/template.js
@@ -4,4 +4,4 @@ export const _setup_ = () => {};
 import { data as _data, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _data(_scope["#text/0"], input.x));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/migrate-input/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/migrate-input/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/migrate-out-global/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/migrate-out-global/__snapshots__/dom.expected/template.js
@@ -4,4 +4,4 @@ import { data as _data, createRenderer as _createRenderer, createTemplate as _cr
 export function _setup_(_scope) {
   _data(_scope["#text/0"], _scope.$global.x);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/migrate-out-global/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/migrate-out-global/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export const _children_ = /* @__PURE__ */_value("children", (_scope, children) =
 }]));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _children_(_scope, input.children));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/move-and-clear-children/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.expected/template.js
@@ -10,4 +10,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _for(_s
   return c.id;
 }]));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/move-and-clear-top-level/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.expected/template.js
@@ -10,4 +10,4 @@ const _if = /* @__PURE__ */_conditional("#text/1");
 export function _setup_(_scope) {
   _if(_scope, true ? _ifBody : null);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
+++ b/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/components/hello-setter.js
@@ -11,4 +11,4 @@ const _el__effect = _register("packages/translator-tags/src/__tests__/fixtures/n
 export const _el_ = /* @__PURE__ */_value("el", (_scope, el) => _queueEffect(_scope, _el__effect));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _el_(_scope, input.el));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/components/hello-setter.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/components/hello-setter.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _helloSetter(_scope["#childScope/1"]);
   _helloSetter__el_(_scope["#childScope/1"], /* @__PURE__ */_bindFunction(_scope, el_getter));
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect-child/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ const _setup__effect = _register("packages/translator-tags/src/__tests__/fixture
 export function _setup_(_scope) {
   _queueEffect(_scope, _setup__effect);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/native-tag-ref-effect/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
@@ -22,4 +22,4 @@ export function _setup_(_scope) {
   _lastCount(_scope, 0);
   _lastCount2(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/nested-assignment-expression/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/placeholders/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _html(_scope, "Hello HTML <a/>", "#text/4");
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/placeholders/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/placeholders/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
@@ -39,4 +39,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/reassignment-expression-counter/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.expected/template.js
@@ -11,4 +11,4 @@ export const _children_ = /* @__PURE__ */_value("children", (_scope, children) =
 }]));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _children_(_scope, input.children));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/remove-and-add-rows/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/components/child.js
@@ -5,4 +5,4 @@ const _x = /* @__PURE__ */_value("x", (_scope, x) => _tagVarSignal(_scope, x), _
 export function _setup_(_scope) {
   _x(_scope, 1);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
 }
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/return-tag-no-var/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/__snapshots__/dom.expected/template.js
@@ -12,4 +12,4 @@ export const _b_ = /* @__PURE__ */_value("b", (_scope, b) => {
 export const _pattern__ = /* @__PURE__ */_value("_pattern_", (_scope, _pattern_) => _b_(_scope, _pattern_.b));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _pattern__(_scope, input.a));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.js
@@ -31,4 +31,4 @@ const _count = /* @__PURE__ */_value("count", (_scope, count) => {
 export function _setup_(_scope) {
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/same-source-non-alias/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/server-client/__snapshots__/dom.expected/template.js
@@ -6,4 +6,4 @@ import { data as _data, createRenderer as _createRenderer, createTemplate as _cr
 export function _setup_(_scope) {
   _data(_scope["#text/0"], x);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/server-client/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/server-client/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.js
@@ -59,4 +59,4 @@ export function _setup_(_scope) {
   _count3(_scope, 0);
   _count4(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/shadow-same-scope/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/shadow-same-scope/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/style-tag-modules-default/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/style-tag-modules-default/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ import { classAttr as _classAttr, createRenderer as _createRenderer, createTempl
 export function _setup_(_scope) {
   _classAttr(_scope["#div/1"], myStyles.content);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-modules-default/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-modules-default/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/style-tag-modules-destructured/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/style-tag-modules-destructured/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ import { classAttr as _classAttr, createRenderer as _createRenderer, createTempl
 export function _setup_(_scope) {
   _classAttr(_scope["#div/1"], content);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-modules-destructured/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-modules-destructured/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/style-tag-type/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/style-tag-type/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ import "virtual:./template.marko.less \n  .content {\n    color: green;\n  }\n";
 import "virtual:./template.marko.less \n  .content {\n    color: blue;\n  }\n";
 import "virtual:./template.marko.less \n  .content {\n    color: red;\n  }\n";
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-type/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag-type/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/style-tag/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/style-tag/__snapshots__/dom.expected/template.js
@@ -3,4 +3,4 @@ export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import "virtual:./template.marko.css \n  .content {\n    color: green;\n  }\n";
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/style-tag/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.expected/components/baz.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.expected/components/baz.js
@@ -2,4 +2,4 @@ export const _template_ = "<span></span>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/components/baz.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/components/baz.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ const _dynamicTagName = /* @__PURE__ */_conditional("#text/0");
 export function _setup_(_scope) {
   _dynamicTagName(_scope, baz);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-resolution-priority/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
@@ -49,4 +49,4 @@ export function _setup_(_scope) {
   _d(_scope, 0);
   _e(_scope, []);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/tag-var-destructure/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.expected/template.js
@@ -8,4 +8,4 @@ const _if = /* @__PURE__ */_conditional("#text/0");
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _if(_scope, value ? _ifBody : null), _intersections([_if, _inConditionalScope(_value$ifBody, "#text/0")]));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value), _value_);
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/toggle-first-child/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/toggle-first-child/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
@@ -57,4 +57,4 @@ export function _setup_(_scope) {
   _inner(_scope, true);
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/toggle-nested-2/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => {
   _value2_(_scope, input.value2);
 }, _intersections([_show_, _value1_, _value2_]));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]), _input_);
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/toggle-nested/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/toggle-nested/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/update-attr/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/update-attr/__snapshots__/dom.expected/template.js
@@ -4,4 +4,4 @@ export const _setup_ = () => {};
 import { attr as _attr, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _attr(_scope["#div/0"], "b", input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-attr/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-attr/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/dom.expected/template.js
@@ -30,4 +30,4 @@ export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) =>
 export function _setup_(_scope) {
   _a(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-dynamic-attrs/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/update-html/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ import { html as _html, value as _value, createRenderer as _createRenderer, crea
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _html(_scope, value, "#text/0"));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-html/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-html/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/update-text/__snapshots__/dom.expected/template.js
@@ -5,4 +5,4 @@ import { data as _data, value as _value, createRenderer as _createRenderer, crea
 export const _value_ = /* @__PURE__ */_value("value", (_scope, value) => _data(_scope["#text/0"], value));
 export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _value_(_scope, input.value));
 export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-text/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/update-text/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.js
@@ -21,4 +21,4 @@ export function _setup_(_scope) {
   _a(_scope, 0);
   _b(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, _params__), "packages/translator-tags/src/__tests__/fixtures/user-effect-abort-signal/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.expected/components/child.js
+++ b/packages/translator-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.expected/components/child.js
@@ -2,4 +2,4 @@ export const _template_ = "<span>Hello</span>";
 export const _walks_ = /* over(1) */"b";
 export const _setup_ = () => {};
 import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/walk-over-child/components/child.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/walk-over-child/components/child.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.expected/template.js
@@ -7,4 +7,4 @@ export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
   _count(_scope, 0);
 }
-export default /* @__PURE__ */_createTemplate( /* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/walk-over-child/template.marko");
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/walk-over-child/template.marko");


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

- updated `VComment` to not assume the host is the document
- regenerated lockfile, primarily to update `@babel/generate`
- updated `it-fails` to get a fix for an issue that caused the process to exit early
- updated lots of snapshots that had whitespace changes due to `@babel/generate` changes

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] ~I have updated/added documentation affected by my changes.~
- [ ] ~I have added tests to cover my changes.~
