### PR TITLE
chore: release tags api as 6.0.0

### DIFF
--- a/.changeset/flat-teeth-return.md
+++ b/.changeset/flat-teeth-return.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": major
+---
+
+Release Tags API as 6.0.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10543,7 +10543,7 @@
     },
     "packages/runtime-tags": {
       "name": "@marko/runtime-tags",
-      "version": "0.3.86",
+      "version": "5.0.0",
       "license": "MIT",
       "dependencies": {
         "@marko/compiler": "^5.39.18",
@@ -10560,7 +10560,7 @@
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@marko/runtime-tags": "^0.3.86",
+        "@marko/runtime-tags": "^5.0.0",
         "marko": "^5.37.25"
       },
       "engines": {

--- a/packages/runtime-tags/package.json
+++ b/packages/runtime-tags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@marko/runtime-tags",
-  "version": "0.3.86",
+  "version": "5.0.0",
   "description": "Optimized runtime for Marko templates.",
   "keywords": [
     "api",

--- a/packages/translator-interop/package.json
+++ b/packages/translator-interop/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@babel/code-frame": "^7.26.2",
-    "@marko/runtime-tags": "^0.3.86",
+    "@marko/runtime-tags": "^5.0.0",
     "marko": "^5.37.25"
   },
   "peerDependencies": {

--- a/scripts/publish-alias.ts
+++ b/scripts/publish-alias.ts
@@ -9,7 +9,6 @@ const originalPkgSource = fs.readFileSync(runtimeTagsPkgFile, "utf-8");
 const pkg = JSON.parse(originalPkgSource);
 
 pkg.name = "marko";
-pkg.version = "6.0.0-next." + pkg.version.replace(/^(0\.)+/, "");
 
 try {
   fs.writeFileSync(runtimeTagsPkgFile, JSON.stringify(pkg, null, 2) + "\n");


### PR DESCRIPTION
## Description

Releases `marko@6.0.0` which will be tagged as `next` until [stable milestone tasks](https://github.com/orgs/marko-js/projects/2/views/12?filterQuery=-status%3ADone+milestones%3A%22TagsAPI+Stable%22) are completed.
