### PR TITLE
fix: use MarkoTagBody for control flow

### DIFF
--- a/.changeset/mean-ants-perform.md
+++ b/.changeset/mean-ants-perform.md
@@ -1,0 +1,11 @@
+---
+"@marko/translator-default": patch
+"@marko/translator-tags": patch
+"@marko/babel-utils": patch
+"@marko/compiler": patch
+"marko": patch
+"@marko/runtime-tags": patch
+"@marko/translator-interop-class-tags": patch
+---
+
+Always use MarkoTagBody AST nodes for control flow (even with attribute tags). This fixes a regression with the @marko/tags-api-preview and is more accurate to what is actually happening, especially from a variable scoping perspective.

--- a/packages/babel-utils/src/tags.js
+++ b/packages/babel-utils/src/tags.js
@@ -213,7 +213,10 @@ export function findParentTag(path) {
 }
 
 export function findAttributeTags(path, attributeTags = []) {
-  path.get("attributeTags").forEach((child) => {
+  const attrTags = path.node.body.attributeTags
+    ? path.get("body").get("body")
+    : path.get("attributeTags");
+  attrTags.forEach((child) => {
     if (isAttributeTag(child)) {
       attributeTags.push(child);
     } else if (isTransparentTag(child)) {

--- a/packages/compiler/src/babel-types/types/definitions.js
+++ b/packages/compiler/src/babel-types/types/definitions.js
@@ -175,6 +175,10 @@ const MarkoDefinitions = {
         ]),
         default: [],
       },
+      attributeTags: {
+        validate: assertValueType("boolean"),
+        default: false,
+      },
     },
   },
 

--- a/packages/translator-default/src/tag/index.js
+++ b/packages/translator-default/src/tag/index.js
@@ -50,8 +50,8 @@ export default {
     if (!isAttributeTag(path)) {
       if (
         !tagDef &&
-        path.node.attributeTags.length &&
         path.hub.file.markoOpts.ignoreUnrecognizedTags &&
+        (path.node.attributeTags.length || path.node.body.attributeTags) &&
         !isDynamicTag(path)
       ) {
         moveIgnoredAttrTags(path);
@@ -261,9 +261,13 @@ function isMarkoFile(request) {
 }
 
 function moveIgnoredAttrTags(parentTag) {
-  if (!parentTag.node.attributeTags.length) return;
+  const attrTags = parentTag.node.body.attributeTags
+    ? parentTag.get("body").get("body")
+    : parentTag.get("attributeTags");
 
-  for (const attrTag of parentTag.get("attributeTags")) {
+  if (!attrTags.length) return;
+
+  for (const attrTag of attrTags) {
     if (attrTag.isMarkoTag()) {
       if (isAttributeTag(attrTag)) {
         attrTag.set(

--- a/packages/translator-default/src/taglib/core/conditional/translate-else.js
+++ b/packages/translator-default/src/taglib/core/conditional/translate-else.js
@@ -15,10 +15,6 @@ export function exit(path) {
       );
   }
 
-  ifStatement.alternate = t.blockStatement(
-    path.node.attributeTags.length
-      ? path.node.attributeTags
-      : path.node.body.body,
-  );
+  ifStatement.alternate = t.blockStatement(path.node.body.body);
   path.remove();
 }

--- a/packages/translator-default/src/taglib/core/conditional/util.js
+++ b/packages/translator-default/src/taglib/core/conditional/util.js
@@ -12,11 +12,7 @@ export function buildIfStatement(path, args) {
 
   const ifStatement = t.ifStatement(
     args.length === 1 ? args[0] : t.sequenceExpression(args),
-    t.blockStatement(
-      path.node.attributeTags.length
-        ? path.node.attributeTags
-        : path.node.body.body,
-    ),
+    t.blockStatement(path.node.body.body),
   );
 
   let nextPath = path.getNextSibling();

--- a/packages/translator-default/src/taglib/core/translate-for.js
+++ b/packages/translator-default/src/taglib/core/translate-for.js
@@ -7,7 +7,7 @@ export function exit(path) {
     attributes,
     body: { params },
   } = node;
-  const body = node.attributeTags.length ? node.attributeTags : node.body.body;
+  const body = node.body.body;
   const namePath = path.get("name");
   const ofAttr = findName(attributes, "of");
   const inAttr = findName(attributes, "in");

--- a/packages/translator-default/src/taglib/core/translate-while.js
+++ b/packages/translator-default/src/taglib/core/translate-while.js
@@ -24,11 +24,7 @@ export function exit(path) {
     withPreviousLocation(
       t.whileStatement(
         getArgOrSequence(path),
-        t.blockStatement(
-          path.node.attributeTags.length
-            ? path.node.attributeTags
-            : path.node.body.body,
-        ),
+        t.blockStatement(path.node.body.body),
       ),
       path.node,
     ),

--- a/packages/translator-default/src/util/optimize-vdom-create.js
+++ b/packages/translator-default/src/util/optimize-vdom-create.js
@@ -72,6 +72,7 @@ const analyzeStaticVisitor = {
       let isStatic =
         isNativeTag(path) &&
         !path.node.attributeTags.length &&
+        !path.node.body.attributeTags &&
         !path.node.body.params.length &&
         !path.node.arguments &&
         !hasUserKey(path);

--- a/packages/translator-tags/src/core/if.ts
+++ b/packages/translator-tags/src/core/if.ts
@@ -60,7 +60,7 @@ declare module "@marko/compiler/dist/types" {
 export const IfTag = {
   analyze(tag) {
     assertValidCondition(tag);
-    if (tag.node.attributeTags.length) return;
+    if (tag.node.body.attributeTags) return;
 
     const [isLast, branches] = getBranches(tag, startSection(tag.get("body")));
     if (isLast) {
@@ -103,7 +103,7 @@ export const IfTag = {
   translate: translateByTarget({
     html: {
       enter(tag) {
-        if (tag.node.attributeTags.length) return;
+        if (tag.node.body.attributeTags) return;
 
         const tagBody = tag.get("body");
         const bodySection = getSectionForBody(tagBody);
@@ -130,7 +130,7 @@ export const IfTag = {
         }
       },
       exit(tag) {
-        if (tag.node.attributeTags.length) return;
+        if (tag.node.body.attributeTags) return;
 
         const tagBody = tag.get("body");
         const section = getSection(tag);
@@ -271,7 +271,7 @@ export const IfTag = {
     },
     dom: {
       enter(tag) {
-        if (tag.node.attributeTags.length) return;
+        if (tag.node.body.attributeTags) return;
 
         const tagBody = tag.get("body");
         const bodySection = getSectionForBody(tagBody);
@@ -287,7 +287,7 @@ export const IfTag = {
         walks.enterShallow(tag);
       },
       exit(tag) {
-        if (tag.node.attributeTags.length) return;
+        if (tag.node.body.attributeTags) return;
 
         const [isLast, branches] = getBranches(
           tag,

--- a/packages/translator-tags/src/util/get-parent-tag.ts
+++ b/packages/translator-tags/src/util/get-parent-tag.ts
@@ -1,0 +1,12 @@
+import type { types as t } from "@marko/compiler";
+
+export function getParentTag(tag: t.NodePath<t.MarkoTag>) {
+  const parent =
+    tag.parent.type === "MarkoTagBody"
+      ? tag.parentPath.parentPath
+      : tag.parentPath;
+
+  if (parent!.type === "MarkoTag") {
+    return parent as t.NodePath<t.MarkoTag>;
+  }
+}

--- a/packages/translator-tags/src/util/references.ts
+++ b/packages/translator-tags/src/util/references.ts
@@ -701,7 +701,9 @@ export function getAllTagReferenceNodes(
     referenceNodes.push(attr.value);
   }
 
-  for (const child of tag.attributeTags) {
+  for (const child of tag.body.attributeTags
+    ? tag.body.body
+    : tag.attributeTags) {
     switch (child.type) {
       case "MarkoTag":
         getAllTagReferenceNodes(child, referenceNodes);

--- a/packages/translator-tags/src/util/sections.ts
+++ b/packages/translator-tags/src/util/sections.ts
@@ -99,6 +99,7 @@ export function getOrCreateSection(path: t.NodePath<any>) {
     if (
       cur.type === "Program" ||
       (cur.type === "MarkoTagBody" &&
+        !cur.node.attributeTags &&
         analyzeTagNameType(cur.parentPath as t.NodePath<t.MarkoTag>) !==
           TagNameType.NativeTag &&
         (cur.parent as { name: t.StringLiteral }).name.value !== "html-comment")

--- a/packages/translator-tags/src/visitors/tag/attribute-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/attribute-tag.ts
@@ -2,6 +2,7 @@ import { assertNoArgs, assertNoVar, findParentTag } from "@marko/babel-utils";
 import { types as t } from "@marko/compiler";
 
 import { isOutputHTML } from "../../util/marko-config";
+import { BindingType, trackParamsReferences } from "../../util/references";
 import { startSection } from "../../util/sections";
 import { writeHTMLResumeStatements } from "../../util/signals";
 import type { TemplateVisitor } from "../../util/visitors";
@@ -12,7 +13,9 @@ export default {
     enter(tag) {
       assertNoVar(tag);
       assertNoArgs(tag);
-      startSection(tag.get("body"));
+      const body = tag.get("body");
+      startSection(body);
+      trackParamsReferences(body, BindingType.param);
       if (!findParentTag(tag)) {
         throw tag
           .get("name")

--- a/packages/translator-tags/src/visitors/tag/custom-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/custom-tag.ts
@@ -398,7 +398,10 @@ function analyzeAttrs(
       seen.add(attrTagLookup[attrTagName].name);
     }
 
-    for (const child of tag.get("attributeTags")) {
+    const attrTags = tag.node.body.attributeTags
+      ? tag.get("body").get("body")
+      : tag.get("attributeTags");
+    for (const child of attrTags) {
       if (child.isMarkoTag()) {
         if (isAttributeTag(child)) {
           const attrTagMeta = attrTagLookup[getTagName(child)];


### PR DESCRIPTION
## Description

Partially revert https://github.com/marko-js/marko/commit/8e07673ca07cc83d9910c68ff8359264015c28d1.

Specifically the control flow tags now have their body content as a `MarkoTagBody` instead of the `attributeTags` list.
This was done for two reasons:
1. The `for` tag needs to have a scope for it's tag parameters which could not properly be reflected on the refactored ast.
2. Getting rid of the body for the control flow indirectly broke the `@marko/tags-api-preview`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
