### PR TITLE
fix: downgrade minimatch

### DIFF
--- a/.changeset/hip-roses-prove.md
+++ b/.changeset/hip-roses-prove.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Downgrade minimatch module since latest version requires node 20.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10892,7 +10892,7 @@
         "csstype": "^3.1.3",
         "events-light": "^1.0.5",
         "listener-tracker": "^2.0.0",
-        "minimatch": "^10.0.1",
+        "minimatch": "^9.0.5",
         "raptor-util": "^3.2.0",
         "resolve-from": "^5.0.0",
         "self-closing-tags": "^1.0.1",
@@ -10910,13 +10910,15 @@
       }
     },
     "packages/marko/node_modules/minimatch": {
-      "version": "10.0.1",
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": ">=16 || 14 >=14.17"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/packages/marko/package.json
+++ b/packages/marko/package.json
@@ -74,7 +74,7 @@
     "csstype": "^3.1.3",
     "events-light": "^1.0.5",
     "listener-tracker": "^2.0.0",
-    "minimatch": "^10.0.1",
+    "minimatch": "^9.0.5",
     "raptor-util": "^3.2.0",
     "resolve-from": "^5.0.0",
     "self-closing-tags": "^1.0.1",


### PR DESCRIPTION
Downgrade minimatch module since latest version requires node 20 while we support 18+.