### PR TITLE
fix: cancelling readable stream

### DIFF
--- a/.changeset/busy-carrots-allow.md
+++ b/.changeset/busy-carrots-allow.md
@@ -1,0 +1,6 @@
+---
+"marko": patch
+"@marko/runtime-tags": patch
+---
+
+Prevents error when readable stream is cancelled externally


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Prevents error when readable stream from `toReadable` is cancelled externally

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
