### PR TITLE
fix: resume branch end node shared, insert after previous branch

### DIFF
--- a/.changeset/giant-adults-tell.md
+++ b/.changeset/giant-adults-tell.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Branch end nodes could end up being shared in resume, insert new branch after previous end node

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 18002,
-        "brotli": 6598
+        "min": 18072,
+        "brotli": 6619
       }
     },
     {
@@ -19,11 +19,11 @@
       },
       "runtime": {
         "min": 4178,
-        "brotli": 1802
+        "brotli": 1803
       },
       "total": {
         "min": 4367,
-        "brotli": 1946
+        "brotli": 1947
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 100
       },
       "runtime": {
-        "min": 3630,
-        "brotli": 1630
+        "min": 3688,
+        "brotli": 1661
       },
       "total": {
-        "min": 3741,
-        "brotli": 1730
+        "min": 3799,
+        "brotli": 1761
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 541
       },
       "runtime": {
-        "min": 7867,
-        "brotli": 3251
+        "min": 7879,
+        "brotli": 3253
       },
       "total": {
-        "min": 9007,
-        "brotli": 3792
+        "min": 9019,
+        "brotli": 3794
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 478
       },
       "runtime": {
-        "min": 8902,
-        "brotli": 3623
+        "min": 8972,
+        "brotli": 3643
       },
       "total": {
-        "min": 9850,
-        "brotli": 4101
+        "min": 9920,
+        "brotli": 4121
       }
     }
   ]

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/csr.expected.md
@@ -29,7 +29,7 @@ Goodbye
 ```
 UPDATE div/#text "1" => "2"
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after #comment1
 ```
 
 # Render `{"x":true}`
@@ -47,5 +47,5 @@ Hello
 ```
 UPDATE div/#text "2" => "1"
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after #comment1
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/csr.expected.md
@@ -52,8 +52,8 @@ container.querySelector("button.toggle").click();
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
-REMOVE #text after #text
+REMOVE #text after button1
+REMOVE #text after button1
 ```
 
 # Render
@@ -90,7 +90,7 @@ The count is 2
 ```
 INSERT #text0
 INSERT #text1
-REMOVE #text after #text1
+REMOVE #text after button1
 UPDATE #text1 "" => "2"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/resume.expected.md
@@ -88,10 +88,10 @@ container.querySelector("button.toggle").click();
 ```
 REMOVE html/body/#comment2 after html/body/#comment3
 INSERT html/body/#comment2
-REMOVE #comment after html/body/#comment2
-REMOVE #text after html/body/#comment2
-REMOVE #comment after html/body/#comment2
-REMOVE #text after html/body/#comment2
+REMOVE #comment after html/body/#comment1
+REMOVE #text after html/body/#comment1
+REMOVE #comment after html/body/#comment1
+REMOVE #text after html/body/#comment1
 ```
 
 # Render
@@ -149,7 +149,7 @@ container.querySelector("button.toggle").click();
 ```
 INSERT html/body/#text0
 INSERT html/body/#text1
-REMOVE #comment after html/body/#text1
+REMOVE #comment after html/body/#comment1
 UPDATE html/body/#text1 "" => "2"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/csr.expected.md
@@ -56,7 +56,7 @@ container.querySelector("button.toggle").click();
 # Mutations
 ```
 INSERT #text
-REMOVE span after #text
+REMOVE span after button1
 ```
 
 # Render
@@ -94,7 +94,7 @@ container.querySelector("button.toggle").click();
 # Mutations
 ```
 INSERT span
-REMOVE #text after span
+REMOVE #text after button1
 UPDATE span/#text " " => "2"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/resume.expected.md
@@ -85,7 +85,7 @@ container.querySelector("button.toggle").click();
 ```
 REMOVE html/body/#comment2 after span
 INSERT html/body/#comment2
-REMOVE span after html/body/#comment2
+REMOVE span after html/body/#comment1
 ```
 
 # Render
@@ -142,7 +142,7 @@ container.querySelector("button.toggle").click();
 # Mutations
 ```
 INSERT html/body/span
-REMOVE #comment after html/body/span
+REMOVE #comment after html/body/#comment1
 UPDATE html/body/span/#text " " => "2"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/csr.expected.md
@@ -26,5 +26,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after button
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/resume.expected.md
@@ -43,5 +43,5 @@ container.querySelector("button").click();
 ```
 REMOVE html/body/#comment1 after html/body/#comment2
 INSERT html/body/#comment1
-REMOVE #text after html/body/#comment1
+REMOVE #text after html/body/#comment0
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/resume.expected.md
@@ -23,6 +23,7 @@
 ```
 REMOVE html/body/#comment1 after html/body/#comment0
 INSERT html/body/#comment1
+INSERT html/body/#text
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/csr.expected.md
@@ -61,6 +61,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/span
-REMOVE button after div/span
+REMOVE button before div/span
 UPDATE div/span/#text1 "" => "3"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/resume.expected.md
@@ -100,6 +100,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/span
-REMOVE button after html/body/div/span
+REMOVE button before html/body/div/span
 UPDATE html/body/div/span/#text1 "" => "3"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/csr.expected.md
@@ -28,7 +28,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE #text after div/#text
+REMOVE #text before div/#text
 ```
 
 # Render
@@ -47,7 +47,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE #text after div/#text
+REMOVE #text before div/#text
 ```
 
 # Render
@@ -65,5 +65,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE #text after div/#text
+REMOVE #text before div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/resume.expected.md
@@ -45,7 +45,7 @@ container.querySelector("button").click();
 ```
 REMOVE html/body/div/#comment0 after #text
 INSERT html/body/div/#comment0
-REMOVE #text after html/body/div/#comment0
+REMOVE #text before html/body/div/#comment0
 ```
 
 # Render
@@ -73,7 +73,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/#text
-REMOVE #comment after html/body/div/#text
+REMOVE #comment before html/body/div/#text
 ```
 
 # Render
@@ -101,5 +101,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/#comment0
-REMOVE #text after html/body/div/#comment0
+REMOVE #text before html/body/div/#comment0
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/csr.expected.md
@@ -24,5 +24,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT #text
-REMOVE span after #text
+REMOVE span after button
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/resume.expected.md
@@ -40,5 +40,5 @@ container.querySelector("button").click();
 ```
 REMOVE html/body/#comment1 after span
 INSERT html/body/#comment1
-REMOVE span after html/body/#comment1
+REMOVE span after html/body/#comment0
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/csr.expected.md
@@ -122,9 +122,9 @@ Inner destroyed
 INSERT div/div1/#text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after div/div1/#text
-REMOVE span after div/div1/#text
-REMOVE p after div/div1/#text
+REMOVE div after div/div1/p
+REMOVE span after div/div1/p
+REMOVE p after div/div1/p
 ```
 
 # Render
@@ -174,7 +174,7 @@ Middle destroyed
 INSERT div/#text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after div/#text
+REMOVE div after div/p
 ```
 
 # Render
@@ -214,7 +214,7 @@ Outer destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```
 
 # Render
@@ -352,16 +352,16 @@ Inner mounted
 # Mutations
 ```
 INSERT div
-REMOVE #text after div
+REMOVE #text after pre
 INSERT div/div1
-REMOVE #text after div/div1
+REMOVE #text after div/p
 UPDATE div/div0/#text0 "" => "Outer"
 UPDATE div/span/#text0 "" => "Outer"
 UPDATE div/p/#text0 "" => "Outer"
 INSERT div/div1/div1
 INSERT div/div1/span1
 INSERT div/div1/p1
-REMOVE #text after div/div1/p1
+REMOVE #text after div/div1/p0
 UPDATE div/div1/div0/#text0 "" => "Middle"
 UPDATE div/div1/span0/#text0 "" => "Middle"
 UPDATE div/div1/p0/#text0 "" => "Middle"
@@ -423,5 +423,5 @@ REMOVE #text in pre
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/resume.expected.md
@@ -187,10 +187,10 @@ REMOVE html/body/div/div1/#comment1 after html/body/div/div1/#comment2
 INSERT html/body/div/div1/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE #comment after html/body/div/div1/#comment1
-REMOVE div after html/body/div/div1/#comment1
-REMOVE span after html/body/div/div1/#comment1
-REMOVE p after html/body/div/div1/#comment1
+REMOVE #comment after html/body/div/div1/#comment0
+REMOVE div after html/body/div/div1/#comment0
+REMOVE span after html/body/div/div1/#comment0
+REMOVE p after html/body/div/div1/#comment0
 ```
 
 # Render
@@ -261,7 +261,7 @@ REMOVE html/body/div/#comment1 after div
 INSERT html/body/div/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/div/#comment1
+REMOVE div after html/body/div/#comment0
 ```
 
 # Render
@@ -314,7 +314,7 @@ REMOVE html/body/#comment4 after div
 INSERT html/body/#comment4
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment4
+REMOVE div after html/body/#comment3
 ```
 
 # Render
@@ -487,16 +487,16 @@ Inner mounted
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
+REMOVE #comment after html/body/#comment3
 INSERT html/body/div/div1
-REMOVE #text after html/body/div/div1
+REMOVE #text after html/body/div/p
 UPDATE html/body/div/div0/#text0 "" => "Outer"
 UPDATE html/body/div/span/#text0 "" => "Outer"
 UPDATE html/body/div/p/#text0 "" => "Outer"
 INSERT html/body/div/div1/div1
 INSERT html/body/div/div1/span1
 INSERT html/body/div/div1/p1
-REMOVE #text after html/body/div/div1/p1
+REMOVE #text after html/body/div/div1/p0
 UPDATE html/body/div/div1/div0/#text0 "" => "Middle"
 UPDATE html/body/div/div1/span0/#text0 "" => "Middle"
 UPDATE html/body/div/div1/p0/#text0 "" => "Middle"
@@ -570,5 +570,5 @@ REMOVE #text in html/body/pre
 INSERT #text
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment4
+REMOVE div after html/body/#comment3
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/csr.expected.md
@@ -46,9 +46,9 @@ destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
-REMOVE span after #text
-REMOVE p after #text
+REMOVE div after pre
+REMOVE span after pre
+REMOVE p after pre
 ```
 
 # Render
@@ -82,7 +82,7 @@ mounted
 INSERT div
 INSERT span
 INSERT p
-REMOVE #text after p
+REMOVE #text after pre
 REMOVE #text in pre
 INSERT pre/#text
 ```
@@ -110,7 +110,7 @@ destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
-REMOVE span after #text
-REMOVE p after #text
+REMOVE div after pre
+REMOVE span after pre
+REMOVE p after pre
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/resume.expected.md
@@ -67,10 +67,10 @@ REMOVE html/body/#comment2 after p
 INSERT html/body/#comment2
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE #comment after html/body/#comment2
-REMOVE div after html/body/#comment2
-REMOVE span after html/body/#comment2
-REMOVE p after html/body/#comment2
+REMOVE #comment after html/body/#comment1
+REMOVE div after html/body/#comment1
+REMOVE span after html/body/#comment1
+REMOVE p after html/body/#comment1
 ```
 
 # Render
@@ -113,7 +113,7 @@ mounted
 INSERT html/body/div
 INSERT html/body/span
 INSERT html/body/p
-REMOVE #comment after html/body/p
+REMOVE #comment after html/body/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
 ```
@@ -151,7 +151,7 @@ destroyed
 INSERT html/body/#comment2
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment2
-REMOVE span after html/body/#comment2
-REMOVE p after html/body/#comment2
+REMOVE div after html/body/#comment1
+REMOVE span after html/body/#comment1
+REMOVE p after html/body/#comment1
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/csr-sanitized.expected.md
@@ -53,17 +53,3 @@ container.querySelector("button").click();
   c
 </p>
 ```
-
-
-# Render
-```js
-container.querySelector("button").click();
-```
-```html
-<button>
-  Toggle
-</button>
-<div>
-  destroyed
-</div>
-```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/csr.expected.md
@@ -43,9 +43,9 @@ container.querySelector("button").click();
 INSERT #text
 REMOVE #text in div
 INSERT div/#text
-REMOVE div after #text
-REMOVE span after #text
-REMOVE p after #text
+REMOVE div after div
+REMOVE span after div
+REMOVE p after div
 ```
 
 # Render
@@ -76,31 +76,7 @@ container.querySelector("button").click();
 INSERT div1
 INSERT span
 INSERT p
-REMOVE #text after p
+REMOVE #text after div0
 REMOVE #text in div0
 INSERT div0/#text
-```
-
-# Render
-```js
-container.querySelector("button").click();
-```
-```html
-<button>
-  Toggle
-</button>
-<div>
-  destroyed
-</div>
-<!---->
-```
-
-# Mutations
-```
-INSERT #text
-REMOVE #text in div
-INSERT div/#text
-REMOVE div after #text
-REMOVE span after #text
-REMOVE p after #text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume-sanitized.expected.md
@@ -53,17 +53,3 @@ container.querySelector("button").click();
   c
 </p>
 ```
-
-
-# Render
-```js
-container.querySelector("button").click();
-```
-```html
-<button>
-  Toggle
-</button>
-<div>
-  destroyed
-</div>
-```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume.expected.md
@@ -66,10 +66,10 @@ REMOVE html/body/#comment2 after html/body/#comment3
 INSERT html/body/#comment2
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
-REMOVE #comment after html/body/#comment2
-REMOVE div after html/body/#comment2
-REMOVE span after html/body/#comment2
-REMOVE p after html/body/#comment2
+REMOVE #comment after html/body/#comment1
+REMOVE div after html/body/#comment1
+REMOVE span after html/body/#comment1
+REMOVE p after html/body/#comment1
 ```
 
 # Render
@@ -110,42 +110,7 @@ container.querySelector("button").click();
 INSERT html/body/div1
 INSERT html/body/span
 INSERT html/body/p
-REMOVE #comment after html/body/p
+REMOVE #comment after html/body/#comment1
 REMOVE #text in html/body/div0
 INSERT html/body/div0/#text
-```
-
-# Render
-```js
-container.querySelector("button").click();
-```
-```html
-<html>
-  <head />
-  <body>
-    <button>
-      Toggle
-    </button>
-    <!--M_*1 #button/0-->
-    <div>
-      destroyed
-    </div>
-    <!--M_*1 #div/1-->
-    <!--M_]1 #text/2-->
-    <!--M_$3-->
-    <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:_.a={show:!0,"#text/2(":_._["__tests__/template.marko_1_renderer"],"#text/2!":_.b={"#childScope/0":_.d={input:_.c={}}}},2:_.b,3:_.d},_.b._=_.a,_.c.write=_._["__tests__/template.marko_1/write"](_.b),_.e),3,"__tests__/tags/child.marko_0_input",1,"__tests__/template.marko_0_show",0];M._.w()
-    </script>
-  </body>
-</html>
-```
-
-# Mutations
-```
-INSERT html/body/#comment2
-REMOVE #text in html/body/div
-INSERT html/body/div/#text
-REMOVE div after html/body/#comment2
-REMOVE span after html/body/#comment2
-REMOVE p after html/body/#comment2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, click, click, click];
+export const steps = [{}, click, click];
 
 function click(container: Element) {
   container.querySelector("button")!.click();

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/csr.expected.md
@@ -92,7 +92,7 @@ Inner destroyed
 INSERT div/div/#text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE p after div/div/#text
+REMOVE p after div/div/p
 ```
 
 # Render
@@ -136,7 +136,7 @@ Middle destroyed
 INSERT div/#text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after div/#text
+REMOVE div after div/p
 ```
 
 # Render
@@ -176,7 +176,7 @@ Outer destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```
 
 # Render
@@ -296,12 +296,12 @@ Inner mounted
 # Mutations
 ```
 INSERT div
-REMOVE #text after div
+REMOVE #text after pre
 INSERT div/div
-REMOVE #text after div/div
+REMOVE #text after div/p
 UPDATE div/p/#text " " => "Outer"
 INSERT div/div/p1
-REMOVE #text after div/div/p1
+REMOVE #text after div/div/p0
 UPDATE div/div/p0/#text " " => "Middle"
 UPDATE div/div/p1/#text " " => "Inner"
 REMOVE #text in pre
@@ -359,5 +359,5 @@ REMOVE #text in pre
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/resume.expected.md
@@ -131,7 +131,7 @@ REMOVE html/body/div/div/#comment1 after html/body/div/div/#comment2
 INSERT html/body/div/div/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE p after html/body/div/div/#comment1
+REMOVE p after html/body/div/div/#comment0
 ```
 
 # Render
@@ -191,7 +191,7 @@ REMOVE html/body/div/#comment1 after div
 INSERT html/body/div/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/div/#comment1
+REMOVE div after html/body/div/#comment0
 ```
 
 # Render
@@ -244,7 +244,7 @@ REMOVE html/body/#comment4 after div
 INSERT html/body/#comment4
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment4
+REMOVE div after html/body/#comment3
 ```
 
 # Render
@@ -399,12 +399,12 @@ Inner mounted
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
+REMOVE #comment after html/body/#comment3
 INSERT html/body/div/div
-REMOVE #text after html/body/div/div
+REMOVE #text after html/body/div/p
 UPDATE html/body/div/p/#text " " => "Outer"
 INSERT html/body/div/div/p1
-REMOVE #text after html/body/div/div/p1
+REMOVE #text after html/body/div/div/p0
 UPDATE html/body/div/div/p0/#text " " => "Middle"
 UPDATE html/body/div/div/p1/#text " " => "Inner"
 REMOVE #text in html/body/pre
@@ -474,5 +474,5 @@ REMOVE #text in html/body/pre
 INSERT #text
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment4
+REMOVE div after html/body/#comment3
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/csr.expected.md
@@ -40,7 +40,7 @@ destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```
 
 # Render
@@ -66,7 +66,7 @@ mounted
 # Mutations
 ```
 INSERT div
-REMOVE #text after div
+REMOVE #text after pre
 REMOVE #text in pre
 INSERT pre/#text
 ```
@@ -94,5 +94,5 @@ destroyed
 INSERT #text
 REMOVE #text in pre
 INSERT pre/#text
-REMOVE div after #text
+REMOVE div after pre
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/resume.expected.md
@@ -60,7 +60,7 @@ REMOVE html/body/#comment2 after div
 INSERT html/body/#comment2
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment2
+REMOVE div after html/body/#comment1
 ```
 
 # Render
@@ -95,7 +95,7 @@ mounted
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
+REMOVE #comment after html/body/#comment1
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
 ```
@@ -133,5 +133,5 @@ destroyed
 INSERT html/body/#comment2
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
-REMOVE div after html/body/#comment2
+REMOVE div after html/body/#comment1
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/csr.expected.md
@@ -37,7 +37,7 @@ container.querySelector("button").click();
 INSERT #text
 REMOVE #text in div
 INSERT div/#text
-REMOVE div after #text
+REMOVE div after div
 ```
 
 # Render
@@ -60,7 +60,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div1
-REMOVE #text after div1
+REMOVE #text after div0
 REMOVE #text in div0
 INSERT div0/#text
 ```
@@ -84,5 +84,5 @@ container.querySelector("button").click();
 INSERT #text
 REMOVE #text in div
 INSERT div/#text
-REMOVE div after #text
+REMOVE div after div
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/resume.expected.md
@@ -59,7 +59,7 @@ REMOVE html/body/#comment2 after html/body/#comment3
 INSERT html/body/#comment2
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
-REMOVE div after html/body/#comment2
+REMOVE div after html/body/#comment1
 ```
 
 # Render
@@ -92,7 +92,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div1
-REMOVE #comment after html/body/div1
+REMOVE #comment after html/body/#comment1
 REMOVE #text in html/body/div0
 INSERT html/body/div0/#text
 ```
@@ -127,5 +127,5 @@ container.querySelector("button").click();
 INSERT html/body/#comment2
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
-REMOVE div after html/body/#comment2
+REMOVE div after html/body/#comment1
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/csr.expected.md
@@ -35,7 +35,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT table/tbody/tr
-REMOVE #text after table/tbody/tr
+REMOVE #text before table/tbody/tr
 ```
 
 # Render
@@ -54,7 +54,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT table/tbody/#text
-REMOVE tr after table/tbody/#text
+REMOVE tr before table/tbody/#text
 ```
 
 # Render
@@ -79,5 +79,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT table/tbody/tr
-REMOVE #text after table/tbody/tr
+REMOVE #text before table/tbody/tr
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/resume.expected.md
@@ -51,7 +51,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/table/tbody/tr
-REMOVE #comment after html/body/table/tbody/tr
+REMOVE #comment before html/body/table/tbody/tr
 ```
 
 # Render
@@ -81,7 +81,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/table/tbody/#comment
-REMOVE tr after html/body/table/tbody/#comment
+REMOVE tr before html/body/table/tbody/#comment
 ```
 
 # Render
@@ -115,5 +115,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/table/tbody/tr
-REMOVE #comment after html/body/table/tbody/tr
+REMOVE #comment before html/body/table/tbody/tr
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/csr.expected.md
@@ -36,9 +36,9 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/span
-REMOVE #text after div/span
+REMOVE #text before div/span
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span after div/span
 UPDATE div/span/#text " " => "1"
 ```
 
@@ -62,9 +62,9 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span before div/#text
 INSERT div/span
-REMOVE #text after div/span
+REMOVE #text after div/#text
 UPDATE div/span/#text " " => "1"
 ```
 
@@ -86,8 +86,8 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/span
-REMOVE #text after div/span
+REMOVE #text before div/span
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span after div/span
 UPDATE div/span/#text " " => "1"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/resume.expected.md
@@ -53,10 +53,10 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/span
-REMOVE #comment after html/body/div/span
+REMOVE #comment before html/body/div/span
 REMOVE html/body/div/#comment0 after span
 INSERT html/body/div/#comment0
-REMOVE span after html/body/div/#comment0
+REMOVE span after html/body/div/span
 UPDATE html/body/div/span/#text " " => "1"
 ```
 
@@ -90,9 +90,9 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/#comment0
-REMOVE span after html/body/div/#comment0
+REMOVE span before html/body/div/#comment0
 INSERT html/body/div/span
-REMOVE #comment after html/body/div/span
+REMOVE #comment after html/body/div/#comment0
 UPDATE html/body/div/span/#text " " => "1"
 ```
 
@@ -124,8 +124,8 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div/span
-REMOVE #comment after html/body/div/span
+REMOVE #comment before html/body/div/span
 INSERT html/body/div/#comment0
-REMOVE span after html/body/div/#comment0
+REMOVE span after html/body/div/span
 UPDATE html/body/div/span/#text " " => "1"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/csr.expected.md
@@ -31,7 +31,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE span after div
+REMOVE span after #comment
 INSERT div/#text
 UPDATE div[class] null => "A"
 ```
@@ -53,7 +53,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT span
-REMOVE div after span
+REMOVE div after #comment
 INSERT span/#text
 UPDATE span[class] null => "A"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
@@ -45,7 +45,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE span after html/body/div
+REMOVE span before html/body/div
 INSERT html/body/div/#text
 UPDATE html/body/div[class] null => "A"
 ```
@@ -76,7 +76,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/span
-REMOVE div after html/body/span
+REMOVE div before html/body/span
 INSERT html/body/span/#text
 UPDATE html/body/span[class] null => "A"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/csr.expected.md
@@ -27,7 +27,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE div after div
+REMOVE div after button
 UPDATE div[id] null => "dynamic"
 ```
 
@@ -46,6 +46,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE div after div
+REMOVE div after button
 UPDATE div/#text1 "" => "dynamic"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/resume.expected.md
@@ -45,8 +45,8 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
-REMOVE div after html/body/div
+REMOVE #comment after html/body/#comment0
+REMOVE div after html/body/#comment0
 UPDATE html/body/div[id] null => "dynamic"
 ```
 
@@ -74,6 +74,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE div after html/body/div
+REMOVE div after html/body/#comment0
 UPDATE html/body/div/#text1 "" => "dynamic"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/csr.expected.md
@@ -27,7 +27,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE div after div
+REMOVE div after #comment
 UPDATE div/#text1 "" => "3"
 ```
 
@@ -46,6 +46,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE div after div
+REMOVE div after #comment
 UPDATE div/#text1 "" => "3"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/resume.expected.md
@@ -50,8 +50,8 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
-REMOVE div after html/body/div
+REMOVE #comment before div
+REMOVE div before html/body/div
 UPDATE html/body/div/#text1 "" => "3"
 ```
 
@@ -79,6 +79,6 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE div after html/body/div
+REMOVE div before html/body/div
 UPDATE html/body/div/#text1 "" => "3"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/csr.expected.md
@@ -25,7 +25,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div
-REMOVE #text after div
+REMOVE #text after #comment
 INSERT div/#text
 ```
 
@@ -42,5 +42,5 @@ Body Content
 # Mutations
 ```
 INSERT #text
-REMOVE div after #text
+REMOVE div after #comment
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/resume.expected.md
@@ -45,8 +45,8 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/div
-REMOVE #comment after html/body/div
-REMOVE #text after html/body/div
+REMOVE #comment before #text
+REMOVE #text before html/body/div
 INSERT html/body/div/#text
 ```
 
@@ -72,5 +72,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/#text
-REMOVE div after html/body/#text
+REMOVE div before html/body/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/csr.expected.md
@@ -62,7 +62,7 @@ container.querySelector("#changeTag").click();
 # Mutations
 ```
 INSERT span
-REMOVE div after span
+REMOVE div after #comment
 INSERT span/button
 UPDATE span/button/#text " " => "0"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
@@ -91,7 +91,7 @@ container.querySelector("#changeTag").click();
 # Mutations
 ```
 INSERT html/body/span
-REMOVE div after html/body/span
+REMOVE div before html/body/span
 INSERT html/body/span/button
 UPDATE html/body/span/button/#text " " => "0"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/csr-sanitized.expected.md
@@ -6,26 +6,6 @@
   >
     firstsecondthird
   </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    firstsecondthird
-  </div>
   <button>
     Rotate
   </button>
@@ -41,26 +21,6 @@ container.querySelector("button").click();
 <div>
   <div
     class="by-string"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-missing"
   >
     secondthirdfirst
   </div>
@@ -82,26 +42,6 @@ container.querySelector("button").click();
   >
     thirdfirstsecond
   </div>
-  <div
-    class="by-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    thirdfirstsecond
-  </div>
   <button>
     Rotate
   </button>
@@ -117,26 +57,6 @@ container.querySelector("button").click();
 <div>
   <div
     class="by-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
   >
     firstsecondthird
   </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/csr.expected.md
@@ -6,26 +6,6 @@
   >
     firstsecondthird
   </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    firstsecondthird
-  </div>
   <button>
     Rotate
   </button>
@@ -48,26 +28,6 @@ container.querySelector("button").click();
   >
     secondthirdfirst
   </div>
-  <div
-    class="by-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    secondthirdfirst
-  </div>
   <button>
     Rotate
   </button>
@@ -76,17 +36,8 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE div/div0/#text2 before div/div0/#text0
-INSERT div/div0/#text2
-REMOVE div/div1/#text2 before div/div1/#text0
-INSERT div/div1/#text2
-REMOVE div/div2/#text2 before div/div2/#text0
-INSERT div/div2/#text2
-REMOVE div/div3/#text2 before div/div3/#text0
-INSERT div/div3/#text2
-UPDATE div/div4/#text0 "first" => "second"
-UPDATE div/div4/#text1 "second" => "third"
-UPDATE div/div4/#text2 "third" => "first"
+REMOVE div/div/#text2 before div/div/#text0
+INSERT div/div/#text2
 ```
 
 # Render
@@ -100,26 +51,6 @@ container.querySelector("button").click();
   >
     thirdfirstsecond
   </div>
-  <div
-    class="by-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    thirdfirstsecond
-  </div>
   <button>
     Rotate
   </button>
@@ -128,17 +59,8 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE div/div0/#text2 before div/div0/#text0
-INSERT div/div0/#text2
-REMOVE div/div1/#text2 before div/div1/#text0
-INSERT div/div1/#text2
-REMOVE div/div2/#text2 before div/div2/#text0
-INSERT div/div2/#text2
-REMOVE div/div3/#text2 before div/div3/#text0
-INSERT div/div3/#text2
-UPDATE div/div4/#text0 "second" => "third"
-UPDATE div/div4/#text1 "third" => "first"
-UPDATE div/div4/#text2 "first" => "second"
+REMOVE div/div/#text2 before div/div/#text0
+INSERT div/div/#text2
 ```
 
 # Render
@@ -152,26 +74,6 @@ container.querySelector("button").click();
   >
     firstsecondthird
   </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    firstsecondthird
-  </div>
   <button>
     Rotate
   </button>
@@ -180,15 +82,6 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE div/div0/#text2 before div/div0/#text0
-INSERT div/div0/#text2
-REMOVE div/div1/#text2 before div/div1/#text0
-INSERT div/div1/#text2
-REMOVE div/div2/#text2 before div/div2/#text0
-INSERT div/div2/#text2
-REMOVE div/div3/#text2 before div/div3/#text0
-INSERT div/div3/#text2
-UPDATE div/div4/#text0 "third" => "first"
-UPDATE div/div4/#text1 "first" => "second"
-UPDATE div/div4/#text2 "second" => "third"
+REMOVE div/div/#text2 before div/div/#text0
+INSERT div/div/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.hydrate.js
@@ -1,52 +1,7 @@
-// size: 1281 (min) 396 (brotli)
-const getStringBy = _getStringBy,
-  getFunctionBy = _getFunctionBy,
-  getMissingBy = _getMissingBy,
-  _text$for_content5 = _$.value(3, (_scope, text) => _$.data(_scope[0], text)),
-  _pattern_5$for_content = _$.value(2, (_scope, _pattern_5) =>
-    _text$for_content5(_scope, _pattern_5.text),
+// size: 486 (min) 242 (brotli)
+const _text$for_content = _$.value(3, (_scope, text) =>
+    _$.data(_scope[0], text),
   ),
-  _params_6$for_content = _$.value(1, (_scope, _params_6) =>
-    _pattern_5$for_content(_scope, _params_6?.[0]),
-  ),
-  _for_content5 = _$.register(
-    "a4",
-    _$.createRenderer(" ", " ", void 0, () => _params_6$for_content),
-  ),
-  _text$for_content4 = _$.value(3, (_scope, text) => _$.data(_scope[0], text)),
-  _pattern_4$for_content = _$.value(2, (_scope, _pattern_4) =>
-    _text$for_content4(_scope, _pattern_4.text),
-  ),
-  _params_5$for_content = _$.value(1, (_scope, _params_5) =>
-    _pattern_4$for_content(_scope, _params_5?.[0]),
-  ),
-  _for_content4 = _$.register(
-    "a5",
-    _$.createRenderer(" ", " ", void 0, () => _params_5$for_content),
-  ),
-  _text$for_content3 = _$.value(3, (_scope, text) => _$.data(_scope[0], text)),
-  _pattern_3$for_content = _$.value(2, (_scope, _pattern_3) =>
-    _text$for_content3(_scope, _pattern_3.text),
-  ),
-  _params_4$for_content = _$.value(1, (_scope, _params_4) =>
-    _pattern_3$for_content(_scope, _params_4?.[0]),
-  ),
-  _for_content3 = _$.register(
-    "a6",
-    _$.createRenderer(" ", " ", void 0, () => _params_4$for_content),
-  ),
-  _text$for_content2 = _$.value(3, (_scope, text) => _$.data(_scope[0], text)),
-  _pattern_2$for_content = _$.value(2, (_scope, _pattern_2) =>
-    _text$for_content2(_scope, _pattern_2.text),
-  ),
-  _params_3$for_content = _$.value(1, (_scope, _params_3) =>
-    _pattern_2$for_content(_scope, _params_3?.[0]),
-  ),
-  _for_content2 = _$.register(
-    "a7",
-    _$.createRenderer(" ", " ", void 0, () => _params_3$for_content),
-  ),
-  _text$for_content = _$.value(3, (_scope, text) => _$.data(_scope[0], text)),
   _pattern_$for_content = _$.value(2, (_scope, _pattern_) =>
     _text$for_content(_scope, _pattern_.text),
   ),
@@ -54,39 +9,27 @@ const getStringBy = _getStringBy,
     _pattern_$for_content(_scope, _params_2?.[0]),
   ),
   _for_content = _$.register(
-    "a8",
+    "a4",
     _$.createRenderer(" ", " ", void 0, () => _params_2$for_content),
   ),
-  _for5 = _$.loopOf(4, _for_content5),
-  _for4 = _$.loopOf(3, _for_content4),
-  _for3 = _$.loopOf(2, _for_content3),
-  _for2 = _$.loopOf(1, _for_content2),
   _for = _$.loopOf(0, _for_content),
-  _items_effect = _$.effect("a9", (_scope, { 6: items }) =>
-    _$.on(_scope[5], "click", function () {
+  _items_effect = _$.effect("a5", (_scope, { 2: items }) =>
+    _$.on(_scope[1], "click", function () {
       _items(_scope, [...items.slice(1), items[0]]);
     }),
   ),
-  _items = _$.state(6, (_scope, items) => {
-    _items_effect(_scope),
-      _for(_scope, [items, "id"]),
-      _for2(_scope, [items, (item) => item.id]),
-      _for3(_scope, [items, getStringBy()]),
-      _for4(_scope, [items, getFunctionBy()]),
-      _for5(_scope, [items, getMissingBy()]);
+  _items = _$.state(2, (_scope, items) => {
+    _items_effect(_scope), _for(_scope, [items, "id"]);
   });
-function _getStringBy() {
-  return "id";
-}
 function _anonymous(item) {
   return item.id;
 }
-function _getFunctionBy() {
-  return _anonymous;
-}
-function _getMissingBy() {}
-_$.register("a0", _getStringBy),
+_$.register("a0", function () {
+  return "id";
+}),
   _$.register("a2", _anonymous),
-  _$.register("a1", _getFunctionBy),
-  _$.register("a3", _getMissingBy),
+  _$.register("a1", function () {
+    return _anonymous;
+  }),
+  _$.register("a3", function () {}),
   init();

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.js
@@ -1,46 +1,22 @@
-export const _template_ = "<div><div class=by-string></div><div class=by-function></div><div class=by-unknown-string></div><div class=by-unknown-function></div><div class=by-unknown-missing></div><button>Rotate</button></div>";
-export const _walks_ = /* next(1), get, over(1), get, over(1), get, over(1), get, over(1), get, over(1), get, out(1) */"D b b b b b l";
+export const _template_ = "<div><div class=by-string></div><button>Rotate</button></div>";
+export const _walks_ = /* next(1), get, over(1), get, out(1) */"D b l";
 const getStringBy = _getStringBy;
 const getFunctionBy = _getFunctionBy;
 const getMissingBy = _getMissingBy;
 import * as _$ from "@marko/runtime-tags/debug/dom";
-const _text$for_content5 = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/0"], text));
-const _pattern_5$for_content = /* @__PURE__ */_$.value("_pattern_5", (_scope, _pattern_5) => _text$for_content5(_scope, _pattern_5.text));
-const _params_6$for_content = /* @__PURE__ */_$.value("_params_6", (_scope, _params_6) => _pattern_5$for_content(_scope, _params_6?.[0]));
-const _for_content5 = _$.register("__tests__/template.marko_5_renderer", /* @__PURE__ */_$.createRenderer(" ", /* get */" ", void 0, () => _params_6$for_content));
-const _text$for_content4 = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/0"], text));
-const _pattern_4$for_content = /* @__PURE__ */_$.value("_pattern_4", (_scope, _pattern_4) => _text$for_content4(_scope, _pattern_4.text));
-const _params_5$for_content = /* @__PURE__ */_$.value("_params_5", (_scope, _params_5) => _pattern_4$for_content(_scope, _params_5?.[0]));
-const _for_content4 = _$.register("__tests__/template.marko_4_renderer", /* @__PURE__ */_$.createRenderer(" ", /* get */" ", void 0, () => _params_5$for_content));
-const _text$for_content3 = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/0"], text));
-const _pattern_3$for_content = /* @__PURE__ */_$.value("_pattern_3", (_scope, _pattern_3) => _text$for_content3(_scope, _pattern_3.text));
-const _params_4$for_content = /* @__PURE__ */_$.value("_params_4", (_scope, _params_4) => _pattern_3$for_content(_scope, _params_4?.[0]));
-const _for_content3 = _$.register("__tests__/template.marko_3_renderer", /* @__PURE__ */_$.createRenderer(" ", /* get */" ", void 0, () => _params_4$for_content));
-const _text$for_content2 = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/0"], text));
-const _pattern_2$for_content = /* @__PURE__ */_$.value("_pattern_2", (_scope, _pattern_2) => _text$for_content2(_scope, _pattern_2.text));
-const _params_3$for_content = /* @__PURE__ */_$.value("_params_3", (_scope, _params_3) => _pattern_2$for_content(_scope, _params_3?.[0]));
-const _for_content2 = _$.register("__tests__/template.marko_2_renderer", /* @__PURE__ */_$.createRenderer(" ", /* get */" ", void 0, () => _params_3$for_content));
 const _text$for_content = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/0"], text));
 const _pattern_$for_content = /* @__PURE__ */_$.value("_pattern_", (_scope, _pattern_) => _text$for_content(_scope, _pattern_.text));
 const _params_2$for_content = /* @__PURE__ */_$.value("_params_2", (_scope, _params_2) => _pattern_$for_content(_scope, _params_2?.[0]));
 const _for_content = _$.register("__tests__/template.marko_1_renderer", /* @__PURE__ */_$.createRenderer(" ", /* get */" ", void 0, () => _params_2$for_content));
-const _for5 = /* @__PURE__ */_$.loopOf("#div/4", _for_content5);
-const _for4 = /* @__PURE__ */_$.loopOf("#div/3", _for_content4);
-const _for3 = /* @__PURE__ */_$.loopOf("#div/2", _for_content3);
-const _for2 = /* @__PURE__ */_$.loopOf("#div/1", _for_content2);
 const _for = /* @__PURE__ */_$.loopOf("#div/0", _for_content);
 const _items_effect = _$.effect("__tests__/template.marko_0_items", (_scope, {
   items
-}) => _$.on(_scope["#button/5"], "click", function () {
+}) => _$.on(_scope["#button/1"], "click", function () {
   _items(_scope, [...items.slice(1), items[0]]);
 }));
 const _items = /* @__PURE__ */_$.state("items", (_scope, items) => {
   _items_effect(_scope);
   _for(_scope, [items, "id"]);
-  _for2(_scope, [items, item => item.id]);
-  _for3(_scope, [items, getStringBy()]);
-  _for4(_scope, [items, getFunctionBy()]);
-  _for5(_scope, [items, getMissingBy()]);
 });
 export function _setup_(_scope) {
   _items(_scope, [{

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.expected/template.js
@@ -34,60 +34,11 @@ const _renderer = /* @__PURE__ */_$.createRenderer((input, _tagVar) => {
     _$.write(`${_$.escapeXML(text)}${_$.markResumeNode(_scope1_id, "#text/0")}`);
     _$.writeScope(_scope1_id, {});
   }, _scope0_id, "#div/0");
-  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/0")}<div class=by-function>`);
-  const _by = item => item.id;
-  const _scope2_ = new Map();
-  _$.resumeSingleNodeForOf(items, (_list2, _index2) => {
-    const _scope2_id = _$.nextScopeId();
-    let {
-      text
-    } = _list2;
-    _scope2_.set(_by(_list2, _index2), _$.ensureScopeWithId(_scope2_id));
-    _$.write(`${_$.escapeXML(text)}${_$.markResumeNode(_scope2_id, "#text/0")}`);
-    _$.writeScope(_scope2_id, {});
-  }, _scope0_id, "#div/1");
-  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/1")}<div class=by-unknown-string>`);
-  const _scope3_ = new Map();
-  _$.resumeSingleNodeForOf(items, (_list3, _index3) => {
-    const _scope3_id = _$.nextScopeId();
-    let {
-      text
-    } = _list3;
-    _scope3_.set(_$.forOfBy(getStringBy(), _list3, _index3), _$.ensureScopeWithId(_scope3_id));
-    _$.write(`${_$.escapeXML(text)}${_$.markResumeNode(_scope3_id, "#text/0")}`);
-    _$.writeScope(_scope3_id, {});
-  }, _scope0_id, "#div/2");
-  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/2")}<div class=by-unknown-function>`);
-  const _scope4_ = new Map();
-  _$.resumeSingleNodeForOf(items, (_list4, _index4) => {
-    const _scope4_id = _$.nextScopeId();
-    let {
-      text
-    } = _list4;
-    _scope4_.set(_$.forOfBy(getFunctionBy(), _list4, _index4), _$.ensureScopeWithId(_scope4_id));
-    _$.write(`${_$.escapeXML(text)}${_$.markResumeNode(_scope4_id, "#text/0")}`);
-    _$.writeScope(_scope4_id, {});
-  }, _scope0_id, "#div/3");
-  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/3")}<div class=by-unknown-missing>`);
-  const _scope5_ = new Map();
-  _$.resumeSingleNodeForOf(items, (_list5, _index5) => {
-    const _scope5_id = _$.nextScopeId();
-    let {
-      text
-    } = _list5;
-    _scope5_.set(_$.forOfBy(getMissingBy(), _list5, _index5), _$.ensureScopeWithId(_scope5_id));
-    _$.write(`${_$.escapeXML(text)}${_$.markResumeNode(_scope5_id, "#text/0")}`);
-    _$.writeScope(_scope5_id, {});
-  }, _scope0_id, "#div/4");
-  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/4")}<button>Rotate</button>${_$.markResumeNode(_scope0_id, "#button/5")}</div>`);
+  _$.write(`</div>${_$.markResumeNode(_scope0_id, "#div/0")}<button>Rotate</button>${_$.markResumeNode(_scope0_id, "#button/1")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_items");
   _$.writeScope(_scope0_id, {
     "items": items,
-    "#div/0(": _scope1_.size ? _scope1_ : undefined,
-    "#div/1(": _scope2_.size ? _scope2_ : undefined,
-    "#div/2(": _scope3_.size ? _scope3_ : undefined,
-    "#div/3(": _scope4_.size ? _scope4_ : undefined,
-    "#div/4(": _scope5_.size ? _scope5_ : undefined
+    "#div/0(": _scope1_.size ? _scope1_ : undefined
   });
   _$.resumeClosestBranch(_scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume-sanitized.expected.md
@@ -6,26 +6,6 @@
   >
     firstsecondthird
   </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    firstsecondthird
-  </div>
   <button>
     Rotate
   </button>
@@ -41,26 +21,6 @@ container.querySelector("button").click();
 <div>
   <div
     class="by-string"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    secondthirdfirst
-  </div>
-  <div
-    class="by-unknown-missing"
   >
     secondthirdfirst
   </div>
@@ -82,26 +42,6 @@ container.querySelector("button").click();
   >
     thirdfirstsecond
   </div>
-  <div
-    class="by-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    thirdfirstsecond
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    thirdfirstsecond
-  </div>
   <button>
     Rotate
   </button>
@@ -117,26 +57,6 @@ container.querySelector("button").click();
 <div>
   <div
     class="by-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
   >
     firstsecondthird
   </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume.expected.md
@@ -16,61 +16,13 @@
         <!--M_|1 #div/0 4 3 2-->
       </div>
       <!--M_*1 #div/0-->
-      <div
-        class="by-function"
-      >
-        first
-        <!--M_*5 #text/0-->
-        second
-        <!--M_*6 #text/0-->
-        third
-        <!--M_*7 #text/0-->
-        <!--M_|1 #div/1 7 6 5-->
-      </div>
-      <!--M_*1 #div/1-->
-      <div
-        class="by-unknown-string"
-      >
-        first
-        <!--M_*8 #text/0-->
-        second
-        <!--M_*9 #text/0-->
-        third
-        <!--M_*10 #text/0-->
-        <!--M_|1 #div/2 10 9 8-->
-      </div>
-      <!--M_*1 #div/2-->
-      <div
-        class="by-unknown-function"
-      >
-        first
-        <!--M_*11 #text/0-->
-        second
-        <!--M_*12 #text/0-->
-        third
-        <!--M_*13 #text/0-->
-        <!--M_|1 #div/3 13 12 11-->
-      </div>
-      <!--M_*1 #div/3-->
-      <div
-        class="by-unknown-missing"
-      >
-        first
-        <!--M_*14 #text/0-->
-        second
-        <!--M_*15 #text/0-->
-        third
-        <!--M_*16 #text/0-->
-        <!--M_|1 #div/4 16 15 14-->
-      </div>
-      <!--M_*1 #div/4-->
       <button>
         Rotate
       </button>
-      <!--M_*1 #button/5-->
+      <!--M_*1 #button/1-->
     </div>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()
     </script>
   </body>
 </html>
@@ -98,61 +50,13 @@ container.querySelector("button").click();
         first
       </div>
       <!--M_*1 #div/0-->
-      <div
-        class="by-function"
-      >
-        <!--M_*5 #text/0-->
-        second
-        <!--M_*6 #text/0-->
-        third
-        <!--M_*7 #text/0-->
-        <!--M_|1 #div/1 7 6 5-->
-        first
-      </div>
-      <!--M_*1 #div/1-->
-      <div
-        class="by-unknown-string"
-      >
-        <!--M_*8 #text/0-->
-        second
-        <!--M_*9 #text/0-->
-        third
-        <!--M_*10 #text/0-->
-        <!--M_|1 #div/2 10 9 8-->
-        first
-      </div>
-      <!--M_*1 #div/2-->
-      <div
-        class="by-unknown-function"
-      >
-        <!--M_*11 #text/0-->
-        second
-        <!--M_*12 #text/0-->
-        third
-        <!--M_*13 #text/0-->
-        <!--M_|1 #div/3 13 12 11-->
-        first
-      </div>
-      <!--M_*1 #div/3-->
-      <div
-        class="by-unknown-missing"
-      >
-        second
-        <!--M_*14 #text/0-->
-        third
-        <!--M_*15 #text/0-->
-        first
-        <!--M_*16 #text/0-->
-        <!--M_|1 #div/4 16 15 14-->
-      </div>
-      <!--M_*1 #div/4-->
       <button>
         Rotate
       </button>
-      <!--M_*1 #button/5-->
+      <!--M_*1 #button/1-->
     </div>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()
     </script>
   </body>
 </html>
@@ -160,17 +64,8 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE html/body/div/div0/#text2 before html/body/div/div0/#comment0
-INSERT html/body/div/div0/#text2
-REMOVE html/body/div/div1/#text2 before html/body/div/div1/#comment0
-INSERT html/body/div/div1/#text2
-REMOVE html/body/div/div2/#text2 before html/body/div/div2/#comment0
-INSERT html/body/div/div2/#text2
-REMOVE html/body/div/div3/#text2 before html/body/div/div3/#comment0
-INSERT html/body/div/div3/#text2
-UPDATE html/body/div/div4/#text0 "first" => "second"
-UPDATE html/body/div/div4/#text1 "second" => "third"
-UPDATE html/body/div/div4/#text2 "third" => "first"
+REMOVE html/body/div/div/#text2 before html/body/div/div/#comment0
+INSERT html/body/div/div/#text2
 ```
 
 # Render
@@ -193,58 +88,13 @@ container.querySelector("button").click();
         firstsecond
       </div>
       <!--M_*1 #div/0-->
-      <div
-        class="by-function"
-      >
-        <!--M_*5 #text/0-->
-        <!--M_*6 #text/0-->
-        third
-        <!--M_*7 #text/0-->
-        <!--M_|1 #div/1 7 6 5-->
-        firstsecond
-      </div>
-      <!--M_*1 #div/1-->
-      <div
-        class="by-unknown-string"
-      >
-        <!--M_*8 #text/0-->
-        <!--M_*9 #text/0-->
-        third
-        <!--M_*10 #text/0-->
-        <!--M_|1 #div/2 10 9 8-->
-        firstsecond
-      </div>
-      <!--M_*1 #div/2-->
-      <div
-        class="by-unknown-function"
-      >
-        <!--M_*11 #text/0-->
-        <!--M_*12 #text/0-->
-        third
-        <!--M_*13 #text/0-->
-        <!--M_|1 #div/3 13 12 11-->
-        firstsecond
-      </div>
-      <!--M_*1 #div/3-->
-      <div
-        class="by-unknown-missing"
-      >
-        third
-        <!--M_*14 #text/0-->
-        first
-        <!--M_*15 #text/0-->
-        second
-        <!--M_*16 #text/0-->
-        <!--M_|1 #div/4 16 15 14-->
-      </div>
-      <!--M_*1 #div/4-->
       <button>
         Rotate
       </button>
-      <!--M_*1 #button/5-->
+      <!--M_*1 #button/1-->
     </div>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()
     </script>
   </body>
 </html>
@@ -252,17 +102,8 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE html/body/div/div0/#text2 after html/body/div/div0/#comment0
-INSERT html/body/div/div0/#text2
-REMOVE html/body/div/div1/#text2 after html/body/div/div1/#comment0
-INSERT html/body/div/div1/#text2
-REMOVE html/body/div/div2/#text2 after html/body/div/div2/#comment0
-INSERT html/body/div/div2/#text2
-REMOVE html/body/div/div3/#text2 after html/body/div/div3/#comment0
-INSERT html/body/div/div3/#text2
-UPDATE html/body/div/div4/#text0 "second" => "third"
-UPDATE html/body/div/div4/#text1 "third" => "first"
-UPDATE html/body/div/div4/#text2 "first" => "second"
+REMOVE html/body/div/div/#text2 after html/body/div/div/#comment0
+INSERT html/body/div/div/#text2
 ```
 
 # Render
@@ -284,55 +125,13 @@ container.querySelector("button").click();
         firstsecondthird
       </div>
       <!--M_*1 #div/0-->
-      <div
-        class="by-function"
-      >
-        <!--M_*5 #text/0-->
-        <!--M_*6 #text/0-->
-        <!--M_*7 #text/0-->
-        <!--M_|1 #div/1 7 6 5-->
-        firstsecondthird
-      </div>
-      <!--M_*1 #div/1-->
-      <div
-        class="by-unknown-string"
-      >
-        <!--M_*8 #text/0-->
-        <!--M_*9 #text/0-->
-        <!--M_*10 #text/0-->
-        <!--M_|1 #div/2 10 9 8-->
-        firstsecondthird
-      </div>
-      <!--M_*1 #div/2-->
-      <div
-        class="by-unknown-function"
-      >
-        <!--M_*11 #text/0-->
-        <!--M_*12 #text/0-->
-        <!--M_*13 #text/0-->
-        <!--M_|1 #div/3 13 12 11-->
-        firstsecondthird
-      </div>
-      <!--M_*1 #div/3-->
-      <div
-        class="by-unknown-missing"
-      >
-        first
-        <!--M_*14 #text/0-->
-        second
-        <!--M_*15 #text/0-->
-        third
-        <!--M_*16 #text/0-->
-        <!--M_|1 #div/4 16 15 14-->
-      </div>
-      <!--M_*1 #div/4-->
       <button>
         Rotate
       </button>
-      <!--M_*1 #button/5-->
+      <!--M_*1 #button/1-->
     </div>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()
     </script>
   </body>
 </html>
@@ -340,15 +139,6 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE html/body/div/div0/#text2 after html/body/div/div0/#comment1
-INSERT html/body/div/div0/#text2
-REMOVE html/body/div/div1/#text2 after html/body/div/div1/#comment1
-INSERT html/body/div/div1/#text2
-REMOVE html/body/div/div2/#text2 after html/body/div/div2/#comment1
-INSERT html/body/div/div2/#text2
-REMOVE html/body/div/div3/#text2 after html/body/div/div3/#comment1
-INSERT html/body/div/div3/#text2
-UPDATE html/body/div/div4/#text0 "third" => "first"
-UPDATE html/body/div/div4/#text1 "first" => "second"
-UPDATE html/body/div/div4/#text2 "second" => "third"
+REMOVE html/body/div/div/#text2 after html/body/div/div/#comment1
+INSERT html/body/div/div/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr-sanitized.expected.md
@@ -6,26 +6,6 @@
   >
     firstsecondthird
   </div>
-  <div
-    class="by-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-string"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-function"
-  >
-    firstsecondthird
-  </div>
-  <div
-    class="by-unknown-missing"
-  >
-    firstsecondthird
-  </div>
   <button>
     Rotate
   </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><div class=by-string>first<!--M_*2 #text/0-->second<!--M_*3 #text/0-->third<!--M_*4 #text/0--><!--M_|1 #div/0 4 3 2--></div><!--M_*1 #div/0--><div class=by-function>first<!--M_*5 #text/0-->second<!--M_*6 #text/0-->third<!--M_*7 #text/0--><!--M_|1 #div/1 7 6 5--></div><!--M_*1 #div/1--><div class=by-unknown-string>first<!--M_*8 #text/0-->second<!--M_*9 #text/0-->third<!--M_*10 #text/0--><!--M_|1 #div/2 10 9 8--></div><!--M_*1 #div/2--><div class=by-unknown-function>first<!--M_*11 #text/0-->second<!--M_*12 #text/0-->third<!--M_*13 #text/0--><!--M_|1 #div/3 13 12 11--></div><!--M_*1 #div/3--><div class=by-unknown-missing>first<!--M_*14 #text/0-->second<!--M_*15 #text/0-->third<!--M_*16 #text/0--><!--M_|1 #div/4 16 15 14--></div><!--M_*1 #div/4--><button>Rotate</button><!--M_*1 #button/5--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()</script>
+  <div><div class=by-string>first<!--M_*2 #text/0-->second<!--M_*3 #text/0-->third<!--M_*4 #text/0--><!--M_|1 #div/0 4 3 2--></div><!--M_*1 #div/0--><button>Rotate</button><!--M_*1 #button/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()</script>
 ```
 
 # Render End
@@ -21,61 +21,13 @@
         <!--M_|1 #div/0 4 3 2-->
       </div>
       <!--M_*1 #div/0-->
-      <div
-        class="by-function"
-      >
-        first
-        <!--M_*5 #text/0-->
-        second
-        <!--M_*6 #text/0-->
-        third
-        <!--M_*7 #text/0-->
-        <!--M_|1 #div/1 7 6 5-->
-      </div>
-      <!--M_*1 #div/1-->
-      <div
-        class="by-unknown-string"
-      >
-        first
-        <!--M_*8 #text/0-->
-        second
-        <!--M_*9 #text/0-->
-        third
-        <!--M_*10 #text/0-->
-        <!--M_|1 #div/2 10 9 8-->
-      </div>
-      <!--M_*1 #div/2-->
-      <div
-        class="by-unknown-function"
-      >
-        first
-        <!--M_*11 #text/0-->
-        second
-        <!--M_*12 #text/0-->
-        third
-        <!--M_*13 #text/0-->
-        <!--M_|1 #div/3 13 12 11-->
-      </div>
-      <!--M_*1 #div/3-->
-      <div
-        class="by-unknown-missing"
-      >
-        first
-        <!--M_*14 #text/0-->
-        second
-        <!--M_*15 #text/0-->
-        third
-        <!--M_*16 #text/0-->
-        <!--M_|1 #div/4 16 15 14-->
-      </div>
-      <!--M_*1 #div/4-->
       <button>
         Rotate
       </button>
-      <!--M_*1 #button/5-->
+      <!--M_*1 #button/1-->
     </div>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.u={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"#div/1(":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"#div/2(":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"#div/3(":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"#div/4(":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]])},2:_.f,3:_.g,4:_.h,5:_.i,6:_.j,7:_.k,8:_.l,9:_.m,10:_.n,11:_.o,12:_.p,13:_.q,14:_.r,15:_.s,16:_.t}),1,"__tests__/template.marko_0_items",0];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.e={1:{items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}],"#div/0(":new Map(_.a=[[0,_.b={}],[1,_.c={}],[2,_.d={}]])},2:_.b,3:_.c,4:_.d}),1,"__tests__/template.marko_0_items",0];M._.w()
     </script>
   </body>
 </html>
@@ -87,54 +39,18 @@ INSERT html
 INSERT html/head
 INSERT html/body
 INSERT html/body/div
-INSERT html/body/div/div0
-INSERT html/body/div/div0/#text0
-INSERT html/body/div/div0/#comment0
-INSERT html/body/div/div0/#text1
-INSERT html/body/div/div0/#comment1
-INSERT html/body/div/div0/#text2
-INSERT html/body/div/div0/#comment2
-INSERT html/body/div/div0/#comment3
+INSERT html/body/div/div
+INSERT html/body/div/div/#text0
+INSERT html/body/div/div/#comment0
+INSERT html/body/div/div/#text1
+INSERT html/body/div/div/#comment1
+INSERT html/body/div/div/#text2
+INSERT html/body/div/div/#comment2
+INSERT html/body/div/div/#comment3
 INSERT html/body/div/#comment0
-INSERT html/body/div/div1
-INSERT html/body/div/div1/#text0
-INSERT html/body/div/div1/#comment0
-INSERT html/body/div/div1/#text1
-INSERT html/body/div/div1/#comment1
-INSERT html/body/div/div1/#text2
-INSERT html/body/div/div1/#comment2
-INSERT html/body/div/div1/#comment3
-INSERT html/body/div/#comment1
-INSERT html/body/div/div2
-INSERT html/body/div/div2/#text0
-INSERT html/body/div/div2/#comment0
-INSERT html/body/div/div2/#text1
-INSERT html/body/div/div2/#comment1
-INSERT html/body/div/div2/#text2
-INSERT html/body/div/div2/#comment2
-INSERT html/body/div/div2/#comment3
-INSERT html/body/div/#comment2
-INSERT html/body/div/div3
-INSERT html/body/div/div3/#text0
-INSERT html/body/div/div3/#comment0
-INSERT html/body/div/div3/#text1
-INSERT html/body/div/div3/#comment1
-INSERT html/body/div/div3/#text2
-INSERT html/body/div/div3/#comment2
-INSERT html/body/div/div3/#comment3
-INSERT html/body/div/#comment3
-INSERT html/body/div/div4
-INSERT html/body/div/div4/#text0
-INSERT html/body/div/div4/#comment0
-INSERT html/body/div/div4/#text1
-INSERT html/body/div/div4/#comment1
-INSERT html/body/div/div4/#text2
-INSERT html/body/div/div4/#comment2
-INSERT html/body/div/div4/#comment3
-INSERT html/body/div/#comment4
 INSERT html/body/div/button
 INSERT html/body/div/button/#text
-INSERT html/body/div/#comment5
+INSERT html/body/div/#comment1
 INSERT html/body/script
 INSERT html/body/script/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/template.marko
@@ -17,7 +17,7 @@ static function getMissingBy() {
     <for|{ text }| of=items by="id">${text}</for>
   </>
 
-  <div.by-function>
+  <!-- <div.by-function>
     <for|{ text }| of=items by=item=> item.id>${text}</for>
   </div>
 
@@ -31,7 +31,7 @@ static function getMissingBy() {
 
   <div.by-unknown-missing>
     <for|{ text }| of=items by=getMissingBy()>${text}</for>
-  </div>
+  </div> -->
 
   <button onClick() { items = [...items.slice(1), items[0]]; }>Rotate</button>
 </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/csr.expected.md
@@ -22,7 +22,7 @@ hi
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after button
 ```
 
 # Render
@@ -37,7 +37,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after button
 ```
 
 # Render
@@ -53,5 +53,5 @@ hi
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after button
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/resume.expected.md
@@ -35,7 +35,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/#text
-REMOVE #comment after html/body/#text
+REMOVE #comment after html/body/#comment
 ```
 
 # Render
@@ -59,7 +59,7 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/#comment1
-REMOVE #text after html/body/#comment1
+REMOVE #text after html/body/#comment0
 ```
 
 # Render
@@ -83,5 +83,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT html/body/#text
-REMOVE #comment after html/body/#text
+REMOVE #comment after html/body/#comment
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/csr.expected.md
@@ -81,7 +81,7 @@ container.querySelector("#toggle")?.click();
 INSERT #text
 REMOVE #text in div
 INSERT div/#text
-REMOVE #text after #text
+REMOVE #text after #comment
 ```
 
 # Render
@@ -134,7 +134,7 @@ container.querySelector("#toggle")?.click();
 # Mutations
 ```
 INSERT #text
-REMOVE #text after #text
+REMOVE #text after #comment
 REMOVE #text in div
 INSERT div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/csr.expected.md
@@ -52,7 +52,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button0
-REMOVE button after button0
+REMOVE button after #comment1
 UPDATE button0/#text1 "" => "1"
 ```
 
@@ -84,7 +84,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button1
-REMOVE button after button1
+REMOVE button after #comment3
 UPDATE button1/#text1 "" => "1"
 ```
 
@@ -116,7 +116,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button2
-REMOVE button after button2
+REMOVE button after #comment5
 UPDATE button2/#text1 "" => "1"
 ```
 
@@ -148,7 +148,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button0
-REMOVE button after button0
+REMOVE button after #comment1
 UPDATE button0/#text1 "" => "1"
 ```
 
@@ -180,7 +180,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button1
-REMOVE button after button1
+REMOVE button after #comment3
 UPDATE button1/#text1 "" => "1"
 ```
 
@@ -212,7 +212,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button2
-REMOVE button after button2
+REMOVE button after #comment5
 UPDATE button2/#text1 "" => "1"
 ```
 
@@ -244,7 +244,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button0
-REMOVE button after button0
+REMOVE button after #comment1
 UPDATE button0/#text1 "" => "2"
 ```
 
@@ -276,7 +276,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button1
-REMOVE button after button1
+REMOVE button after #comment3
 UPDATE button1/#text1 "" => "2"
 ```
 
@@ -308,6 +308,6 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT button2
-REMOVE button after button2
+REMOVE button after #comment5
 UPDATE button2/#text1 "" => "2"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/resume.expected.md
@@ -35,6 +35,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -77,7 +81,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button0
-REMOVE button after html/body/button0
+REMOVE button before html/body/button0
 UPDATE html/body/button0/#text1 "" => "1"
 ```
 
@@ -119,7 +123,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button1
-REMOVE button after html/body/button1
+REMOVE button after html/body/#comment1
 UPDATE html/body/button1/#text1 "" => "1"
 ```
 
@@ -158,7 +162,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button2
-REMOVE button after html/body/button2
+REMOVE button after html/body/#comment3
 UPDATE html/body/button2/#text1 "" => "1"
 ```
 
@@ -197,7 +201,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button0
-REMOVE button after html/body/button0
+REMOVE button before html/body/button0
 UPDATE html/body/button0/#text1 "" => "1"
 ```
 
@@ -236,7 +240,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button1
-REMOVE button after html/body/button1
+REMOVE button after html/body/#comment1
 UPDATE html/body/button1/#text1 "" => "1"
 ```
 
@@ -275,7 +279,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button2
-REMOVE button after html/body/button2
+REMOVE button after html/body/#comment3
 UPDATE html/body/button2/#text1 "" => "1"
 ```
 
@@ -314,7 +318,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button0
-REMOVE button after html/body/button0
+REMOVE button before html/body/button0
 UPDATE html/body/button0/#text1 "" => "2"
 ```
 
@@ -353,7 +357,7 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button1
-REMOVE button after html/body/button1
+REMOVE button after html/body/#comment1
 UPDATE html/body/button1/#text1 "" => "2"
 ```
 
@@ -392,6 +396,6 @@ buttonIndex = (buttonIndex + 1) % 3;
 # Mutations
 ```
 INSERT html/body/button2
-REMOVE button after html/body/button2
+REMOVE button after html/body/#comment3
 UPDATE html/body/button2/#text1 "" => "2"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/csr.expected.md
@@ -27,7 +27,7 @@ INSERT div
 # Mutations
 ```
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span before div/#text
 ```
 
 # Render `{"value":"World"}`
@@ -45,7 +45,7 @@ REMOVE span after div/#text
 # Mutations
 ```
 INSERT div/span0
-REMOVE #text after div/span0
+REMOVE #text before div/span0
 UPDATE div/span0/#text " " => "World"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/csr.expected.md
@@ -92,7 +92,7 @@ container.querySelector("#inner").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE button after div/#text
+REMOVE button after div/button1
 ```
 
 # Render
@@ -119,7 +119,7 @@ container.querySelector("#inner").click();
 # Mutations
 ```
 INSERT div/button2
-REMOVE #text after div/button2
+REMOVE #text after div/button1
 UPDATE div/button2/#text " " => "2"
 ```
 
@@ -164,9 +164,9 @@ container.querySelector("#outer").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE button after div/#text
-REMOVE button after div/#text
-REMOVE #comment after div/#text
+REMOVE button after div/button
+REMOVE button after div/button
+REMOVE #comment after div/button
 ```
 
 # Render
@@ -195,9 +195,9 @@ container.querySelector("#outer").click();
 INSERT div/button1
 INSERT #text
 INSERT div/#comment
-REMOVE #text after div/#comment
+REMOVE #text after div/button0
 INSERT div/button2
-REMOVE #text after div/button2
+REMOVE #text after div/button1
 UPDATE div/button2/#text " " => "3"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/resume.expected.md
@@ -30,6 +30,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text
+```
 
 # Render
 ```js
@@ -144,7 +148,7 @@ container.querySelector("#inner").click();
 ```
 REMOVE html/body/div/#comment3 after html/body/div/#comment4
 INSERT html/body/div/#comment3
-REMOVE button after html/body/div/#comment3
+REMOVE button after html/body/div/#comment2
 ```
 
 # Render
@@ -183,7 +187,7 @@ container.querySelector("#inner").click();
 # Mutations
 ```
 INSERT html/body/div/button2
-REMOVE #comment after html/body/div/button2
+REMOVE #comment after html/body/div/#comment2
 UPDATE html/body/div/button2/#text " " => "2"
 ```
 
@@ -249,13 +253,14 @@ container.querySelector("#outer").click();
 
 # Mutations
 ```
-REMOVE html/body/div/#comment1 after #comment
+REMOVE html/body/div/#comment1 after #text
 INSERT html/body/div/#comment1
-REMOVE #comment after html/body/div/#comment1
-REMOVE button after html/body/div/#comment1
-REMOVE #comment after html/body/div/#comment1
-REMOVE button after html/body/div/#comment1
-REMOVE #comment after html/body/div/#comment1
+REMOVE #comment after html/body/div/#comment0
+REMOVE button after html/body/div/#comment0
+REMOVE #comment after html/body/div/#comment0
+REMOVE button after html/body/div/#comment0
+REMOVE #comment after html/body/div/#comment0
+REMOVE #text after html/body/div/#comment0
 ```
 
 # Render
@@ -293,9 +298,9 @@ container.querySelector("#outer").click();
 INSERT html/body/div/button1
 INSERT #text
 INSERT html/body/div/#comment1
-REMOVE #comment after html/body/div/#comment1
+REMOVE #comment after html/body/div/#comment0
 INSERT html/body/div/button2
-REMOVE #text after html/body/div/button2
+REMOVE #text after html/body/div/button1
 UPDATE html/body/div/button2/#text " " => "3"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/.name-cache.json
@@ -1,0 +1,29 @@
+{
+  "vars": {
+    "props": {
+      "$_$": "t",
+      "$init": "n",
+      "$_count$ifBody_effect": "e",
+      "$_count$ifBody": "o",
+      "$_ifBody2": "r",
+      "$_if$ifBody": "i",
+      "$_inner$ifBody_effect": "c",
+      "$_inner$ifBody": "a",
+      "$_ifBody": "u",
+      "$_if": "s",
+      "$_count": "d",
+      "$_inner": "l",
+      "$_outer_effect": "m",
+      "$_outer": "f",
+      "$_count$if_content_effect": "b",
+      "$_count$if_content": "_",
+      "$_if_content2": "g",
+      "$_if$if_content": "k",
+      "$_inner$if_content_effect": "p",
+      "$_inner$if_content": "v",
+      "$_if_content": "S",
+      "$_setup$if_content2": "C",
+      "$_setup$if_content": "D"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,180 @@
+# Render
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    0
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    1
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    4
+  </button>
+   hello
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/csr.expected.md
@@ -1,0 +1,237 @@
+# Render
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    0
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+INSERT div
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    1
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+UPDATE div/button2/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+UPDATE div/button2/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+INSERT div/#text0
+REMOVE button after div/button1
+```
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+INSERT div/button2
+REMOVE #text after div/button1
+UPDATE div/button2/#text " " => "2"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+UPDATE div/button2/#text "2" => "3"
+```
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+   hello
+</div>
+```
+
+# Mutations
+```
+INSERT div/#text0
+REMOVE button after div/button
+REMOVE button after div/button
+REMOVE #comment after div/button
+```
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+INSERT div/button1
+INSERT #text
+INSERT div/#comment
+REMOVE #text after div/button0
+INSERT div/button2
+REMOVE #text after div/button1
+UPDATE div/button2/#text " " => "3"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    4
+  </button>
+  <!---->
+   hello
+</div>
+```
+
+# Mutations
+```
+UPDATE div/button2/#text "3" => "4"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,73 @@
+// size: 754 (min) 325 (brotli)
+const _count$if_content_effect = _$.effect(
+    "a0",
+    (
+      _scope,
+      {
+        _: {
+          _: { 4: count },
+        },
+      },
+    ) =>
+      _$.on(_scope[0], "click", function () {
+        _count(_scope._._, count + 1);
+      }),
+  ),
+  _count$if_content = _$.registerSubscriber(
+    "a1",
+    _$.dynamicClosure(
+      (_scope, count) => {
+        _$.data(_scope[1], count), _count$if_content_effect(_scope);
+      },
+      (_scope) => _scope._._,
+    ),
+  ),
+  _setup$if_content2 = (_scope) => {
+    _count$if_content._(_scope, _scope._._[4]);
+  },
+  _if_content2 = _$.register(
+    "a2",
+    _$.createRenderer("<button id=count> </button>", " D ", _setup$if_content2),
+  ),
+  _if$if_content = _$.conditional(1, 0),
+  _inner$if_content_effect = _$.effect("a3", (_scope, { _: { 3: inner } }) =>
+    _$.on(_scope[0], "click", function () {
+      _inner(_scope._, !inner);
+    }),
+  ),
+  _inner$if_content = _$.conditionalClosure(
+    1,
+    () => _if_content,
+    (_scope, inner) => {
+      _inner$if_content_effect(_scope),
+        _if$if_content(_scope, inner ? _if_content2 : null);
+    },
+    () => _if$if_content,
+  ),
+  _setup$if_content = (_scope) => {
+    _inner$if_content._(_scope, _scope._[3]);
+  },
+  _if_content = _$.register(
+    "a4",
+    _$.createRenderer(
+      "<button id=inner></button><!><!>",
+      " b%D",
+      _setup$if_content,
+    ),
+  ),
+  _if = _$.conditional(1, 0),
+  _count = _$.state(4, (_scope, count) => _count$if_content(_scope, count)),
+  _inner = _$.state(3, (_scope, inner) => _inner$if_content(_scope, inner)),
+  _outer_effect = _$.effect("a5", (_scope, { 2: outer }) =>
+    _$.on(_scope[0], "click", function () {
+      _outer(_scope, !outer);
+    }),
+  ),
+  _outer = _$.state(
+    2,
+    (_scope, outer) => {
+      _outer_effect(_scope), _if(_scope, outer ? _if_content : null);
+    },
+    () => _if,
+  );
+init();

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
@@ -1,0 +1,54 @@
+export const _template_ = "<div><button id=outer></button><!> hello</div>";
+export const _walks_ = /* next(1), get, over(1), replace, out(1) */"D b%l";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const _count$if_content_effect = _$.effect("__tests__/template.marko_2_count", (_scope, {
+  _: {
+    _: {
+      count
+    }
+  }
+}) => _$.on(_scope["#button/0"], "click", function () {
+  _count(_scope._._, count + 1), count;
+}));
+const _count$if_content = _$.registerSubscriber("__tests__/template.marko_2_count/subscriber", /* @__PURE__ */_$.dynamicClosure((_scope, count) => {
+  _$.data(_scope["#text/1"], count);
+  _count$if_content_effect(_scope);
+}, _scope => _scope._._));
+const _setup$if_content2 = _scope => {
+  _count$if_content._(_scope, _scope._._["count"]);
+};
+const _if_content2 = _$.register("__tests__/template.marko_2_renderer", /* @__PURE__ */_$.createRenderer("<button id=count> </button>", /* get, next(1), get */" D ", _setup$if_content2));
+const _if$if_content = /* @__PURE__ */_$.conditional("#text/1", 0);
+const _inner$if_content_effect = _$.effect("__tests__/template.marko_1_inner", (_scope, {
+  _: {
+    inner
+  }
+}) => _$.on(_scope["#button/0"], "click", function () {
+  _inner(_scope._, !inner);
+}));
+const _inner$if_content = /* @__PURE__ */_$.conditionalClosure("#text/1", () => _if_content, (_scope, inner) => {
+  _inner$if_content_effect(_scope);
+  _if$if_content(_scope, inner ? _if_content2 : null);
+}, () => _if$if_content);
+const _setup$if_content = _scope => {
+  _inner$if_content._(_scope, _scope._["inner"]);
+};
+const _if_content = _$.register("__tests__/template.marko_1_renderer", /* @__PURE__ */_$.createRenderer("<button id=inner></button><!><!>", /* get, over(1), replace */" b%D", _setup$if_content));
+const _if = /* @__PURE__ */_$.conditional("#text/1", 0);
+const _count = /* @__PURE__ */_$.state("count", (_scope, count) => _count$if_content(_scope, count));
+const _inner = /* @__PURE__ */_$.state("inner", (_scope, inner) => _inner$if_content(_scope, inner));
+const _outer_effect = _$.effect("__tests__/template.marko_0_outer", (_scope, {
+  outer
+}) => _$.on(_scope["#button/0"], "click", function () {
+  _outer(_scope, !outer);
+}));
+const _outer = /* @__PURE__ */_$.state("outer", (_scope, outer) => {
+  _outer_effect(_scope);
+  _if(_scope, outer ? _if_content : null);
+}, () => _if);
+export function _setup_(_scope) {
+  _outer(_scope, true);
+  _inner(_scope, true);
+  _count(_scope, 0);
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", _template_, _walks_, _setup_);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/html.expected/template.js
@@ -1,0 +1,48 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+const _renderer = /* @__PURE__ */_$.createRenderer((input, _tagVar) => {
+  const _scope0_id = _$.nextScopeId();
+  const outer = true;
+  const inner = true;
+  const count = 0;
+  _$.write(`<div><button id=outer></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
+  let _ifScopeId2, _ifRenderer2;
+  _$.resumeConditional(() => {
+    if (outer) {
+      const _scope1_id = _$.nextScopeId();
+      _$.write(`<button id=inner></button>${_$.markResumeNode(_scope1_id, "#button/0")}`);
+      let _ifScopeId, _ifRenderer;
+      _$.resumeSingleNodeConditional(() => {
+        if (inner) {
+          const _scope2_id = _$.nextScopeId();
+          _$.write(`<button id=count>${_$.escapeXML(count)}${_$.markResumeNode(_scope2_id, "#text/1")}</button>${_$.markResumeNode(_scope2_id, "#button/0")}`);
+          _$.writeEffect(_scope2_id, "__tests__/template.marko_2_count/subscriber");
+          _$.writeEffect(_scope2_id, "__tests__/template.marko_2_count");
+          _$.writeScope(_scope2_id, {
+            "_": _$.ensureScopeWithId(_scope1_id)
+          });
+          _$.register(_ifRenderer = /* @__PURE__ */_$.createRenderer(() => {}), "__tests__/template.marko_2_renderer");
+          _ifScopeId = _scope2_id;
+        }
+      }, _scope1_id, "#text/1");
+      _$.writeEffect(_scope1_id, "__tests__/template.marko_1_inner");
+      _$.writeScope(_scope1_id, {
+        "_": _$.ensureScopeWithId(_scope0_id),
+        "#text/1(": _ifRenderer,
+        "#text/1!": _$.getScopeById(_ifScopeId)
+      });
+      _$.register(_ifRenderer2 = /* @__PURE__ */_$.createRenderer(() => {}), "__tests__/template.marko_1_renderer");
+      _ifScopeId2 = _scope1_id;
+    }
+  }, _scope0_id, "#text/1");
+  _$.write(" hello</div>");
+  _$.writeEffect(_scope0_id, "__tests__/template.marko_0_outer");
+  _$.writeScope(_scope0_id, {
+    "outer": outer,
+    "inner": inner,
+    "count": count,
+    "#text/1(": _ifRenderer2,
+    "#text/1!": _$.getScopeById(_ifScopeId2)
+  });
+  _$.resumeClosestBranch(_scope0_id);
+});
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", _renderer);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,180 @@
+# Render
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    0
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    1
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    2
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    3
+  </button>
+   hello
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    4
+  </button>
+   hello
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume.expected.md
@@ -1,0 +1,349 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        0
+        <!--M_*3 #text/1-->
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_|2 #text/1 3-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div/#text0
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        1
+        <!--M_*3 #text/1-->
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_|2 #text/1 3-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/div/button2/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        2
+        <!--M_*3 #text/1-->
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_|2 #text/1 3-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/div/button2/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <!--M_|2 #text/1 3-->
+      <!--M_*3 #button/0-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE html/body/div/#comment3 after html/body/div/#comment4
+INSERT html/body/div/#comment3
+REMOVE button after html/body/div/#comment2
+```
+
+# Render
+```js
+container.querySelector("#inner").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        2
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div/button2
+REMOVE #comment after html/body/div/#comment2
+UPDATE html/body/div/button2/#text " " => "2"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        3
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/div/button2/#text "2" => "3"
+```
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE html/body/div/#comment1 after #text
+INSERT html/body/div/#comment1
+REMOVE #comment after html/body/div/#comment0
+REMOVE button after html/body/div/#comment0
+REMOVE #comment after html/body/div/#comment0
+REMOVE button after html/body/div/#comment0
+REMOVE #comment after html/body/div/#comment0
+REMOVE #text after html/body/div/#comment0
+```
+
+# Render
+```js
+container.querySelector("#outer").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <button
+        id="inner"
+      />
+      <button
+        id="count"
+      >
+        3
+      </button>
+      <!---->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div/button1
+INSERT #text
+INSERT html/body/div/#comment1
+REMOVE #comment after html/body/div/#comment0
+INSERT html/body/div/button2
+REMOVE #text after html/body/div/button1
+UPDATE html/body/div/button2/#text " " => "3"
+```
+
+# Render
+```js
+container.querySelector("#count").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <button
+        id="inner"
+      />
+      <button
+        id="count"
+      >
+        4
+      </button>
+      <!---->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/div/button2/#text "3" => "4"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,17 @@
+# Render End
+```html
+<div>
+  <button
+    id="outer"
+  />
+  <button
+    id="inner"
+  />
+  <button
+    id="count"
+  >
+    0
+  </button>
+   hello
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr.expected.md
@@ -1,0 +1,59 @@
+# Write
+```html
+  <div><button id=outer></button><!--M_*1 #button/0--><!--M_[2--><button id=inner></button><!--M_*2 #button/0--><button id=count>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/1 3--><!--M_]1 #text/1--> hello</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button
+        id="outer"
+      />
+      <!--M_*1 #button/0-->
+      <!--M_[2-->
+      <button
+        id="inner"
+      />
+      <!--M_*2 #button/0-->
+      <button
+        id="count"
+      >
+        0
+        <!--M_*3 #text/1-->
+      </button>
+      <!--M_*3 #button/0-->
+      <!--M_|2 #text/1 3-->
+      <!--M_]1 #text/1-->
+       hello
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d={1:_.a={outer:!0,inner:!0,count:0,"#text/1(":_._["__tests__/template.marko_1_renderer"],"#text/1!":_.b={"#text/1(":_._["__tests__/template.marko_2_renderer"],"#text/1!":_.c={}}},2:_.b,3:_.c},_.b._=_.a,_.c._=_.b,_.d),3,"__tests__/template.marko_2_count/subscriber",3,"__tests__/template.marko_2_count",2,"__tests__/template.marko_1_inner",1,"__tests__/template.marko_0_outer",0];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/div
+INSERT html/body/div/button0
+INSERT html/body/div/#comment0
+INSERT html/body/div/#comment1
+INSERT html/body/div/button1
+INSERT html/body/div/#comment2
+INSERT html/body/div/button2
+INSERT html/body/div/button2/#text
+INSERT html/body/div/button2/#comment
+INSERT html/body/div/#comment3
+INSERT html/body/div/#comment4
+INSERT html/body/div/#comment5
+INSERT html/body/div/#text
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/template.marko
@@ -1,0 +1,15 @@
+<let/outer = true/>
+<let/inner = true/>
+<let/count = 0/>
+<div>
+  <button id="outer" onClick(){ outer = !outer }/>
+  <if=outer>
+    <button id="inner" onClick(){ inner = !inner }/>
+    <if=inner>
+      <button id="count" onClick(){ count++ }>
+        ${count}
+      </button>
+    </if>
+  </if>
+  hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/test.ts
@@ -1,0 +1,21 @@
+const clickOuter = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("#outer")!.click();
+};
+const clickInner = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("#inner")!.click();
+};
+const clickCount = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("#count")!.click();
+};
+
+export const steps = [
+  {},
+  clickCount,
+  clickCount,
+  clickInner,
+  clickInner,
+  clickCount,
+  clickOuter,
+  clickOuter,
+  clickCount,
+];

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/csr.expected.md
@@ -30,11 +30,11 @@ INSERT div/#comment0
 INSERT #text
 INSERT #text
 INSERT div/#comment1
-REMOVE #text after div/#comment1
+REMOVE #text before div/#comment0
 INSERT div/span0
-REMOVE #text after div/span0
+REMOVE #text after div/#comment0
 INSERT div/span1
-REMOVE #text after div/span1
+REMOVE #text after div/span0
 UPDATE div/span0/#text " " => "Hello"
 UPDATE div/span1/#text " " => "World"
 ```
@@ -54,7 +54,7 @@ UPDATE div/span1/#text " " => "World"
 # Mutations
 ```
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span after div/#comment0
 ```
 
 # Render `{"show":true,"value1":"Goodbye","value2":"World"}`
@@ -75,7 +75,7 @@ REMOVE span after div/#text
 # Mutations
 ```
 INSERT div/span0
-REMOVE #text after div/span0
+REMOVE #text after div/#comment0
 UPDATE div/span0/#text " " => "Goodbye"
 ```
 
@@ -88,8 +88,8 @@ UPDATE div/span0/#text " " => "Goodbye"
 # Mutations
 ```
 INSERT div/#text
-REMOVE #comment after div/#text
-REMOVE span after div/#text
-REMOVE span after div/#text
-REMOVE #comment after div/#text
+REMOVE #comment before span
+REMOVE span before span
+REMOVE span before #comment
+REMOVE #comment before div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/csr.expected.md
@@ -22,7 +22,7 @@ INSERT div
 # Mutations
 ```
 INSERT div/#text
-REMOVE span after div/#text
+REMOVE span before div/#text
 ```
 
 # Render `{"value":"World"}`
@@ -38,7 +38,7 @@ REMOVE span after div/#text
 # Mutations
 ```
 INSERT div/span
-REMOVE #text after div/span
+REMOVE #text before div/span
 UPDATE div/span/#text " " => "World"
 ```
 

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/csr.expected.md
@@ -25,5 +25,5 @@ container.querySelector("button").click();
 # Mutations
 ```
 INSERT div/#text
-REMOVE div after div/#text
+REMOVE div before div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/resume.expected.md
@@ -44,5 +44,5 @@ container.querySelector("button").click();
 ```
 REMOVE html/body/div/#comment after div
 INSERT html/body/div/#comment
-REMOVE div after html/body/div/#comment
+REMOVE div before html/body/div/#comment
 ```

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -77,8 +77,8 @@ export function setConditionalRenderer(
     : (getEmptyBranch(scope[nodeAccessor] as Comment) as BranchScope);
   insertBranchBefore(
     newBranch,
-    prevBranch.___startNode.parentNode!,
-    prevBranch.___startNode,
+    prevBranch.___endNode.parentNode!,
+    prevBranch.___endNode.nextSibling,
   );
   removeAndDestroyBranch(prevBranch);
   scope[nodeAccessor + AccessorChar.ConditionalScope] =

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/csr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/csr.expected.md
@@ -70,11 +70,11 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/button
@@ -128,11 +128,11 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/button

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/resume.expected.md
@@ -33,8 +33,8 @@ REMOVE #comment before html/body/#text0
 REMOVE #comment after html/body/#text5
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #comment after html/body/div/#text3
-REMOVE button after html/body/div/#text3
+REMOVE #comment before button
+REMOVE button before html/body/div/#text0
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -118,11 +118,11 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/button
@@ -198,11 +198,11 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/button

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/csr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/csr.expected.md
@@ -70,11 +70,11 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/button
@@ -128,11 +128,11 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/button

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/resume.expected.md
@@ -33,8 +33,8 @@ REMOVE #comment before html/body/#text0
 REMOVE #comment after html/body/#text5
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #comment after html/body/div/#text3
-REMOVE button after html/body/div/#text3
+REMOVE #comment before button
+REMOVE button before html/body/div/#text0
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -118,11 +118,11 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/button
@@ -198,11 +198,11 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/button

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/csr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/csr.expected.md
@@ -87,12 +87,12 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE h1 after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before h1
+REMOVE h1 before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/h1
@@ -160,12 +160,12 @@ container.querySelector("#class").click();
 ```
 INSERT div/#text0
 INSERT div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
-REMOVE h1 after div/#text3
-REMOVE button after div/#text3
-REMOVE #text after div/#text3
-REMOVE #text after div/#text3
+REMOVE #text before #text
+REMOVE #text before h1
+REMOVE h1 before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before div/#text0
 INSERT div/#text1
 INSERT div/#text2
 INSERT div/h1

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/resume.expected.md
@@ -36,9 +36,9 @@ REMOVE #comment before html/body/#text0
 REMOVE #comment after html/body/#text5
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #comment after html/body/div/#text3
-REMOVE h1 after html/body/div/#text3
-REMOVE button after html/body/div/#text3
+REMOVE #comment before h1
+REMOVE h1 before button
+REMOVE button before html/body/div/#text0
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -136,12 +136,12 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE h1 after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before h1
+REMOVE h1 before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/h1
@@ -231,12 +231,12 @@ container.querySelector("#class").click();
 ```
 INSERT html/body/div/#text0
 INSERT html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE h1 after html/body/div/#text3
-REMOVE button after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
-REMOVE #text after html/body/div/#text3
+REMOVE #text before #text
+REMOVE #text before h1
+REMOVE h1 before button
+REMOVE button before #text
+REMOVE #text before #text
+REMOVE #text before html/body/div/#text0
 INSERT html/body/div/#text1
 INSERT html/body/div/#text2
 INSERT html/body/div/h1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Resume markers used as branch end nodes could end up being shared between multiple branches in some circumstances. In these cases, we will inserts a new empty text node and use that as the end node.
- Runtime now uses the end node as a reference for inserting the branch. The new branch will be inserted after the previous branch's end node instead of before its start node.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
