### PR TITLE
fix: improve parse error locations and aggregate errors

### DIFF
--- a/.changeset/strong-steaks-jam.md
+++ b/.changeset/strong-steaks-jam.md
@@ -1,0 +1,8 @@
+---
+"marko": patch
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+"@marko/translator-interop-class-tags": patch
+---
+
+Support aggregate errors when final error is a HTMLJS parser error.

--- a/.changeset/tall-stingrays-fry.md
+++ b/.changeset/tall-stingrays-fry.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix invalid sourcemapping of parse errors in a class block.

--- a/packages/runtime-class/src/translator/taglib/core/parse-class.js
+++ b/packages/runtime-class/src/translator/taglib/core/parse-class.js
@@ -14,7 +14,8 @@ export default function (path) {
   } = path;
   const {
     rawValue: code,
-    name: { start, end },
+    name: { start },
+    end,
   } = node;
   const meta = file.metadata.marko;
 
@@ -40,7 +41,9 @@ export default function (path) {
 
   const parsed = parseExpression(file, code.replace(/;\s*$/, ""), start, end);
   if (parsed.type === "MarkoParseError") {
-    path.replaceWith(t.markoClass([t.expressionStatement(parsed)]));
+    const replacement = t.markoClass(t.classBody([]));
+    replacement.body.body.push(parsed);
+    path.replaceWith(replacement);
     return;
   }
 

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/cjs-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/generated-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/generated-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/html-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/vdom-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,18 @@
+CompileErrors: 
+    at __tests__/template.marko:7:9
+       5 |     }};
+       6 |     
+    >  7 |     this.hello = {
+         |         ^ Unexpected token
+       8 |     	world: true
+       9 |     };
+      10 |   }
+
+    at __tests__/template.marko:11:3
+       9 |     };
+      10 |   }
+    > 11 |   onFoo() {
+         |   ^ Line has extra indentation at the beginning
+      12 |     console.log("bar")
+      13 |   }
+      14 | }

--- a/packages/runtime-class/test/translator/fixtures/error-class-syntax/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-class-syntax/template.marko
@@ -1,0 +1,16 @@
+class {
+  onCreate() {
+  	this.state = {
+    	v : null
+    }};
+    
+    this.hello = {
+    	world: true
+    };
+  }
+  onFoo() {
+    console.log("bar")
+  }
+}
+
+<div/>


### PR DESCRIPTION
Resolves https://github.com/marko-js/marko/issues/1328 and https://github.com/marko-js/marko/issues/1329

* Errors from the htmljs-parser will now _also_ display any compile errors as an aggregate error.
* The `class` block errors were being bounded to the incorrect end position for the `class` block.