### PR TITLE
Misc Improcements

### DIFF
--- a/.changeset/afraid-pugs-rush.md
+++ b/.changeset/afraid-pugs-rush.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid using push/unshift container which causes unecessary revisits.

--- a/.changeset/chubby-gifts-cut.md
+++ b/.changeset/chubby-gifts-cut.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid priting identifiers for value and closure parameters when the value is not referenced.

--- a/.changeset/four-showers-tan.md
+++ b/.changeset/four-showers-tan.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Expose `toReadable` api for whatwg streams in any environment.

--- a/.changeset/spicy-apes-argue.md
+++ b/.changeset/spicy-apes-argue.md
@@ -1,0 +1,6 @@
+---
+"marko": patch
+"@marko/runtime-tags": patch
+---
+
+Expose better types for working with ssr and csr rendered template results.

--- a/.changeset/stale-moments-shout.md
+++ b/.changeset/stale-moments-shout.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Ensure `toReadable` api on rendered ssr templates are text encoded.

--- a/.sizes.json
+++ b/.sizes.json
@@ -44,16 +44,16 @@
     {
       "name": "comments",
       "user": {
-        "min": 981,
-        "brotli": 467
+        "min": 961,
+        "brotli": 465
       },
       "runtime": {
         "min": 7037,
         "brotli": 3005
       },
       "total": {
-        "min": 8018,
-        "brotli": 3472
+        "min": 7998,
+        "brotli": 3470
       }
     },
     {

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -1,18 +1,15 @@
-// size: 981 (min) 467 (brotli)
+// size: 961 (min) 465 (brotli)
 const _expr_comment_comments_id$if_content = intersection(1, (_scope) => {
     const {
       _: { 8: comment_comments, 11: id },
     } = _scope;
     _input_$1(_scope[0], { comments: comment_comments, path: id });
   }),
-  _id$if_content = conditionalClosure(11, 4, 0, (_scope, id) =>
+  _id$if_content = conditionalClosure(11, 4, 0, (_scope) =>
     _expr_comment_comments_id$if_content(_scope),
   ),
-  _comment_comments$if_content = conditionalClosure(
-    8,
-    4,
-    0,
-    (_scope, comment_comments) => _expr_comment_comments_id$if_content(_scope),
+  _comment_comments$if_content = conditionalClosure(8, 4, 0, (_scope) =>
+    _expr_comment_comments_id$if_content(_scope),
   ),
   _if_content = createRenderer(
     "<ul></ul>",
@@ -46,9 +43,7 @@ const _expr_comment_comments_id$if_content = intersection(1, (_scope) => {
   _id$for_content = value(11, (_scope, id) => {
     attr(_scope[0], "id", id), _id$if_content(_scope);
   }),
-  _i$for_content = value(9, (_scope, i) =>
-    _expr_input_path_i$for_content(_scope),
-  ),
+  _i$for_content = value(9, (_scope) => _expr_input_path_i$for_content(_scope)),
   _comment_comments$for_content = value(8, (_scope, comment_comments) => {
     _if$for_content(_scope, comment_comments ? 0 : 1),
       _comment_comments$if_content(_scope);
@@ -64,7 +59,7 @@ const _expr_comment_comments_id$if_content = intersection(1, (_scope) => {
     _comment$for_content(_scope, _params_2[0]),
       _i$for_content(_scope, _params_2[1]);
   }),
-  _input_path$for_content = loopClosure(4, 0, (_scope, input_path) =>
+  _input_path$for_content = loopClosure(4, 0, (_scope) =>
     _expr_input_path_i$for_content(_scope),
   ),
   _for = loopOf(
@@ -79,9 +74,7 @@ const _expr_comment_comments_id$if_content = intersection(1, (_scope) => {
       (_scope) => _input_path$for_content._(_scope),
     ),
   ),
-  _input_path_ = value(4, (_scope, input_path) =>
-    _input_path$for_content(_scope),
-  ),
+  _input_path_ = value(4, (_scope) => _input_path$for_content(_scope)),
   _input_comments_ = value(3, (_scope, input_comments) =>
     _for(_scope, [input_comments]),
   ),

--- a/packages/runtime-class/src/node_modules/@internal/create-readable/index-browser.js
+++ b/packages/runtime-class/src/node_modules/@internal/create-readable/index-browser.js
@@ -2,7 +2,6 @@ var encoder = new TextEncoder();
 var noop = function () {};
 
 module.exports = function (data) {
-   
   var transformStream = new TransformStream();
   var writer = transformStream.writable.getWriter();
   var facade = {

--- a/packages/runtime-class/src/runtime/html/AsyncStream.js
+++ b/packages/runtime-class/src/runtime/html/AsyncStream.js
@@ -232,6 +232,23 @@ var proto = (AsyncStream.prototype = {
     });
   },
 
+  toReadable() {
+    return new ReadableStream({
+      async start(ctrl) {
+        const encoder = new TextEncoder();
+        try {
+          for await (const chunk of this) {
+            ctrl.enqueue(encoder.encode(chunk));
+          }
+
+          ctrl.close();
+        } catch (err) {
+          ctrl.error(err);
+        }
+      },
+    });
+  },
+
   sync: function () {
     this._sync = true;
   },

--- a/packages/runtime-tags/index.d.ts
+++ b/packages/runtime-tags/index.d.ts
@@ -33,6 +33,24 @@ declare global {
       $global?: Global;
     };
 
+    /** The result of calling `template.render`. */
+    export type RenderedTemplate = Promise<string> &
+      AsyncIterable<string> & {
+        toReadable(): ReadableStream<Uint8Array<ArrayBufferLike>>;
+        pipe(stream: {
+          write(chunk: string): unknown;
+          end(): unknown;
+          flush?(): void;
+        }): void;
+        toString(): string;
+      };
+
+    /** The result of calling `template.mount`. */
+    export type MountedTemplate<Input = unknown> = {
+      update(input: Marko.TemplateInput<Input>): void;
+      destroy(): void;
+    };
+
     /** Body content created by a template. */
     export interface Body<
       in Params extends readonly any[] = [],
@@ -68,26 +86,16 @@ declare global {
 
       /** @marko-overload-start */
       /** Render the template to a string. */
-      abstract render(input: Marko.TemplateInput<Input>): Promise<string> &
-        AsyncIterable<string> & {
-          toReadable(): ReadableStream;
-          pipe(stream: {
-            write(chunk: string): unknown;
-            end(): unknown;
-            flush?(): void;
-          }): void;
-          toString(): string;
-        };
+      abstract render(
+        input: Marko.TemplateInput<Input>,
+      ): Marko.RenderedTemplate;
 
       /** Render and attach the template to a DOM node. */
       abstract mount(
         input: Marko.TemplateInput<Input>,
         reference: Node,
         position?: "afterbegin" | "afterend" | "beforebegin" | "beforeend",
-      ): {
-        update(input: Marko.TemplateInput<Input>): void;
-        destroy(): void;
-      };
+      ): Marko.MountedTemplate<typeof input>;
       /** @marko-overload-end */
     }
 

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 363 (min) 206 (brotli)
+// size: 359 (min) 212 (brotli)
 _$.enableCatch();
 const _value$await_content = _$.value(2, (_scope, value) =>
     _$.data(_scope[0], value),
@@ -18,7 +18,7 @@ const _await$try_content = _$.awaitTag(0, _await_content),
       _clickCount(_scope, clickCount + 1);
     }),
   ),
-  _clickCount = _$.state(2, (_scope, clickCount) => {
+  _clickCount = _$.state(2, (_scope) => {
     _clickCount_closure(_scope), _clickCount_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", (_
 }) => _$.on(_scope["#button/0"], "click", function () {
   _clickCount(_scope, clickCount + 1), clickCount;
 }));
-const _clickCount = /* @__PURE__ */_$.state("clickCount/2", (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_$.state("clickCount/2", _scope => {
   _clickCount_closure(_scope);
   _clickCount_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.expected/template.js
@@ -38,15 +38,15 @@ const _expr_c_d = /* @__PURE__ */_$.intersection(9, _scope => {
   }]);
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/3");
-export const _d_ = /* @__PURE__ */_$.value("d", (_scope, d) => {
+export const _d_ = /* @__PURE__ */_$.value("d", _scope => {
   _expr_c_d(_scope);
   _expr_input_test_c_d(_scope);
 });
-export const _c_ = /* @__PURE__ */_$.value("c", (_scope, c) => {
+export const _c_ = /* @__PURE__ */_$.value("c", _scope => {
   _expr_c_d(_scope);
   _expr_input_test_c_d(_scope);
 });
-export const _input_test_ = /* @__PURE__ */_$.value("input_test", (_scope, input_test) => _expr_input_test_c_d(_scope));
+export const _input_test_ = /* @__PURE__ */_$.value("input_test", _scope => _expr_input_test_c_d(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_test_(_scope, input.test);
   _c_(_scope, input.c);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 292 (min) 138 (brotli)
+// size: 288 (min) 139 (brotli)
 const _count$await_content3 = _$.dynamicClosureRead(4, (_scope, count) =>
     _$.data(_scope[1], count),
   ),
@@ -18,7 +18,7 @@ const _count$await_content3 = _$.dynamicClosureRead(4, (_scope, count) =>
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(4, (_scope, count) => {
+  _count = _$.state(4, (_scope) => {
     _count_closure(_scope), _count_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.js
@@ -23,7 +23,7 @@ const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
 }) => _$.on(_scope["#button/3"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _count_closure(_scope);
   _count_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/tags/my-button.js
@@ -6,7 +6,7 @@ export const _text_ = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
   _text_(_scope, input.text);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 241 (min) 154 (brotli)
+// size: 237 (min) 155 (brotli)
 const _text_ = _$.value(5, (_scope, text) => _$.data(_scope[1], text)),
   _onClick__effect = _$.effect("a0", (_scope, { 4: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(4, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(4, (_scope) => _onClick__effect(_scope)),
   _clickCount = _$.state(1, (_scope, clickCount) => {
     _text_(_scope[0], clickCount), _onClick_(_scope[0], _onClick(_scope));
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/tags/my-button.js
@@ -5,7 +5,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _text_ = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(_scope["#text/1"], text));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _text_(_scope, input.text);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 241 (min) 156 (brotli)
+// size: 237 (min) 155 (brotli)
 const _onClick__effect = _$.effect("a0", (_scope, { 5: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(5, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(5, (_scope) => _onClick__effect(_scope)),
   _text_ = _$.value(4, (_scope, text) => _$.data(_scope[1], text)),
   _clickCount = _$.state(1, (_scope, clickCount) => {
     _text_(_scope[0], clickCount), _onClick_(_scope[0], _onClick(_scope));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/tags/my-button.js
@@ -13,7 +13,7 @@ export const _pattern__ = /* @__PURE__ */_$.value("_pattern_", (_scope, _pattern
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
   _pattern__(_scope, input.value);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 407 (min) 195 (brotli)
+// size: 403 (min) 198 (brotli)
 const _text_ = _$.value(7, (_scope, text) => {
     _$.data(_scope[1], text),
       ((_scope, textAlias) => {
@@ -11,7 +11,7 @@ const _text_ = _$.value(7, (_scope, text) => {
   _onClick__effect = _$.effect("a0", (_scope, { 5: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(5, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(5, (_scope) => _onClick__effect(_scope)),
   _clickCount = _$.state(2, (_scope, clickCount) => {
     _pattern__(_scope[0], { text: clickCount }),
       _onClick_(_scope[0], _onClick(_scope)),

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/tags/my-button.js
@@ -12,7 +12,7 @@ export const _text_ = /* @__PURE__ */_$.value("text", (_scope, text) => {
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
   _text_(_scope, input.text);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 274 (min) 164 (brotli)
+// size: 270 (min) 163 (brotli)
 const _text_ = _$.value(6, (_scope, text) => {
     _$.data(_scope[1], text),
       ((_scope, textAlias) => {
@@ -8,7 +8,7 @@ const _text_ = _$.value(6, (_scope, text) => {
   _onClick__effect = _$.effect("a0", (_scope, { 5: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(5, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(5, (_scope) => _onClick__effect(_scope)),
   _clickCount = _$.state(1, (_scope, clickCount) => {
     _text_(_scope[0], clickCount), _onClick_(_scope[0], _onClick(_scope));
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/tags/my-button.js
@@ -6,7 +6,7 @@ export const _text_ = /* @__PURE__ */_$.value("text", (_scope, text) => _$.data(
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
   _text_(_scope, input.text);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 241 (min) 154 (brotli)
+// size: 237 (min) 155 (brotli)
 const _text_ = _$.value(5, (_scope, text) => _$.data(_scope[1], text)),
   _onClick__effect = _$.effect("a0", (_scope, { 4: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(4, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(4, (_scope) => _onClick__effect(_scope)),
   _clickCount = _$.state(1, (_scope, clickCount) => {
     _text_(_scope[0], clickCount), _onClick_(_scope[0], _onClick(_scope));
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/tags/my-button.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/tags/my-button.js
@@ -7,7 +7,7 @@ export const _content_ = /* @__PURE__ */_$.value("content", (_scope, content) =>
 const _onClick__effect = _$.effect("__tests__/tags/my-button.marko_0_onClick", (_scope, {
   onClick
 }) => _$.on(_scope["#button/0"], "click", onClick));
-export const _onClick_ = /* @__PURE__ */_$.value("onClick", (_scope, onClick) => _onClick__effect(_scope));
+export const _onClick_ = /* @__PURE__ */_$.value("onClick", _scope => _onClick__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _onClick_(_scope, input.onClick);
   _content_(_scope, input.content);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 271 (min) 164 (brotli)
+// size: 267 (min) 166 (brotli)
 const _onClick__effect = _$.effect("a0", (_scope, { 4: onClick }) =>
     _$.on(_scope[0], "click", onClick),
   ),
-  _onClick_ = _$.value(4, (_scope, onClick) => _onClick__effect(_scope)),
+  _onClick_ = _$.value(4, (_scope) => _onClick__effect(_scope)),
   _clickCount$myButton_content = _$.dynamicClosureRead(
     1,
     (_scope, clickCount) => _$.data(_scope[0], clickCount),

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 362 (min) 199 (brotli)
+// size: 358 (min) 198 (brotli)
 const _count$if_content = _$.conditionalClosure(4, 2, 0, (_scope, count) =>
     _$.data(_scope[0], count),
   ),
@@ -11,7 +11,7 @@ const _count$if_content = _$.conditionalClosure(4, 2, 0, (_scope, count) =>
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(4, (_scope, count) => {
+  _count = _$.state(4, (_scope) => {
     _count$if_content(_scope), _count_effect(_scope);
   }),
   _show_effect = _$.effect("a1", (_scope, { 3: show }) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
 }) => _$.on(_scope["#button/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _count$if_content(_scope);
   _count_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 360 (min) 199 (brotli)
+// size: 356 (min) 196 (brotli)
 const _count$if_content = _$.conditionalClosure(4, 2, 0, (_scope, count) =>
     _$.data(_scope[0], count),
   ),
@@ -11,7 +11,7 @@ const _count$if_content = _$.conditionalClosure(4, 2, 0, (_scope, count) =>
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(4, (_scope, count) => {
+  _count = _$.state(4, (_scope) => {
     _count$if_content(_scope), _count_effect(_scope);
   }),
   _show_effect = _$.effect("a1", (_scope, { 3: show }) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
 }) => _$.on(_scope["#button/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _count$if_content(_scope);
   _count_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/dom.expected/template.js
@@ -10,15 +10,15 @@ const _expr_a_b$if_content = /* @__PURE__ */_$.intersection(1, _scope => {
   } = _scope;
   _$.data(_scope["#text/0"], a + b);
 });
-const _b$if_content = /* @__PURE__ */_$.conditionalClosure("b", "#text/0", 0, (_scope, b) => _expr_a_b$if_content(_scope));
-const _a$if_content = /* @__PURE__ */_$.conditionalClosure("a", "#text/0", 0, (_scope, a) => _expr_a_b$if_content(_scope));
+const _b$if_content = /* @__PURE__ */_$.conditionalClosure("b", "#text/0", 0, _scope => _expr_a_b$if_content(_scope));
+const _a$if_content = /* @__PURE__ */_$.conditionalClosure("a", "#text/0", 0, _scope => _expr_a_b$if_content(_scope));
 const _if_content = /* @__PURE__ */_$.createRenderer(" ", /* get */" ", 0, 0, _scope => {
   _a$if_content._(_scope);
   _b$if_content._(_scope);
 });
 const _if = /* @__PURE__ */_$.conditional("#text/0", _if_content);
-const _b = /* @__PURE__ */_$.state("b/2", (_scope, b) => _b$if_content(_scope));
-const _a = /* @__PURE__ */_$.state("a/1", (_scope, a) => _a$if_content(_scope));
+const _b = /* @__PURE__ */_$.state("b/2", _scope => _b$if_content(_scope));
+const _a = /* @__PURE__ */_$.state("a/1", _scope => _a$if_content(_scope));
 export function _setup_(_scope) {
   _a(_scope, 0);
   _b(_scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 206 (min) 142 (brotli)
+// size: 202 (min) 147 (brotli)
 const _increment_effect = _$.effect("a1", (_scope, { 3: increment }) =>
     _$.on(_scope[0], "click", increment),
   ),
-  _increment = _$.value(3, (_scope, increment) => _increment_effect(_scope)),
+  _increment = _$.value(3, (_scope) => _increment_effect(_scope)),
   _clickCount = _$.state(2, (_scope, clickCount) => {
     _$.data(_scope[1], clickCount), _increment(_scope, _increment2(_scope));
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _increment_effect = _$.effect("__tests__/template.marko_0_increment", (_scope, {
   increment
 }) => _$.on(_scope["#button/0"], "click", increment));
-const _increment = /* @__PURE__ */_$.value("increment", (_scope, increment) => _increment_effect(_scope));
+const _increment = /* @__PURE__ */_$.value("increment", _scope => _increment_effect(_scope));
 const _clickCount = /* @__PURE__ */_$.state("clickCount/2", (_scope, clickCount) => {
   _$.data(_scope["#text/1"], clickCount);
   _increment(_scope, _increment2(_scope));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 327 (min) 180 (brotli)
+// size: 323 (min) 179 (brotli)
 const _expr_count_multiplier = _$.intersection(6, (_scope) => {
     const { 4: count, 5: multiplier } = _scope;
     _multipliedCount(_scope, count * multiplier);
@@ -21,7 +21,7 @@ const _expr_count_multiplier = _$.intersection(6, (_scope) => {
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(4, (_scope, count) => {
+  _count = _$.state(4, (_scope) => {
     _expr_count_multiplier(_scope), _count_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
@@ -24,7 +24,7 @@ const _count_effect = _$.effect("__tests__/template.marko_0_count", (_scope, {
 }) => _$.on(_scope["#button/2"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _expr_count_multiplier(_scope);
   _count_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 295 (min) 187 (brotli)
+// size: 291 (min) 185 (brotli)
 const _message_text$if_content = _$.conditionalClosure(
     3,
     1,
@@ -10,9 +10,7 @@ const _message_text$if_content = _$.conditionalClosure(
   ),
   _if = _$.conditional(1, _if_content),
   _show = _$.state(4, (_scope, show) => _if(_scope, show ? 0 : 1)),
-  _message_text = _$.value(3, (_scope, message_text) =>
-    _message_text$if_content(_scope),
-  ),
+  _message_text = _$.value(3, (_scope) => _message_text$if_content(_scope)),
   _message = _$.state(2, (_scope, message) =>
     _message_text(_scope, message?.text),
   );

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const _message_text$if_content = /* @__PURE__ */_$.conditionalClosure("message_t
 const _if_content = /* @__PURE__ */_$.createRenderer(" ", /* get */" ", 0, 0, _scope => _message_text$if_content._(_scope));
 const _if = /* @__PURE__ */_$.conditional("#text/1", _if_content);
 const _show = /* @__PURE__ */_$.state("show/4", (_scope, show) => _if(_scope, show ? 0 : 1));
-const _message_text = /* @__PURE__ */_$.value("message_text", (_scope, message_text) => _message_text$if_content(_scope));
+const _message_text = /* @__PURE__ */_$.value("message_text", _scope => _message_text$if_content(_scope));
 const _message = /* @__PURE__ */_$.state("message/2", (_scope, message) => _message_text(_scope, message?.text));
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => _$.on(_scope["#button/0"], "click", function () {
   _message(_scope, null);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const _expr_a_b_effect = _$.effect("__tests__/template.marko_0_a_b", (_scope, {
   _a(_scope, a.map(a => b));
 }));
 const _expr_a_b = /* @__PURE__ */_$.intersection(4, _scope => _expr_a_b_effect(_scope));
-const _b = /* @__PURE__ */_$.state("b/3", (_scope, b) => _expr_a_b(_scope));
+const _b = /* @__PURE__ */_$.state("b/3", _scope => _expr_a_b(_scope));
 const _a = /* @__PURE__ */_$.state("a/2", (_scope, a) => {
   _$.data(_scope["#text/1"], a.join(""));
   _expr_a_b(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/tags/comments.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/tags/comments.js
@@ -15,8 +15,8 @@ const _expr_comment_comments_id$if_content = /* @__PURE__ */_$.intersection(1, _
     path: id
   });
 });
-const _id$if_content = /* @__PURE__ */_$.conditionalClosure("id", "#text/4", 0, (_scope, id) => _expr_comment_comments_id$if_content(_scope));
-const _comment_comments$if_content = /* @__PURE__ */_$.conditionalClosure("comment_comments", "#text/4", 0, (_scope, comment_comments) => _expr_comment_comments_id$if_content(_scope));
+const _id$if_content = /* @__PURE__ */_$.conditionalClosure("id", "#text/4", 0, _scope => _expr_comment_comments_id$if_content(_scope));
+const _comment_comments$if_content = /* @__PURE__ */_$.conditionalClosure("comment_comments", "#text/4", 0, _scope => _expr_comment_comments_id$if_content(_scope));
 const _setup$if_content = _scope => {
   _setup_(_scope["#childScope/0"]);
 };
@@ -48,7 +48,7 @@ const _id$for_content = /* @__PURE__ */_$.value("id", (_scope, id) => {
   _$.attr(_scope["#li/0"], "id", id);
   _id$if_content(_scope);
 });
-const _i$for_content = /* @__PURE__ */_$.value("i", (_scope, i) => _expr_input_path_i$for_content(_scope));
+const _i$for_content = /* @__PURE__ */_$.value("i", _scope => _expr_input_path_i$for_content(_scope));
 const _comment_comments$for_content = /* @__PURE__ */_$.value("comment_comments", (_scope, comment_comments) => {
   _if$for_content(_scope, comment_comments ? 0 : 1);
   _comment_comments$if_content(_scope);
@@ -62,13 +62,13 @@ const _params_2$for_content = /* @__PURE__ */_$.value("_params_2", (_scope, _par
   _comment$for_content(_scope, _params_2[0]);
   _i$for_content(_scope, _params_2[1]);
 });
-const _input_path$for_content = /* @__PURE__ */_$.loopClosure("input_path", "#ul/0", (_scope, input_path) => _expr_input_path_i$for_content(_scope));
+const _input_path$for_content = /* @__PURE__ */_$.loopClosure("input_path", "#ul/0", _scope => _expr_input_path_i$for_content(_scope));
 const _setup$for_content = _scope => {
   _open$for_content(_scope, true);
 };
 const _for_content = /* @__PURE__ */_$.createRenderer("<li><span> </span><button> </button><!></li>", /* get, next(2), get, out(1), get, next(1), get, out(1), replace */" E l D l%", _setup$for_content, _params_2$for_content, _scope => _input_path$for_content._(_scope));
 const _for = /* @__PURE__ */_$.loopOf("#ul/0", _for_content);
-export const _input_path_ = /* @__PURE__ */_$.value("input_path", (_scope, input_path) => _input_path$for_content(_scope));
+export const _input_path_ = /* @__PURE__ */_$.value("input_path", _scope => _input_path$for_content(_scope));
 export const _input_comments_ = /* @__PURE__ */_$.value("input_comments", (_scope, input_comments) => _for(_scope, [input_comments]));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_comments_(_scope, input.comments);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ import { _setup_ as _layout, _content_ as _layout_input_content, _template_ as _
 const _name$layout_content = /* @__PURE__ */_$.dynamicClosureRead("name", (_scope, name) => _$.data(_scope["#text/0"], name));
 const _layout_content = /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", "<h1>Hello <!></h1>", /* next(1), over(1), replace */"Db%", 0, 0, _scope => _name$layout_content(_scope));
 const _name__closure = /* @__PURE__ */_$.dynamicClosure(_name$layout_content);
-export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => _name__closure(_scope));
+export const _name_ = /* @__PURE__ */_$.value("name", _scope => _name__closure(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _name_(_scope, input.name));
 export function _setup_(_scope) {
   _layout(_scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 295 (min) 193 (brotli)
+// size: 291 (min) 194 (brotli)
 const _expr_items_index_effect = _$.effect(
     "a0",
     (_scope, { 3: items, 5: index }) =>
@@ -11,7 +11,7 @@ const _expr_items_index_effect = _$.effect(
     const { 3: items, 5: index } = _scope;
     _$.data(_scope[1], items[index]), _expr_items_index_effect(_scope);
   }),
-  _index = _$.state(5, (_scope, index) => _expr_items_index(_scope)),
+  _index = _$.state(5, (_scope) => _expr_items_index(_scope)),
   _items_ = _$.value(4, (_scope, items_0) => _$.data(_scope[0], items_0)),
   _items = _$.state(3, (_scope, items) => {
     _items_(_scope, items?.[0]), _expr_items_index(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _expr_items_index = /* @__PURE__ */_$.intersection(6, _scope => {
   _$.data(_scope["#text/1"], items[index]);
   _expr_items_index_effect(_scope);
 });
-const _index = /* @__PURE__ */_$.state("index/5", (_scope, index) => _expr_items_index(_scope));
+const _index = /* @__PURE__ */_$.state("index/5", _scope => _expr_items_index(_scope));
 const _items_ = /* @__PURE__ */_$.value("items_0", (_scope, items_0) => _$.data(_scope["#text/0"], items_0));
 const _items = /* @__PURE__ */_$.state("items/3", (_scope, items) => {
   _items_(_scope, items?.[0]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 591 (min) 324 (brotli)
+// size: 579 (min) 316 (brotli)
 const _name_ = _$.value(3, (_scope, name) => _$.data(_scope[0], name)),
   _expr_outer_inner$for_content = _$.intersection(3, (_scope) => {
     const {
@@ -7,10 +7,10 @@ const _name_ = _$.value(3, (_scope, name) => _$.data(_scope[0], name)),
     } = _scope;
     _name_(_scope[0], `${outer}.${inner}`);
   }),
-  _outer$for_content = _$.loopClosure(2, 0, (_scope, outer) =>
+  _outer$for_content = _$.loopClosure(2, 0, (_scope) =>
     _expr_outer_inner$for_content(_scope),
   ),
-  _inner$for_content = _$.value(2, (_scope, inner) =>
+  _inner$for_content = _$.value(2, (_scope) =>
     _expr_outer_inner$for_content(_scope),
   ),
   _params_3$for_content = _$.value(1, (_scope, _params_3) =>
@@ -30,9 +30,7 @@ const _name_ = _$.value(3, (_scope, name) => _$.data(_scope[0], name)),
   _items$for_content = _$.loopClosure(2, 1, (_scope, items) =>
     _for$for_content(_scope, [items]),
   ),
-  _outer$for_content2 = _$.value(2, (_scope, outer) =>
-    _outer$for_content(_scope),
-  ),
+  _outer$for_content2 = _$.value(2, (_scope) => _outer$for_content(_scope)),
   _params_2$for_content = _$.value(1, (_scope, _params_2) =>
     _outer$for_content2(_scope, _params_2[0]),
   ),

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.js
@@ -11,8 +11,8 @@ const _expr_outer_inner$for_content = /* @__PURE__ */_$.intersection(3, _scope =
   } = _scope;
   _child_input_name(_scope["#childScope/0"], `${outer}.${inner}`);
 });
-const _outer$for_content = /* @__PURE__ */_$.loopClosure("outer", "#text/0", (_scope, outer) => _expr_outer_inner$for_content(_scope));
-const _inner$for_content = /* @__PURE__ */_$.value("inner", (_scope, inner) => _expr_outer_inner$for_content(_scope));
+const _outer$for_content = /* @__PURE__ */_$.loopClosure("outer", "#text/0", _scope => _expr_outer_inner$for_content(_scope));
+const _inner$for_content = /* @__PURE__ */_$.value("inner", _scope => _expr_outer_inner$for_content(_scope));
 const _params_3$for_content = /* @__PURE__ */_$.value("_params_3", (_scope, _params_3) => _inner$for_content(_scope, _params_3[0]));
 const _setup$for_content = _scope => {
   _child(_scope["#childScope/0"]);
@@ -20,7 +20,7 @@ const _setup$for_content = _scope => {
 const _for_content2 = /* @__PURE__ */_$.createRenderer(_child_template, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$for_content, _params_3$for_content, _scope => _outer$for_content._(_scope));
 const _for$for_content = /* @__PURE__ */_$.loopOf("#text/0", _for_content2);
 const _items$for_content = /* @__PURE__ */_$.loopClosure("items", "#text/1", (_scope, items) => _for$for_content(_scope, [items]));
-const _outer$for_content2 = /* @__PURE__ */_$.value("outer", (_scope, outer) => _outer$for_content(_scope));
+const _outer$for_content2 = /* @__PURE__ */_$.value("outer", _scope => _outer$for_content(_scope));
 const _params_2$for_content = /* @__PURE__ */_$.value("_params_2", (_scope, _params_2) => _outer$for_content2(_scope, _params_2[0]));
 const _for_content = /* @__PURE__ */_$.createRenderer("<!><!><!>", /* replace */"D%D", 0, _params_2$for_content, _scope => _items$for_content._(_scope));
 const _for = /* @__PURE__ */_$.loopOf("#text/1", _for_content);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/tags/child.js
@@ -10,8 +10,8 @@ const _expr_content_value = /* @__PURE__ */_$.intersection(5, _scope => {
   _dynamicTag(_scope, content, () => value);
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0");
-export const _value_ = /* @__PURE__ */_$.value("value", (_scope, value) => _expr_content_value(_scope));
-export const _content_ = /* @__PURE__ */_$.value("content", (_scope, content) => _expr_content_value(_scope));
+export const _value_ = /* @__PURE__ */_$.value("value", _scope => _expr_content_value(_scope));
+export const _content_ = /* @__PURE__ */_$.value("content", _scope => _expr_content_value(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _content_(_scope, input.content);
   _value_(_scope, input.value);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 656 (min) 306 (brotli)
+// size: 644 (min) 311 (brotli)
 const _expr_content_value = _$.intersection(5, (_scope) => {
     const { 3: content, 4: value } = _scope;
     _dynamicTag(_scope, content, () => value);
   }),
   _dynamicTag = _$.dynamicTag(),
-  _value_ = _$.value(4, (_scope, value) => _expr_content_value(_scope)),
-  _content_ = _$.value(3, (_scope, content) => _expr_content_value(_scope)),
+  _value_ = _$.value(4, (_scope) => _expr_content_value(_scope)),
+  _content_ = _$.value(3, (_scope) => _expr_content_value(_scope)),
   _inner$child_content = _$.value(3, (_scope, inner) =>
     _$.data(_scope[1], inner),
   ),
@@ -27,7 +27,7 @@ const _expr_content_value = _$.intersection(5, (_scope) => {
     _value_(_scope[0], y),
   ),
   _outer$child_content2_closure = _$.dynamicClosure(_outer$child_content),
-  _outer$child_content2 = _$.value(2, (_scope, outer) =>
+  _outer$child_content2 = _$.value(2, (_scope) =>
     _outer$child_content2_closure(_scope),
   ),
   _params_2$child_content = _$.value(1, (_scope, _params_2) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const _params_3$child_content = /* @__PURE__ */_$.value("_params_3", (_scope, _p
 const _child_content2 = _$.registerContent("__tests__/template.marko_2_renderer", "<div><!>.<!></div>", /* next(1), replace, over(2), replace */"D%c%", 0, _params_3$child_content, _scope => _outer$child_content(_scope));
 const _y$child_content = /* @__PURE__ */_$.dynamicClosureRead("y", (_scope, y) => _child_input_value(_scope["#childScope/0"], y));
 const _outer$child_content2_closure = /* @__PURE__ */_$.dynamicClosure(_outer$child_content);
-const _outer$child_content2 = /* @__PURE__ */_$.value("outer", (_scope, outer) => _outer$child_content2_closure(_scope));
+const _outer$child_content2 = /* @__PURE__ */_$.value("outer", _scope => _outer$child_content2_closure(_scope));
 const _params_2$child_content = /* @__PURE__ */_$.value("_params_2", (_scope, _params_2) => _outer$child_content2(_scope, _params_2[0]));
 const _setup$child_content = _scope => {
   _child(_scope["#childScope/0"]);
@@ -16,7 +16,7 @@ const _setup$child_content = _scope => {
 };
 const _child_content = _$.registerContent("__tests__/template.marko_1_renderer", _child_template, /* beginChild, _child_walks, endChild */`/${_child_walks}&`, _setup$child_content, _params_2$child_content, _scope => _y$child_content(_scope));
 const _y_closure = /* @__PURE__ */_$.dynamicClosure(_y$child_content);
-const _y = /* @__PURE__ */_$.state("y/3", (_scope, y) => _y_closure(_scope));
+const _y = /* @__PURE__ */_$.state("y/3", _scope => _y_closure(_scope));
 const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
   x
 }) => _$.on(_scope["#button/0"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 194 (min) 142 (brotli)
+// size: 190 (min) 139 (brotli)
 const _count$child_content_effect = _$.effect(
     "b1",
     (_scope, { _: { 1: count } }) =>
@@ -10,5 +10,5 @@ const _count$child_content_effect = _$.effect(
     _$.data(_scope[1], count), _count$child_content_effect(_scope);
   }),
   _count_closure = _$.dynamicClosure(_count$child_content),
-  _count = _$.state(1, (_scope, count) => _count_closure(_scope));
+  _count = _$.state(1, (_scope) => _count_closure(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
@@ -15,7 +15,7 @@ const _count$child_content = /* @__PURE__ */_$.dynamicClosureRead("count", (_sco
 });
 const _child_content = /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", "<button> </button>", /* get, next(1), get */" D ", 0, 0, _scope => _count$child_content(_scope));
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$child_content);
-const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => _count_closure(_scope));
+const _count = /* @__PURE__ */_$.state("count/1", _scope => _count_closure(_scope));
 export function _setup_(_scope) {
   _child(_scope["#childScope/0"]);
   _count(_scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 265 (min) 177 (brotli)
+// size: 261 (min) 173 (brotli)
 const _count$falseChild_content_effect = _$.effect(
     "b1",
     (_scope, { _: { 1: count } }) =>
@@ -13,5 +13,5 @@ _$.registerContent("b0", "<button> </button>", " D ", 0, 0, (_scope) =>
   _count$falseChild_content(_scope),
 );
 const _count_closure = _$.dynamicClosure(_count$falseChild_content),
-  _count = _$.state(1, (_scope, count) => _count_closure(_scope));
+  _count = _$.state(1, (_scope) => _count_closure(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const _count$falseChild_content = /* @__PURE__ */_$.dynamicClosureRead("count", 
 const _falseChild_content = _$.registerContent("__tests__/template.marko_1_renderer", "<button> </button>", /* get, next(1), get */" D ", 0, 0, _scope => _count$falseChild_content(_scope));
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", _falseChild_content);
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$falseChild_content);
-const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => _count_closure(_scope));
+const _count = /* @__PURE__ */_$.state("count/1", _scope => _count_closure(_scope));
 export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTag(_scope, false || Child);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 267 (min) 168 (brotli)
+// size: 259 (min) 169 (brotli)
 const _expr_selected_num$for_content = _$.intersection(4, (_scope) => {
   const {
     _: { 1: selected },
@@ -12,8 +12,8 @@ _$.effect("a0", (_scope, { 3: num }) =>
     _selected(_scope._, num);
   }),
 );
-const _selected$for_content = _$.loopClosure(1, 0, (_scope, selected) =>
+const _selected$for_content = _$.loopClosure(1, 0, (_scope) =>
     _expr_selected_num$for_content(_scope),
   ),
-  _selected = _$.state(1, (_scope, selected) => _selected$for_content(_scope));
+  _selected = _$.state(1, (_scope) => _selected$for_content(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -22,10 +22,10 @@ const _num$for_content = /* @__PURE__ */_$.value("num", (_scope, num) => {
   _num$for_content_effect(_scope);
 });
 const _params_2$for_content = /* @__PURE__ */_$.value("_params_2", (_scope, _params_2) => _num$for_content(_scope, _params_2[0]));
-const _selected$for_content = /* @__PURE__ */_$.loopClosure("selected", "#text/0", (_scope, selected) => _expr_selected_num$for_content(_scope));
+const _selected$for_content = /* @__PURE__ */_$.loopClosure("selected", "#text/0", _scope => _expr_selected_num$for_content(_scope));
 const _for_content = /* @__PURE__ */_$.createRenderer("<button> </button>", /* get, next(1), get */" D ", 0, _params_2$for_content, _scope => _selected$for_content._(_scope));
 const _for = /* @__PURE__ */_$.loopOf("#text/0", _for_content);
-const _selected = /* @__PURE__ */_$.state("selected/1", (_scope, selected) => _selected$for_content(_scope));
+const _selected = /* @__PURE__ */_$.state("selected/1", _scope => _selected$for_content(_scope));
 export function _setup_(_scope) {
   _selected(_scope, 0);
   _for(_scope, [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 409 (min) 228 (brotli)
+// size: 405 (min) 228 (brotli)
 const _item$for_content = _$.value(2, (_scope, item) =>
     _$.data(_scope[0], item),
   ),
@@ -24,5 +24,5 @@ const _item$for_content = _$.value(2, (_scope, item) =>
   _items = _$.state(4, (_scope, items) => {
     _for(_scope, [items]), _expr_id_items(_scope), _items_effect(_scope);
   }),
-  _id = _$.state(3, (_scope, id) => _expr_id_items(_scope));
+  _id = _$.state(3, (_scope) => _expr_id_items(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -25,7 +25,7 @@ const _items = /* @__PURE__ */_$.state("items/4", (_scope, items) => {
   _expr_id_items(_scope);
   _items_effect(_scope);
 });
-const _id = /* @__PURE__ */_$.state("id/3", (_scope, id) => _expr_id_items(_scope));
+const _id = /* @__PURE__ */_$.state("id/3", _scope => _expr_id_items(_scope));
 export function _setup_(_scope) {
   _id(_scope, 0);
   _items(_scope, []);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
@@ -1,8 +1,8 @@
 export const _template_ = "<div><button> </button></div>";
 export const _walks_ = /* next(1), get, next(1), get, out(2) */"D D m";
 import * as _$ from "@marko/runtime-tags/debug/dom";
-const _unused_2 = (_scope, unused_2) => {};
-const _unused_ = (_scope, unused_1) => {};
+const _unused_2 = _scope => {};
+const _unused_ = _scope => {};
 const _clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", (_scope, {
   clickCount
 }) => _$.on(_scope["#button/0"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 292 (min) 187 (brotli)
+// size: 288 (min) 187 (brotli)
 const _message$if_content = _$.conditionalClosure(3, 1, 0, (_scope, message) =>
     _$.data(_scope[0], message),
   ),
@@ -6,7 +6,7 @@ const _message$if_content = _$.conditionalClosure(3, 1, 0, (_scope, message) =>
     _message$if_content._(_scope),
   ),
   _if = _$.conditional(1, _if_content),
-  _message = _$.state(3, (_scope, message) => _message$if_content(_scope)),
+  _message = _$.state(3, (_scope) => _message$if_content(_scope)),
   _show_effect = _$.effect("a0", (_scope, { 2: show }) =>
     _$.on(_scope[0], "click", function () {
       _message(_scope, "bye"), _show(_scope, !show);

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _message$if_content = /* @__PURE__ */_$.conditionalClosure("message", "#text/1", 0, (_scope, message) => _$.data(_scope["#text/0"], message));
 const _if_content = /* @__PURE__ */_$.createRenderer("<span> </span>", /* next(1), get */"D ", 0, 0, _scope => _message$if_content._(_scope));
 const _if = /* @__PURE__ */_$.conditional("#text/1", _if_content);
-const _message = /* @__PURE__ */_$.state("message/3", (_scope, message) => _message$if_content(_scope));
+const _message = /* @__PURE__ */_$.state("message/3", _scope => _message$if_content(_scope));
 const _show_effect = _$.effect("__tests__/template.marko_0_show", (_scope, {
   show
 }) => _$.on(_scope["#button/0"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 215 (min) 148 (brotli)
+// size: 207 (min) 144 (brotli)
 const _expr_a_b_effect = _$.effect("a0", (_scope, { 2: a, 3: b }) =>
     _$.on(_scope[0], "click", function () {
       _a(_scope, a + 1), _b(_scope, b + 1);
@@ -8,6 +8,6 @@ const _expr_a_b_effect = _$.effect("a0", (_scope, { 2: a, 3: b }) =>
     const { 2: a, 3: b } = _scope;
     _$.data(_scope[1], a + b), _expr_a_b_effect(_scope);
   }),
-  _b = _$.state(3, (_scope, b) => _expr_a_b(_scope)),
-  _a = _$.state(2, (_scope, a) => _expr_a_b(_scope));
+  _b = _$.state(3, (_scope) => _expr_a_b(_scope)),
+  _a = _$.state(2, (_scope) => _expr_a_b(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
@@ -16,8 +16,8 @@ const _expr_a_b = /* @__PURE__ */_$.intersection(4, _scope => {
   _$.data(_scope["#text/1"], a + b);
   _expr_a_b_effect(_scope);
 });
-const _b = /* @__PURE__ */_$.state("b/3", (_scope, b) => _expr_a_b(_scope));
-const _a = /* @__PURE__ */_$.state("a/2", (_scope, a) => _expr_a_b(_scope));
+const _b = /* @__PURE__ */_$.state("b/3", _scope => _expr_a_b(_scope));
+const _a = /* @__PURE__ */_$.state("a/2", _scope => _expr_a_b(_scope));
 export function _setup_(_scope) {
   _a(_scope, 0);
   _b(_scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/tags/child.js
@@ -15,7 +15,7 @@ const _expr_name_write = /* @__PURE__ */_$.intersection(7, _scope => {
   _$.resetAbortSignal(_scope, 0);
   _expr_name_write_effect(_scope);
 });
-export const _write_ = /* @__PURE__ */_$.value("write", (_scope, write) => _expr_name_write(_scope));
+export const _write_ = /* @__PURE__ */_$.value("write", _scope => _expr_name_write(_scope));
 export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => {
   _$.data(_scope["#text/0"], name);
   _$.data(_scope["#text/1"], name);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 708 (min) 377 (brotli)
+// size: 704 (min) 376 (brotli)
 const _expr_name_write_effect = _$.effect(
     "a0",
     (_scope, { 5: name, 6: write }) => {
@@ -11,7 +11,7 @@ const _expr_name_write_effect = _$.effect(
   _expr_name_write = _$.intersection(7, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _expr_name_write_effect(_scope);
   }),
-  _write_ = _$.value(6, (_scope, write) => _expr_name_write(_scope)),
+  _write_ = _$.value(6, (_scope) => _expr_name_write(_scope)),
   _name_ = _$.value(5, (_scope, name) => {
     _$.data(_scope[0], name),
       _$.data(_scope[1], name),

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/tags/child.js
@@ -15,7 +15,7 @@ const _expr_name_write = /* @__PURE__ */_$.intersection(7, _scope => {
   _$.resetAbortSignal(_scope, 0);
   _expr_name_write_effect(_scope);
 });
-export const _write_ = /* @__PURE__ */_$.value("write", (_scope, write) => _expr_name_write(_scope));
+export const _write_ = /* @__PURE__ */_$.value("write", _scope => _expr_name_write(_scope));
 export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => {
   _$.data(_scope["#text/0"], name);
   _$.data(_scope["#text/1"], name);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1374 (min) 517 (brotli)
+// size: 1362 (min) 518 (brotli)
 const _template_ = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   _expr_name_write_effect = _$.effect("a0", (_scope, { 5: name, 6: write }) => {
     write(`${name} mounted`),
@@ -9,7 +9,7 @@ const _template_ = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   _expr_name_write = _$.intersection(7, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _expr_name_write_effect(_scope);
   }),
-  _write_ = _$.value(6, (_scope, write) => _expr_name_write(_scope)),
+  _write_ = _$.value(6, (_scope) => _expr_name_write(_scope)),
   _name_ = _$.value(5, (_scope, name) => {
     _$.data(_scope[0], name),
       _$.data(_scope[1], name),
@@ -83,7 +83,7 @@ const _template_ = "<div><!> a</div><span><!> a</span><p><!> a</p>",
       _showInner(_scope, !showInner);
     }),
   ),
-  _showInner = _$.state(7, (_scope, showInner) => {
+  _showInner = _$.state(7, (_scope) => {
     _showInner_closure(_scope), _showInner_effect(_scope);
   }),
   _showMiddle_effect = _$.effect("b2", (_scope, { 6: showMiddle }) =>
@@ -91,7 +91,7 @@ const _template_ = "<div><!> a</div><span><!> a</span><p><!> a</p>",
       _showMiddle(_scope, !showMiddle);
     }),
   ),
-  _showMiddle = _$.state(6, (_scope, showMiddle) => {
+  _showMiddle = _$.state(6, (_scope) => {
     _showMiddle$if_content(_scope), _showMiddle_effect(_scope);
   }),
   _showOuter_effect = _$.effect("b3", (_scope, { 5: showOuter }) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.js
@@ -38,7 +38,7 @@ const _showInner_effect = _$.effect("__tests__/template.marko_0_showInner", (_sc
 }) => _$.on(_scope["#button/2"], "click", function () {
   _showInner(_scope, !showInner);
 }));
-const _showInner = /* @__PURE__ */_$.state("showInner/7", (_scope, showInner) => {
+const _showInner = /* @__PURE__ */_$.state("showInner/7", _scope => {
   _showInner_closure(_scope);
   _showInner_effect(_scope);
 });
@@ -47,7 +47,7 @@ const _showMiddle_effect = _$.effect("__tests__/template.marko_0_showMiddle", (_
 }) => _$.on(_scope["#button/1"], "click", function () {
   _showMiddle(_scope, !showMiddle);
 }));
-const _showMiddle = /* @__PURE__ */_$.state("showMiddle/6", (_scope, showMiddle) => {
+const _showMiddle = /* @__PURE__ */_$.state("showMiddle/6", _scope => {
   _showMiddle$if_content(_scope);
   _showMiddle_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/tags/child.js
@@ -10,7 +10,7 @@ const _input__effect = _$.effect("__tests__/tags/child.marko_0_input", (_scope, 
     input.write('destroyed');
   };
 });
-export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
+export const _input_ = /* @__PURE__ */_$.value("input", _scope => {
   _$.resetAbortSignal(_scope, 0);
   _input__effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 473 (min) 281 (brotli)
+// size: 469 (min) 282 (brotli)
 const _input__effect = _$.effect("a0", (_scope, { 1: input }) => {
     input.write("mounted"),
       (_$.getAbortSignal(_scope, 0).onabort = () => {
         input.write("destroyed");
       });
   }),
-  _input_ = _$.value(1, (_scope, input) => {
+  _input_ = _$.value(1, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _input__effect(_scope);
   }),
   _setup$if_content = (_scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/tags/child.js
@@ -12,7 +12,7 @@ const _expr_name_write = /* @__PURE__ */_$.intersection(5, _scope => {
   _$.resetAbortSignal(_scope, 0);
   _expr_name_write_effect(_scope);
 });
-export const _write_ = /* @__PURE__ */_$.value("write", (_scope, write) => _expr_name_write(_scope));
+export const _write_ = /* @__PURE__ */_$.value("write", _scope => _expr_name_write(_scope));
 export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => {
   _$.data(_scope["#text/0"], name);
   _expr_name_write(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1035 (min) 468 (brotli)
+// size: 1023 (min) 478 (brotli)
 const _expr_name_write_effect = _$.effect(
     "a0",
     (_scope, { 3: name, 4: write }) =>
@@ -9,7 +9,7 @@ const _expr_name_write_effect = _$.effect(
   _expr_name_write = _$.intersection(5, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _expr_name_write_effect(_scope);
   }),
-  _write_ = _$.value(4, (_scope, write) => _expr_name_write(_scope)),
+  _write_ = _$.value(4, (_scope) => _expr_name_write(_scope)),
   _name_ = _$.value(3, (_scope, name) => {
     _$.data(_scope[0], name), _expr_name_write(_scope);
   }),
@@ -25,10 +25,10 @@ const _expr_name_write_effect = _$.effect(
     (_scope, write) => _write_(_scope[0], write),
     (_scope) => _scope._._,
   ),
-  _outerItem$for_content2 = _$.loopClosure(3, 1, (_scope, outerItem) =>
+  _outerItem$for_content2 = _$.loopClosure(3, 1, (_scope) =>
     _expr_outerItem_middleItem$for_content(_scope),
   ),
-  _middleItem$for_content = _$.value(2, (_scope, middleItem) =>
+  _middleItem$for_content = _$.value(2, (_scope) =>
     _expr_outerItem_middleItem$for_content(_scope),
   ),
   _params_3$for_content = _$.value(1, (_scope, _params_3) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.js
@@ -12,8 +12,8 @@ const _expr_outerItem_middleItem$for_content = /* @__PURE__ */_$.intersection(3,
   _child_input_name(_scope["#childScope/0"], `${outerItem}.${middleItem}`);
 });
 const _write$for_content2 = /* @__PURE__ */_$.dynamicClosureRead("write", (_scope, write) => _child_input_write(_scope["#childScope/0"], write), _scope => _scope._._);
-const _outerItem$for_content2 = /* @__PURE__ */_$.loopClosure("outerItem", "#text/1", (_scope, outerItem) => _expr_outerItem_middleItem$for_content(_scope));
-const _middleItem$for_content = /* @__PURE__ */_$.value("middleItem", (_scope, middleItem) => _expr_outerItem_middleItem$for_content(_scope));
+const _outerItem$for_content2 = /* @__PURE__ */_$.loopClosure("outerItem", "#text/1", _scope => _expr_outerItem_middleItem$for_content(_scope));
+const _middleItem$for_content = /* @__PURE__ */_$.value("middleItem", _scope => _expr_outerItem_middleItem$for_content(_scope));
 const _params_3$for_content = /* @__PURE__ */_$.value("_params_3", (_scope, _params_3) => _middleItem$for_content(_scope, _params_3[0]));
 const _setup$for_content2 = _scope => {
   _child(_scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/tags/child.js
@@ -15,7 +15,7 @@ const _expr_name_write = /* @__PURE__ */_$.intersection(5, _scope => {
   _$.resetAbortSignal(_scope, 0);
   _expr_name_write_effect(_scope);
 });
-export const _write_ = /* @__PURE__ */_$.value("write", (_scope, write) => _expr_name_write(_scope));
+export const _write_ = /* @__PURE__ */_$.value("write", _scope => _expr_name_write(_scope));
 export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => {
   _$.data(_scope["#text/0"], name);
   _expr_name_write(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 650 (min) 351 (brotli)
+// size: 646 (min) 349 (brotli)
 const _expr_name_write_effect = _$.effect(
     "a0",
     (_scope, { 3: name, 4: write }) => {
@@ -11,7 +11,7 @@ const _expr_name_write_effect = _$.effect(
   _expr_name_write = _$.intersection(5, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _expr_name_write_effect(_scope);
   }),
-  _write_ = _$.value(4, (_scope, write) => _expr_name_write(_scope)),
+  _write_ = _$.value(4, (_scope) => _expr_name_write(_scope)),
   _name_ = _$.value(3, (_scope, name) => {
     _$.data(_scope[0], name), _expr_name_write(_scope);
   }),

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/tags/child.js
@@ -15,7 +15,7 @@ const _expr_name_write = /* @__PURE__ */_$.intersection(5, _scope => {
   _$.resetAbortSignal(_scope, 0);
   _expr_name_write_effect(_scope);
 });
-export const _write_ = /* @__PURE__ */_$.value("write", (_scope, write) => _expr_name_write(_scope));
+export const _write_ = /* @__PURE__ */_$.value("write", _scope => _expr_name_write(_scope));
 export const _name_ = /* @__PURE__ */_$.value("name", (_scope, name) => {
   _$.data(_scope["#text/0"], name);
   _expr_name_write(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1292 (min) 492 (brotli)
+// size: 1280 (min) 491 (brotli)
 const _expr_name_write_effect = _$.effect(
     "a0",
     (_scope, { 3: name, 4: write }) => {
@@ -11,7 +11,7 @@ const _expr_name_write_effect = _$.effect(
   _expr_name_write = _$.intersection(5, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _expr_name_write_effect(_scope);
   }),
-  _write_ = _$.value(4, (_scope, write) => _expr_name_write(_scope)),
+  _write_ = _$.value(4, (_scope) => _expr_name_write(_scope)),
   _name_ = _$.value(3, (_scope, name) => {
     _$.data(_scope[0], name), _expr_name_write(_scope);
   }),
@@ -82,7 +82,7 @@ const _expr_name_write_effect = _$.effect(
       _showInner(_scope, !showInner);
     }),
   ),
-  _showInner = _$.state(7, (_scope, showInner) => {
+  _showInner = _$.state(7, (_scope) => {
     _showInner_closure(_scope), _showInner_effect(_scope);
   }),
   _showMiddle_effect = _$.effect("b2", (_scope, { 6: showMiddle }) =>
@@ -90,7 +90,7 @@ const _expr_name_write_effect = _$.effect(
       _showMiddle(_scope, !showMiddle);
     }),
   ),
-  _showMiddle = _$.state(6, (_scope, showMiddle) => {
+  _showMiddle = _$.state(6, (_scope) => {
     _showMiddle$if_content(_scope), _showMiddle_effect(_scope);
   }),
   _showOuter_effect = _$.effect("b3", (_scope, { 5: showOuter }) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.js
@@ -38,7 +38,7 @@ const _showInner_effect = _$.effect("__tests__/template.marko_0_showInner", (_sc
 }) => _$.on(_scope["#button/2"], "click", function () {
   _showInner(_scope, !showInner);
 }));
-const _showInner = /* @__PURE__ */_$.state("showInner/7", (_scope, showInner) => {
+const _showInner = /* @__PURE__ */_$.state("showInner/7", _scope => {
   _showInner_closure(_scope);
   _showInner_effect(_scope);
 });
@@ -47,7 +47,7 @@ const _showMiddle_effect = _$.effect("__tests__/template.marko_0_showMiddle", (_
 }) => _$.on(_scope["#button/1"], "click", function () {
   _showMiddle(_scope, !showMiddle);
 }));
-const _showMiddle = /* @__PURE__ */_$.state("showMiddle/6", (_scope, showMiddle) => {
+const _showMiddle = /* @__PURE__ */_$.state("showMiddle/6", _scope => {
   _showMiddle$if_content(_scope);
   _showMiddle_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/tags/child.js
@@ -10,7 +10,7 @@ const _input__effect = _$.effect("__tests__/tags/child.marko_0_input", (_scope, 
     input.write('destroyed');
   };
 });
-export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
+export const _input_ = /* @__PURE__ */_$.value("input", _scope => {
   _$.resetAbortSignal(_scope, 0);
   _input__effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 455 (min) 271 (brotli)
+// size: 451 (min) 270 (brotli)
 const _input__effect = _$.effect("a0", (_scope, { 1: input }) => {
     input.write("mounted"),
       (_$.getAbortSignal(_scope, 0).onabort = () => {
         input.write("destroyed");
       });
   }),
-  _input_ = _$.value(1, (_scope, input) => {
+  _input_ = _$.value(1, (_scope) => {
     _$.resetAbortSignal(_scope, 0), _input__effect(_scope);
   }),
   _setup$if_content = (_scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/tags/counter.js
@@ -13,11 +13,11 @@ const _count_effect = _$.effect("__tests__/tags/counter.marko_0_count", (_scope,
 }) => _$.on(_scope["#button/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _expr_input_count(_scope);
   _count_effect(_scope);
 });
-export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _expr_input_count(_scope));
+export const _input_ = /* @__PURE__ */_$.value("input", _scope => _expr_input_count(_scope));
 export function _setup_(_scope) {
   _count(_scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/tags/display-intersection.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/tags/display-intersection.js
@@ -8,8 +8,8 @@ const _expr_value_dummy = /* @__PURE__ */_$.intersection(5, _scope => {
   } = _scope;
   _$.data(_scope["#text/0"], (dummy, value));
 });
-const _dummy = /* @__PURE__ */_$.state("dummy/4", (_scope, dummy) => _expr_value_dummy(_scope));
-export const _value_ = /* @__PURE__ */_$.value("value", (_scope, value) => _expr_value_dummy(_scope));
+const _dummy = /* @__PURE__ */_$.state("dummy/4", _scope => _expr_value_dummy(_scope));
+export const _value_ = /* @__PURE__ */_$.value("value", _scope => _expr_value_dummy(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _value_(_scope, input.value));
 export function _setup_(_scope) {
   _dummy(_scope, {});

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 207 (min) 150 (brotli)
+// size: 203 (min) 152 (brotli)
 const _expr_value_dummy = _$.intersection(5, (_scope) => {
     const { 3: value, 4: dummy } = _scope;
     _$.data(_scope[0], value);
   }),
-  _value_ = _$.value(3, (_scope, value) => _expr_value_dummy(_scope)),
+  _value_ = _$.value(3, (_scope) => _expr_value_dummy(_scope)),
   _count_effect = _$.effect("b0", (_scope, { 2: count }) =>
     _$.on(_scope[1], "click", function () {
       _count(_scope, count + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/tags/counter.js
@@ -13,11 +13,11 @@ const _count_effect = _$.effect("__tests__/tags/counter.marko_0_count", (_scope,
 }) => _$.on(_scope["#button/0"], "click", function () {
   _count(_scope, count + 1), count;
 }));
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => {
+const _count = /* @__PURE__ */_$.state("count/4", _scope => {
   _expr_input_count(_scope);
   _count_effect(_scope);
 });
-export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _expr_input_count(_scope));
+export const _input_ = /* @__PURE__ */_$.value("input", _scope => _expr_input_count(_scope));
 export function _setup_(_scope) {
   _count(_scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 295 (min) 173 (brotli)
+// size: 291 (min) 177 (brotli)
 const _expr_input_count = _$.intersection(5, (_scope) => {
     const { 3: input, 4: count } = _scope;
     _$.data(_scope[1], input.format(count));
@@ -8,7 +8,7 @@ const _expr_input_count = _$.intersection(5, (_scope) => {
       _count(_scope, count + 1);
     }),
   ),
-  _count = _$.state(4, (_scope, count) => {
+  _count = _$.state(4, (_scope) => {
     _expr_input_count(_scope), _count_effect(_scope);
   });
 _$.register("b0", function (n) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/dom.expected/template.js
@@ -10,7 +10,7 @@ const _expr_checkedValue__checkedValueChange = /* @__PURE__ */_$.intersection(6,
   _$.controllable_input_checkedValue(_scope, "#input/1", checkedValue, _checkedValueChange, "b");
   _$.controllable_input_checkedValue(_scope, "#input/2", checkedValue, _checkedValueChange, "c");
 });
-const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", (_scope, _checkedValueChange) => _expr_checkedValue__checkedValueChange(_scope));
+const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", _scope => _expr_checkedValue__checkedValueChange(_scope));
 const _checkedValue = /* @__PURE__ */_$.state("checkedValue/4", (_scope, checkedValue) => {
   _$.data(_scope["#text/3"], checkedValue);
   _expr_checkedValue__checkedValueChange(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.expected/template.js
@@ -23,7 +23,7 @@ const _expr_checkedValue__checkedValueChange = /* @__PURE__ */_$.intersection(6,
     value: "c"
   });
 });
-const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", (_scope, _checkedValueChange) => _expr_checkedValue__checkedValueChange(_scope));
+const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", _scope => _expr_checkedValue__checkedValueChange(_scope));
 const _checkedValue = /* @__PURE__ */_$.state("checkedValue/4", (_scope, checkedValue) => {
   _$.data(_scope["#text/3"], checkedValue);
   _expr_checkedValue__checkedValueChange(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/dom.expected/template.js
@@ -10,7 +10,7 @@ const _expr_checkedValue__checkedValueChange = /* @__PURE__ */_$.intersection(6,
   _$.controllable_input_checkedValue(_scope, "#input/1", checkedValue, _checkedValueChange, "b");
   _$.controllable_input_checkedValue(_scope, "#input/2", checkedValue, _checkedValueChange, "c");
 });
-const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", (_scope, _checkedValueChange) => _expr_checkedValue__checkedValueChange(_scope));
+const _checkedValueChange2 = /* @__PURE__ */_$.value("_checkedValueChange", _scope => _expr_checkedValue__checkedValueChange(_scope));
 const _checkedValue = /* @__PURE__ */_$.state("checkedValue/4", (_scope, checkedValue) => {
   _$.data(_scope["#text/3"], checkedValue);
   _expr_checkedValue__checkedValueChange(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/dom.expected/template.js
@@ -30,7 +30,7 @@ const _expr_value_tag = /* @__PURE__ */_$.intersection(4, _scope => {
   }));
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", _tagSelect_content);
-const _tag = /* @__PURE__ */_$.value("tag", (_scope, tag) => _expr_value_tag(_scope));
+const _tag = /* @__PURE__ */_$.value("tag", _scope => _expr_value_tag(_scope));
 const _value = /* @__PURE__ */_$.state("value/2", (_scope, value) => {
   _$.data(_scope["#text/1"], value);
   _expr_value_tag(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.expected/template.js
@@ -14,9 +14,9 @@ const _expr_input_from_input_to_input_step = /* @__PURE__ */_$.intersection(6, _
   _for(_scope, [input_to, input_from, input_step]);
 }, 2);
 const _for = /* @__PURE__ */_$.loopTo("#div/0", _for_content);
-export const _input_step_ = /* @__PURE__ */_$.value("input_step", (_scope, input_step) => _expr_input_from_input_to_input_step(_scope));
-export const _input_to_ = /* @__PURE__ */_$.value("input_to", (_scope, input_to) => _expr_input_from_input_to_input_step(_scope));
-export const _input_from_ = /* @__PURE__ */_$.value("input_from", (_scope, input_from) => _expr_input_from_input_to_input_step(_scope));
+export const _input_step_ = /* @__PURE__ */_$.value("input_step", _scope => _expr_input_from_input_to_input_step(_scope));
+export const _input_to_ = /* @__PURE__ */_$.value("input_to", _scope => _expr_input_from_input_to_input_step(_scope));
+export const _input_from_ = /* @__PURE__ */_$.value("input_from", _scope => _expr_input_from_input_to_input_step(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_from_(_scope, input.from);
   _input_to_(_scope, input.to);

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 341 (min) 195 (brotli)
+// size: 337 (min) 195 (brotli)
 const _value = _$.state(3, (_scope, value) => _$.tagVarSignal(_scope, value));
 _$.register("a0", function (_scope) {
   return (_new_value) => {
@@ -18,6 +18,6 @@ const _count$myTag_content_effect = _$.effect(
   _count_closure = _$.dynamicClosure(_count$myTag_content);
 _$.registerBoundSignal(
   "c2",
-  _$.value(3, (_scope, count) => _count_closure(_scope)),
+  _$.value(3, (_scope) => _count_closure(_scope)),
 ),
   init();

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const _count$myTag_content = /* @__PURE__ */_$.dynamicClosureRead("count", (_sco
 });
 const _myTag_content = /* @__PURE__ */_$.createContent("__tests__/template.marko_1_renderer", "<button> </button>", /* get, next(1), get */" D ", 0, 0, _scope => _count$myTag_content(_scope));
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$myTag_content);
-const _count = _$.registerBoundSignal("__tests__/template.marko_0_count/var", /* @__PURE__ */_$.value("count", (_scope, count) => _count_closure(_scope)));
+const _count = _$.registerBoundSignal("__tests__/template.marko_0_count/var", /* @__PURE__ */_$.value("count", _scope => _count_closure(_scope)));
 export function _setup_(_scope) {
   _$.setTagVar(_scope, "#childScope/0", _count);
   _myLet(_scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/tags/custom-tag.js
@@ -28,7 +28,7 @@ const _x = /* @__PURE__ */_$.state("x/7", (_scope, x) => {
   _expr_x_y(_scope);
   _expr_input_content_x_y(_scope);
 });
-export const _input_content_ = /* @__PURE__ */_$.value("input_content", (_scope, input_content) => _expr_input_content_x_y(_scope));
+export const _input_content_ = /* @__PURE__ */_$.value("input_content", _scope => _expr_input_content_x_y(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_content_(_scope, input.content));
 export function _setup_(_scope) {
   _x(_scope, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/tags/custom-tag.js
@@ -23,8 +23,8 @@ const _x = /* @__PURE__ */_$.state("x/7", (_scope, x) => {
   _expr_input_content_input_name_x(_scope);
   _x_effect(_scope);
 });
-export const _input_name_ = /* @__PURE__ */_$.value("input_name", (_scope, input_name) => _expr_input_content_input_name_x(_scope));
-export const _input_content_ = /* @__PURE__ */_$.value("input_content", (_scope, input_content) => _expr_input_content_input_name_x(_scope));
+export const _input_name_ = /* @__PURE__ */_$.value("input_name", _scope => _expr_input_content_input_name_x(_scope));
+export const _input_content_ = /* @__PURE__ */_$.value("input_content", _scope => _expr_input_content_input_name_x(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_content_(_scope, input.content);
   _input_name_(_scope, input.name);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/tags/custom-tag.js
@@ -19,7 +19,7 @@ const _x = /* @__PURE__ */_$.state("x/6", (_scope, x) => {
   _expr_input_content_x(_scope);
   _x_effect(_scope);
 });
-export const _input_content_ = /* @__PURE__ */_$.value("input_content", (_scope, input_content) => _expr_input_content_x(_scope));
+export const _input_content_ = /* @__PURE__ */_$.value("input_content", _scope => _expr_input_content_x(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_content_(_scope, input.content));
 export function _setup_(_scope) {
   _x(_scope, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/tags/child.js
@@ -18,7 +18,7 @@ const _x = /* @__PURE__ */_$.state("x/5", (_scope, x) => {
   _expr_input_extra_x(_scope);
   _x_effect(_scope);
 });
-export const _input_extra_ = /* @__PURE__ */_$.value("input_extra", (_scope, input_extra) => _expr_input_extra_x(_scope));
+export const _input_extra_ = /* @__PURE__ */_$.value("input_extra", _scope => _expr_input_extra_x(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_extra_(_scope, input.extra));
 export function _setup_(_scope) {
   _x(_scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 352 (min) 226 (brotli)
+// size: 348 (min) 226 (brotli)
 const _expr_input_extra_x = _$.intersection(6, (_scope) => {
     const { 4: input_extra, 5: x } = _scope;
     _$.tagVarSignal(_scope, x + input_extra);
@@ -23,6 +23,6 @@ const _expr_input_extra_x = _$.intersection(6, (_scope) => {
   _message = _$.value(6, (_scope, message) => _$.data(_scope[2], message));
 _$.registerBoundSignal(
   "b0",
-  _$.value(4, (_scope, data) => _expr_name_data(_scope)),
+  _$.value(4, (_scope) => _expr_name_data(_scope)),
 ),
   init();

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.js
@@ -10,8 +10,8 @@ const _expr_name_data = /* @__PURE__ */_$.intersection(5, _scope => {
   _message(_scope, `${name} ${data}`);
 }, 1, "#scopeOffset/1");
 const _message = /* @__PURE__ */_$.value("message", (_scope, message) => _$.data(_scope["#text/2"], message));
-const _data = _$.registerBoundSignal("__tests__/template.marko_0_data/var", /* @__PURE__ */_$.value("data", (_scope, data) => _expr_name_data(_scope)));
-const _name = /* @__PURE__ */_$.state("name/3", (_scope, name) => _expr_name_data(_scope));
+const _data = _$.registerBoundSignal("__tests__/template.marko_0_data/var", /* @__PURE__ */_$.value("data", _scope => _expr_name_data(_scope)));
+const _name = /* @__PURE__ */_$.state("name/3", _scope => _expr_name_data(_scope));
 export function _setup_(_scope) {
   _$.setTagVar(_scope, "#childScope/0", _data);
   _child(_scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/dom.expected/tags/child.js
@@ -8,8 +8,8 @@ const _expr_x_y = /* @__PURE__ */_$.intersection(2, _scope => {
   } = _scope;
   _$.tagVarSignal(_scope, x + y);
 });
-const _y = /* @__PURE__ */_$.state("y/1", (_scope, y) => _expr_x_y(_scope));
-const _x = /* @__PURE__ */_$.state("x/0", (_scope, x) => _expr_x_y(_scope));
+const _y = /* @__PURE__ */_$.state("y/1", _scope => _expr_x_y(_scope));
+const _x = /* @__PURE__ */_$.state("x/0", _scope => _expr_x_y(_scope));
 export function _setup_(_scope) {
   _x(_scope, 1);
   _y(_scope, 2);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
@@ -18,7 +18,7 @@ const _expr_x_MyTag = /* @__PURE__ */_$.intersection(5, _scope => {
   _dynamicTag(_scope, MyTag, () => [1, "Hello", x]);
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", 0, 0, 1);
-const _MyTag = /* @__PURE__ */_$.value("MyTag", (_scope, MyTag) => _expr_x_MyTag(_scope));
+const _MyTag = /* @__PURE__ */_$.value("MyTag", _scope => _expr_x_MyTag(_scope));
 const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
   x
 }) => _$.on(_scope["#button/1"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
@@ -15,7 +15,7 @@ const _expr_x_MyTag = /* @__PURE__ */_$.intersection(5, _scope => {
   }));
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0");
-const _MyTag = /* @__PURE__ */_$.value("MyTag", (_scope, MyTag) => _expr_x_MyTag(_scope));
+const _MyTag = /* @__PURE__ */_$.value("MyTag", _scope => _expr_x_MyTag(_scope));
 const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
   x
 }) => _$.on(_scope["#button/1"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 232 (min) 147 (brotli)
+// size: 228 (min) 146 (brotli)
 const _c$if_content = _$.dynamicClosureRead(
     4,
     (_scope, c) => _$.data(_scope[2], c),
@@ -8,7 +8,7 @@ const _c$if_content = _$.dynamicClosureRead(
     _$.data(_scope[2], c),
   ),
   _c_closure = _$.dynamicClosure(_c$customTag_content, _c$if_content),
-  _c = _$.state(4, (_scope, c) => _c_closure(_scope));
+  _c = _$.state(4, (_scope) => _c_closure(_scope));
 _$.effect("b1", (_scope) =>
   _$.on(_scope[0], "click", function () {
     _c(_scope, 4);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.expected/template.js
@@ -28,7 +28,7 @@ const _customTag_content = /* @__PURE__ */_$.createContent("__tests__/template.m
 });
 const _if = /* @__PURE__ */_$.conditional("#div/2", _if_content);
 const _c_closure = /* @__PURE__ */_$.dynamicClosure(_c$customTag_content, _c$if_content);
-const _c = /* @__PURE__ */_$.state("c/4", (_scope, c) => _c_closure(_scope));
+const _c = /* @__PURE__ */_$.state("c/4", _scope => _c_closure(_scope));
 const _b = /* @__PURE__ */_$.value("b");
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => _$.on(_scope["#button/0"], "click", function () {
   _c(_scope, 4);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 266 (min) 177 (brotli)
+// size: 262 (min) 175 (brotli)
 const _tagName_content = _$.registerContent("a0", "body content"),
   _expr_tagName_className = _$.intersection(4, (_scope) => {
     const { 2: tagName, 3: className } = _scope;
@@ -10,7 +10,7 @@ const _tagName_content = _$.registerContent("a0", "body content"),
       _tagName(_scope, "span" === tagName ? "div" : "span");
     }),
   ),
-  _tagName = _$.state(2, (_scope, tagName) => {
+  _tagName = _$.state(2, (_scope) => {
     _expr_tagName_className(_scope), _tagName_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -12,13 +12,13 @@ const _expr_tagName_className = /* @__PURE__ */_$.intersection(4, _scope => {
   }));
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", _tagName_content);
-const _className = /* @__PURE__ */_$.state("className/3", (_scope, className) => _expr_tagName_className(_scope));
+const _className = /* @__PURE__ */_$.state("className/3", _scope => _expr_tagName_className(_scope));
 const _tagName_effect = _$.effect("__tests__/template.marko_0_tagName", (_scope, {
   tagName
 }) => _$.on(_scope["#button/1"], "click", function () {
   _tagName(_scope, tagName === "span" ? "div" : "span");
 }));
-const _tagName = /* @__PURE__ */_$.state("tagName/2", (_scope, tagName) => {
+const _tagName = /* @__PURE__ */_$.state("tagName/2", _scope => {
   _expr_tagName_className(_scope);
   _tagName_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 518 (min) 256 (brotli)
+// size: 514 (min) 253 (brotli)
 const _setup_$1 = () => {},
   _value_$1 = _$.value(3, (_scope, value) => _$.data(_scope[0], value)),
   _input_$1 = _$.value(2, (_scope, input) => _value_$1(_scope, input.value));
@@ -29,7 +29,7 @@ const _expr_tagName_val = _$.intersection(4, (_scope) => {
       _tagName(_scope, tagName === child1 ? child2 : child1);
     }),
   ),
-  _tagName = _$.state(2, (_scope, tagName) => {
+  _tagName = _$.state(2, (_scope) => {
     _expr_tagName_val(_scope), _tagName_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -13,13 +13,13 @@ const _expr_tagName_val = /* @__PURE__ */_$.intersection(4, _scope => {
   }));
 });
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0");
-const _val = /* @__PURE__ */_$.state("val/3", (_scope, val) => _expr_tagName_val(_scope));
+const _val = /* @__PURE__ */_$.state("val/3", _scope => _expr_tagName_val(_scope));
 const _tagName_effect = _$.effect("__tests__/template.marko_0_tagName", (_scope, {
   tagName
 }) => _$.on(_scope["#button/1"], "click", function () {
   _tagName(_scope, tagName === child1 ? child2 : child1);
 }));
-const _tagName = /* @__PURE__ */_$.state("tagName/2", (_scope, tagName) => {
+const _tagName = /* @__PURE__ */_$.state("tagName/2", _scope => {
   _expr_tagName_val(_scope);
   _tagName_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.expected/template.js
@@ -140,9 +140,9 @@ const _dynamicTag4 = /* @__PURE__ */_$.dynamicTag("#text/3");
 const _dynamicTag3 = /* @__PURE__ */_$.dynamicTag("#text/2");
 const _dynamicTag2 = /* @__PURE__ */_$.dynamicTag("#text/1");
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0");
-const _tagConstB = /* @__PURE__ */_$.value("tagConstB", (_scope, tagConstB) => _expr_other_tagConstB(_scope));
-const _tagConstA = /* @__PURE__ */_$.value("tagConstA", (_scope, tagConstA) => _expr_other_tagConstA(_scope));
-const _largeHeading = /* @__PURE__ */_$.value("largeHeading", (_scope, largeHeading) => _expr_other_largeHeading(_scope));
+const _tagConstB = /* @__PURE__ */_$.value("tagConstB", _scope => _expr_other_tagConstB(_scope));
+const _tagConstA = /* @__PURE__ */_$.value("tagConstA", _scope => _expr_other_tagConstA(_scope));
+const _largeHeading = /* @__PURE__ */_$.value("largeHeading", _scope => _expr_other_largeHeading(_scope));
 export const _other_ = /* @__PURE__ */_$.value("other", (_scope, other) => {
   _dynamicTag11(_scope, global.x = "a" + "b", () => ({
     class: ["a", "b"],
@@ -159,19 +159,19 @@ export const _other_ = /* @__PURE__ */_$.value("other", (_scope, other) => {
   _expr_other_tagConstA(_scope);
   _expr_other_tagConstB(_scope);
 });
-export const _level_ = /* @__PURE__ */_$.value("level", (_scope, level) => _expr_level_other(_scope));
-export const _tag_ = /* @__PURE__ */_$.value("tag", (_scope, tag) => _expr_tag_other(_scope));
+export const _level_ = /* @__PURE__ */_$.value("level", _scope => _expr_level_other(_scope));
+export const _tag_ = /* @__PURE__ */_$.value("tag", _scope => _expr_tag_other(_scope));
 export const _isLarge_ = /* @__PURE__ */_$.value("isLarge", (_scope, isLarge) => {
   _largeHeading(_scope, isLarge && "h1");
   _expr_isLarge_other(_scope);
 });
-export const _showTagA_ = /* @__PURE__ */_$.value("showTagA", (_scope, showTagA) => _expr_showTagA_other(_scope));
+export const _showTagA_ = /* @__PURE__ */_$.value("showTagA", _scope => _expr_showTagA_other(_scope));
 export const _show_ = /* @__PURE__ */_$.value("show", (_scope, show) => {
   _tagConstB(_scope, show ? "div" : null);
   _expr_show_other(_scope);
 });
-export const _x_ = /* @__PURE__ */_$.value("x", (_scope, x) => _expr_x_other(_scope));
-export const _content_ = /* @__PURE__ */_$.value("content", (_scope, content) => _expr_content_other(_scope));
+export const _x_ = /* @__PURE__ */_$.value("x", _scope => _expr_x_other(_scope));
+export const _content_ = /* @__PURE__ */_$.value("content", _scope => _expr_content_other(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _content_(_scope, input.content);
   _x_(_scope, input.x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 475 (min) 258 (brotli)
+// size: 471 (min) 252 (brotli)
 const _x_effect = _$.effect("a1", (_scope, { 2: x }) =>
     _$.on(_scope[0], "click", function () {
       _x(_scope, x + 1);
@@ -22,7 +22,7 @@ var Counter = _$.createTemplate(
   " D l",
   _setup_,
 );
-_$.registerBoundSignal("b1", (_scope, count) => {}),
+_$.registerBoundSignal("b1", (_scope) => {}),
   _$.effect("b2", (_scope) =>
     _$.on(_scope[2], "click", function () {
       _$.tagVarSignalChange(_scope.d0, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import Counter from "./tags/counter.marko";
 const getCounter = _getCounter;
 import * as _$ from "@marko/runtime-tags/debug/dom";
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", 0, () => _count);
-const _count = _$.registerBoundSignal("__tests__/template.marko_0_count/var", (_scope, count) => {});
+const _count = _$.registerBoundSignal("__tests__/template.marko_0_count/var", _scope => {});
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => _$.on(_scope["#button/2"], "click", function () {
   _$.tagVarSignalChange(_scope["ConditionalScope:#text/0"], 0);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/__snapshots__/dom.expected/template.js
@@ -6,8 +6,8 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _dynamicTag3 = /* @__PURE__ */_$.dynamicTag("#text/6", 0, () => _el);
 const _dynamicTag2 = /* @__PURE__ */_$.dynamicTag("#text/4", 0, () => _data3);
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/2", 0, () => _data2);
-const _el = _$.registerBoundSignal("__tests__/template.marko_0_el1/var", (_scope, el1) => {});
-const _data3 = _$.registerBoundSignal("__tests__/template.marko_0_data3/var", (_scope, data3) => {});
+const _el = _$.registerBoundSignal("__tests__/template.marko_0_el1/var", _scope => {});
+const _data3 = _$.registerBoundSignal("__tests__/template.marko_0_data3/var", _scope => {});
 export const _input_dynamic_ = /* @__PURE__ */_$.value("input_dynamic", (_scope, input_dynamic) => _dynamicTag2(_scope, input_dynamic));
 export const _input_show_ = /* @__PURE__ */_$.value("input_show", (_scope, input_show) => {
   _dynamicTag(_scope, input_show && child);
@@ -17,8 +17,8 @@ export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_show_(_scope, input.show);
   _input_dynamic_(_scope, input.dynamic);
 });
-const _data2 = _$.registerBoundSignal("__tests__/template.marko_0_data2/var", (_scope, data2) => {});
-const _data = _$.registerBoundSignal("__tests__/template.marko_0_data1/var", (_scope, data1) => {});
+const _data2 = _$.registerBoundSignal("__tests__/template.marko_0_data2/var", _scope => {});
+const _data = _$.registerBoundSignal("__tests__/template.marko_0_data1/var", _scope => {});
 export function _setup_(_scope) {
   _$.setTagVar(_scope, "#childScope/0", _data);
   _child(_scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/dom.expected/template.js
@@ -11,10 +11,10 @@ const _expr_user_fullName_user_firstName_user_middleName_user_lastName = /* @__P
   _fullName(_scope, user_fullName = `${user_firstName} ${user_middleName} ${user_lastName}`);
 }, 3);
 const _fullName = /* @__PURE__ */_$.value("fullName", (_scope, fullName) => _$.data(_scope["#text/0"], fullName));
-const _user_lastName = /* @__PURE__ */_$.value("user_lastName", (_scope, user_lastName) => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
-const _user_middleName = /* @__PURE__ */_$.value("user_middleName", (_scope, user_middleName) => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
-const _user_firstName = /* @__PURE__ */_$.value("user_firstName", (_scope, user_firstName) => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
-const _user_fullName = /* @__PURE__ */_$.value("user_fullName", (_scope, user_fullName) => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
+const _user_lastName = /* @__PURE__ */_$.value("user_lastName", _scope => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
+const _user_middleName = /* @__PURE__ */_$.value("user_middleName", _scope => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
+const _user_firstName = /* @__PURE__ */_$.value("user_firstName", _scope => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
+const _user_fullName = /* @__PURE__ */_$.value("user_fullName", _scope => _expr_user_fullName_user_firstName_user_middleName_user_lastName(_scope));
 const _user = /* @__PURE__ */_$.value("user", (_scope, user) => {
   _user_fullName(_scope, user.fullName);
   _user_firstName(_scope, user.firstName);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-sync/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-sync/__snapshots__/dom.expected/template.js
@@ -1,6 +1,6 @@
 export const _template_ = "a";
 export const _walks_ = /* over(1) */"b";
-const _2 = (_scope, _) => {};
+const _2 = _scope => {};
 export function _setup_(_scope) {
   _2(_scope, (() => {
     throw new Error("ERROR!");

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
@@ -27,7 +27,7 @@ const _items = /* @__PURE__ */_$.state("items/3", (_scope, items) => {
   _for(_scope, [items]);
   _items_effect(_scope);
 });
-const _id = (_scope, id) => {};
+const _id = _scope => {};
 export function _setup_(_scope) {
   _id(_scope, 0);
   _items(_scope, [{

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 313 (min) 207 (brotli)
+// size: 309 (min) 204 (brotli)
 const _i$for_content = _$.value(3, (_scope, i) => _$.data(_scope[1], i)),
   _params_2$for_content = _$.value(2, (_scope, _params_2) =>
     _i$for_content(_scope, _params_2[0]),
@@ -8,7 +8,7 @@ const _i$for_content = _$.value(3, (_scope, i) => _$.data(_scope[1], i)),
       _num(_scope._, num + 1);
     }),
   ),
-  _num$for_content = _$.loopClosure(1, 0, (_scope, num) =>
+  _num$for_content = _$.loopClosure(1, 0, (_scope) =>
     _num$for_content_effect(_scope),
   ),
   _for_content = _$.createRenderer(

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
@@ -10,7 +10,7 @@ const _num$for_content_effect = _$.effect("__tests__/template.marko_1_num", (_sc
 }) => _$.on(_scope["#button/0"], "click", function () {
   _num(_scope._, num + 1), num;
 }));
-const _num$for_content = /* @__PURE__ */_$.loopClosure("num", "#text/0", (_scope, num) => _num$for_content_effect(_scope));
+const _num$for_content = /* @__PURE__ */_$.loopClosure("num", "#text/0", _scope => _num$for_content_effect(_scope));
 const _for_content = /* @__PURE__ */_$.createRenderer("<button> </button>", /* get, next(1), get */" D ", 0, _params_2$for_content, _scope => _num$for_content._(_scope));
 const _for = /* @__PURE__ */_$.loopTo("#text/0", _for_content);
 const _num = /* @__PURE__ */_$.state("num/1", (_scope, num) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _hoisted_setHtml_effect = _$.effect("__tests__/template.marko_0__hoisted_s
     fn('Hoist from custom tag');
   }
 });
-const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", (_scope, _hoisted_setHtml) => _hoisted_setHtml_effect(_scope));
+const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", _scope => _hoisted_setHtml_effect(_scope));
 export function _setup_(_scope) {
   _thing(_scope["#childScope/0"]);
   _thing_input_what(_scope["#childScope/0"], _$.attrTag({

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
@@ -39,7 +39,7 @@ const _hoisted_setHtml_effect = _$.effect("__tests__/template.marko_0__hoisted_s
     fn('Hoist from custom tag');
   }
 });
-const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", (_scope, _hoisted_setHtml) => _hoisted_setHtml_effect(_scope));
+const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", _scope => _hoisted_setHtml_effect(_scope));
 export const _input_show_ = /* @__PURE__ */_$.value("input_show", (_scope, input_show) => {
   _dynamicTag(_scope, input_show ? Thing : null);
   _dynamicTag2(_scope, input_show ? 'section' : null);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.expected/template.js
@@ -43,7 +43,7 @@ const _hoisted_setHtml_effect = _$.effect("__tests__/template.marko_0__hoisted_s
     }
   }
 });
-const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml3", (_scope, _hoisted_setHtml3) => _hoisted_setHtml_effect(_scope));
+const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml3", _scope => _hoisted_setHtml_effect(_scope));
 const _to = /* @__PURE__ */_$.state("to/3", (_scope, to) => _for2(_scope, [to, 0, 1]));
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => {
   _get_hoisted_setHtml3(_scope)('First Only');

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.expected/tags/thing.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.expected/tags/thing.js
@@ -5,6 +5,6 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _input_value__effect = _$.effect("__tests__/tags/thing.marko_0_input_value", ({
   input_value
 }) => input_value);
-export const _input_value_ = /* @__PURE__ */_$.value("input_value", (_scope, input_value) => _input_value__effect(_scope));
+export const _input_value_ = /* @__PURE__ */_$.value("input_value", _scope => _input_value__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_value_(_scope, input.value));
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/thing.marko", _template_, _walks_, _setup_, _input_);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
@@ -39,7 +39,7 @@ const _hoisted_setHtml_effect = _$.effect("__tests__/template.marko_0__hoisted_s
     fn('Hoist from custom tag');
   }
 });
-const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", (_scope, _hoisted_setHtml) => _hoisted_setHtml_effect(_scope));
+const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml", _scope => _hoisted_setHtml_effect(_scope));
 export const _input_show_ = /* @__PURE__ */_$.value("input_show", (_scope, input_show) => {
   _dynamicTag(_scope, input_show ? Thing : null);
   _dynamicTag2(_scope, input_show ? 'section' : null);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/dom.expected/template.js
@@ -43,7 +43,7 @@ const _hoisted_setHtml_effect = _$.effect("__tests__/template.marko_0__hoisted_s
     }
   }
 });
-const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml3", (_scope, _hoisted_setHtml3) => _hoisted_setHtml_effect(_scope));
+const _hoisted_setHtml = /* @__PURE__ */_$.value("_hoisted_setHtml3", _scope => _hoisted_setHtml_effect(_scope));
 const _to = /* @__PURE__ */_$.state("to/3", (_scope, to) => _for2(_scope, [to, 0, 1]));
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => {
   _get_hoisted_setHtml3(_scope)('First Only');

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.expected/tags/thing.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.expected/tags/thing.js
@@ -5,6 +5,6 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _input_value__effect = _$.effect("__tests__/tags/thing.marko_0_input_value", ({
   input_value
 }) => input_value);
-export const _input_value_ = /* @__PURE__ */_$.value("input_value", (_scope, input_value) => _input_value__effect(_scope));
+export const _input_value_ = /* @__PURE__ */_$.value("input_value", _scope => _input_value__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_value_(_scope, input.value));
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/thing.marko", _template_, _walks_, _setup_, _input_);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 773 (min) 360 (brotli)
+// size: 769 (min) 332 (brotli)
 const _dynamicTag2 = _$.dynamicTag(1),
   _dynamicTag = _$.dynamicTag(),
   _input_content_ = _$.value(4, (_scope, input_content) => {
@@ -23,10 +23,8 @@ const _child_content2 = _$.createContent(
       for (const element of 1) element().classList.add("inner");
     },
   ),
-  _hoisted_el2$inputShowChildNull_content = _$.value(
-    1,
-    (_scope, _hoisted_el2) =>
-      _hoisted_el2$inputShowChildNull_content_effect(_scope),
+  _hoisted_el2$inputShowChildNull_content = _$.value(1, (_scope) =>
+    _hoisted_el2$inputShowChildNull_content_effect(_scope),
   );
 _$.registerContent(
   "b4",

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.expected/template.js
@@ -15,7 +15,7 @@ const _hoisted_el2$inputShowChildNull_content_effect = _$.effect("__tests__/temp
     element().classList.add('inner');
   }
 });
-const _hoisted_el2$inputShowChildNull_content = /* @__PURE__ */_$.value("_hoisted_el2", (_scope, _hoisted_el2) => _hoisted_el2$inputShowChildNull_content_effect(_scope));
+const _hoisted_el2$inputShowChildNull_content = /* @__PURE__ */_$.value("_hoisted_el2", _scope => _hoisted_el2$inputShowChildNull_content_effect(_scope));
 const _setup$inputShowChildNull_content = _scope => {
   _child(_scope["#childScope/0"]);
   _child_input_content(_scope["#childScope/0"], _child_content2(_scope));
@@ -33,7 +33,7 @@ const _hoisted_el2_effect = _$.effect("__tests__/template.marko_0__hoisted_el3",
     element().classList.add('outer');
   }
 });
-const _hoisted_el2 = /* @__PURE__ */_$.value("_hoisted_el3", (_scope, _hoisted_el3) => _hoisted_el2_effect(_scope));
+const _hoisted_el2 = /* @__PURE__ */_$.value("_hoisted_el3", _scope => _hoisted_el2_effect(_scope));
 const _hoisted_el_effect = _$.effect("__tests__/template.marko_0__hoisted_el", ({
   _hoisted_el
 }) => {
@@ -41,7 +41,7 @@ const _hoisted_el_effect = _$.effect("__tests__/template.marko_0__hoisted_el", (
     element().innerHTML = 'Hoist from custom tag';
   }
 });
-const _hoisted_el = /* @__PURE__ */_$.value("_hoisted_el", (_scope, _hoisted_el) => _hoisted_el_effect(_scope));
+const _hoisted_el = /* @__PURE__ */_$.value("_hoisted_el", _scope => _hoisted_el_effect(_scope));
 export const _input_show_ = /* @__PURE__ */_$.value("input_show", (_scope, input_show) => {
   _dynamicTag(_scope, input_show ? Child : null);
   _dynamicTag2(_scope, input_show ? 'section' : null);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/dom.expected/template.js
@@ -11,8 +11,8 @@ const _expr_i_j$for_content = /* @__PURE__ */_$.intersection(3, _scope => {
   } = _scope;
   _$.attr(_scope["#li/0"], "data-index", i * 4 + j);
 });
-const _i$for_content = /* @__PURE__ */_$.loopClosure("i", "#ul/0", (_scope, i) => _expr_i_j$for_content(_scope));
-const _j$for_content = /* @__PURE__ */_$.value("j", (_scope, j) => _expr_i_j$for_content(_scope));
+const _i$for_content = /* @__PURE__ */_$.loopClosure("i", "#ul/0", _scope => _expr_i_j$for_content(_scope));
+const _j$for_content = /* @__PURE__ */_$.value("j", _scope => _expr_i_j$for_content(_scope));
 const _params_3$for_content = /* @__PURE__ */_$.value("_params_3", (_scope, _params_3) => _j$for_content(_scope, _params_3[0]));
 const _for_content4 = /* @__PURE__ */_$.createRenderer("<li></li>", /* get */" ", 0, _params_3$for_content, _scope => _i$for_content._(_scope));
 const _for$for_content = /* @__PURE__ */_$.loopTo("#ul/0", _for_content4);
@@ -39,7 +39,7 @@ const _hoisted_el_effect = _$.effect("__tests__/template.marko_0__hoisted_el3", 
     }
   }
 });
-const _hoisted_el = /* @__PURE__ */_$.value("_hoisted_el3", (_scope, _hoisted_el3) => _hoisted_el_effect(_scope));
+const _hoisted_el = /* @__PURE__ */_$.value("_hoisted_el3", _scope => _hoisted_el_effect(_scope));
 const _to = /* @__PURE__ */_$.state("to/3", (_scope, to) => _for2(_scope, [to, 0, 1]));
 const _setup__effect = _$.effect("__tests__/template.marko_0", _scope => {
   {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/__snapshots__/dom.expected/tags/child.js
@@ -6,5 +6,5 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _input__effect = _$.effect("__tests__/tags/child.marko_0_input", ({
   input
 }) => input.value()?.classList.add(`child${id++}`));
-export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input__effect(_scope));
+export const _input_ = /* @__PURE__ */_$.value("input", _scope => _input__effect(_scope));
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/child.marko", _template_, _walks_, _setup_, _input_);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.expected/template.js
@@ -25,10 +25,10 @@ const _expr_input_a_input_b = /* @__PURE__ */_$.intersection(7, _scope => {
 const _if3 = /* @__PURE__ */_$.conditional("#div/2", _if_content3, _elseIf_content, _else_content);
 const _if2 = /* @__PURE__ */_$.conditional("#text/1", _if_content2);
 const _if = /* @__PURE__ */_$.conditional("#text/0", _if_content);
-export const _input_y_ = /* @__PURE__ */_$.value("input_y", (_scope, input_y) => _expr_input_x_input_y(_scope));
-export const _input_x_ = /* @__PURE__ */_$.value("input_x", (_scope, input_x) => _expr_input_x_input_y(_scope));
-export const _input_b_ = /* @__PURE__ */_$.value("input_b", (_scope, input_b) => _expr_input_a_input_b(_scope));
-export const _input_a_ = /* @__PURE__ */_$.value("input_a", (_scope, input_a) => _expr_input_a_input_b(_scope));
+export const _input_y_ = /* @__PURE__ */_$.value("input_y", _scope => _expr_input_x_input_y(_scope));
+export const _input_x_ = /* @__PURE__ */_$.value("input_x", _scope => _expr_input_x_input_y(_scope));
+export const _input_b_ = /* @__PURE__ */_$.value("input_b", _scope => _expr_input_a_input_b(_scope));
+export const _input_a_ = /* @__PURE__ */_$.value("input_a", _scope => _expr_input_a_input_b(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_a_(_scope, input.a);
   _input_b_(_scope, input.b);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
@@ -27,7 +27,7 @@ const _state = /* @__PURE__ */_$.state("state/11", (_scope, state) => {
   _$.data(_scope["#text/2"], state);
   _state_effect(_scope);
 });
-const _input_valueChange = /* @__PURE__ */_$.value("input_valueChange", (_scope, input_valueChange) => _expr_input_value_input_valueChange(_scope));
+const _input_valueChange = /* @__PURE__ */_$.value("input_valueChange", _scope => _expr_input_value_input_valueChange(_scope));
 const _input_value = /* @__PURE__ */_$.value("input_value", (_scope, input_value) => {
   _$.data(_scope["#text/1"], input_value);
   _$.data(_scope["#text/4"], input_value);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 595 (min) 248 (brotli)
+// size: 591 (min) 250 (brotli)
 const _expr_input_value_input_valueChange = _$.intersection(10, (_scope) => {
     const { 8: input_value, 9: input_valueChange } = _scope;
     _state(_scope, input_value, input_valueChange);
@@ -19,7 +19,7 @@ const _expr_input_value_input_valueChange = _$.intersection(10, (_scope) => {
   _state = _$.state(11, (_scope, state) => {
     _$.data(_scope[2], state), _state_effect(_scope);
   }),
-  _input_valueChange = _$.value(9, (_scope, input_valueChange) =>
+  _input_valueChange = _$.value(9, (_scope) =>
     _expr_input_value_input_valueChange(_scope),
   ),
   _input_value = _$.value(8, (_scope, input_value) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 374 (min) 203 (brotli)
+// size: 370 (min) 195 (brotli)
 const _expr_x_yChange = _$.intersection(6, (_scope) => {
     const { 4: x, 5: yChange } = _scope;
     _y(_scope, x, yChange);
@@ -11,7 +11,7 @@ const _expr_x_yChange = _$.intersection(6, (_scope) => {
   _y = _$.state(7, (_scope, y) => {
     _$.data(_scope[2], y), _y_effect(_scope);
   }),
-  _yChange = _$.state(5, (_scope, yChange) => _expr_x_yChange(_scope)),
+  _yChange = _$.state(5, (_scope) => _expr_x_yChange(_scope)),
   _x = _$.state(4, (_scope, x) => {
     _$.data(_scope[1], x), _expr_x_yChange(_scope);
   });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _y = /* @__PURE__ */_$.state("y/7", (_scope, y) => {
   _$.data(_scope["#text/2"], y);
   _y_effect(_scope);
 });
-const _yChange = /* @__PURE__ */_$.state("yChange/5", (_scope, yChange) => _expr_x_yChange(_scope));
+const _yChange = /* @__PURE__ */_$.state("yChange/5", _scope => _expr_x_yChange(_scope));
 const _x = /* @__PURE__ */_$.state("x/4", (_scope, x) => {
   _$.data(_scope["#text/1"], x);
   _expr_x_yChange(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _y = /* @__PURE__ */_$.state("y/6", (_scope, y) => {
   _$.data(_scope["#text/2"], y);
   _y_effect(_scope);
 });
-const _handler = /* @__PURE__ */_$.state("handler/4", (_scope, handler) => _expr_x_handler(_scope));
+const _handler = /* @__PURE__ */_$.state("handler/4", _scope => _expr_x_handler(_scope));
 const _x = /* @__PURE__ */_$.state("x/3", (_scope, x) => {
   _$.data(_scope["#text/1"], x);
   _expr_x_handler(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const _x$if_content_effect = _$.effect("__tests__/template.marko_1_x", (_scope, 
     document.getElementById("ref").textContent = "Destroy";
   }
 }));
-const _x$if_content = /* @__PURE__ */_$.conditionalClosure("x", "#text/0", 0, (_scope, x) => _x$if_content_effect(_scope));
+const _x$if_content = /* @__PURE__ */_$.conditionalClosure("x", "#text/0", 0, _scope => _x$if_content_effect(_scope));
 const _if_content = /* @__PURE__ */_$.createRenderer(0, 0, 0, 0, _scope => _x$if_content._(_scope));
 const _if = /* @__PURE__ */_$.conditional("#text/0", _if_content);
 const _show_effect = _$.effect("__tests__/template.marko_0_show", (_scope, {
@@ -33,7 +33,7 @@ const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
 }) => _$.on(_scope["#button/1"], "click", function () {
   _x(_scope, x + 1), x;
 }));
-const _x = /* @__PURE__ */_$.state("x/3", (_scope, x) => {
+const _x = /* @__PURE__ */_$.state("x/3", _scope => {
   _x$if_content(_scope);
   _x_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 267 (min) 170 (brotli)
+// size: 263 (min) 161 (brotli)
 const _x_effect = _$.effect("a0", (_scope, { 1: x }) => {
     _$.lifecycle(_scope, 3, {
       onMount: function () {
@@ -14,5 +14,5 @@ const _x_effect = _$.effect("a0", (_scope, { 1: x }) => {
         _x(_scope, x + 1);
       });
   }),
-  _x = _$.state(1, (_scope, x) => _x_effect(_scope));
+  _x = _$.state(1, (_scope) => _x_effect(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
@@ -17,7 +17,7 @@ const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
     _x(_scope, x + 1), x;
   });
 });
-const _x = /* @__PURE__ */_$.state("x/1", (_scope, x) => _x_effect(_scope));
+const _x = /* @__PURE__ */_$.state("x/1", _scope => _x_effect(_scope));
 export function _setup_(_scope) {
   _x(_scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 280 (min) 148 (brotli)
+// size: 276 (min) 146 (brotli)
 const _x_effect = _$.effect("a0", (_scope, { 1: x }) => {
     _$.lifecycle(_scope, 3, {
       onMount: function () {
@@ -12,5 +12,5 @@ const _x_effect = _$.effect("a0", (_scope, { 1: x }) => {
         _x(_scope, x + 1);
       });
   }),
-  _x = _$.state(1, (_scope, x) => _x_effect(_scope));
+  _x = _$.state(1, (_scope) => _x_effect(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const _x_effect = _$.effect("__tests__/template.marko_0_x", (_scope, {
     _x(_scope, x + 1), x;
   });
 });
-const _x = /* @__PURE__ */_$.state("x/1", (_scope, x) => _x_effect(_scope));
+const _x = /* @__PURE__ */_$.state("x/1", _scope => _x_effect(_scope));
 export function _setup_(_scope) {
   _x(_scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/tags/2counters.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/tags/2counters.js
@@ -34,10 +34,10 @@ const _count = /* @__PURE__ */_$.state("count1/12", (_scope, count1) => {
   _$.data(_scope["#text/1"], count1);
   _count_effect(_scope);
 });
-export const _input_count2Change_ = /* @__PURE__ */_$.value("input_count2Change", (_scope, input_count2Change) => _expr_input_count2_input_count2Change(_scope));
-export const _input_count2_ = /* @__PURE__ */_$.value("input_count2", (_scope, input_count2) => _expr_input_count2_input_count2Change(_scope));
-export const _input_count1Change_ = /* @__PURE__ */_$.value("input_count1Change", (_scope, input_count1Change) => _expr_input_count1_input_count1Change(_scope));
-export const _input_count1_ = /* @__PURE__ */_$.value("input_count1", (_scope, input_count1) => _expr_input_count1_input_count1Change(_scope));
+export const _input_count2Change_ = /* @__PURE__ */_$.value("input_count2Change", _scope => _expr_input_count2_input_count2Change(_scope));
+export const _input_count2_ = /* @__PURE__ */_$.value("input_count2", _scope => _expr_input_count2_input_count2Change(_scope));
+export const _input_count1Change_ = /* @__PURE__ */_$.value("input_count1Change", _scope => _expr_input_count1_input_count1Change(_scope));
+export const _input_count1_ = /* @__PURE__ */_$.value("input_count1", _scope => _expr_input_count1_input_count1Change(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_count1_(_scope, input.count1);
   _input_count1Change_(_scope, input.count1Change);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 608 (min) 236 (brotli)
+// size: 600 (min) 233 (brotli)
 const _expr_input_count2_input_count2Change = _$.intersection(11, (_scope) => {
     const { 9: input_count2, 10: input_count2Change } = _scope;
     _count2$1(_scope, input_count2, input_count2Change);
@@ -23,10 +23,10 @@ const _expr_input_count2_input_count2Change = _$.intersection(11, (_scope) => {
   _count$1 = _$.state(12, (_scope, count1) => {
     _$.data(_scope[1], count1), _count_effect(_scope);
   }),
-  _input_count2_ = _$.value(9, (_scope, input_count2) =>
+  _input_count2_ = _$.value(9, (_scope) =>
     _expr_input_count2_input_count2Change(_scope),
   ),
-  _input_count1_ = _$.value(6, (_scope, input_count1) =>
+  _input_count1_ = _$.value(6, (_scope) =>
     _expr_input_count1_input_count1Change(_scope),
   ),
   _count2 = _$.state(4, (_scope, count2) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/tags/hello-setter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.expected/tags/hello-setter.js
@@ -5,6 +5,6 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _el__effect = _$.effect("__tests__/tags/hello-setter.marko_0_el", ({
   el
 }) => (el().textContent = "hello"));
-export const _el_ = /* @__PURE__ */_$.value("el", (_scope, el) => _el__effect(_scope));
+export const _el_ = /* @__PURE__ */_$.value("el", _scope => _el__effect(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _el_(_scope, input.el));
 export default /* @__PURE__ */_$.createTemplate("__tests__/tags/hello-setter.marko", _template_, _walks_, _setup_, _input_);

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 925 (min) 419 (brotli)
+// size: 909 (min) 418 (brotli)
 const _count$else_content = _$.conditionalClosure(2, 0, 1, (_scope, count) =>
     _$.data(_scope[1], count),
   ),
@@ -43,7 +43,7 @@ const _count$else_content = _$.conditionalClosure(2, 0, 1, (_scope, count) =>
     (_scope) => _expr_counts_count_i$if_content_effect(_scope),
     2,
   ),
-  _i$if_content = _$.conditionalClosure(3, 0, 0, (_scope, i) =>
+  _i$if_content = _$.conditionalClosure(3, 0, 0, (_scope) =>
     _expr_counts_count_i$if_content(_scope),
   ),
   _count$if_content = _$.conditionalClosure(2, 0, 0, (_scope, count) => {
@@ -51,7 +51,7 @@ const _count$else_content = _$.conditionalClosure(2, 0, 1, (_scope, count) =>
   }),
   _counts$if_content = _$.dynamicClosureRead(
     1,
-    (_scope, counts) => _expr_counts_count_i$if_content(_scope),
+    (_scope) => _expr_counts_count_i$if_content(_scope),
     (_scope) => _scope._._,
   ),
   _if_content = _$.createRenderer(
@@ -69,8 +69,8 @@ const _count$else_content = _$.conditionalClosure(2, 0, 1, (_scope, count) =>
   _editing$for_content = _$.state(4, (_scope, editing) =>
     _if$for_content(_scope, editing ? 0 : 1),
   ),
-  _i$for_content = _$.value(3, (_scope, i) => _i$if_content(_scope)),
-  _count$for_content = _$.value(2, (_scope, count) => {
+  _i$for_content = _$.value(3, (_scope) => _i$if_content(_scope)),
+  _count$for_content = _$.value(2, (_scope) => {
     _count$if_content(_scope), _count$else_content(_scope);
   }),
   _params_2$for_content = _$.value(1, (_scope, _params_2) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.js
@@ -22,12 +22,12 @@ const _expr_counts_count_i$if_content_effect = _$.effect("__tests__/template.mar
   _editing$for_content(_scope._, false);
 }));
 const _expr_counts_count_i$if_content = /* @__PURE__ */_$.intersection(2, _scope => _expr_counts_count_i$if_content_effect(_scope), 2);
-const _i$if_content = /* @__PURE__ */_$.conditionalClosure("i", "#text/0", 0, (_scope, i) => _expr_counts_count_i$if_content(_scope));
+const _i$if_content = /* @__PURE__ */_$.conditionalClosure("i", "#text/0", 0, _scope => _expr_counts_count_i$if_content(_scope));
 const _count$if_content = /* @__PURE__ */_$.conditionalClosure("count", "#text/0", 0, (_scope, count) => {
   _$.data(_scope["#text/1"], count + 1);
   _expr_counts_count_i$if_content(_scope);
 });
-const _counts$if_content = /* @__PURE__ */_$.dynamicClosureRead("counts", (_scope, counts) => _expr_counts_count_i$if_content(_scope), _scope => _scope._._);
+const _counts$if_content = /* @__PURE__ */_$.dynamicClosureRead("counts", _scope => _expr_counts_count_i$if_content(_scope), _scope => _scope._._);
 const _if_content = /* @__PURE__ */_$.createRenderer("<button>Confirm <!></button>", /* get, next(1), over(1), replace */" Db%", 0, 0, _scope => {
   _counts$if_content(_scope);
   _count$if_content._(_scope);
@@ -35,8 +35,8 @@ const _if_content = /* @__PURE__ */_$.createRenderer("<button>Confirm <!></butto
 });
 const _if$for_content = /* @__PURE__ */_$.conditional("#text/0", _if_content, _else_content);
 const _editing$for_content = /* @__PURE__ */_$.state("editing/4", (_scope, editing) => _if$for_content(_scope, editing ? 0 : 1));
-const _i$for_content = /* @__PURE__ */_$.value("i", (_scope, i) => _i$if_content(_scope));
-const _count$for_content = /* @__PURE__ */_$.value("count", (_scope, count) => {
+const _i$for_content = /* @__PURE__ */_$.value("i", _scope => _i$if_content(_scope));
+const _count$for_content = /* @__PURE__ */_$.value("count", _scope => {
   _count$if_content(_scope);
   _count$else_content(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.expected/tags/child.js
@@ -7,7 +7,7 @@ const _expr_input_x_effect = _$.effect("__tests__/tags/child.marko_0_input_x", (
   x
 }) => (input.output().innerHTML = x));
 const _expr_input_x = /* @__PURE__ */_$.intersection(6, _scope => _expr_input_x_effect(_scope), 1, "#scopeOffset/1");
-const _x = _$.registerBoundSignal("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */_$.value("x", (_scope, x) => _expr_input_x(_scope)));
+const _x = _$.registerBoundSignal("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */_$.value("x", _scope => _expr_input_x(_scope)));
 const _input_foo = /* @__PURE__ */_$.value("input_foo", (_scope, input_foo) => _myConst_input_value(_scope["#childScope/0"], input_foo));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_foo(_scope, input.foo);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 173 (min) 143 (brotli)
+// size: 169 (min) 136 (brotli)
 const _expr_input_x_effect = _$.effect(
     "a0",
     ({ 3: input, 5: x }) => (input.output().innerHTML = x),
@@ -11,7 +11,7 @@ const _expr_input_x_effect = _$.effect(
   );
 _$.registerBoundSignal(
   "a1",
-  _$.value(5, (_scope, x) => _expr_input_x(_scope)),
+  _$.value(5, (_scope) => _expr_input_x(_scope)),
 ),
   _$.nodeRef("c0", "j0"),
   init();

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.expected/tags/child.js
@@ -7,7 +7,7 @@ const _expr_input_x_effect = _$.effect("__tests__/tags/child.marko_0_input_x", (
   x
 }) => (input.output().innerHTML = x));
 const _expr_input_x = /* @__PURE__ */_$.intersection(6, _scope => _expr_input_x_effect(_scope), 1, "#scopeOffset/1");
-const _x = _$.registerBoundSignal("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */_$.value("x", (_scope, x) => _expr_input_x(_scope)));
+const _x = _$.registerBoundSignal("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */_$.value("x", _scope => _expr_input_x(_scope)));
 const _input_foo = /* @__PURE__ */_$.value("input_foo", (_scope, input_foo) => _myConst_input_value(_scope["#childScope/0"], input_foo));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => {
   _input_foo(_scope, input.foo);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 173 (min) 143 (brotli)
+// size: 169 (min) 136 (brotli)
 const _expr_input_x_effect = _$.effect(
     "a0",
     ({ 3: input, 5: x }) => (input.output().innerHTML = x),
@@ -11,7 +11,7 @@ const _expr_input_x_effect = _$.effect(
   );
 _$.registerBoundSignal(
   "a1",
-  _$.value(5, (_scope, x) => _expr_input_x(_scope)),
+  _$.value(5, (_scope) => _expr_input_x(_scope)),
 ),
   _$.nodeRef("c0", "j0"),
   init();

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,12 +1,12 @@
-// size: 1302 (min) 421 (brotli)
+// size: 1278 (min) 424 (brotli)
 const _expr_value_call$define_content2 = _$.intersection(4, (_scope) => {
     const { 2: value, 3: call } = _scope;
     _$.tagVarSignal(_scope, _return(_scope));
   }),
-  _call$define_content2 = _$.state(3, (_scope, call) =>
+  _call$define_content2 = _$.state(3, (_scope) =>
     _expr_value_call$define_content2(_scope),
   ),
-  _value$define_content2 = _$.value(2, (_scope, value) =>
+  _value$define_content2 = _$.value(2, (_scope) =>
     _expr_value_call$define_content2(_scope),
   ),
   _pattern_2$define_content = _$.value(1, (_scope, _pattern_2) =>
@@ -28,10 +28,10 @@ const _expr_value_call$define_content = _$.intersection(4, (_scope) => {
     const { 2: value, 3: call } = _scope;
     _$.tagVarSignal(_scope, _return2(_scope));
   }),
-  _call$define_content = _$.state(3, (_scope, call) =>
+  _call$define_content = _$.state(3, (_scope) =>
     _expr_value_call$define_content(_scope),
   ),
-  _value$define_content = _$.value(2, (_scope, value) =>
+  _value$define_content = _$.value(2, (_scope) =>
     _expr_value_call$define_content(_scope),
   ),
   _pattern_$define_content = _$.value(1, (_scope, _pattern_) =>
@@ -64,7 +64,7 @@ const _expr_Twice_clickTwiceCount = _$.intersection(14, (_scope) => {
   ),
   _onClickTwice = _$.registerBoundSignal(
     "a7",
-    _$.value(15, (_scope, onClickTwice) => _onClickTwice_effect(_scope)),
+    _$.value(15, (_scope) => _onClickTwice_effect(_scope)),
   ),
   _clickTwiceCount = _$.state(13, (_scope, clickTwiceCount) => {
     _$.data(_scope[7], clickTwiceCount), _expr_Twice_clickTwiceCount(_scope);
@@ -74,7 +74,7 @@ const _expr_Twice_clickTwiceCount = _$.intersection(14, (_scope) => {
   ),
   _onClickOnce = _$.registerBoundSignal(
     "a9",
-    _$.value(11, (_scope, onClickOnce) => _onClickOnce_effect(_scope)),
+    _$.value(11, (_scope) => _onClickOnce_effect(_scope)),
   ),
   _clickOnceCount = _$.state(9, (_scope, clickOnceCount) => {
     _$.data(_scope[3], clickOnceCount), _expr_Once_clickOnceCount(_scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.js
@@ -8,8 +8,8 @@ const _expr_value_call$define_content2 = /* @__PURE__ */_$.intersection(4, _scop
   } = _scope;
   _$.tagVarSignal(_scope, _return(_scope));
 });
-const _call$define_content2 = /* @__PURE__ */_$.state("call/3", (_scope, call) => _expr_value_call$define_content2(_scope));
-const _value$define_content2 = /* @__PURE__ */_$.value("value", (_scope, value) => _expr_value_call$define_content2(_scope));
+const _call$define_content2 = /* @__PURE__ */_$.state("call/3", _scope => _expr_value_call$define_content2(_scope));
+const _value$define_content2 = /* @__PURE__ */_$.value("value", _scope => _expr_value_call$define_content2(_scope));
 const _pattern_2$define_content = /* @__PURE__ */_$.value("_pattern_2", (_scope, _pattern_2) => _value$define_content2(_scope, _pattern_2.value));
 const _params_3$define_content = /* @__PURE__ */_$.value("_params_3", (_scope, _params_3) => _pattern_2$define_content(_scope, _params_3?.[0]));
 const _setup$define_content2 = _scope => {
@@ -23,8 +23,8 @@ const _expr_value_call$define_content = /* @__PURE__ */_$.intersection(4, _scope
   } = _scope;
   _$.tagVarSignal(_scope, _return2(_scope));
 });
-const _call$define_content = /* @__PURE__ */_$.state("call/3", (_scope, call) => _expr_value_call$define_content(_scope));
-const _value$define_content = /* @__PURE__ */_$.value("value", (_scope, value) => _expr_value_call$define_content(_scope));
+const _call$define_content = /* @__PURE__ */_$.state("call/3", _scope => _expr_value_call$define_content(_scope));
+const _value$define_content = /* @__PURE__ */_$.value("value", _scope => _expr_value_call$define_content(_scope));
 const _pattern_$define_content = /* @__PURE__ */_$.value("_pattern_", (_scope, _pattern_) => _value$define_content(_scope, _pattern_.value));
 const _params_2$define_content = /* @__PURE__ */_$.value("_params_2", (_scope, _params_2) => _pattern_$define_content(_scope, _params_2?.[0]));
 const _setup$define_content = _scope => {
@@ -54,21 +54,21 @@ const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", 0, () => _onClickOnc
 const _onClickTwice_effect = _$.effect("__tests__/template.marko_0_onClickTwice", (_scope, {
   onClickTwice
 }) => _$.on(_scope["#button/6"], "click", onClickTwice));
-const _onClickTwice = _$.registerBoundSignal("__tests__/template.marko_0_onClickTwice/var", /* @__PURE__ */_$.value("onClickTwice", (_scope, onClickTwice) => _onClickTwice_effect(_scope)));
+const _onClickTwice = _$.registerBoundSignal("__tests__/template.marko_0_onClickTwice/var", /* @__PURE__ */_$.value("onClickTwice", _scope => _onClickTwice_effect(_scope)));
 const _clickTwiceCount = /* @__PURE__ */_$.state("clickTwiceCount/13", (_scope, clickTwiceCount) => {
   _$.data(_scope["#text/7"], clickTwiceCount);
   _expr_Twice_clickTwiceCount(_scope);
 });
-const _Twice = /* @__PURE__ */_$.value("Twice", (_scope, Twice) => _expr_Twice_clickTwiceCount(_scope));
+const _Twice = /* @__PURE__ */_$.value("Twice", _scope => _expr_Twice_clickTwiceCount(_scope));
 const _onClickOnce_effect = _$.effect("__tests__/template.marko_0_onClickOnce", (_scope, {
   onClickOnce
 }) => _$.on(_scope["#button/2"], "click", onClickOnce));
-const _onClickOnce = _$.registerBoundSignal("__tests__/template.marko_0_onClickOnce/var", /* @__PURE__ */_$.value("onClickOnce", (_scope, onClickOnce) => _onClickOnce_effect(_scope)));
+const _onClickOnce = _$.registerBoundSignal("__tests__/template.marko_0_onClickOnce/var", /* @__PURE__ */_$.value("onClickOnce", _scope => _onClickOnce_effect(_scope)));
 const _clickOnceCount = /* @__PURE__ */_$.state("clickOnceCount/9", (_scope, clickOnceCount) => {
   _$.data(_scope["#text/3"], clickOnceCount);
   _expr_Once_clickOnceCount(_scope);
 });
-const _Once = /* @__PURE__ */_$.value("Once", (_scope, Once) => _expr_Once_clickOnceCount(_scope));
+const _Once = /* @__PURE__ */_$.value("Once", _scope => _expr_Once_clickOnceCount(_scope));
 export function _setup_(_scope) {
   _Once(_scope, {
     content: _define_content(_scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const _x_effect = _$.effect("__tests__/template.marko_0_x", ({
   x
 }) => (document.getElementById("ref").textContent = x));
-const _x = /* @__PURE__ */_$.state("x/0", (_scope, x) => _x_effect(_scope));
+const _x = /* @__PURE__ */_$.state("x/0", _scope => _x_effect(_scope));
 export function _setup_(_scope) {
   _x(_scope, 1);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const _promise_effect = _$.effect("__tests__/template.marko_0_promise", ({
 }) => (async () => {
   document.getElementById("ref").textContent = await promise;
 })());
-const _promise = /* @__PURE__ */_$.value("promise", (_scope, promise) => _promise_effect(_scope));
+const _promise = /* @__PURE__ */_$.value("promise", _scope => _promise_effect(_scope));
 export function _setup_(_scope) {
   _promise(_scope, Promise.resolve("hello"));
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 159 (min) 109 (brotli)
+// size: 155 (min) 107 (brotli)
 const _clickCount_effect = _$.effect("a0", (_scope, { 1: clickCount }) => {
     (document.getElementById("button").textContent = clickCount),
       _$.on(_scope[0], "click", function () {
         _clickCount(_scope, clickCount + 1);
       });
   }),
-  _clickCount = _$.state(1, (_scope, clickCount) => _clickCount_effect(_scope));
+  _clickCount = _$.state(1, (_scope) => _clickCount_effect(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const _clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", (_
     _clickCount(_scope, clickCount + 1), clickCount;
   });
 });
-const _clickCount = /* @__PURE__ */_$.state("clickCount/1", (_scope, clickCount) => _clickCount_effect(_scope));
+const _clickCount = /* @__PURE__ */_$.state("clickCount/1", _scope => _clickCount_effect(_scope));
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 673 (min) 302 (brotli)
+// size: 665 (min) 302 (brotli)
 const _count$if_content_effect = _$.effect(
     "a0",
     (
@@ -45,8 +45,8 @@ const _count$if_content_effect = _$.effect(
   ),
   _if = _$.conditional(1, _if_content),
   _count_closure = _$.dynamicClosure(_count$if_content),
-  _count = _$.state(4, (_scope, count) => _count_closure(_scope)),
-  _inner = _$.state(3, (_scope, inner) => _inner$if_content(_scope)),
+  _count = _$.state(4, (_scope) => _count_closure(_scope)),
+  _inner = _$.state(3, (_scope) => _inner$if_content(_scope)),
   _outer_effect = _$.effect("a2", (_scope, { 2: outer }) =>
     _$.on(_scope[0], "click", function () {
       _outer(_scope, !outer);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
@@ -30,8 +30,8 @@ const _inner$if_content = /* @__PURE__ */_$.conditionalClosure("inner", "#text/1
 const _if_content = /* @__PURE__ */_$.createRenderer("<button id=inner></button><!><!>", /* get, over(1), replace */" b%D", 0, 0, _scope => _inner$if_content._(_scope));
 const _if = /* @__PURE__ */_$.conditional("#text/1", _if_content);
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$if_content);
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => _count_closure(_scope));
-const _inner = /* @__PURE__ */_$.state("inner/3", (_scope, inner) => _inner$if_content(_scope));
+const _count = /* @__PURE__ */_$.state("count/4", _scope => _count_closure(_scope));
+const _inner = /* @__PURE__ */_$.state("inner/3", _scope => _inner$if_content(_scope));
 const _outer_effect = _$.effect("__tests__/template.marko_0_outer", (_scope, {
   outer
 }) => _$.on(_scope["#button/0"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 673 (min) 302 (brotli)
+// size: 665 (min) 302 (brotli)
 const _count$if_content_effect = _$.effect(
     "a0",
     (
@@ -45,8 +45,8 @@ const _count$if_content_effect = _$.effect(
   ),
   _if = _$.conditional(1, _if_content),
   _count_closure = _$.dynamicClosure(_count$if_content),
-  _count = _$.state(4, (_scope, count) => _count_closure(_scope)),
-  _inner = _$.state(3, (_scope, inner) => _inner$if_content(_scope)),
+  _count = _$.state(4, (_scope) => _count_closure(_scope)),
+  _inner = _$.state(3, (_scope) => _inner$if_content(_scope)),
   _outer_effect = _$.effect("a2", (_scope, { 2: outer }) =>
     _$.on(_scope[0], "click", function () {
       _outer(_scope, !outer);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
@@ -30,8 +30,8 @@ const _inner$if_content = /* @__PURE__ */_$.conditionalClosure("inner", "#text/1
 const _if_content = /* @__PURE__ */_$.createRenderer("<button id=inner></button><!><!>", /* get, over(1), replace */" b%D", 0, 0, _scope => _inner$if_content._(_scope));
 const _if = /* @__PURE__ */_$.conditional("#text/1", _if_content);
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$if_content);
-const _count = /* @__PURE__ */_$.state("count/4", (_scope, count) => _count_closure(_scope));
-const _inner = /* @__PURE__ */_$.state("inner/3", (_scope, inner) => _inner$if_content(_scope));
+const _count = /* @__PURE__ */_$.state("count/4", _scope => _count_closure(_scope));
+const _inner = /* @__PURE__ */_$.state("inner/3", _scope => _inner$if_content(_scope));
 const _outer_effect = _$.effect("__tests__/template.marko_0_outer", (_scope, {
   outer
 }) => _$.on(_scope["#button/0"], "click", function () {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.expected/template.js
@@ -16,12 +16,12 @@ const _if_content = /* @__PURE__ */_$.createRenderer("<!><!><!><!>", /* replace,
 });
 const _if = /* @__PURE__ */_$.conditional("#div/0", _if_content);
 const _value2__closure = /* @__PURE__ */_$.dynamicClosure(_value2$if_content);
-export const _value2_ = /* @__PURE__ */_$.value("value2", (_scope, value2) => {
+export const _value2_ = /* @__PURE__ */_$.value("value2", _scope => {
   _value2$if_content2(_scope);
   _value2__closure(_scope);
 });
 const _value1__closure = /* @__PURE__ */_$.dynamicClosure(_value1$if_content);
-export const _value1_ = /* @__PURE__ */_$.value("value1", (_scope, value1) => {
+export const _value1_ = /* @__PURE__ */_$.value("value1", _scope => {
   _value1$if_content2(_scope);
   _value1__closure(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/tags/counter.js
@@ -14,7 +14,7 @@ const _clickCount = /* @__PURE__ */_$.state("clickCount/5", (_scope, clickCount)
   })(), clickCount));
   _expr_input_onCount_clickCount(_scope);
 });
-export const _input_onCount_ = /* @__PURE__ */_$.value("input_onCount", (_scope, input_onCount) => _expr_input_onCount_clickCount(_scope));
+export const _input_onCount_ = /* @__PURE__ */_$.value("input_onCount", _scope => _expr_input_onCount_clickCount(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_onCount_(_scope, input.onCount));
 export function _setup_(_scope) {
   _clickCount(_scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 607 (min) 335 (brotli)
+// size: 603 (min) 337 (brotli)
 const _expr_input_onCount_clickCount_effect = _$.effect(
     "a0",
     (_scope, { 4: input_onCount, 5: clickCount }) =>
@@ -22,7 +22,7 @@ const _expr_input_onCount_clickCount_effect = _$.effect(
     ),
       _expr_input_onCount_clickCount(_scope);
   }),
-  _input_onCount_ = _$.value(4, (_scope, input_onCount) =>
+  _input_onCount_ = _$.value(4, (_scope) =>
     _expr_input_onCount_clickCount(_scope),
   );
 const _onCount$if_content = _$.conditionalClosure(2, 0, 0, (_scope, onCount) =>

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 580 (min) 302 (brotli)
+// size: 576 (min) 303 (brotli)
 _$.enableCatch();
 const _value$await_content = _$.value(2, (_scope, value) =>
     _$.data(
@@ -41,7 +41,7 @@ const _await$try_content = _$.awaitTag(0, _await_content),
       _clickCount(_scope, clickCount + 1);
     }),
   ),
-  _clickCount = _$.state(3, (_scope, clickCount) => {
+  _clickCount = _$.state(3, (_scope) => {
     _clickCount_closure(_scope), _clickCount_effect(_scope);
   });
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.js
@@ -30,7 +30,7 @@ const _clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", (_
 }) => _$.on(_scope["#button/0"], "click", function () {
   _clickCount(_scope, clickCount + 1), clickCount;
 }));
-const _clickCount = /* @__PURE__ */_$.state("clickCount/3", (_scope, clickCount) => {
+const _clickCount = /* @__PURE__ */_$.state("clickCount/3", _scope => {
   _clickCount_closure(_scope);
   _clickCount_effect(_scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 385 (min) 224 (brotli)
+// size: 381 (min) 222 (brotli)
 _$.enableCatch();
 const _err$catch_content = _$.value(2, (_scope, err) =>
     _$.data(_scope[0], err),
@@ -26,7 +26,5 @@ const _clickCount$try_content_effect = _$.effect(
       _clickCount$try_content_effect(_scope);
   }),
   _clickCount_closure = _$.dynamicClosure(_clickCount$try_content),
-  _clickCount = _$.state(2, (_scope, clickCount) =>
-    _clickCount_closure(_scope),
-  );
+  _clickCount = _$.state(2, (_scope) => _clickCount_closure(_scope));
 init();

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.js
@@ -24,7 +24,7 @@ const _clickCount$try_content = /* @__PURE__ */_$.dynamicClosureRead("clickCount
 const _try_content = /* @__PURE__ */_$.createRenderer("<button>inc</button> -- <!>", /* get, over(2), replace */" c%", 0, 0, _scope => _clickCount$try_content(_scope));
 const _try = /* @__PURE__ */_$.createTry("#text/1", _try_content);
 const _clickCount_closure = /* @__PURE__ */_$.dynamicClosure(_clickCount$try_content);
-const _clickCount = /* @__PURE__ */_$.state("clickCount/2", (_scope, clickCount) => _clickCount_closure(_scope));
+const _clickCount = /* @__PURE__ */_$.state("clickCount/2", _scope => _clickCount_closure(_scope));
 export function _setup_(_scope) {
   _clickCount(_scope, 0);
   _try(_scope, {

--- a/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/__snapshots__/dom.expected/template.js
@@ -11,7 +11,7 @@ const _input_value__effect = _$.effect("__tests__/template.marko_0_input_value",
     _$.getAbortSignal(_scope, 0).onabort = () => _b(_scope, previousValue);
   }
 });
-export const _input_value_ = /* @__PURE__ */_$.value("input_value", (_scope, input_value) => {
+export const _input_value_ = /* @__PURE__ */_$.value("input_value", _scope => {
   _$.resetAbortSignal(_scope, 0);
   _input_value__effect(_scope);
 });

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -101,18 +101,18 @@ export interface Template {
     input: Input,
     reference: Node,
     position?: InsertPosition,
-  ): TemplateInstance;
-  render(input?: Input): RenderResult;
+  ): MountedTemplate;
+  render(input?: Input): RenderedTemplate;
 }
 
-export interface TemplateInstance {
+export interface MountedTemplate {
   update(input: unknown): void;
   destroy(): void;
 }
 
-export type RenderResult = PromiseLike<string> &
+export type RenderedTemplate = PromiseLike<string> &
   AsyncIterable<string> & {
-    toReadable(): ReadableStream;
+    toReadable(): ReadableStream<Uint8Array<ArrayBufferLike>>;
   };
 
 export enum ControlledType {

--- a/packages/runtime-tags/src/dom/template.ts
+++ b/packages/runtime-tags/src/dom/template.ts
@@ -1,10 +1,10 @@
 import { DEFAULT_RENDER_ID, DEFAULT_RUNTIME_ID } from "../common/meta";
 import type {
   BranchScope,
+  MountedTemplate,
   Scope,
   Template,
   TemplateInput,
-  TemplateInstance,
 } from "../common/types";
 import { insertChildNodes } from "./dom";
 import { prepareEffects, runEffects } from "./queue";
@@ -45,7 +45,7 @@ function mount(
   input: TemplateInput = {},
   reference: Node,
   position?: InsertPosition,
-): TemplateInstance {
+): MountedTemplate {
   let branch!: BranchScope;
   let parentNode = reference as ParentNode;
   let nextSibling: Node | null = null;

--- a/packages/runtime-tags/src/translator/core/html-comment.ts
+++ b/packages/runtime-tags/src/translator/core/html-comment.ts
@@ -119,8 +119,7 @@ export default {
           getterFnIdentifier = currentProgramPath.scope.generateUidIdentifier(
             `get_${varName}`,
           );
-          currentProgramPath.pushContainer(
-            "body",
+          currentProgramPath.node.body.push(
             t.variableDeclaration("const", [
               t.variableDeclarator(
                 getterFnIdentifier,

--- a/packages/runtime-tags/src/translator/core/html-script.ts
+++ b/packages/runtime-tags/src/translator/core/html-script.ts
@@ -192,8 +192,7 @@ export default {
           getterFnIdentifier = currentProgramPath.scope.generateUidIdentifier(
             `get_${varName}`,
           );
-          currentProgramPath.pushContainer(
-            "body",
+          currentProgramPath.node.body.push(
             t.variableDeclaration("const", [
               t.variableDeclarator(
                 getterFnIdentifier,

--- a/packages/runtime-tags/src/translator/core/html-style.ts
+++ b/packages/runtime-tags/src/translator/core/html-style.ts
@@ -192,8 +192,7 @@ export default {
           getterFnIdentifier = currentProgramPath.scope.generateUidIdentifier(
             `get_${varName}`,
           );
-          currentProgramPath.pushContainer(
-            "body",
+          currentProgramPath.node.body.push(
             t.variableDeclaration("const", [
               t.variableDeclarator(
                 getterFnIdentifier,

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -112,21 +112,18 @@ export default {
 
     if (importPath) {
       if (!node.var) {
-        currentProgramPath.pushContainer(
-          "body",
+        currentProgramPath.node.body.push(
           t.importDeclaration([], t.stringLiteral(importPath)),
         );
       } else if (t.isIdentifier(node.var)) {
-        currentProgramPath.pushContainer(
-          "body",
+        currentProgramPath.node.body.push(
           t.importDeclaration(
             [t.importDefaultSpecifier(node.var)],
             t.stringLiteral(importPath),
           ),
         );
       } else {
-        currentProgramPath.pushContainer(
-          "body",
+        currentProgramPath.node.body.push(
           t.variableDeclaration("const", [
             t.variableDeclarator(
               node.var,

--- a/packages/runtime-tags/src/translator/core/try.ts
+++ b/packages/runtime-tags/src/translator/core/try.ts
@@ -180,8 +180,7 @@ export default {
           );
         }
 
-        currentProgramPath.pushContainer(
-          "body",
+        currentProgramPath.node.body.push(
           t.expressionStatement(callRuntime("enableCatch")),
         );
 

--- a/packages/runtime-tags/src/translator/util/writer.ts
+++ b/packages/runtime-tags/src/translator/util/writer.ts
@@ -87,7 +87,7 @@ export function flushInto(
   >;
   const expr = consumeHTML(target);
   if (expr) {
-    target.pushContainer("body", expr)[0].skip();
+    target.node.body.push(expr as any);
   }
 }
 

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -61,17 +61,16 @@ export default {
         ),
       );
 
-      program.pushContainer(
-        "body",
-        contentId
-          ? [
-              t.variableDeclaration("const", [
-                t.variableDeclarator(t.identifier(contentId), contentFn),
-              ]),
-              exportDefault,
-            ]
-          : exportDefault,
-      );
+      if (contentId) {
+        program.node.body.push(
+          t.variableDeclaration("const", [
+            t.variableDeclarator(t.identifier(contentId), contentFn),
+          ]),
+          exportDefault,
+        );
+      } else {
+        program.node.body.push(exportDefault);
+      }
     },
   },
 } satisfies TemplateVisitor<t.Program>;

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -136,8 +136,7 @@ export default {
         // We use the dynamic tag when a custom tag from the class runtime is used
 
         if (isOutputHTML()) {
-          currentProgramPath.pushContainer(
-            "body",
+          currentProgramPath.node.body.push(
             t.markoScriptlet(
               [
                 t.expressionStatement(
@@ -154,8 +153,7 @@ export default {
             ),
           );
         } else {
-          currentProgramPath.pushContainer(
-            "body",
+          currentProgramPath.node.body.push(
             t.expressionStatement(
               callRuntime(
                 "register",

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -346,8 +346,7 @@ export default {
             getterFnIdentifier = currentProgramPath.scope.generateUidIdentifier(
               `get_${varName}`,
             );
-            currentProgramPath.pushContainer(
-              "body",
+            currentProgramPath.node.body.push(
               t.variableDeclaration("const", [
                 t.variableDeclarator(
                   getterFnIdentifier,

--- a/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -28,7 +28,7 @@ const _x = /* @__PURE__ */_$.state("x/7", (_scope, x) => {
   _expr_x_y(_scope);
   _expr_input_content_x_y(_scope);
 });
-export const _input_content_ = /* @__PURE__ */_$.value("input_content", (_scope, input_content) => _expr_input_content_x_y(_scope));
+export const _input_content_ = /* @__PURE__ */_$.value("input_content", _scope => _expr_input_content_x_y(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_content_(_scope, input.content));
 export function _setup_(_scope) {
   _x(_scope, 1);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
@@ -18,7 +18,7 @@ const _count$classLayout_content = /* @__PURE__ */_$.dynamicClosureRead("count",
 const _classLayout_content = _$.registerContent("__tests__/template.marko_1_renderer", "<button id=tags> </button>", /* get, next(1), get */" D ", 0, 0, _scope => _count$classLayout_content(_scope));
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", _classLayout_content);
 const _count_closure = /* @__PURE__ */_$.dynamicClosure(_count$classLayout_content);
-const _count = /* @__PURE__ */_$.state("count/1", (_scope, count) => _count_closure(_scope));
+const _count = /* @__PURE__ */_$.state("count/1", _scope => _count_closure(_scope));
 export function _setup_(_scope) {
   _count(_scope, 0);
   _dynamicTag(_scope, _classLayout);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -19,7 +19,7 @@ const _count = /* @__PURE__ */_$.state("count/6", (_scope, count) => {
   _expr_input_content_count(_scope);
   _count_effect(_scope);
 });
-export const _input_content_ = /* @__PURE__ */_$.value("input_content", (_scope, input_content) => _expr_input_content_count(_scope));
+export const _input_content_ = /* @__PURE__ */_$.value("input_content", _scope => _expr_input_content_count(_scope));
 export const _input_ = /* @__PURE__ */_$.value("input", (_scope, input) => _input_content_(_scope, input.content));
 export function _setup_(_scope) {
   _count(_scope, 0);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
@@ -37,7 +37,7 @@ const _multiplier$classLayout_content = /* @__PURE__ */_$.dynamicClosureRead("mu
 const _classLayout_content = _$.registerContent("__tests__/template.marko_1_renderer", "<h1> </h1><button id=tags><!> * <!> = <!></button>", /* next(1), get, out(1), get, next(1), replace, over(2), replace, over(2), replace */"D l D%c%c%", 0, _params_2$classLayout_content, _scope => _multiplier$classLayout_content(_scope));
 const _dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", _classLayout_content);
 const _multiplier_closure = /* @__PURE__ */_$.dynamicClosure(_multiplier$classLayout_content);
-const _multiplier = /* @__PURE__ */_$.state("multiplier/1", (_scope, multiplier) => _multiplier_closure(_scope));
+const _multiplier = /* @__PURE__ */_$.state("multiplier/1", _scope => _multiplier_closure(_scope));
 export function _setup_(_scope) {
   _multiplier(_scope, 1);
   _dynamicTag(_scope, _classLayout);


### PR DESCRIPTION
## Description

### Tags api
* Remove unnecessary trailing params for compiled const/let.
* Avoid using `pushContainer` and `unshiftContainer` apis which were causing unnecessary (re)traversal.
* Ensure `toReadable` api returns a `ReadableStream` that is text encoded to work better with other whatwg apis.
* Expose`Marko.RenderedTemplate` and `Marko.MountedTempalte` types.

### Class API
* Expose `toReadable` api on render result which returns a text encoded whatwg ReadableStream.
* Expose`Marko.RenderedTemplate` and `Marko.MountedTempalte` types.
