### PR TITLE
fix: properly resolve lasso manifest in hydrate output

### DIFF
--- a/.changeset/long-lemons-turn.md
+++ b/.changeset/long-lemons-turn.md
@@ -1,0 +1,7 @@
+---
+"@marko/translator-default": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Fix issue where lasso manifest file paths were not being provided correctly for lasso-marko.


### PR DESCRIPTION
## Description

`lasso-marko` uses regular `path.resolve` instead of a `require.resolve` when processing the dependencies provided from the Marko compiler (https://github.com/lasso-js/lasso-marko/blob/9d4a2f7c190167e5bc3ab1015de54b14163e21b6/lasso-marko-plugin.js#L273).

In the hydrate compilation Marko tries to shorten all import paths to trim off `node_modules`, eg `./node_modules/@ebay/ebayui-core/thing` gets shortened to `@ebay/ebayui-core/thing` with the assumption it will be resolved later. However `lasso-marko` was not resolving this, so this PR changes it such that the dependencies provided to lasso are the full (relative) posix path.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
