### PR TITLE
fix(ts): lifecycle tag

### DIFF
--- a/packages/translator-tags/src/visitors/tag/custom-tag.ts
+++ b/packages/translator-tags/src/visitors/tag/custom-tag.ts
@@ -86,7 +86,7 @@ export default {
           throw tag
             .get("name")
             .buildCodeFrameError(
-              `Local variables must in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
+              `Local variables must be in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
             );
         }
         throw tag
@@ -349,7 +349,7 @@ export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          `Local variables must in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
+          `Local variables must be in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
         );
     }
     throw tag

--- a/packages/translator-tags/tag-types/lifecycle.d.marko
+++ b/packages/translator-tags/tag-types/lifecycle.d.marko
@@ -1,7 +1,7 @@
 /** File for types only, not actual implementation **/
 
-export type Input<T extends {
+export type Input<T extends object> = T & {
   onMount?(): unknown;
   onUpdate?(): unknown;
   onDestroy?(): unknown;
-}> = T;
+};


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Change the lifecycle type definition to better match functionality.

This causes multiple errors:

```marko
<lifecycle<{ foo: boolean }>
  onMount() {}
  onUpdate() {}
  onDestroy() {}
/>
```

1) `T` doesn't include `onMount`, `onUpdate`, `onDestroy`
    - Fixed by using`&` instead of `extends`
2) `foo` not included in attributes
    - Initially I was going to "fix" this by forcing all attributes to be optional, but I think it's actually better to make people do that explicitly
    - Developer has two options for fixing:
        - `<lifecycle<{ foo?: boolean }> />`
        - `<lifecycle<{ foo: boolean }> foo=false />`
        
 ---
      
Also bonus change with grammar fix

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
