### PR TITLE
fix: direct import of tags in translator-default

### DIFF
--- a/.changeset/sharp-monkeys-deny.md
+++ b/.changeset/sharp-monkeys-deny.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Allow child template analysis on manually imported tags in translator-default and optimize direct reference of imported tag

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/csr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/csr.expected.md
@@ -1,0 +1,136 @@
+# Render {}
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  data-parent="0"
+  id="tags"
+>
+  0
+</button>
+```
+
+# Mutations
+```
+inserted #text0, button1, #text2, #text3, button4, #text5, #text6, #text7
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  data-parent="0"
+  id="tags"
+>
+  1
+</button>
+```
+
+# Mutations
+```
+button4/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("#class").click()
+
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  data-parent="1"
+  id="tags"
+>
+  1
+</button>
+```
+
+# Mutations
+```
+button4: attr(data-parent) "0" => "1"
+button1/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  data-parent="1"
+  id="tags"
+>
+  2
+</button>
+```
+
+# Mutations
+```
+button4/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("#class").click()
+
+```html
+<button
+  id="class"
+>
+  2
+</button>
+<button
+  data-parent="2"
+  id="tags"
+>
+  2
+</button>
+```
+
+# Mutations
+```
+button4: attr(data-parent) "1" => "2"
+button1/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<button
+  id="class"
+>
+  2
+</button>
+<button
+  data-parent="2"
+  id="tags"
+>
+  3
+</button>
+```
+
+# Mutations
+```
+button4/#text0: "2" => "3"
+```

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/components/tags-counter.js
@@ -1,0 +1,22 @@
+export const _template_ = "<button id=tags> </button>";
+export const _walks_ = /* get, next(1), get, out(1) */" D l";
+import { attr as _attr, on as _on, data as _data, queueSource as _queueSource, register as _register, queueEffect as _queueEffect, value as _value, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/dom";
+const _onClick = _scope => {
+  const {
+    count
+  } = _scope;
+  return function () {
+    _queueSource(_scope, _count, count + 1);
+  };
+};
+const _count_effect = _register("packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count", _scope => _on(_scope["#button/0"], "click", _onClick(_scope)));
+const _count = /* @__PURE__ */_value("count", (_scope, count) => {
+  _data(_scope["#text/1"], count);
+  _queueEffect(_scope, _count_effect);
+});
+export const _input_ = /* @__PURE__ */_value("input", (_scope, input) => _attr(_scope["#button/0"], "data-parent", input.count));
+export const _params__ = /* @__PURE__ */_value("_params_", (_scope, _params_) => _input_(_scope, _params_[0]));
+export function _setup_(_scope) {
+  _count(_scope, 0);
+}
+export default /* @__PURE__ */_createTemplate(/* @__PURE__ */_createRenderer(_template_, _walks_, _setup_, void 0, void 0, () => _params__), "packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,3 @@
+import { init } from "marko/src/runtime/components/index.js";
+import "./template.marko";
+init();

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/template.js
@@ -1,0 +1,38 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import TagsCounter from "./components/tags-counter.marko";
+import "marko/src/runtime/helpers/tags-compat/dom-debug.mjs";
+import _TagsCounter from "./components/tags-counter.marko";
+import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {
+  onCreate() {
+    this.state = {
+      count: 0
+    };
+  },
+  increment() {
+    this.state.count++;
+  }
+};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.be("button", {
+    "id": "class"
+  }, "0", _component, null, 1, {
+    "onclick": _componentDef.d("click", "increment", false)
+  });
+  out.t(state.count, _component);
+  out.ee();
+  _marko_dynamic_tag(out, _TagsCounter, () => ({
+    "count": state.count
+  }), null, null, null, _componentDef, "1");
+}, {
+  t: _marko_componentType,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/components/tags-counter.js
@@ -1,0 +1,11 @@
+import { attr as _attr, escapeXML as _escapeXML, markResumeNode as _markResumeNode, write as _write, writeEffect as _writeEffect, writeScope as _writeScope, nextScopeId as _nextScopeId, createRenderer as _createRenderer, createTemplate as _createTemplate } from "@marko/runtime-tags/debug/html";
+const _renderer = /* @__PURE__ */_createRenderer((input, _tagVar) => {
+  const _scope0_id = _nextScopeId();
+  const count = 0;
+  _write(`<button id=tags${_attr("data-parent", input.count)}>${_escapeXML(count)}${_markResumeNode(_scope0_id, "#text/1")}</button>${_markResumeNode(_scope0_id, "#button/0")}`);
+  _writeEffect(_scope0_id, "packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count");
+  _writeScope(_scope0_id, {
+    "count": count
+  });
+});
+export default /* @__PURE__ */_createTemplate(_renderer, "packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/template.js
@@ -1,0 +1,34 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import TagsCounter from "./components/tags-counter.marko";
+import { x as _marko_escapeXml } from "marko/src/runtime/html/helpers/escape-xml.js";
+import "marko/src/runtime/helpers/tags-compat/html-debug.mjs";
+import _TagsCounter from "./components/tags-counter.marko";
+import _marko_dynamic_tag from "marko/src/runtime/helpers/dynamic-tag.js";
+import _initComponents from "marko/src/core-tags/components/init-components-tag.js";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {
+  onCreate() {
+    this.state = {
+      count: 0
+    };
+  },
+  increment() {
+    this.state.count++;
+  }
+};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.w("<button id=class>");
+  out.w(_marko_escapeXml(state.count));
+  out.w("</button>");
+  _marko_dynamic_tag(out, _TagsCounter, () => ({
+    "count": state.count
+  }), null, null, null, _componentDef, "1");
+  _marko_tag(_initComponents, {}, out, _componentDef, "2");
+}, {
+  t: _marko_componentType,
+  d: true
+}, _marko_component);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/resume.expected.md
@@ -1,0 +1,208 @@
+# Render {}
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      0
+    </button>
+    <button
+      data-parent="0"
+      id="tags"
+    >
+      0
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0/body1/#text0
+inserted #document/html0/body1/#text8
+removed #comment before #document/html0/body1/#text0
+removed #comment after #document/html0/body1/#text8
+#document/html0/body1/button4: attr(data-parent) "0" => "0"
+inserted #document/html0/body1/#text2
+inserted #document/html0/body1/#text7
+inserted #document/html0/body1/#text3
+inserted #document/html0/body1/#text6
+removed #comment after #document/html0/body1/#text3
+removed #comment after #document/html0/body1/#comment5
+removed #document/html0/body1/#text7 after #document/html0/body1/#text6
+inserted #document/html0/body1/#text7
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      0
+    </button>
+    <button
+      data-parent="0"
+      id="tags"
+    >
+      1
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button4/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("#class").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      1
+    </button>
+    <button
+      data-parent="1"
+      id="tags"
+    >
+      1
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button4: attr(data-parent) "0" => "1"
+#document/html0/body1/button1/#text0: "0" => "1"
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      1
+    </button>
+    <button
+      data-parent="1"
+      id="tags"
+    >
+      2
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button4/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("#class").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      2
+    </button>
+    <button
+      data-parent="2"
+      id="tags"
+    >
+      2
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button4: attr(data-parent) "1" => "2"
+#document/html0/body1/button1/#text0: "1" => "2"
+```
+
+
+# Render 
+container.querySelector("#tags").click()
+
+```html
+<html>
+  <head />
+  <body>
+    <button
+      id="class"
+    >
+      2
+    </button>
+    <button
+      data-parent="2"
+      id="tags"
+    >
+      3
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+#document/html0/body1/button4/#text0: "2" => "3"
+```

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/ssr.expected.md
@@ -1,0 +1,51 @@
+# Write
+  <!--M#s0--><button id=class>0</button><!--F#1--><button id=tags data-parent=0>0<!--M_*0 #text/1--></button><!--M_*0 #button/0--><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})</script>
+
+
+# Render "End"
+```html
+<html>
+  <head />
+  <body>
+    <!--M#s0-->
+    <button
+      id="class"
+    >
+      0
+    </button>
+    <!--F#1-->
+    <button
+      data-parent="0"
+      id="tags"
+    >
+      0
+      <!--M_*0 #text/1-->
+    </button>
+    <!--M_*0 #button/0-->
+    <!--F/-->
+    <!--M/-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={0:{m5c:"s0-1",count:0}}),0,"$compat_setScope",0,"packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko_0_count",0];M._.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko"]})
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+inserted #document/html0
+inserted #document/html0/head0
+inserted #document/html0/body1
+inserted #document/html0/body1/#comment0
+inserted #document/html0/body1/button1
+inserted #document/html0/body1/button1/#text0
+inserted #document/html0/body1/#comment2
+inserted #document/html0/body1/button3
+inserted #document/html0/body1/button3/#text0
+inserted #document/html0/body1/button3/#comment1
+inserted #document/html0/body1/#comment4
+inserted #document/html0/body1/#comment5
+inserted #document/html0/body1/#comment6
+inserted #document/html0/body1/script7
+inserted #document/html0/body1/script7/#text0
+```

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/components/tags-counter.marko
@@ -1,0 +1,4 @@
+<let/count = 0/>
+<button id="tags" data-parent=input.count onClick() { count++ }>
+  ${count}
+</button>

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/template.marko
@@ -1,0 +1,15 @@
+import TagsCounter from "./components/tags-counter.marko";
+
+class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+  increment() {
+    this.state.count++;
+  }
+}
+<button id="class" onClick("increment")>
+  ${state.count}
+</button>
+<TagsCounter count=state.count/>
+<init-components/>

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/test.ts
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/test.ts
@@ -1,0 +1,16 @@
+export const steps = [
+  {},
+  clickTags,
+  clickClass,
+  clickTags,
+  clickClass,
+  clickTags,
+];
+
+function clickClass(container: Element) {
+  (container.querySelector("#class") as HTMLButtonElement).click();
+}
+
+function clickTags(container: Element) {
+  (container.querySelector("#tags") as HTMLButtonElement).click();
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Manually imported tags in Marko 5 can now be analyzed and are optimized to use the import instead of being a dynamic tag.

<!--- Describe your changes in detail -->

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
