### PR TITLE
fix: throw error instead of printing CDATA

### DIFF
--- a/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.error.txt
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/translator-tags/src/__tests__/fixtures/cdata/template.marko:1:31
+    > 1 | <div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>
+        |                               ^^^^^^^^^^^^^^^^^^^ CDATA sections are not supported in Marko.
+      2 |

--- a/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/dom.expected/template.js
@@ -1,5 +1,0 @@
-export const _template_ = "<div>Here is a CDATA section:  with all kinds of unescaped text.</div>";
-export const _walks_ = /* over(1) */"b";
-export const _setup_ = () => {};
-import { createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
-export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_), "packages/translator-tags/src/__tests__/fixtures/cdata/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/html.expected/template.error.txt
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/html.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/translator-tags/src/__tests__/fixtures/cdata/template.marko:1:31
+    > 1 | <div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>
+        |                               ^^^^^^^^^^^^^^^^^^^ CDATA sections are not supported in Marko.
+      2 |

--- a/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/html.expected/template.js
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/__snapshots__/html.expected/template.js
@@ -1,6 +1,0 @@
-import { write as _write, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/html";
-const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
-  const _scope0_id = _nextScopeId();
-  _write("<div>Here is a CDATA section: <![CDATA[ < > & ]]> with all kinds of unescaped text.</div>");
-});
-export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-tags/src/__tests__/fixtures/cdata/template.marko");

--- a/packages/translator-tags/src/__tests__/fixtures/cdata/test.ts
+++ b/packages/translator-tags/src/__tests__/fixtures/cdata/test.ts
@@ -1,2 +1,1 @@
-export const skip_csr = true;
-export const skip_ssr = true;
+export const error_compiler = true;

--- a/packages/translator-tags/src/visitors/cdata.ts
+++ b/packages/translator-tags/src/visitors/cdata.ts
@@ -1,15 +1,11 @@
 import type { types as t } from "@marko/compiler";
 
-import { isOutputHTML } from "../util/marko-config";
-import * as writer from "../util/writer";
-
 export default {
   translate: {
-    exit(cdata: t.NodePath<t.MarkoCDATA>) {
-      if (isOutputHTML()) {
-        writer.writeTo(cdata)`<![CDATA[${cdata.node.value}]]>`;
-      }
-      cdata.remove();
+    enter(path: t.NodePath<t.MarkoCDATA>) {
+      throw path.buildCodeFrameError(
+        "CDATA sections are not supported in Marko.",
+      );
     },
   },
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- People shouldn't be using CDATA in `.marko` files, let's throw an error instead.

