### PR TITLE
fix: check for errors in ServerRendered.toString

### DIFF
--- a/packages/runtime-tags/src/html/template.ts
+++ b/packages/runtime-tags/src/html/template.ts
@@ -284,7 +284,9 @@ class ServerRendered implements RenderedTemplate {
     const head = this.#head;
     this.#head = null;
     if (!head) throw new Error("Cannot read from a consumed render result");
-    if (!head.boundary.done) throw new Error("Cannot fork in sync mode");
+    const { boundary } = head;
+    if (!boundary.done) throw new Error("Cannot fork in sync mode");
+    if (boundary.signal.aborted) throw boundary.signal.reason;
     return head.consume().flushHTML();
   }
 }


### PR DESCRIPTION
## Description

without this check, a synchronous render with an error will return all of the text up to the error, which is likely to be invalid HTML.

## Checklist:

- [X] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [X] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
