### PR TITLE
fix: emit errors properly

### DIFF
--- a/packages/runtime-tags/src/html/template.ts
+++ b/packages/runtime-tags/src/html/template.ts
@@ -127,15 +127,17 @@ class ServerRenderResult implements RenderResult {
         stream.write(html);
       },
       (err) => {
-        const socket = ("socket" in stream && stream.socket) as Record<
-          PropertyKey,
-          unknown
-        >;
-        if (typeof socket.destroySoon === "function") {
+        const socket = ("socket" in stream && stream.socket) as
+          | Record<PropertyKey, unknown>
+          | undefined
+          | false;
+        if (socket && typeof socket.destroySoon === "function") {
           socket.destroySoon();
         }
 
-        stream.emit?.("error", err);
+        if (!stream.emit?.("error", err)) {
+          throw err;
+        }
       },
       () => {
         stream.end();


### PR DESCRIPTION
- Handle edge case where `stream.emit` doesn't exist or it doesn't emit an error properly.
- Improve safety of `socket`