### PR TITLE
fix: ignore events during the render phase

### DIFF
--- a/.changeset/popular-experts-applaud.md
+++ b/.changeset/popular-experts-applaud.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Ignore events during the render phase

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,7 +7,7 @@
     {
       "name": "*",
       "total": {
-        "min": 17998,
+        "min": 18002,
         "brotli": 6598
       }
     },
@@ -18,12 +18,12 @@
         "brotli": 144
       },
       "runtime": {
-        "min": 4174,
-        "brotli": 1799
+        "min": 4178,
+        "brotli": 1802
       },
       "total": {
-        "min": 4363,
-        "brotli": 1943
+        "min": 4367,
+        "brotli": 1946
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 100
       },
       "runtime": {
-        "min": 3626,
-        "brotli": 1631
+        "min": 3630,
+        "brotli": 1630
       },
       "total": {
-        "min": 3737,
-        "brotli": 1731
+        "min": 3741,
+        "brotli": 1730
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 541
       },
       "runtime": {
-        "min": 7863,
-        "brotli": 3245
+        "min": 7867,
+        "brotli": 3251
       },
       "total": {
-        "min": 9003,
-        "brotli": 3786
+        "min": 9007,
+        "brotli": 3792
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 478
       },
       "runtime": {
-        "min": 8898,
-        "brotli": 3619
+        "min": 8902,
+        "brotli": 3623
       },
       "total": {
-        "min": 9846,
-        "brotli": 4097
+        "min": 9850,
+        "brotli": 4101
       }
     }
   ]

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 17998 (min) 6598 (brotli)
+// size: 18002 (min) 6598 (brotli)
 var empty = [],
   rest = Symbol();
 function attrTag(attrs2) {
@@ -113,7 +113,7 @@ function createDelegator() {
   };
 }
 function handleDelegated(ev) {
-  let target = ev.target;
+  let target = !rendering && ev.target;
   if (target) {
     let handlersByElement = elementHandlersByEvent.get(ev.type);
     if ((handlersByElement.get(target)?.(ev, target), ev.bubbles))

--- a/packages/runtime-tags/src/dom/event.ts
+++ b/packages/runtime-tags/src/dom/event.ts
@@ -1,3 +1,5 @@
+import { rendering } from "./queue";
+
 type EventNames = keyof GlobalEventHandlersEventMap;
 
 const elementHandlersByEvent = new Map<
@@ -50,7 +52,7 @@ export function createDelegator() {
 }
 
 function handleDelegated(ev: GlobalEventHandlersEventMap[EventNames]) {
-  let target = ev.target as ParentNode | null;
+  let target = !rendering && (ev.target as ParentNode | null);
   if (target) {
     const handlersByElement = elementHandlersByEvent.get(ev.type)!;
     handlersByElement.get(target)?.(ev, target);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- There is a [Google Chrome Bug](https://issues.chromium.org/issues/41484175) where blur events are fired when elements are removed from the DOM (this behavior does not match that of other browsers). This causes issues when Marko removes elements during the render phase.
- This PR changes Marko's behavior so that if an event happens during the render phase, handlers do not fire. Incidentally, this means behavior matches React for the `blur` case but not any of the other frameworks.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
