### PR TITLE
fix: dynamic attrs on html and body tags

### DIFF
--- a/.changeset/old-cameras-cheat.md
+++ b/.changeset/old-cameras-cheat.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Dynamic attrs on trailing tags

--- a/packages/runtime-class/test/package.json
+++ b/packages/runtime-class/test/package.json
@@ -1,4 +1,5 @@
 {
   "name": "marko-test",
-  "version": "1.0.0"
+  "version": "1.0.0",
+  "type": "commonjs"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/.name-cache.json
@@ -1,0 +1,10 @@
+{
+  "vars": {
+    "props": {
+      "$_$": "t",
+      "$init": "o",
+      "$_toggle_effect": "a",
+      "$_toggle": "m"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,10 @@
+// size: 139 (min) 105 (brotli)
+const _toggle_effect = _$.effect("a0", (_scope, { 2: toggle }) =>
+    _$.on(_scope[1], "click", function () {
+      _toggle(_scope, !toggle);
+    }),
+  ),
+  _toggle = _$.state(2, (_scope, toggle) => {
+    _$.attr(_scope[0], "data-toggle", toggle), _toggle_effect(_scope);
+  });
+init();

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.js
@@ -1,0 +1,16 @@
+export const _template_ = "<html><body><button>Toggle</button></body></html>";
+export const _walks_ = /* next(1), get, next(1), get, out(2) */"D D m";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const _toggle_effect = _$.effect("__tests__/template.marko_0_toggle", (_scope, {
+  toggle
+}) => _$.on(_scope["#button/1"], "click", function () {
+  _toggle(_scope, !toggle);
+}));
+const _toggle = /* @__PURE__ */_$.state("toggle/2", (_scope, toggle) => {
+  _$.attr(_scope["#body/0"], "data-toggle", toggle);
+  _toggle_effect(_scope);
+});
+export function _setup_(_scope) {
+  _toggle(_scope, false);
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", _template_, _walks_, _setup_);

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.expected/template.js
@@ -1,0 +1,13 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
+  const _scope0_id = _$.nextScopeId();
+  const toggle = false;
+  _$.write(`<html><body${_$.attr("data-toggle", toggle)}><button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/1")}</body>${_$.markResumeNode(_scope0_id, "#body/0")}`), _$.writeTrailers("</html>");
+  _$.writeEffect(_scope0_id, "__tests__/template.marko_0_toggle");
+  _$.writeScope(_scope0_id, {
+    toggle
+  }, "__tests__/template.marko", 0, {
+    toggle: "1:5"
+  });
+  _$.resumeClosestBranch(_scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<button>
+  Toggle
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button")?.click();
+```
+```html
+<button>
+  Toggle
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button")?.click();
+```
+```html
+<button>
+  Toggle
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/resume.expected.md
@@ -1,0 +1,69 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      Toggle
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={1:{toggle:!1}}),1,"__tests__/template.marko_0_toggle",0];M._.w()
+    </script>
+  </body>
+  <!--M_*1 #body/0-->
+</html>
+```
+
+
+# Render
+```js
+container.querySelector("button")?.click();
+```
+```html
+<html>
+  <head />
+  <body
+    data-toggle=""
+  >
+    <button>
+      Toggle
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={1:{toggle:!1}}),1,"__tests__/template.marko_0_toggle",0];M._.w()
+    </script>
+  </body>
+  <!--M_*1 #body/0-->
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body[data-toggle] null => ""
+```
+
+# Render
+```js
+container.querySelector("button")?.click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      Toggle
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={1:{toggle:!1}}),1,"__tests__/template.marko_0_toggle",0];M._.w()
+    </script>
+  </body>
+  <!--M_*1 #body/0-->
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body[data-toggle] "" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render End
+```html
+<button>
+  Toggle
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/ssr.expected.md
@@ -1,0 +1,34 @@
+# Write
+```html
+  <html><body><button>Toggle</button><!--M_*1 #button/1--></body><!--M_*1 #body/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a={1:{toggle:!1}}),1,"__tests__/template.marko_0_toggle",0];M._.w()</script></html>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      Toggle
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a={1:{toggle:!1}}),1,"__tests__/template.marko_0_toggle",0];M._.w()
+    </script>
+  </body>
+  <!--M_*1 #body/0-->
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/button
+INSERT html/body/button/#text
+INSERT html/body/#comment
+INSERT html/#comment
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/template.marko
@@ -1,0 +1,5 @@
+let/toggle=false
+
+html
+  body data-toggle=toggle
+    button onClick() { toggle = !toggle } -- Toggle

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/test.ts
@@ -1,0 +1,8 @@
+export const skip_csr = true;
+export const skip_resume = false;
+
+export const steps = [{}, click, click]
+
+function click(container: HTMLElement) {
+  container.querySelector("button")?.click()
+}

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -707,10 +707,19 @@ export default {
         tag.insertBefore(tag.node.body.body).forEach((child) => child.skip());
       }
 
+      const shouldMark =
+        nodeRef &&
+        (extra[kSerializeMarker] ||
+          (extra[kSerializeMarker] === undefined &&
+            (isStatefulReferences(extra.referencedBindings) ||
+              tag.node.attributes.some((attr) =>
+                isStatefulReferences(attr.value.extra?.referencedBindings),
+              ))));
+
       if (!openTagOnly && !selectArgs) {
         writer.writeTo(
           tag,
-          isHTML && (tagName === "html" || tagName === "body"),
+          isHTML && !shouldMark && (tagName === "html" || tagName === "body"),
         )`</${tag.node.name}>`;
       }
 
@@ -723,15 +732,7 @@ export default {
           .skip();
       }
 
-      if (
-        nodeRef &&
-        (extra[kSerializeMarker] ||
-          (extra[kSerializeMarker] === undefined &&
-            (isStatefulReferences(extra.referencedBindings) ||
-              tag.node.attributes.some((attr) =>
-                isStatefulReferences(attr.value.extra?.referencedBindings),
-              ))))
-      ) {
+      if (shouldMark) {
         writer.markNode(tag, nodeRef);
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Allow dynamic attrs on `<body>` and `<html>` tags, which are special cased as trailing tags

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
