### PR TITLE
fix: ininial sync content flush not scheduled

### DIFF
--- a/.changeset/polite-ducks-sin.md
+++ b/.changeset/polite-ducks-sin.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix initial sync content not scheduled for flush

--- a/packages/runtime-class/src/runtime/html/AsyncStream.js
+++ b/packages/runtime-class/src/runtime/html/AsyncStream.js
@@ -198,6 +198,7 @@ var proto = (AsyncStream.prototype = {
       writer.next = originalWriter.next;
       writer.state = this._state;
       writer.merge(originalWriter);
+      writer.scheduleFlush();
 
       this._state.stream = stream;
       this._state.writer = writer;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

Synchronous content is not flushed immediately and waits until the first async flush. This change ensures an existing writer is scheduled for flush right away.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
