### PR TITLE
chore: add engines field and add node 22 ci

### DIFF
--- a/.changeset/large-colts-fold.md
+++ b/.changeset/large-colts-fold.md
@@ -1,0 +1,8 @@
+---
+"@marko/translator-interop-class-tags": patch
+"marko": patch
+"@marko/runtime-tags": patch
+"@marko/compiler": patch
+---
+
+Add engines field to package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Use node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [18, 20]
+        node: [18, 20, 22]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - name: Install dependencies
         run: npm ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -10300,6 +10300,9 @@
       },
       "devDependencies": {
         "marko": "^5.37.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "packages/runtime-class": {
@@ -10325,6 +10328,9 @@
       },
       "bin": {
         "markoc": "bin/markoc"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "packages/runtime-class/node_modules/brace-expansion": {
@@ -10355,6 +10361,9 @@
         "@marko/compiler": "^5.39.7",
         "csstype": "^3.1.3",
         "magic-string": "^0.30.17"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "packages/translator-interop": {
@@ -10365,6 +10374,9 @@
         "@babel/code-frame": "^7.26.2",
         "@marko/runtime-tags": "^0.3.14",
         "marko": "^5.37.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       },
       "peerDependencies": {
         "@marko/compiler": "^5.23.0"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -88,6 +88,9 @@
   "devDependencies": {
     "marko": "^5.37.8"
   },
+  "engines": {
+    "node": "18 || 20 || >=22"
+  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/runtime-class/package.json
+++ b/packages/runtime-class/package.json
@@ -85,6 +85,9 @@
     "self-closing-tags": "^1.0.1",
     "warp10": "^2.1.0"
   },
+  "engines": {
+    "node": "18 || 20 || >=22"
+  },
   "logo": {
     "url": "https://raw.githubusercontent.com/marko-js/branding/master/marko-logo-small.png"
   }

--- a/packages/runtime-tags/package.json
+++ b/packages/runtime-tags/package.json
@@ -43,6 +43,9 @@
     "csstype": "^3.1.3",
     "magic-string": "^0.30.17"
   },
+  "engines": {
+    "node": "18 || 20 || >=22"
+  },
   "exports:override": {
     ".": {
       "types": "./index.d.ts"

--- a/packages/translator-interop/package.json
+++ b/packages/translator-interop/package.json
@@ -36,5 +36,8 @@
   "peerDependencies": {
     "@marko/compiler": "^5.23.0"
   },
+  "engines": {
+    "node": "18 || 20 || >=22"
+  },
   "main:override": "dist/index.js"
 }


### PR DESCRIPTION
## Description
Updated version of https://github.com/marko-js/marko/pull/2097
Resolves #2096

* Adds `engines` field to all packages with node `18`, `20` and `>=22`.
* Add node `22` to CI test matrix.
