### PR TITLE
fix: ts was not finding `.marko` files

### DIFF
--- a/.changeset/calm-boxes-give.md
+++ b/.changeset/calm-boxes-give.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"marko": patch
+---
+
+TypeScript dependency fix

--- a/packages/compiler/src/taglib/index.js
+++ b/packages/compiler/src/taglib/index.js
@@ -133,5 +133,5 @@ function resolveTaglib(id) {
 
 function hasRootDependency(id) {
   const pkg = getRootPackage(process.cwd());
-  return !!((pkg && pkg.dependencies?.[id]) || pkg.devDependencies?.[id]);
+  return !!(pkg && (pkg.dependencies?.[id] || pkg.devDependencies?.[id]));
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

```ts
import type { Input } from "./index.marko";
//                         ^^^^^^^^^^^^^^^  File './index.marko' is not a module.
```

## Description

- Thanks @DylanPiercey for finding this fix


## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
