### PR TITLE
Tags API fixes

### DIFF
--- a/.changeset/funny-socks-wave.md
+++ b/.changeset/funny-socks-wave.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix issue where ssr compiled let tags were becoming consts and causing syntax errors.

--- a/.changeset/slow-emus-push.md
+++ b/.changeset/slow-emus-push.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Optimize html-script and html-style to avoid creating body sections.

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const hide = undefined;
+  let hide = undefined;
   _$.resumeSingleNodeConditional(() => {
     if (!hide) {
       const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
-  const lastClickCount = undefined;
+  let clickCount = 0;
+  let lastClickCount = undefined;
   _$.write(`<button>+</button>${_$.markResumeNode(_scope0_id, "#button/0")}<span>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")} was <!>${_$.escapeXML(lastClickCount)}${_$.markResumeNode(_scope0_id, "#text/2")}</span>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const disabled = true;
+  let disabled = true;
   _$.write(`<input${_$.attr("disabled", disabled)}>${_$.markResumeNode(_scope0_id, "#input/0")}<button>${_$.escapeXML(disabled ? "enable" : "disable")}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/1")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_disabled");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
-  const count = 0;
+  let count = 0;
   _$.write("<div>");
   _$.fork(Promise.resolve("a"), value => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const y = x * 2;
   const z = y * 3;
   _$.write(`<div>${_$.escapeXML(z)}${_$.markResumeNode(_scope0_id, "#text/0")}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _myButton from "./tags/my-button.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _myButton from "./tags/my-button.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _myButton from "./tags/my-button.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     value: {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _myButton from "./tags/my-button.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _myButton from "./tags/my-button.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _myButton from "./tags/my-button.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _clickCount_closures = new Set();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _myButton({
     onClick: _$.register(function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<button>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
-  const count = 0;
+  let show = true;
+  let count = 0;
   _$.write(`<button class=inc></button>${_$.markResumeNode(_scope0_id, "#button/0")}<button class=toggle></button>${_$.markResumeNode(_scope0_id, "#button/1")}`);
   _$.resumeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
-  const count = 0;
+  let show = true;
+  let count = 0;
   _$.write(`<button class=inc></button>${_$.markResumeNode(_scope0_id, "#button/0")}<button class=toggle></button>${_$.markResumeNode(_scope0_id, "#button/1")}`);
   _$.resumeSingleNodeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId;
-  const a = 0;
-  const b = 0;
+  let a = 0;
+  let b = 0;
   if (true) {
     const _scope1_id = _$.nextScopeId();
     _$.write(`${_$.escapeXML(a + b)}${_$.markResumeNode(_scope1_id, "#text/0")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   const increment = _$.register(function () {
     clickCount++;
   }, "__tests__/template.marko_0/increment", _scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
-  const multiplier = 1;
+  let count = 0;
+  let multiplier = 1;
   const multipliedCount = count * multiplier;
   _$.write(`<button id=multiplier>increase multiplier (<!>${_$.escapeXML(multiplier)}${_$.markResumeNode(_scope0_id, "#text/1")})</button>${_$.markResumeNode(_scope0_id, "#button/0")}<button id=count>increase count</button>${_$.markResumeNode(_scope0_id, "#button/2")}<div>${_$.escapeXML(multipliedCount)}${_$.markResumeNode(_scope0_id, "#text/3")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_count");

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<div><button>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.expected/template.js
@@ -2,10 +2,10 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const message = {
+  let message = {
     text: "hi"
   };
-  const show = true;
+  let show = true;
   _$.write(`<button>hide</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeSingleNodeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = [0];
-  const b = 1;
+  let a = [0];
+  let b = 1;
   _$.write(`<button>${_$.escapeXML(a.join(""))}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_a_b");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const data = 0;
+  let data = 0;
   _$.write(`<button>${_$.escapeXML(data)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.expected/tags/comments.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.expected/tags/comments.js
@@ -7,7 +7,7 @@ const _content = input => {
     const _scope1_id = _$.nextScopeId();
     let _ifScopeId, _ifBranch;
     const id = `${input.path || "c"}-${i}`;
-    const open = true;
+    let open = true;
     _$.write(`<li${_$.attr("id", id)}${_$.attr("hidden", !open)}><span>${_$.escapeXML(comment.text)}${_$.markResumeNode(_scope1_id, "#text/1")}</span><button>${_$.escapeXML(open ? "[-]" : "[+]")}${_$.markResumeNode(_scope1_id, "#text/3")}</button>${_$.markResumeNode(_scope1_id, "#button/2")}`);
     _$.resumeSingleNodeConditional(() => {
       if (comment.comments) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const items = ["a", "b", "c"];
-  const index = 0;
+  let items = ["a", "b", "c"];
+  let index = 0;
   _$.write(`<div>${_$.escapeXML(items[0])}${_$.markResumeNode(_scope0_id, "#text/0")}</div><div>${_$.escapeXML(items[index])}${_$.markResumeNode(_scope0_id, "#text/1")}</div><button>Update</button>${_$.markResumeNode(_scope0_id, "#button/2")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_items_index");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const foo = {};
+  let foo = {};
   const {
     class: fooClass
   } = foo;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const items = [0, 1];
+  let items = [0, 1];
   _$.write(`<button>Push</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeSingleNodeForOf(items, (outer, _index2) => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.expected/template.js
@@ -3,8 +3,8 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _y_closures = new Set();
-  const x = 1;
-  const y = 2;
+  let x = 1;
+  let y = 2;
   _$.write(`<button>Inc</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _childScope2 = _$.peekNextScope();
   _child({

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
-  const count = 0;
+  let count = 0;
   _child({
     content: /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", () => {
       const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
-  const count = 0;
+  let count = 0;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", false || Child, {}, _$.registerContent("__tests__/template.marko_1_renderer", () => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const selected = 0;
+  let selected = 0;
   _$.forOf([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], (num, _index) => {
     const _scope1_id = _$.nextScopeId();
     _scope1_.set(_index, _$.ensureScopeWithId(_scope1_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write("<div>");
   _$.resumeSingleNodeConditional(() => {
     if (clickCount < 3) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const id = 0;
-  const items = [];
+  let id = 0;
+  let items = [];
   _$.write("<div>");
   _$.resumeSingleNodeForOf(items, (item, _index) => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const open = true;
-  const list = [1, 2, 3];
+  let open = true;
+  let list = [1, 2, 3];
   _$.write(`<ul${_$.attr("hidden", !open)}>`);
   const _by = function (x) {
     return x;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   _$.write("<div>");
   _$.resumeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/html.expected/template.js
@@ -1,9 +1,9 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const unused_1 = 123;
+  let unused_1 = 123;
   const unused_2 = 456;
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<div><button>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
-  const message = "hi";
+  let show = true;
+  let message = "hi";
   _$.write(`<button></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeSingleNodeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = 0;
-  const b = 0;
+  let a = 0;
+  let b = 0;
   _$.write(`<button>${_$.escapeXML(a + b)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_a_b");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _FancyButton from "./tags/FancyButton.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _clickCount_closures = new Set();
-  const clickCount = 0;
+  let clickCount = 0;
   const _childScope = _$.peekNextScope();
   _FancyButton({
     onClick: _$.register(function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const items = [1, 2, 3];
+  let items = [1, 2, 3];
   const el = _$.nodeRef();
   const write = _$.register(function (msg) {
     el().innerHTML += '\n' + msg;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/html.expected/template.js
@@ -4,9 +4,9 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _showInner_closures = new Set();
   let _ifScopeId3, _ifBranch3;
-  const showOuter = true;
-  const showMiddle = true;
-  const showInner = true;
+  let showOuter = true;
+  let showMiddle = true;
+  let showInner = true;
   const el = _$.nodeRef();
   const write = _$.register(function (msg) {
     el().innerHTML += '\n' + msg;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   const el = _$.nodeRef();
   _$.write(`<button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/0")}<pre></pre>${_$.markResumeNode(_scope0_id, "#pre/1")}`);
   _$.resumeConditional(() => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   const el = _$.nodeRef();
   _$.write(`<button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div></div>${_$.markResumeNode(_scope0_id, "#div/1")}`);
   _$.resumeConditional(() => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const items = [1, 2, 3];
+  let items = [1, 2, 3];
   const el = _$.nodeRef();
   const write = _$.register(function (msg) {
     el().innerHTML += '\n' + msg;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const items = [1, 2, 3];
+  let items = [1, 2, 3];
   const el = _$.nodeRef();
   const write = _$.register(function (msg) {
     el().innerHTML += '\n' + msg;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/html.expected/template.js
@@ -4,9 +4,9 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _showInner_closures = new Set();
   let _ifScopeId3, _ifBranch3;
-  const showOuter = true;
-  const showMiddle = true;
-  const showInner = true;
+  let showOuter = true;
+  let showMiddle = true;
+  let showInner = true;
   const el = _$.nodeRef();
   const write = _$.register(function (msg) {
     el().innerHTML += '\n' + msg;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   const el = _$.nodeRef();
   _$.write(`<button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/0")}<pre></pre>${_$.markResumeNode(_scope0_id, "#pre/1")}`);
   _$.resumeSingleNodeConditional(() => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   const el = _$.nodeRef();
   _$.write(`<button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div></div>${_$.markResumeNode(_scope0_id, "#div/1")}`);
   _$.resumeSingleNodeConditional(() => {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button>${_$.escapeXML(input.format(count))}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.expected/tags/display-intersection.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.expected/tags/display-intersection.js
@@ -4,7 +4,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/tags/display-intersec
   const {
     value
   } = input;
-  const dummy = {};
+  let dummy = {};
   _$.write(`<div>${_$.escapeXML((dummy, value))}${_$.markResumeNode(_scope0_id, "#text/0")}</div>`);
   _$.writeScope(_scope0_id, {
     value,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _displayIntersection from "./tags/display-intersection.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   const _childScope = _$.peekNextScope();
   _displayIntersection({
     value: count

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button>${_$.escapeXML(input.format(count))}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = false;
+  let show = false;
   _$.write("<table><tbody>");
   _$.resumeSingleNodeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const z = {
+  let z = {
     x: 1,
     y: 2
   };

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _checkbox from "./tags/checkbox.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const checked = false;
+  let checked = false;
   const _childScope = _$.peekNextScope();
   _checkbox({
     checked: checked,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const checkedValue = "a";
+  let checkedValue = "a";
   const _checkedValueChange = _$.register(_new_checkedValue => {
     checkedValue = _new_checkedValue;
   }, "__tests__/template.marko_0/_checkedValueChange", _scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _checkbox from "./tags/checkbox.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const checkedValue = ["a", "b"];
+  let checkedValue = ["a", "b"];
   const _checkedValueChange = _$.register(_new_checkedValue => {
     checkedValue = _new_checkedValue;
   }, "__tests__/template.marko_0/_checkedValueChange", _scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const checkedValue = ["a", "b"];
+  let checkedValue = ["a", "b"];
   const _checkedValueChange = _$.register(_new_checkedValue => {
     checkedValue = _new_checkedValue;
   }, "__tests__/template.marko_0/_checkedValueChange", _scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const checked = false;
+  let checked = false;
   _$.write(`<input${_$.controllable_input_checked(_scope0_id, "#input/0", checked, _$.register(_new_checked => {
     checked = _new_checked;
   }, "__tests__/template.marko_0/checkedChange", _scope0_id))} type=checkbox>${_$.markResumeNode(_scope0_id, "#input/0")}<span>${_$.escapeXML(String(checked))}${_$.markResumeNode(_scope0_id, "#text/1")}</span>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const value = "hello";
+  let value = "hello";
   _$.write(`<input${_$.controllable_input_value(_scope0_id, "#input/0", value, _$.register(_new_value => {
     value = _new_value;
   }, "__tests__/template.marko_0/valueChange", _scope0_id))} type=text>${_$.markResumeNode(_scope0_id, "#input/0")}<span>${_$.escapeXML(value)}${_$.markResumeNode(_scope0_id, "#text/1")}</span>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const value = "b";
+  let value = "b";
   const tag = "select";
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", tag ? "select" : {}, {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const options = [1, 2, 3];
-  const value = options[0];
+  let options = [1, 2, 3];
+  let value = options[0];
   _$.controllable_select_value(_scope0_id, "#select/0", value, _$.register(_new_value => {
     value = _new_value;
   }, "__tests__/template.marko_0/valueChange", _scope0_id), () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const value = "b";
+  let value = "b";
   _$.controllable_select_value(_scope0_id, "#select/0", value, _$.register(function (v) {
     value = v;
   }, "__tests__/template.marko_0/valueChange", _scope0_id), () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const value = "hello";
+  let value = "hello";
   _$.write(`<textarea>${_$.controllable_textarea_value(_scope0_id, "#textarea/0", value, _$.register(_new_value => {
     value = _new_value;
   }, "__tests__/template.marko_0/valueChange", _scope0_id))}</textarea>${_$.markResumeNode(_scope0_id, "#textarea/0")}<span>${_$.escapeXML(value)}${_$.markResumeNode(_scope0_id, "#text/1")}</span>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = 0;
-  const b = 0;
+  let a = 0;
+  let b = 0;
   _$.write(`<div><button class=a>${_$.escapeXML(a)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")} + <button class=b>${_$.escapeXML(b)}${_$.markResumeNode(_scope0_id, "#text/3")}</button>${_$.markResumeNode(_scope0_id, "#button/2")} = <!>${_$.escapeXML(a + b)}${_$.markResumeNode(_scope0_id, "#text/4")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/html.expected/tags/my-let.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/html.expected/tags/my-let.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/my-let.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const value = input.value;
+  let value = input.value;
   const _return = value;
   _$.writeScope(_scope0_id, {
     "@": _$.register(_new_value => {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _child from "./tags/child.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = "y";
+  let x = "y";
   _child({
     value: 3
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/tags/custom-tag.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/custom-tag.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = 10;
+  let x = 1;
+  let y = 10;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")},<!>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagArgs(_scope0_id, "#text/3", input.content, [x, y]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.expected/tags/custom-tag.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/custom-tag.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", input.content, {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.expected/tags/custom-tag.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/custom-tag.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", input.content, x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button class=inc-child>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _return = x;
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_x");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.expected/tags/child.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write("<span>child</span>");
   const _return = x + 3;
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.expected/tags/child.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 0;
+  let x = 0;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _return = x + input.extra;
   _$.writeEffect(_scope0_id, "__tests__/tags/child.marko_0_x");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _child from "./tags/child.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const name = "Marko";
+  let name = "Marko";
   const _childScope = _$.peekNextScope();
   const data = _child({
     extra: 1

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.expected/tags/child.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = 2;
+  let x = 1;
+  let y = 2;
   _$.write("<span>child</span>");
   const _return = x + y;
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/html.expected/tags/child.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _return = x;
   _$.writeEffect(_scope0_id, "__tests__/tags/child.marko_0_x");

--- a/packages/runtime-tags/src/__tests__/fixtures/debug-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/debug-tag/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   debugger;
   const x = 0;
   debugger;
-  const y = 0;
+  let y = 0;
   debugger;
   _$.resumeClosestBranch(_scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const selected = false;
+  let selected = false;
   const myThing = {
     selected: selected,
     content: /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const myObj = {
     foo: 1,
     bar: x + 1

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const MyTag = {
     content: _$.registerContent("__tests__/template.marko_1_renderer", (a, b, c) => {
       const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const MyTag = {
     content: _$.registerContent("__tests__/template.marko_1_renderer", ({
       number

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _x_closures = new Set();
-  const x = 1;
+  let x = 1;
   const MyTag = {
     content: /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", () => {
       const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.expected/template.js
@@ -6,7 +6,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       name
     }) => {
       const _scope1_id = _$.nextScopeId();
-      const y = 1;
+      let y = 1;
       _$.write(`<div>Hello <!>${_$.escapeXML(name)}${_$.markResumeNode(_scope1_id, "#text/0")} <!>${_$.escapeXML(y)}${_$.markResumeNode(_scope1_id, "#text/1")}</div><button>${_$.escapeXML(y)}${_$.markResumeNode(_scope1_id, "#text/3")}</button>${_$.markResumeNode(_scope1_id, "#button/2")}`);
       _$.writeEffect(_scope1_id, "__tests__/template.marko_1_y");
       _$.writeScope(_scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
   let _ifScopeId2, _ifBranch2;
-  const show = false;
+  let show = false;
   _$.write("<div>");
   _$.resumeSingleNodeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _c_closures = new Set();
   const b = 2;
-  const c = 3;
+  let c = 3;
   _$.write(`<button></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _customTag({
     content: /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<button>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const tagName = "span";
-  const className = "A";
+  let tagName = "span";
+  let className = "A";
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", tagName, {
     class: className

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const tags = [customTag];
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button>Count: <!>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   const y = _$.dynamicTagInput(_scope0_id, "#text/2", tags[0], x, void 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const tags = [customTag];
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button>Count: <!>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagArgs(_scope0_id, "#text/2", tags[0], [x, 'foo']);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const className = "A";
+  let className = "A";
   _$.write(`<p${_$.classAttr(className)}>paragraph</p>${_$.markResumeNode(_scope0_id, "#p/0")}<button></button>${_$.markResumeNode(_scope0_id, "#button/1")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_className");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import child from "./tags/child.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const tagName = child;
+  let tagName = child;
   _$.write(`<button></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/1", tagName, {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/html.expected/template.js
@@ -3,8 +3,8 @@ import child2 from "./tags/child2.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const tagName = child1;
-  const val = 3;
+  let tagName = child1;
+  let val = 3;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", tagName, {
     value: val

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ const tags = [customTag];
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button>Count: <!>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", tags[0], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = null;
+  let x = null;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", x, {}, _$.registerContent("__tests__/template.marko_1_renderer", () => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _return = x;
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_x");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=count>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/counter.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _counter from "./tags/counter.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const tagName = "div";
+  let tagName = "div";
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", tagName, {}, _$.registerContent("__tests__/template.marko_1_renderer", () => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.expected/template.js
@@ -18,7 +18,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope3_ = new Map();
   const _scope4_ = new Map();
   const _scope5_ = new Map();
-  const items = [{
+  let items = [{
     id: 0,
     text: "first"
   }, {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const id = 0;
-  const items = [{
+  let id = 0;
+  let items = [{
     name: "Marko",
     description: "HTML Reimagined"
   }];

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const num = 0;
+  let num = 0;
   _$.resumeSingleNodeForTo(num, 0, 1, i => {
     const _scope1_id = _$.nextScopeId();
     _scope1_.set(i, _$.ensureScopeWithId(_scope1_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const children = [1];
+  let children = [1];
   _$.write(`<div${_$.attr("data-children", children.length)}>`);
   _$.resumeSingleNodeForOf(children, (_list, _index) => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _scope1_ = new Map();
-  const children = [1];
+  let children = [1];
   _$.write(`<div${_$.attr("data-children", children.length)}>Before `);
   _$.resumeForOf(children, (_list, _index) => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/__snapshots__/html.expected/template.js
@@ -7,7 +7,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
     const _scope1_id = _$.nextScopeId();
     _$.write(`<div>${_$.escapeXML(i)}: ${_$.escapeXML(val)}</div>`);
   });
-  const arrB = [1, 2, 3];
+  let arrB = [1, 2, 3];
   _$.resumeSingleNodeForOf(arrB, (val, i) => {
     const _scope2_id = _$.nextScopeId();
     _scope2_.set(i, _$.ensureScopeWithId(_scope2_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.expected/template.js
@@ -17,7 +17,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       setHtml
     }, "__tests__/template.marko", "1:2");
   });
-  const to = 3;
+  let to = 3;
   _$.write("<hr>");
   _$.resumeSingleNodeForTo(to, 0, 1, _value2 => {
     const _scope2_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.expected/template.js
@@ -18,7 +18,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       setHtml
     }, "__tests__/template.marko", "3:2");
   });
-  const to = 3;
+  let to = 3;
   _$.write("<hr>");
   _$.resumeSingleNodeForTo(to, 0, 1, _value2 => {
     const _scope2_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.expected/template.js
@@ -12,7 +12,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
     _$.write(`<div></div>${_$.markResumeNode(_scope1_id, "#div/0")}`);
     _$.writeScope(_scope1_id, {}, "__tests__/template.marko", "1:2");
   });
-  const to = 3;
+  let to = 3;
   _$.write("<hr>");
   _$.resumeSingleNodeForTo(to, 0, 1, _value2 => {
     const _scope2_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<div><button>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<!--${_$.escapeXML(count)} + ${_$.escapeXML(count)} = ${_$.escapeXML(count + count)}-->${_$.markResumeNode(_scope0_id, "#comment/2")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.expected/tags/parent-el.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.expected/tags/parent-el.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/parent-el.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const ref = _$.nodeRef();
-  const tagName = undefined;
+  let tagName = undefined;
   _$.write(`<!--Body Text-->${_$.markResumeNode(_scope0_id, "#comment/0")}`);
   const _return = tagName;
   _$.writeEffect(_scope0_id, "__tests__/tags/parent-el.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.hydrate.js
@@ -1,20 +1,14 @@
-// size: 310 (min) 189 (brotli)
-const _count$htmlScript_content = _$.dynamicClosureRead(1);
-_$.registerContent("a1", 0, 0, 0, 0, (_scope) =>
-  _count$htmlScript_content(_scope),
-);
-const _count_closure = _$.dynamicClosure(_count$htmlScript_content),
-  _count_effect = _$.effect("a2", (_scope, { 1: count }) =>
+// size: 209 (min) 150 (brotli)
+const _count_effect = _$.effect("a1", (_scope, { 2: count }) =>
     _$.on(_scope[0], "click", function () {
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(1, (_scope, count) => {
+  _count = _$.state(2, (_scope, count) => {
     _$.textContent(
       _scope[0],
       `\n  {\n    "imports": {\n      "${count}": "https://markojs.com",\n    }\n  }\n`,
     ),
-      _count_closure(_scope),
       _count_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.js
@@ -1,15 +1,12 @@
 export const _template_ = "<script type=importmap></script>";
 export const _walks_ = /* get, over(1) */" b";
 import * as _$ from "@marko/runtime-tags/debug/dom";
-const _count$htmlScript_content = /* @__PURE__ */_$.dynamicClosureRead("count");
-const _htmlScript_content = _$.registerContent("__tests__/template.marko_1_renderer", 0, 0, 0, 0, _scope => _count$htmlScript_content(_scope));
-const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$htmlScript_content);
 const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
   count
 }) => _$.on(_scope["#script/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/2", (_scope, count) => {
   _$.textContent(_scope["#script/0"], `
   {
     "imports": {
@@ -17,7 +14,6 @@ const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => {
     }
   }
 `);
-  _count_closure(_scope);
   _count_effect(_scope);
 });
 export function _setup_(_scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<script type=importmap>
   {
     "imports": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.hydrate.js
@@ -1,17 +1,11 @@
-// size: 272 (min) 174 (brotli)
-const _count$htmlStyle_content = _$.dynamicClosureRead(1);
-_$.registerContent("a1", 0, 0, 0, 0, (_scope) =>
-  _count$htmlStyle_content(_scope),
-);
-const _count_closure = _$.dynamicClosure(_count$htmlStyle_content),
-  _count_effect = _$.effect("a2", (_scope, { 1: count }) =>
+// size: 171 (min) 136 (brotli)
+const _count_effect = _$.effect("a1", (_scope, { 2: count }) =>
     _$.on(_scope[0], "click", function () {
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(1, (_scope, count) => {
+  _count = _$.state(2, (_scope, count) => {
     _$.textContent(_scope[0], `\n  .test {\n    content: ${count}\n  }\n`),
-      _count_closure(_scope),
       _count_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.js
@@ -1,21 +1,17 @@
 export const _template_ = "<style></style>";
 export const _walks_ = /* get, over(1) */" b";
 import * as _$ from "@marko/runtime-tags/debug/dom";
-const _count$htmlStyle_content = /* @__PURE__ */_$.dynamicClosureRead("count");
-const _htmlStyle_content = _$.registerContent("__tests__/template.marko_1_renderer", 0, 0, 0, 0, _scope => _count$htmlStyle_content(_scope));
-const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$htmlStyle_content);
 const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
   count
 }) => _$.on(_scope["#style/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/2", (_scope, count) => {
   _$.textContent(_scope["#style/0"], `
   .test {
     content: ${count}
   }
 `);
-  _count_closure(_scope);
   _count_effect(_scope);
 });
 export function _setup_(_scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<style>
   .test {
     content: ${_$.escapeStyle(count)}

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = false;
+  let show = false;
   _$.write(`<button></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeConditional(() => {
     if (show) {

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import foo from "./tags/foo.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", x === 1 ? baz : foo, {});
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/tags/child.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const state = input.value;
-  const otherState = input.value;
+  let state = input.value;
+  let otherState = input.value;
   _$.write(`<button>${_$.escapeXML(input.value)}${_$.markResumeNode(_scope0_id, "#text/1")}|<!>${_$.escapeXML(state)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<button>${_$.escapeXML(input.value)}${_$.markResumeNode(_scope0_id, "#text/4")}|<!>${_$.escapeXML(otherState)}${_$.markResumeNode(_scope0_id, "#text/5")}</button>${_$.markResumeNode(_scope0_id, "#button/3")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/child.marko_0_otherState");
   _$.writeEffect(_scope0_id, "__tests__/tags/child.marko_0_state");

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import _child from "./tags/child.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const source = 1;
+  let source = 1;
   const _childScope = _$.peekNextScope();
   _child({
     value: source,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/html.expected/template.js
@@ -1,11 +1,11 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const yChange = _$.register(function (newValue) {
+  let x = 1;
+  let yChange = _$.register(function (newValue) {
     x = newValue + 1;
   }, "__tests__/template.marko_0/yChange", _scope0_id);
-  const y = x;
+  let y = x;
   _$.write(`<button id=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}|<!>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<button id=toggle>toggle</button>${_$.markResumeNode(_scope0_id, "#button/3")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_y");

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/html.expected/template.js
@@ -1,11 +1,11 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const handler = _$.register(function (newValue) {
+  let x = 1;
+  let handler = _$.register(function (newValue) {
     x = newValue + 1;
   }, "__tests__/template.marko_0/handler", _scope0_id);
-  const y = x;
+  let y = x;
   _$.write(`<button>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}|<!>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_y");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = x;
+  let x = 1;
+  let y = x;
   _$.write(`<button>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}|<!>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_y");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const {
     a
   } = input;
-  const b = a * 2;
+  let b = a * 2;
   _$.write(`<button>Increment</button>${_$.markResumeNode(_scope0_id, "#button/0")}${_$.escapeXML(a)}${_$.markResumeNode(_scope0_id, "#text/1")} <!>${_$.escapeXML(b)}${_$.markResumeNode(_scope0_id, "#text/2")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_b");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = 0;
+  let x = 1;
+  let y = 0;
   _$.write(`<span>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/0")}</span><span>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/1")}</span>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   const y = x + 1;
   const z = x + 2;
   const a = y + z;

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = 1;
+  let x = 1;
+  let y = 1;
   _$.write(`<button>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x_y");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = undefined;
+  let x = undefined;
   _$.write(`<div>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 0;
-  const prev = false;
+  let x = 0;
+  let prev = false;
   _$.write(`<div>x=<span>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/0")}</span>, was=<!>${_$.escapeXML(prev)}${_$.markResumeNode(_scope0_id, "#text/1")}</div><button id=increment>Increment</button>${_$.markResumeNode(_scope0_id, "#button/2")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const x = 0;
-  const show = true;
+  let x = 0;
+  let show = true;
   _$.resumeSingleNodeConditional(() => {
     if (show) {
       const _scope1_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 0;
+  let x = 0;
   _$.write(`<div>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 0;
+  let x = 0;
   _$.write(`<div id=ref></div><button id=increment>Increment</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 0;
+  let x = 0;
   _$.write(`<div id=ref></div><button id=increment>Increment</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/log-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/log-tag/__snapshots__/html.expected/template.js
@@ -7,7 +7,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const tagVar = "tag var";
   console.log(tagVar);
   console.log(staticVar);
-  const output = JSON.stringify(testLog);
+  let output = JSON.stringify(testLog);
   _$.write(`<!>${_$.escapeXML(output)}${_$.markResumeNode(_scope0_id, "#text/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write(`<div>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.expected/tags/2counters.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.expected/tags/2counters.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/2counters.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count1 = input.count1;
-  const count2 = input.count2;
+  let count1 = input.count1;
+  let count2 = input.count2;
   _$.write(`<button>${_$.escapeXML(count1)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<button>${_$.escapeXML(count2)}${_$.markResumeNode(_scope0_id, "#text/3")}</button>${_$.markResumeNode(_scope0_id, "#button/2")}`);
   _$.writeEffect(_scope0_id, "__tests__/tags/2counters.marko_0_count2");
   _$.writeEffect(_scope0_id, "__tests__/tags/2counters.marko_0_count1");

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import _counters from "./tags/2counters.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count1 = 0;
-  const count2 = 0;
+  let count1 = 0;
+  let count2 = 0;
   const _childScope = _$.peekNextScope();
   _counters({
     count1: count1,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.expected/template.js
@@ -2,8 +2,8 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _input_value__closures = new Set();
-  const Parent = "div";
-  const Child = "a";
+  let Parent = "div";
+  let Child = "a";
   const el = _$.nodeRef();
   _$.write(`<div><svg>${_$.toString(input.value)}${_$.markResumeNode(_scope0_id, "#text/1")}`);
   const _dynamicScope = _$.peekNextScope();

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/html.expected/template.js
@@ -1,9 +1,9 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
-  const lastCount = 0;
-  const lastCount2 = 0;
+  let clickCount = 0;
+  let lastCount = 0;
+  let lastCount2 = 0;
   _$.write(`<button>${_$.escapeXML(clickCount)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}used to be <span>${_$.escapeXML(lastCount)}${_$.markResumeNode(_scope0_id, "#text/2")}</span> which should be the same as <span>${_$.escapeXML(lastCount2)}${_$.markResumeNode(_scope0_id, "#text/3")}</span>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/html.expected/template.js
@@ -3,11 +3,11 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _counts_closures = new Set();
   const _scope1_ = new Map();
-  const counts = [0, 0, 0];
+  let counts = [0, 0, 0];
   _$.resumeSingleNodeForOf(counts, (count, i) => {
     const _scope1_id = _$.nextScopeId();
     let _ifScopeId, _ifBranch;
-    const editing = false;
+    let editing = false;
     _$.resumeSingleNodeConditional(() => {
       if (editing) {
         const _scope2_id = _$.nextScopeId();

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=addTwo>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<button id=triple>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/3")}</button>${_$.markResumeNode(_scope0_id, "#button/2")}<button id=cube>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/5")}</button>${_$.markResumeNode(_scope0_id, "#button/4")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.expected/tags/child.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write("<span>child</span>");
   const _return = x;
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/html.expected/template.js
@@ -6,7 +6,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       value
     }) => {
       const _scope1_id = _$.nextScopeId();
-      const call = 1;
+      let call = 1;
       const _return = _$.register(function () {
         if (call) {
           call--;
@@ -24,7 +24,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       return _return;
     }, _scope0_id)
   };
-  const clickOnceCount = 0;
+  let clickOnceCount = 0;
   const _dynamicScope = _$.peekNextScope();
   const onClickOnce = _$.dynamicTagInput(_scope0_id, "#text/0", Once, {
     value: _$.register(function () {
@@ -38,7 +38,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       value
     }) => {
       const _scope2_id = _$.nextScopeId();
-      const call = 2;
+      let call = 2;
       const _return2 = _$.register(function () {
         if (call) {
           call--;
@@ -56,7 +56,7 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
       return _return2;
     }, _scope0_id)
   };
-  const clickTwiceCount = 0;
+  let clickTwiceCount = 0;
   const _dynamicScope2 = _$.peekNextScope();
   const onClickTwice = _$.dynamicTagInput(_scope0_id, "#text/4", Twice, {
     value: _$.register(function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/html.expected/template.js
@@ -7,7 +7,7 @@ _$.register(createWrapper, "__tests__/template.marko_0/createWrapper");
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   const {
     a,
     a: b

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
+  let x = 1;
   _$.write("<div id=ref>0</div>");
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_x");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/html.expected/template.js
@@ -1,10 +1,10 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
-  const _count = 0;
-  const _count2 = 0;
-  const _count3 = 0;
+  let count = 0;
+  let _count = 0;
+  let _count2 = 0;
+  let _count3 = 0;
   _$.write(`<div><button>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div><button>${_$.escapeXML(_count)}${_$.markResumeNode(_scope0_id, "#text/3")}</button>${_$.markResumeNode(_scope0_id, "#button/2")}<div><button>${_$.escapeXML(_count2)}${_$.markResumeNode(_scope0_id, "#text/5")}</button>${_$.markResumeNode(_scope0_id, "#button/4")}</div></div></div><div><button>${_$.escapeXML(_count3)}${_$.markResumeNode(_scope0_id, "#text/7")}</button>${_$.markResumeNode(_scope0_id, "#button/6")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0__count3");
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0__count2");

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/html.expected/template.js
@@ -3,11 +3,11 @@ _$.register(noop, "__tests__/template.marko_0/noop");
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = 0;
-  const b = 0;
-  const c = {};
-  const d = 0;
-  const e = [];
+  let a = 0;
+  let b = 0;
+  let c = {};
+  let d = 0;
+  let e = [];
   _$.write(`<button><pre>a    1    <!>${_$.escapeXML(a)}${_$.markResumeNode(_scope0_id, "#text/1")}</pre><pre>b    2    <!>${_$.escapeXML(b)}${_$.markResumeNode(_scope0_id, "#text/2")}</pre><pre>c  {c:4}  <!>${_$.escapeXML(JSON.stringify(c))}${_$.markResumeNode(_scope0_id, "#text/3")}</pre><pre>d    7    <!>${_$.escapeXML(d)}${_$.markResumeNode(_scope0_id, "#text/4")}</pre><pre>f   [9]   <!>${_$.escapeXML(JSON.stringify(e))}${_$.markResumeNode(_scope0_id, "#text/5")}</pre></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0");
   _$.resumeClosestBranch(_scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<div><button id=button>0</button>${_$.markResumeNode(_scope0_id, "#button/0")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_clickCount");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/html.expected/template.js
@@ -3,9 +3,9 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
   let _ifScopeId2, _ifBranch2;
-  const outer = true;
-  const inner = true;
-  const count = 0;
+  let outer = true;
+  let inner = true;
+  let count = 0;
   _$.write(`<div><button id=outer></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeConditional(() => {
     if (outer) {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/html.expected/template.js
@@ -3,9 +3,9 @@ export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", inpu
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
   let _ifScopeId2, _ifBranch2;
-  const outer = true;
-  const inner = true;
-  const count = 0;
+  let outer = true;
+  let inner = true;
+  let count = 0;
   _$.write(`<div><button id=outer></button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.resumeConditional(() => {
     if (outer) {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/html.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/html.expected/tags/counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const clickCount = 0;
+  let clickCount = 0;
   _$.write(`<button>${_$.escapeXML(((() => {
     if (clickCount > 0) throw new Error("This should not have executed since the parent removes this component when the count is greater than 0");
   })(), clickCount))}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _counter from "./tags/counter.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   let _ifScopeId, _ifBranch;
-  const show = true;
+  let show = true;
   const onCount = _$.register(function (count) {
     show = count < 1;
   }, "__tests__/template.marko_0/onCount", _scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const toggle = false;
+  let toggle = false;
   _$.write(`<html><body${_$.attr("data-toggle", toggle)}><button>Toggle</button>${_$.markResumeNode(_scope0_id, "#button/1")}</body>${_$.markResumeNode(_scope0_id, "#body/0")}`), _$.writeTrailers("</html>");
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_toggle");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = 0;
+  let a = 0;
   _$.write(`<div${_$.attrs(input.value, "#div/0", _scope0_id, "div")}></div>${_$.markResumeNode(_scope0_id, "#div/0")}<div${_$.attrs({
     a: a,
     ...input.value

--- a/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/html.expected/template.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const a = 0;
-  const b = 0;
+  let a = 0;
+  let b = 0;
   _$.write(`<div>${_$.escapeXML(a)}${_$.markResumeNode(_scope0_id, "#text/0")} <!>${_$.escapeXML(b)}${_$.markResumeNode(_scope0_id, "#text/1")}</div>`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_input_value");
   _$.writeScope(_scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 import _child from "./tags/child.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write("<section>");
   _child({});
   _$.write(`</section><div>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</div>`);

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -123,7 +123,7 @@ export default {
           return t.callExpression(signal.identifier, [scope, value]);
         };
       } else {
-        translateVar(tag, valueAttr.value);
+        translateVar(tag, valueAttr.value, "let");
 
         if (valueChangeAttr) {
           setSerializedProperty(

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -118,9 +118,7 @@ export function getOrCreateSection(path: t.NodePath<any>) {
       cur.type === "Program" ||
       (cur.type === "MarkoTagBody" &&
         !cur.node.attributeTags &&
-        analyzeTagNameType(cur.parentPath as t.NodePath<t.MarkoTag>) !==
-          TagNameType.NativeTag &&
-        (cur.parent as { name: t.StringLiteral }).name.value !== "html-comment")
+        !isNativeNode(cur.parentPath as t.NodePath<t.MarkoTag>))
     ) {
       return startSection(cur)!;
     }
@@ -329,4 +327,18 @@ export function getCommonSection(section: Section, other: Section) {
     }
   }
   throw new Error("No common section");
+}
+
+function isNativeNode(tag: t.NodePath<t.MarkoTag>) {
+  if (isCoreTag(tag)) {
+    switch (tag.node.name.value) {
+      case "html-comment":
+      case "html-script":
+      case "html-style":
+        return true;
+      default:
+        return false;
+    }
+  }
+  return analyzeTagNameType(tag) === TagNameType.NativeTag;
 }

--- a/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/components/custom-tag.js
+++ b/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.expected/components/custom-tag.js
@@ -1,8 +1,8 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/custom-tag.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const x = 1;
-  const y = 10;
+  let x = 1;
+  let y = 10;
   _$.write(`<button class=inc>${_$.escapeXML(x)}${_$.markResumeNode(_scope0_id, "#text/1")},<!>${_$.escapeXML(y)}${_$.markResumeNode(_scope0_id, "#text/2")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagArgs(_scope0_id, "#text/3", input.content, [x, y]);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/html.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/html.expected/components/tags-counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/tags-counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags${_$.attr("data-parent", input.count)}>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/components/tags-counter.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import * as _$ from "@marko/runtime-tags/debug/html";
 import _classCounter from "./components/class-counter.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", _classCounter, {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/html.expected/components/tags-counter.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/tags-counter.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags${_$.attr("data-parent", input.count)}>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/components/tags-counter.marko_0_count");
   _$.writeScope(_scope0_id, {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/html.expected/template.js
@@ -3,7 +3,7 @@ import _classCounter from "./components/class-counter.marko";
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", _classCounter, {
     onCount: _$.register(function (newCount) {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/tags-layout.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div>`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", input.stuff.content, {});

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/tags-layout.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div>`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/2", input.content, {});

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ import _classLayout from "./components/class-layout.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _count_closures = new Set();
-  const count = 0;
+  let count = 0;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", _classLayout, {}, _$.registerContent("__tests__/template.marko_1_renderer", () => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/html.expected/components/tags-layout.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/components/tags-layout.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button id=tags>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}<div>`);
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagArgs(_scope0_id, "#text/2", input.content, [count, "hello"]);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/html.expected/template.js
@@ -4,7 +4,7 @@ import _classLayout from "./components/class-layout.marko";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
   const _multiplier_closures = new Set();
-  const multiplier = 1;
+  let multiplier = 1;
   const _dynamicScope = _$.peekNextScope();
   _$.dynamicTagInput(_scope0_id, "#text/0", _classLayout, {}, _$.registerContent("__tests__/template.marko_1_renderer", (baseCount, message) => {
     const _scope1_id = _$.nextScopeId();

--- a/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/html.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/html.expected/template.js
@@ -1,7 +1,7 @@
 import * as _$ from "@marko/runtime-tags/debug/html";
 export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", input => {
   const _scope0_id = _$.nextScopeId();
-  const count = 0;
+  let count = 0;
   _$.write(`<button>${_$.escapeXML(count)}${_$.markResumeNode(_scope0_id, "#text/1")}</button>${_$.markResumeNode(_scope0_id, "#button/0")}`);
   _$.writeEffect(_scope0_id, "__tests__/template.marko_0_count");
   _$.writeScope(_scope0_id, {


### PR DESCRIPTION
* Avoid `const` for `<let>` tags in ssr which can lead to syntax errors.
* Avoid creating sections for `html-script` and `html-style` (now properly treated as native tags).