### PR TITLE
fix: remove default compiler cache clearing

### DIFF
--- a/.changeset/forty-eagles-end.md
+++ b/.changeset/forty-eagles-end.md
@@ -1,0 +1,8 @@
+---
+"@marko/translator-tags": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Remove the default cache auto clearing behavior.
+Previously the default compiler "cache" was cleared every setImmediate. This was to support server hot reloading in apps using `Lasso` (and `browser-refresh`). Since we brought back support for `browser-refresh` in the Marko package we now clear this cache when browser-refresh triggers a change making the default cache clearing redundant.

--- a/packages/compiler/src/config.js
+++ b/packages/compiler/src/config.js
@@ -130,10 +130,6 @@ const config = {
   /**
    * Compiling a Marko template may require other (used) Marko templates to compile.
    * To prevent compiling templates more than once, most of the compilation is cached.
-   *
-   * The default cache strategy is to clear the cache on every macrotask.
-   * If the default cache is overwritten it is up to the user to determine when the
-   * cache is cleared.
    */
   cache: new Map(),
 

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -26,7 +26,6 @@ export async function compile(src, filename, config) {
   const markoConfig = loadMarkoConfig(config);
   const babelConfig = await loadBabelConfig(filename, markoConfig);
   const babelResult = await babel.transformAsync(src, babelConfig);
-  scheduleDefaultClear(markoConfig);
   return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
 }
 
@@ -34,7 +33,6 @@ export function compileSync(src, filename, config) {
   const markoConfig = loadMarkoConfig(config);
   const babelConfig = loadBabelConfigSync(filename, markoConfig);
   const babelResult = babel.transformSync(src, babelConfig);
-  scheduleDefaultClear(markoConfig);
   return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
 }
 
@@ -154,23 +152,8 @@ function buildResult(src, filename, errorRecovery, babelResult) {
   return { ast, map, code, meta };
 }
 
-let clearingDefaultCache = false;
-function scheduleDefaultClear(config) {
-  if (
-    !clearingDefaultCache &&
-    (clearingDefaultCache = isDefaultCache(config))
-  ) {
-    setImmediate(_clearDefaults);
-  }
-}
-
 export function _clearDefaults() {
-  clearingDefaultCache = false;
   globalConfig.cache.clear();
-}
-
-function isDefaultCache(config) {
-  return !config.cache || config.cache === globalConfig.cache;
 }
 
 function getFs(config) {

--- a/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/__snapshots__/csr.expected.md
+++ b/packages/translator-tags/src/__tests__/fixtures/let-tag-controllable-runtime-error/__snapshots__/csr.expected.md
@@ -75,9 +75,9 @@ Error: Change handler '_y_change' cannot change from a function to null
     at signal (/packages/runtime-tags/src/dom/signals.ts:94:13)
     at runBatch (/packages/runtime-tags/src/dom/queue.ts:107:5)
     at run (/packages/runtime-tags/src/dom/queue.ts:52:5)
-    at csr (/packages/translator-tags/src/__tests__/main.test.ts:280:17)
+    at csr (/packages/translator-tags/src/__tests__/main.test.ts:282:17)
     at processTicksAndRejections (node:internal/process/task_queues:95:5)
-    at /packages/translator-tags/src/__tests__/main.test.ts:367:37
+    at /packages/translator-tags/src/__tests__/main.test.ts:369:37
     at resolveFixture (/node_modules/mocha-snap/dist/util/resolve-fixture.js:64:16)
     at snap (/node_modules/mocha-snap/dist/snap.js:46:20)
 ```

--- a/packages/translator-tags/src/__tests__/main.test.ts
+++ b/packages/translator-tags/src/__tests__/main.test.ts
@@ -50,6 +50,7 @@ const baseConfig: compiler.Config = {
 
 const htmlConfig: compiler.Config = { ...baseConfig, output: "html" };
 const domConfig: compiler.Config = { ...baseConfig, output: "dom" };
+const snapCache = new Map<unknown, unknown>();
 
 describe("translator-tags", () => {
   before(() => {
@@ -107,6 +108,7 @@ describe("translator-tags", () => {
         });
         const finalConfig: compiler.Config = {
           ...compilerConfig,
+          cache: snapCache, // these need a different cache since they `resolveVirtualDependency` is relevant to the compile cache.
           resolveVirtualDependency(_filename, { code, virtualPath }) {
             return `virtual:${virtualPath} ${code}`;
           },

--- a/packages/translator-tags/src/__tests__/utils/bundle.ts
+++ b/packages/translator-tags/src/__tests__/utils/bundle.ts
@@ -16,6 +16,7 @@ export async function bundle(
   entryTemplate: string,
   compilerConfig: compiler.Config,
 ) {
+  const cache = new Map<unknown, unknown>();
   const optimizeKnownTemplates: string[] = await glob(
     path.join(path.dirname(entryTemplate), "**/*.marko"),
     { absolute: true },
@@ -77,6 +78,7 @@ export async function bundle(
             return (
               await compiler.compile(code, id, {
                 ...compilerConfig,
+                cache,
                 optimize: true,
                 optimizeKnownTemplates,
                 output: isHydrate ? "hydrate" : "dom",


### PR DESCRIPTION
Remove the default cache auto clearing behavior.
Previously the default compiler "cache" was cleared every setImmediate. This was to support server hot reloading in apps using `Lasso` (and `browser-refresh`). Since we brought back support for `browser-refresh` in the Marko package we now clear this cache when browser-refresh triggers a change making the default cache clearing redundant.