### PR TITLE
fix: add stubs for some client side component apis

### DIFF
--- a/.changeset/young-books-sleep.md
+++ b/.changeset/young-books-sleep.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Add stubs for some client side component apis on the server.

--- a/packages/runtime-class/src/runtime/components/ServerComponent.js
+++ b/packages/runtime-class/src/runtime/components/ServerComponent.js
@@ -66,8 +66,76 @@ class ServerComponent {
   onCreate() {}
   onInput() {}
   onRender() {}
+
+  isDestroyed() {
+    return false;
+  }
+
+  setState(name, value) {
+    if (typeof name == "object") {
+      if (this.___state) {
+        Object.assign(this.___state, name);
+      } else {
+        this.___state = name;
+      }
+    } else {
+      this.___state[name] = value;
+    }
+  }
+
+  setStateDirty(name, value) {
+    if (typeof name == "object") {
+      if (this.___state) {
+        Object.assign(this.___state, name);
+      } else {
+        this.___state = name;
+      }
+    } else {
+      this.___state[name] = value;
+    }
+  }
+
+  replaceState(newState) {
+    this.___state = newState;
+  }
+
+  subscribeTo() {
+    notImplemented("subscribeTo");
+  }
+
+  emit() {
+    notImplemented("emit");
+  }
+
+  getEl() {
+    notImplemented("getEl");
+  }
+
+  getEls() {
+    notImplemented("getEls");
+  }
+
+  getComponent() {
+    notImplemented("getComponent");
+  }
+
+  getComponents() {
+    notImplemented("getComponents");
+  }
+
+  forceUpdate() {
+    notImplemented("forceUpdate");
+  }
+
+  update() {
+    notImplemented("update");
+  }
 }
 
 ServerComponent.prototype.getElId = ServerComponent.prototype.elId;
 
 module.exports = ServerComponent;
+
+function notImplemented(name) {
+  throw new Error(name + " method not supported during SSR.");
+}


### PR DESCRIPTION
Resolves https://github.com/marko-js/marko/issues/998

* Adds stubs with better errors for component methods which cannot be used on the server.
* Adds `isDestroyed` and state setting apis to server side component instances.