### PR TITLE
feat(ts): deprecate `Marko.Body` in favor of `Marko.Content`

### DIFF
--- a/packages/runtime-class/index.d.ts
+++ b/packages/runtime-class/index.d.ts
@@ -77,9 +77,11 @@ declare global {
       text(val: string | void): void;
     }
 
-    /** Body content created from by a component, typically held in an object with a renderBody property. */
+    /** @deprecated prefer `Marko.Content` */
+    export interface Body extends Content {}
 
-    export interface Body<
+    /** Body content created from by a component, typically held in an object with a `renderBody` property. */
+    export interface Content<
       in Params extends readonly any[] = [],
       out Return = void,
     > {}

--- a/packages/runtime-tags/index.d.ts
+++ b/packages/runtime-tags/index.d.ts
@@ -33,8 +33,11 @@ declare global {
       $global?: Global;
     };
 
-    /** Body content created by a template. */
-    export interface Body<
+    /** @deprecated prefer `Marko.Content` */
+    export interface Body extends Content {}
+
+    /** Body content created from by a component, typically held in an object with a `content` property. */
+    export interface Content<
       in Params extends readonly any[] = [],
       out Return = void,
     > {}


### PR DESCRIPTION
## Description

- Since we're moving from `input.renderBody` to `input.content`, we should also move from `Marko.Body` to `Marko.Content`.

