### PR TITLE
feat: allow reading tag variables after they are written

### DIFF
--- a/.changeset/few-views-kneel.md
+++ b/.changeset/few-views-kneel.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Allow reading proposed tag variable value after writing.

--- a/.sizes.json
+++ b/.sizes.json
@@ -44,31 +44,31 @@
     {
       "name": "comments",
       "user": {
-        "min": 891,
-        "brotli": 455
+        "min": 893,
+        "brotli": 458
       },
       "runtime": {
         "min": 7019,
         "brotli": 3005
       },
       "total": {
-        "min": 7910,
-        "brotli": 3460
+        "min": 7912,
+        "brotli": 3463
       }
     },
     {
       "name": "comments 💧",
       "user": {
-        "min": 140,
-        "brotli": 119
+        "min": 142,
+        "brotli": 123
       },
       "runtime": {
         "min": 2355,
         "brotli": 1202
       },
       "total": {
-        "min": 2495,
-        "brotli": 1321
+        "min": 2497,
+        "brotli": 1325
       }
     }
   ]

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -1,4 +1,4 @@
-// size: 891 (min) 455 (brotli)
+// size: 893 (min) 458 (brotli)
 const $setup$if$content = ($scope) => {
     ($scope[0],
       $comment_comments$if$content._($scope),
@@ -37,7 +37,7 @@ const $setup$if$content = ($scope) => {
   $i$for$content = value(9, $expr_input_path_i$for$content),
   $open$for$content_effect = effect("a0", ($scope, { 12: open }) =>
     on($scope[2], "click", function () {
-      $open$for$content($scope, !open);
+      $open$for$content($scope, (open = !open));
     }),
   ),
   $open$for$content = state(12, ($scope, open) => {

--- a/.sizes/comments.ssr/entry.js
+++ b/.sizes/comments.ssr/entry.js
@@ -1,7 +1,7 @@
-// size: 140 (min) 119 (brotli)
+// size: 142 (min) 123 (brotli)
 const $open$for$content_effect = effect("a0", ($scope, { 12: open }) =>
     on($scope[2], "click", function () {
-      $open$for$content($scope, !open);
+      $open$for$content($scope, (open = !open));
     }),
   ),
   $open$for$content = state(12, ($scope, open) => {

--- a/.sizes/counter.csr/entry.js
+++ b/.sizes/counter.csr/entry.js
@@ -1,7 +1,7 @@
 // size: 184 (min) 151 (brotli)
 const $clickCount_effect = effect("a0", ($scope, { 2: clickCount }) =>
     on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = state(2, ($scope, clickCount) => {

--- a/.sizes/counter.ssr/entry.js
+++ b/.sizes/counter.ssr/entry.js
@@ -1,7 +1,7 @@
 // size: 106 (min) 97 (brotli)
 const $clickCount_effect = effect("a0", ($scope, { 2: clickCount }) =>
     on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = state(2, ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,7 @@
-// size: 162 (min) 122 (brotli)
+// size: 162 (min) 123 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 3: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      ($lastClickCount($scope, clickCount),
-        $clickCount($scope, clickCount + 1));
+      ($lastClickCount($scope, clickCount), $clickCount($scope, ++clickCount));
     }),
   ),
   $clickCount = _$.state(3, ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
   $lastClickCount($scope, clickCount);
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/3", ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.hydrate.js
@@ -15,7 +15,7 @@ const $await$try$content = _$.awaitTag(0, $await_content),
   $clickCount_closure = _$.dynamicClosure($clickCount$try$content),
   $clickCount_effect = _$.effect("a1", ($scope, { 2: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = _$.state(2, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/dom.expected/template.js
@@ -15,7 +15,7 @@ const $clickCount_closure = /* @__PURE__ */_$.dynamicClosure($clickCount$try$con
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/2", $scope => {
   $clickCount_closure($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 321 (min) 206 (brotli)
+// size: 323 (min) 199 (brotli)
 const $dynamicTag = _$.dynamicTag(0, 0, 0, 1),
   $input_item = _$.value(3, ($scope, input_item) =>
     $dynamicTag($scope, input_item, () => [1]),
@@ -16,7 +16,7 @@ const $dynamicTag = _$.dynamicTag(0, 0, 0, 1),
   ),
   $x_effect = _$.effect("b1", ($scope, { 2: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, !x);
+      $x($scope, (x = !x));
     }),
   ),
   $x = _$.state(2, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $item_content = _$.registerContent("__tests__/template.marko_1_renderer", 
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, !x);
+  $x($scope, x = !x);
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   let $item;

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.expected/template.hydrate.js
@@ -14,7 +14,7 @@ _$.localClosures(_$.registerContent("b0", " ", " ", $setup$item$content), {
 const $mult_closure = _$.dynamicClosure($mult$item$content),
   $mult_effect = _$.effect("b1", ($scope, { 3: mult }) =>
     _$.on($scope[1], "click", function () {
-      $mult($scope, mult + 1);
+      $mult($scope, ++mult);
     }),
   ),
   $mult = _$.state(3, ($scope, mult) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.expected/template.js
@@ -20,7 +20,7 @@ const $mult_closure = /* @__PURE__ */_$.dynamicClosure($mult$item$content);
 const $mult_effect = _$.effect("__tests__/template.marko_0_mult", ($scope, {
   mult
 }) => _$.on($scope["#button/1"], "click", function () {
-  $mult($scope, mult + 1), mult;
+  $mult($scope, ++mult)
 }));
 const $mult = /* @__PURE__ */_$.state("mult/3", ($scope, mult) => {
   _$.data($scope["#text/2"], mult);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 164 (min) 124 (brotli)
+// size: 166 (min) 136 (brotli)
 const $disabled_effect = _$.effect("a0", ($scope, { 3: disabled }) =>
     _$.on($scope[1], "click", function () {
-      $disabled($scope, !disabled);
+      $disabled($scope, (disabled = !disabled));
     }),
   ),
   $disabled = _$.state(3, ($scope, disabled) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $disabled_effect = _$.effect("__tests__/template.marko_0_disabled", ($scope, {
   disabled
 }) => _$.on($scope["#button/1"], "click", function () {
-  $disabled($scope, !disabled);
+  $disabled($scope, disabled = !disabled);
 }));
 const $disabled = /* @__PURE__ */_$.state("disabled/3", ($scope, disabled) => {
   _$.attr($scope["#input/0"], "disabled", disabled);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -15,7 +15,7 @@ const $count$await$content3 = _$.dynamicClosureRead(4, ($scope, count) =>
   ),
   $count_effect = _$.effect("a0", ($scope, { 4: count }) =>
     _$.on($scope[3], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(4, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/dom.expected/template.js
@@ -21,7 +21,7 @@ const $count_closure = /* @__PURE__ */_$.dynamicClosure($count$await$content, $c
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/3"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $count_closure($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 223 (min) 149 (brotli)
+// size: 223 (min) 157 (brotli)
 const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
     _$.on($scope[0], "click", onClick),
   ),
@@ -9,7 +9,7 @@ const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -9,7 +9,7 @@ const $onClick_effect = _$.effect("a0", ($scope, { 5: onClick }) =>
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 389 (min) 201 (brotli)
+// size: 389 (min) 202 (brotli)
 const $onClick_effect = _$.effect("a0", ($scope, { 5: onClick }) =>
     _$.on($scope[0], "click", onClick),
   ),
@@ -18,12 +18,12 @@ const $onClick_effect = _$.effect("a0", ($scope, { 5: onClick }) =>
   });
 function $onClick2($scope, { 2: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 function $onClick($scope, { 2: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b1", $onClick2), _$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.expected/template.js
@@ -19,14 +19,14 @@ function $onClick2($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick2", $onClick2);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 258 (min) 164 (brotli)
+// size: 258 (min) 172 (brotli)
 const $onClick_effect = _$.effect("a0", ($scope, { 5: onClick }) =>
     _$.on($scope[0], "click", onClick),
   ),
@@ -14,7 +14,7 @@ const $onClick_effect = _$.effect("a0", ($scope, { 5: onClick }) =>
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 223 (min) 149 (brotli)
+// size: 223 (min) 157 (brotli)
 const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
     _$.on($scope[0], "click", onClick),
   ),
@@ -9,7 +9,7 @@ const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 253 (min) 161 (brotli)
+// size: 253 (min) 168 (brotli)
 const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
     _$.on($scope[0], "click", onClick),
   ),
@@ -13,7 +13,7 @@ const $onClick_effect = _$.effect("a0", ($scope, { 4: onClick }) =>
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.expected/template.js
@@ -19,7 +19,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/tags/counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $clickCount_effect = _$.effect("__tests__/tags/counter.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/2", ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 120 (min) 102 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 2: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = _$.state(2, ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 334 (min) 195 (brotli)
+// size: 336 (min) 195 (brotli)
 const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
     _$.data($scope[0], count),
   ),
@@ -7,7 +7,7 @@ const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 3: show }) =>
     _$.on($scope[1], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {
@@ -15,7 +15,7 @@ const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
   }),
   $count_effect = _$.effect("a1", ($scope, { 4: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(4, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/1"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);
@@ -17,7 +17,7 @@ const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $count$if$content($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 332 (min) 194 (brotli)
+// size: 334 (min) 192 (brotli)
 const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
     _$.data($scope[0], count),
   ),
@@ -7,7 +7,7 @@ const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 3: show }) =>
     _$.on($scope[1], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {
@@ -15,7 +15,7 @@ const $count$if$content = _$.conditionalClosure(4, 2, 0, ($scope, count) =>
   }),
   $count_effect = _$.effect("a1", ($scope, { 4: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(4, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/1"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);
@@ -17,7 +17,7 @@ const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $count$if$content($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 190 (min) 136 (brotli)
+// size: 190 (min) 150 (brotli)
 const $increment2_effect = _$.effect("a1", ($scope, { 3: increment }) =>
     _$.on($scope[0], "click", increment),
   ),
@@ -8,7 +8,7 @@ const $increment2_effect = _$.effect("a1", ($scope, { 3: increment }) =>
   });
 function $increment($scope, { 2: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("a0", $increment), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ function $increment($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/increment", $increment);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.hydrate.js
@@ -8,7 +8,7 @@ const $multipliedCount = _$.value(7, ($scope, multipliedCount) =>
   }),
   $count_effect = _$.effect("a0", ($scope, { 4: count }) =>
     _$.on($scope[2], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(4, ($scope) => {
@@ -16,7 +16,7 @@ const $multipliedCount = _$.value(7, ($scope, multipliedCount) =>
   }),
   $multiplier_effect = _$.effect("a1", ($scope, { 5: multiplier }) =>
     _$.on($scope[0], "click", function () {
-      $multiplier($scope, multiplier + 1);
+      $multiplier($scope, ++multiplier);
     }),
   ),
   $multiplier = _$.state(5, ($scope, multiplier) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/__snapshots__/dom.expected/template.js
@@ -12,7 +12,7 @@ const $expr_count_multiplier = /* @__PURE__ */_$.intersection(6, $scope => {
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/2"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $expr_count_multiplier($scope);
@@ -21,7 +21,7 @@ const $count = /* @__PURE__ */_$.state("count/4", $scope => {
 const $multiplier_effect = _$.effect("__tests__/template.marko_0_multiplier", ($scope, {
   multiplier
 }) => _$.on($scope["#button/0"], "click", function () {
-  $multiplier($scope, multiplier + 1), multiplier;
+  $multiplier($scope, ++multiplier)
 }));
 const $multiplier = /* @__PURE__ */_$.state("multiplier/5", ($scope, multiplier) => {
   _$.data($scope["#text/1"], multiplier);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 120 (min) 102 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 2: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = _$.state(2, ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/2", ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 120 (min) 102 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 2: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(2, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
   {
-    $count($scope, count + 1), count;
+    $count($scope, ++count)
   }
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.hydrate.js
@@ -1,10 +1,7 @@
-// size: 163 (min) 136 (brotli)
+// size: 165 (min) 139 (brotli)
 const $expr_a_b_effect = _$.effect("a0", ($scope, { 2: a, 3: b }) =>
     _$.on($scope[0], "click", function () {
-      $a(
-        $scope,
-        a.map((a) => b),
-      );
+      $a($scope, (a = a.map((a) => b)));
     }),
   ),
   $expr_a_b = _$.intersection(4, $expr_a_b_effect),

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const $expr_a_b_effect = _$.effect("__tests__/template.marko_0_a_b", ($scope, {
   a,
   b
 }) => _$.on($scope["#button/0"], "click", function () {
-  $a($scope, a.map(a => b));
+  $a($scope, a = a.map(a => b));
 }));
 const $expr_a_b = /* @__PURE__ */_$.intersection(4, $expr_a_b_effect);
 const $a = /* @__PURE__ */_$.state("a/2", ($scope, a) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/tags/comments.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/tags/comments.js
@@ -41,7 +41,7 @@ const $i$for$content = /* @__PURE__ */_$.value("i", $expr_input_path_i$for$conte
 const $open$for$content_effect = _$.effect("__tests__/tags/comments.marko_1_open", ($scope, {
   open
 }) => _$.on($scope["#button/2"], "click", function () {
-  $open$for$content($scope, !open);
+  $open$for$content($scope, open = !open);
 }));
 const $open$for$content = /* @__PURE__ */_$.state("open/12", ($scope, open) => {
   _$.attr($scope["#li/0"], "hidden", !open);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 158 (min) 143 (brotli)
+// size: 160 (min) 131 (brotli)
 const $open$for$content_effect = _$.effect("a0", ($scope, { 12: open }) =>
     _$.on($scope[2], "click", function () {
-      $open$for$content($scope, !open);
+      $open$for$content($scope, (open = !open));
     }),
   ),
   $open$for$content = _$.state(12, ($scope, open) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 273 (min) 199 (brotli)
+// size: 277 (min) 192 (brotli)
 const $expr_items_index_effect = _$.effect(
     "a0",
     ($scope, { 3: items, 5: index }) =>
       _$.on($scope[2], "click", function () {
         const newItems = items.slice(1);
-        ($items($scope, newItems),
-          $index($scope, (index + 1) % newItems.length));
+        ($items($scope, (items = newItems)),
+          $index($scope, (index = (index + 1) % newItems.length)));
       }),
   ),
   $expr_items_index = _$.intersection(6, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/__snapshots__/dom.expected/template.js
@@ -6,8 +6,8 @@ const $expr_items_index_effect = _$.effect("__tests__/template.marko_0_items_ind
   index
 }) => _$.on($scope["#button/2"], "click", function () {
   const newItems = items.slice(1);
-  $items($scope, newItems);
-  $index($scope, (index + 1) % newItems.length);
+  $items($scope, items = newItems);
+  $index($scope, index = (index + 1) % newItems.length);
 }));
 const $expr_items_index = /* @__PURE__ */_$.intersection(6, $scope => {
   const {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 526 (min) 319 (brotli)
+// size: 528 (min) 302 (brotli)
 const $name = _$.value(3, ($scope, name) => _$.data($scope[0], name)),
   $setup$for$content = ($scope) => {
     ($scope[0], $outer$for$content._($scope));
@@ -39,7 +39,7 @@ const $name = _$.value(3, ($scope, name) => _$.data($scope[0], name)),
   $for = _$.loopOf(1, $for_content),
   $items_effect = _$.effect("b0", ($scope, { 2: items }) =>
     _$.on($scope[0], "click", function () {
-      $items($scope, [...items, items.length]);
+      $items($scope, (items = [...items, items.length]));
     }),
   ),
   $items = _$.state(2, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.expected/template.js
@@ -29,7 +29,7 @@ const $for = /* @__PURE__ */_$.loopOf("#text/1", $for_content);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/0"], "click", function () {
-  $items($scope, [...items, items.length]);
+  $items($scope, items = [...items, items.length]);
 }));
 const $items = /* @__PURE__ */_$.state("items/2", ($scope, items) => {
   $for($scope, [items]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 596 (min) 323 (brotli)
+// size: 596 (min) 332 (brotli)
 const $dynamicTag = _$.dynamicTag(0, 0, 0, 1),
   $expr_content_value = _$.intersection(5, ($scope) => {
     const { 3: content, 4: value } = $scope;
@@ -44,7 +44,7 @@ _$.registerContent(
 );
 const $x_effect = _$.effect("b2", ($scope, { 2: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(2, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.expected/template.js
@@ -20,7 +20,7 @@ const $child_content = _$.registerContent("__tests__/template.marko_1_renderer",
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   _child_input_value($scope["#childScope/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -3,7 +3,7 @@ const $count$child$content_effect = _$.effect(
     "b1",
     ($scope, { _: { 1: count } }) =>
       _$.on($scope[0], "click", function () {
-        $count($scope._, count + 1);
+        $count($scope._, ++count);
       }),
   ),
   $count$child$content = _$.dynamicClosureRead(1, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $count$child$content_effect = _$.effect("__tests__/template.marko_1_count"
     count
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope._, count + 1), count;
+  $count($scope._, ++count)
 }));
 const $count$child$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 239 (min) 160 (brotli)
+// size: 239 (min) 156 (brotli)
 const $count$falseChild$content_effect = _$.effect(
     "b1",
     ($scope, { _: { 1: count } }) =>
       _$.on($scope[0], "click", function () {
-        $count($scope._, count + 1);
+        $count($scope._, ++count);
       }),
   ),
   $count$falseChild$content = _$.dynamicClosureRead(1, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $count$falseChild$content_effect = _$.effect("__tests__/template.marko_1_c
     count
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope._, count + 1), count;
+  $count($scope._, ++count)
 }));
 const $count$falseChild$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.hydrate.js
@@ -15,7 +15,7 @@ const $clickCount$else$content = _$.conditionalClosure(
     "a0",
     ($scope, { _: { 1: clickCount } }) =>
       _$.on($scope[0], "click", function () {
-        $clickCount($scope._, clickCount + 1);
+        $clickCount($scope._, ++clickCount);
       }),
   ),
   $clickCount$if$content = _$.conditionalClosure(

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const $clickCount$if$content_effect = _$.effect("__tests__/template.marko_1_clic
     clickCount
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope._, clickCount + 1), clickCount;
+  $clickCount($scope._, ++clickCount)
 }));
 const $clickCount$if$content = /* @__PURE__ */_$.conditionalClosure("clickCount", "#text/0", 0, ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 375 (min) 223 (brotli)
+// size: 381 (min) 225 (brotli)
 const $item$for$content = _$.value(2, ($scope, item) =>
     _$.data($scope[0], item),
   ),
@@ -9,7 +9,8 @@ const $item$for$content = _$.value(2, ($scope, item) =>
   $expr_id_items_effect = _$.effect("a0", ($scope, { 3: id, 4: items }) =>
     _$.on($scope[1], "click", function () {
       const nextId = id + 1;
-      ($id($scope, nextId), $items($scope, [...items, nextId]));
+      ($id($scope, (id = nextId)),
+        $items($scope, (items = [...items, nextId])));
     }),
   ),
   $expr_id_items = _$.intersection(5, $expr_id_items_effect),
@@ -17,7 +18,7 @@ const $item$for$content = _$.value(2, ($scope, item) =>
   $for = _$.loopOf(0, $for_content),
   $items_effect = _$.effect("a1", ($scope, { 4: items }) =>
     _$.on($scope[2], "click", function () {
-      $items($scope, items.slice(0, -1));
+      $items($scope, (items = items.slice(0, -1)));
     }),
   ),
   $items = _$.state(4, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.expected/template.js
@@ -10,8 +10,8 @@ const $expr_id_items_effect = _$.effect("__tests__/template.marko_0_id_items", (
 }) => _$.on($scope["#button/1"], "click", function () {
   // TODO: nested writes ([...items, id++]) don't work
   const nextId = id + 1;
-  $id($scope, nextId);
-  $items($scope, [...items, nextId]);
+  $id($scope, id = nextId);
+  $items($scope, items = [...items, nextId]);
 }));
 const $expr_id_items = /* @__PURE__ */_$.intersection(5, $expr_id_items_effect);
 const $id = /* @__PURE__ */_$.state("id/3", $expr_id_items);
@@ -19,7 +19,7 @@ const $for = /* @__PURE__ */_$.loopOf("#text/0", $for_content);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/2"], "click", function () {
-  $items($scope, items.slice(0, -1));
+  $items($scope, items = items.slice(0, -1));
 }));
 const $items = /* @__PURE__ */_$.state("items/4", ($scope, items) => {
   $for($scope, [items]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 397 (min) 222 (brotli)
+// size: 401 (min) 225 (brotli)
 const $x$for$content = _$.value(2, ($scope, x) => _$.data($scope[0], x)),
   $params2$for$content = _$.value(1, ($scope, $params2) =>
     $x$for$content($scope, $params2[0]),
@@ -6,7 +6,7 @@ const $x$for$content = _$.value(2, ($scope, x) => _$.data($scope[0], x)),
   $for_content = _$.createRenderer("<li> </li>", "D ", 0, $params2$for$content),
   $open_effect = _$.effect("a0", ($scope, { 3: open }) =>
     _$.on($scope[1], "click", function () {
-      $open($scope, !open);
+      $open($scope, (open = !open));
     }),
   ),
   $open = _$.state(3, ($scope, open) => {
@@ -15,7 +15,7 @@ const $x$for$content = _$.value(2, ($scope, x) => _$.data($scope[0], x)),
   $for = _$.loopOf(0, $for_content),
   $list_effect = _$.effect("a1", ($scope, { 4: list }) =>
     _$.on($scope[2], "click", function () {
-      $list($scope, [].concat(list).reverse());
+      $list($scope, (list = [].concat(list).reverse()));
     }),
   ),
   $list = _$.state(4, ($scope, list) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $for_content = /* @__PURE__ */_$.createRenderer("<li> </li>", /* next(1), 
 const $open_effect = _$.effect("__tests__/template.marko_0_open", ($scope, {
   open
 }) => _$.on($scope["#button/1"], "click", function () {
-  $open($scope, !open);
+  $open($scope, open = !open);
 }));
 const $open = /* @__PURE__ */_$.state("open/3", ($scope, open) => {
   _$.attr($scope["#ul/0"], "hidden", !open);
@@ -17,7 +17,7 @@ const $for = /* @__PURE__ */_$.loopOf("#ul/0", $for_content);
 const $list_effect = _$.effect("__tests__/template.marko_0_list", ($scope, {
   list
 }) => _$.on($scope["#button/2"], "click", function () {
-  $list($scope, [].concat(list).reverse());
+  $list($scope, list = [].concat(list).reverse());
 }));
 const $list = /* @__PURE__ */_$.state("list/4", ($scope, list) => {
   $for($scope, [list, function (x) {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 165 (min) 141 (brotli)
+// size: 167 (min) 139 (brotli)
 const $if_content = _$.createRenderer("Hello!"),
   $if = _$.conditional(0, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 2: show }) =>
     _$.on($scope[1], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(2, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/0", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/1"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/2", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 120 (min) 102 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 2: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = _$.state(2, ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $unused_2 = $scope => {};
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/2", ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 262 (min) 178 (brotli)
+// size: 264 (min) 180 (brotli)
 const $message$if$content = _$.conditionalClosure(3, 1, 0, ($scope, message) =>
     _$.data($scope[0], message),
   ),
@@ -7,7 +7,7 @@ const $message$if$content = _$.conditionalClosure(3, 1, 0, ($scope, message) =>
   $if = _$.conditional(1, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 2: show }) =>
     _$.on($scope[0], "click", function () {
-      ($message($scope, "bye"), $show($scope, !show));
+      ($message($scope, "bye"), $show($scope, (show = !show)));
     }),
   ),
   $show = _$.state(2, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
   $message($scope, "bye");
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/2", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 185 (min) 135 (brotli)
+// size: 185 (min) 140 (brotli)
 const $expr_a_b_effect = _$.effect("a0", ($scope, { 2: a, 3: b }) =>
     _$.on($scope[0], "click", function () {
-      ($a($scope, a + 1), $b($scope, b + 1));
+      ($a($scope, ++a), $b($scope, ++b));
     }),
   ),
   $expr_a_b = _$.intersection(4, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/__snapshots__/dom.expected/template.js
@@ -5,8 +5,8 @@ const $expr_a_b_effect = _$.effect("__tests__/template.marko_0_a_b", ($scope, {
   a,
   b
 }) => _$.on($scope["#button/0"], "click", function () {
-  $a($scope, a + 1), a;
-  $b($scope, b + 1), b;
+  $a($scope, ++a)
+  $b($scope, ++b)
 }));
 const $expr_a_b = /* @__PURE__ */_$.intersection(4, $scope => {
   const {

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 437 (min) 248 (brotli)
+// size: 437 (min) 247 (brotli)
 const $attrs_effect = _$.effect("a0", ($scope) => _$.attrsEvents($scope, 0)),
   $attrs = _$.value(5, ($scope, attrs) => {
     (_$.attrs($scope, 0, attrs), $attrs_effect($scope));
@@ -32,7 +32,7 @@ const $attrs_effect = _$.effect("a0", ($scope) => _$.attrsEvents($scope, 0)),
   });
 function $onClick($scope, { 1: clickCount } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1);
+    $clickCount($scope, ++clickCount);
   };
 }
 (_$.register("b0", $onClick), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.expected/template.js
@@ -21,7 +21,7 @@ function $onClick($scope, {
   clickCount
 } = $scope) {
   return function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   };
 }
 _$.register("__tests__/template.marko_0/onClick", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 671 (min) 361 (brotli)
+// size: 673 (min) 363 (brotli)
 const $expr_name_write_effect = _$.effect(
     "a0",
     ($scope, { 5: name, 6: write }) => {
@@ -37,7 +37,7 @@ const $expr_name_write_effect = _$.effect(
   $for = _$.loopOf(2, $for_content),
   $items_effect = _$.effect("b1", ($scope, { 3: items }) =>
     _$.on($scope[0], "click", function () {
-      $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+      $items($scope, (items = items.length ? items.slice(0, -1) : [1, 2, 3]));
     }),
   ),
   $items = _$.state(3, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ const $for = /* @__PURE__ */_$.loopOf("#text/2", $for_content);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/0"], "click", function () {
-  $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+  $items($scope, items = items.length ? items.slice(0, -1) : [1, 2, 3]);
 }));
 const $items = /* @__PURE__ */_$.state("items/3", ($scope, items) => {
   $for($scope, [items]);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1287 (min) 507 (brotli)
+// size: 1293 (min) 508 (brotli)
 const $template = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   $expr_name_write_effect = _$.effect("a0", ($scope, { 5: name, 6: write }) => {
     (write(`${name} mounted`),
@@ -75,7 +75,7 @@ const $template = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   $if = _$.conditional(4, $if_content),
   $showOuter_effect = _$.effect("b1", ($scope, { 5: showOuter }) =>
     _$.on($scope[0], "click", function () {
-      $showOuter($scope, !showOuter);
+      $showOuter($scope, (showOuter = !showOuter));
     }),
   ),
   $showOuter = _$.state(5, ($scope, showOuter) => {
@@ -83,7 +83,7 @@ const $template = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   }),
   $showMiddle_effect = _$.effect("b2", ($scope, { 6: showMiddle }) =>
     _$.on($scope[1], "click", function () {
-      $showMiddle($scope, !showMiddle);
+      $showMiddle($scope, (showMiddle = !showMiddle));
     }),
   ),
   $showMiddle = _$.state(6, ($scope) => {
@@ -92,7 +92,7 @@ const $template = "<div><!> a</div><span><!> a</span><p><!> a</p>",
   $showInner_closure = _$.dynamicClosure($showInner$if$content),
   $showInner_effect = _$.effect("b3", ($scope, { 7: showInner }) =>
     _$.on($scope[2], "click", function () {
-      $showInner($scope, !showInner);
+      $showInner($scope, (showInner = !showInner));
     }),
   ),
   $showInner = _$.state(7, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.expected/template.js
@@ -33,7 +33,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/4", $if_content);
 const $showOuter_effect = _$.effect("__tests__/template.marko_0_showOuter", ($scope, {
   showOuter
 }) => _$.on($scope["#button/0"], "click", function () {
-  $showOuter($scope, !showOuter);
+  $showOuter($scope, showOuter = !showOuter);
 }));
 const $showOuter = /* @__PURE__ */_$.state("showOuter/5", ($scope, showOuter) => {
   $if($scope, showOuter ? 0 : 1);
@@ -42,7 +42,7 @@ const $showOuter = /* @__PURE__ */_$.state("showOuter/5", ($scope, showOuter) =>
 const $showMiddle_effect = _$.effect("__tests__/template.marko_0_showMiddle", ($scope, {
   showMiddle
 }) => _$.on($scope["#button/1"], "click", function () {
-  $showMiddle($scope, !showMiddle);
+  $showMiddle($scope, showMiddle = !showMiddle);
 }));
 const $showMiddle = /* @__PURE__ */_$.state("showMiddle/6", $scope => {
   $showMiddle$if$content($scope);
@@ -52,7 +52,7 @@ const $showInner_closure = /* @__PURE__ */_$.dynamicClosure($showInner$if$conten
 const $showInner_effect = _$.effect("__tests__/template.marko_0_showInner", ($scope, {
   showInner
 }) => _$.on($scope["#button/2"], "click", function () {
-  $showInner($scope, !showInner);
+  $showInner($scope, showInner = !showInner);
 }));
 const $showInner = /* @__PURE__ */_$.state("showInner/7", $scope => {
   $showInner_closure($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 353 (min) 218 (brotli)
+// size: 355 (min) 220 (brotli)
 const $setup$if$content_effect = _$.effect("a0", ($scope) => {
     (($scope._[1].innerHTML += "\nmounted"),
       (_$.getAbortSignal($scope, 0).onabort = () => {
@@ -16,7 +16,7 @@ const $setup$if$content_effect = _$.effect("a0", ($scope) => {
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("a1", ($scope, { 3: show }) =>
     _$.on($scope[0], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 459 (min) 285 (brotli)
+// size: 461 (min) 280 (brotli)
 const $input_effect = _$.effect("a0", ($scope, { 1: input }) => {
     (input.write("mounted"),
       (_$.getAbortSignal($scope, 0).onabort = () => {
@@ -19,7 +19,7 @@ const $input_effect = _$.effect("a0", ($scope, { 1: input }) => {
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("b1", ($scope, { 3: show }) =>
     _$.on($scope[0], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.expected/template.js
@@ -13,7 +13,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 955 (min) 467 (brotli)
+// size: 957 (min) 466 (brotli)
 const $expr_name_write_effect = _$.effect(
     "a0",
     ($scope, { 3: name, 4: write }) =>
@@ -68,7 +68,7 @@ const $expr_name_write_effect = _$.effect(
   $for = _$.loopOf(2, $for_content),
   $items_effect = _$.effect("b1", ($scope, { 3: items }) =>
     _$.on($scope[0], "click", function () {
-      $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+      $items($scope, (items = items.length ? items.slice(0, -1) : [1, 2, 3]));
     }),
   ),
   $items = _$.state(3, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.expected/template.js
@@ -39,7 +39,7 @@ const $for = /* @__PURE__ */_$.loopOf("#text/2", $for_content);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/0"], "click", function () {
-  $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+  $items($scope, items = items.length ? items.slice(0, -1) : [1, 2, 3]);
 }));
 const $items = /* @__PURE__ */_$.state("items/3", ($scope, items) => {
   $for($scope, [items]);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 613 (min) 343 (brotli)
+// size: 615 (min) 346 (brotli)
 const $expr_name_write_effect = _$.effect(
     "a0",
     ($scope, { 3: name, 4: write }) => {
@@ -34,7 +34,7 @@ const $expr_name_write_effect = _$.effect(
   $for = _$.loopOf(2, $for_content),
   $items_effect = _$.effect("b1", ($scope, { 3: items }) =>
     _$.on($scope[0], "click", function () {
-      $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+      $items($scope, (items = items.length ? items.slice(0, -1) : [1, 2, 3]));
     }),
   ),
   $items = _$.state(3, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ const $for = /* @__PURE__ */_$.loopOf("#text/2", $for_content);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/0"], "click", function () {
-  $items($scope, items.length ? items.slice(0, -1) : [1, 2, 3]);
+  $items($scope, items = items.length ? items.slice(0, -1) : [1, 2, 3]);
 }));
 const $items = /* @__PURE__ */_$.state("items/3", ($scope, items) => {
   $for($scope, [items]);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1205 (min) 494 (brotli)
+// size: 1211 (min) 490 (brotli)
 const $expr_name_write_effect = _$.effect(
     "a0",
     ($scope, { 3: name, 4: write }) => {
@@ -70,7 +70,7 @@ const $expr_name_write_effect = _$.effect(
   $if = _$.conditional(4, $if_content),
   $showOuter_effect = _$.effect("b1", ($scope, { 5: showOuter }) =>
     _$.on($scope[0], "click", function () {
-      $showOuter($scope, !showOuter);
+      $showOuter($scope, (showOuter = !showOuter));
     }),
   ),
   $showOuter = _$.state(5, ($scope, showOuter) => {
@@ -78,7 +78,7 @@ const $expr_name_write_effect = _$.effect(
   }),
   $showMiddle_effect = _$.effect("b2", ($scope, { 6: showMiddle }) =>
     _$.on($scope[1], "click", function () {
-      $showMiddle($scope, !showMiddle);
+      $showMiddle($scope, (showMiddle = !showMiddle));
     }),
   ),
   $showMiddle = _$.state(6, ($scope) => {
@@ -87,7 +87,7 @@ const $expr_name_write_effect = _$.effect(
   $showInner_closure = _$.dynamicClosure($showInner$if$content),
   $showInner_effect = _$.effect("b3", ($scope, { 7: showInner }) =>
     _$.on($scope[2], "click", function () {
-      $showInner($scope, !showInner);
+      $showInner($scope, (showInner = !showInner));
     }),
   ),
   $showInner = _$.state(7, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.expected/template.js
@@ -33,7 +33,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/4", $if_content);
 const $showOuter_effect = _$.effect("__tests__/template.marko_0_showOuter", ($scope, {
   showOuter
 }) => _$.on($scope["#button/0"], "click", function () {
-  $showOuter($scope, !showOuter);
+  $showOuter($scope, showOuter = !showOuter);
 }));
 const $showOuter = /* @__PURE__ */_$.state("showOuter/5", ($scope, showOuter) => {
   $if($scope, showOuter ? 0 : 1);
@@ -42,7 +42,7 @@ const $showOuter = /* @__PURE__ */_$.state("showOuter/5", ($scope, showOuter) =>
 const $showMiddle_effect = _$.effect("__tests__/template.marko_0_showMiddle", ($scope, {
   showMiddle
 }) => _$.on($scope["#button/1"], "click", function () {
-  $showMiddle($scope, !showMiddle);
+  $showMiddle($scope, showMiddle = !showMiddle);
 }));
 const $showMiddle = /* @__PURE__ */_$.state("showMiddle/6", $scope => {
   $showMiddle$if$content($scope);
@@ -52,7 +52,7 @@ const $showInner_closure = /* @__PURE__ */_$.dynamicClosure($showInner$if$conten
 const $showInner_effect = _$.effect("__tests__/template.marko_0_showInner", ($scope, {
   showInner
 }) => _$.on($scope["#button/2"], "click", function () {
-  $showInner($scope, !showInner);
+  $showInner($scope, showInner = !showInner);
 }));
 const $showInner = /* @__PURE__ */_$.state("showInner/7", $scope => {
   $showInner_closure($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 335 (min) 207 (brotli)
+// size: 337 (min) 208 (brotli)
 const $setup$if$content_effect = _$.effect("a0", ($scope) => {
     (($scope._[1].innerHTML += "\nmounted"),
       (_$.getAbortSignal($scope, 0).onabort = () => {
@@ -12,7 +12,7 @@ const $setup$if$content_effect = _$.effect("a0", ($scope) => {
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("a1", ($scope, { 3: show }) =>
     _$.on($scope[0], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 441 (min) 266 (brotli)
+// size: 443 (min) 265 (brotli)
 const $input_effect = _$.effect("a0", ($scope, { 1: input }) => {
     (input.write("mounted"),
       (_$.getAbortSignal($scope, 0).onabort = () => {
@@ -15,7 +15,7 @@ const $input_effect = _$.effect("a0", ($scope, { 1: input }) => {
   $if = _$.conditional(2, $if_content),
   $show_effect = _$.effect("b1", ($scope, { 3: show }) =>
     _$.on($scope[0], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.expected/template.js
@@ -13,7 +13,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/2", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.expected/tags/counter.js
@@ -11,7 +11,7 @@ const $expr_input_count = /* @__PURE__ */_$.intersection(5, $scope => {
 const $count_effect = _$.effect("__tests__/tags/counter.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $expr_input_count($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 187 (min) 142 (brotli)
+// size: 187 (min) 145 (brotli)
 const $expr_value_dummy = _$.intersection(5, ($scope) => {
     const { 3: value, 4: dummy } = $scope;
     _$.data($scope[0], value);
@@ -6,7 +6,7 @@ const $expr_value_dummy = _$.intersection(5, ($scope) => {
   $value = _$.value(3, $expr_value_dummy),
   $count_effect = _$.effect("b0", ($scope, { 2: count }) =>
     _$.on($scope[1], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(2, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/1"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {
   _displayIntersection_input_value($scope["#childScope/0"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/tags/counter.js
@@ -11,7 +11,7 @@ const $expr_input_count = /* @__PURE__ */_$.intersection(5, $scope => {
 const $count_effect = _$.effect("__tests__/tags/counter.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/4", $scope => {
   $expr_input_count($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 279 (min) 168 (brotli)
+// size: 279 (min) 176 (brotli)
 const $expr_input_count = _$.intersection(5, ($scope) => {
     const { 3: input, 4: count } = $scope;
     _$.data($scope[1], input.format(count));
   }),
   $count_effect = _$.effect("a0", ($scope, { 4: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(4, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 179 (min) 132 (brotli)
+// size: 181 (min) 146 (brotli)
 const $if_content = _$.createRenderer("<tr><td>Hi</td></tr>"),
   $if = _$.conditional(0, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 2: show }) =>
     _$.on($scope[1], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(2, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $if = /* @__PURE__ */_$.conditional("#tbody/0", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/1"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/2", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 625 (min) 321 (brotli)
+// size: 629 (min) 327 (brotli)
 const $opt$for$content = _$.value(3, ($scope, opt) => {
     (_$.attr($scope[0], "value", opt), _$.data($scope[1], opt));
   }),
@@ -14,10 +14,13 @@ const $opt$for$content = _$.value(3, ($scope, opt) => {
   $for = _$.loopOf(0, $for_content),
   $options_effect = _$.effect("a1", ($scope, { 4: options }) => {
     (_$.on($scope[2], "click", function () {
-      $options($scope, options.slice(1));
+      $options($scope, (options = options.slice(1)));
     }),
       _$.on($scope[3], "click", function () {
-        $options($scope, [options.length ? options[0] - 1 : 3, ...options]);
+        $options(
+          $scope,
+          (options = [options.length ? options[0] - 1 : 3, ...options]),
+        );
       }));
   }),
   $options = _$.state(4, ($scope, options) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/dom.expected/template.js
@@ -12,10 +12,10 @@ const $options_effect = _$.effect("__tests__/template.marko_0_options", ($scope,
   options
 }) => {
   _$.on($scope["#button/2"], "click", function () {
-    $options($scope, options.slice(1));
+    $options($scope, options = options.slice(1));
   });
   _$.on($scope["#button/3"], "click", function () {
-    $options($scope, [options.length ? options[0] - 1 : 3, ...options]);
+    $options($scope, options = [options.length ? options[0] - 1 : 3, ...options]);
   });
 });
 const $options = /* @__PURE__ */_$.state("options/4", ($scope, options) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 307 (min) 188 (brotli)
+// size: 307 (min) 199 (brotli)
 const $value = _$.state(3, _$.tagVarSignal);
 _$.register("a0", function ($scope) {
   return (_new_value) => {
@@ -9,7 +9,7 @@ const $count$mytag$content_effect = _$.effect(
     "c1",
     ($scope, { _: { 3: count } }) =>
       _$.on($scope[0], "click", function () {
-        _$.tagVarSignalChange($scope._[0], count + 1);
+        _$.tagVarSignalChange($scope._[0], ++count);
       }),
   ),
   $count$mytag$content = _$.dynamicClosureRead(3, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $count$mytag$content_effect = _$.effect("__tests__/template.marko_1_count"
     count
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  _$.tagVarSignalChange($scope._["#childScope/0"], count + 1), count;
+  _$.tagVarSignalChange($scope._["#childScope/0"], ++count)
 }));
 const $count$mytag$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/tags/custom-tag.js
@@ -5,8 +5,8 @@ const $expr_x_y_effect = _$.effect("__tests__/tags/custom-tag.marko_0_x_y", ($sc
   x,
   y
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
-  $y($scope, y + 1), y;
+  $x($scope, ++x)
+  $y($scope, ++y)
 }));
 const $expr_x_y = /* @__PURE__ */_$.intersection(9, $expr_x_y_effect);
 const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/3", 0, 0, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 474 (min) 272 (brotli)
+// size: 474 (min) 271 (brotli)
 const $expr_x_y_effect = _$.effect("a0", ($scope, { 7: x, 8: y }) =>
     _$.on($scope[0], "click", function () {
-      ($x($scope, x + 1), $y($scope, y + 1));
+      ($x($scope, ++x), $y($scope, ++y));
     }),
   ),
   $expr_x_y = _$.intersection(9, $expr_x_y_effect),

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/tags/custom-tag.js
@@ -16,7 +16,7 @@ const $expr_input_content_input_name_x = /* @__PURE__ */_$.intersection(8, $scop
 const $x_effect = _$.effect("__tests__/tags/custom-tag.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/7", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 436 (min) 272 (brotli)
+// size: 436 (min) 274 (brotli)
 const $dynamicTag = _$.dynamicTag(2),
   $expr_input_content_input_name_x = _$.intersection(
     8,
@@ -13,7 +13,7 @@ const $dynamicTag = _$.dynamicTag(2),
   ),
   $x_effect = _$.effect("a0", ($scope, { 7: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(7, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/tags/custom-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/tags/custom-tag.js
@@ -12,7 +12,7 @@ const $expr_input_content_x = /* @__PURE__ */_$.intersection(7, $scope => {
 const $x_effect = _$.effect("__tests__/tags/custom-tag.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/6", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/dom.expected/template.hydrate.js
@@ -6,7 +6,7 @@ const $dynamicTag = _$.dynamicTag(2, 0, 0, 1),
   }),
   $x_effect = _$.effect("a0", ($scope, { 6: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(6, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/tags/counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $x_effect = _$.effect("__tests__/tags/counter.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 431 (min) 200 (brotli)
+// size: 431 (min) 201 (brotli)
 const $x_effect = _$.effect("a1", ($scope, { 2: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(2, ($scope, x) => {
@@ -14,7 +14,7 @@ _$.register("a0", function ($scope) {
 });
 const $count_effect = _$.effect("b0", ($scope, { 5: count }) =>
   _$.on($scope[2], "click", function () {
-    _$.tagVarSignalChange($scope[0], count + 1);
+    _$.tagVarSignalChange($scope[0], ++count);
   }),
 );
 (_$.registerBoundSignal(

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/2"], "click", function () {
-  _$.tagVarSignalChange($scope["#childScope/0"], count + 1), count;
+  _$.tagVarSignalChange($scope["#childScope/0"], ++count)
 }));
 const $count = _$.registerBoundSignal("__tests__/template.marko_0_count/var", /* @__PURE__ */_$.value("count", ($scope, count) => {
   _$.data($scope["#text/3"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/tags/child.js
@@ -11,7 +11,7 @@ const $expr_input_extra_x = /* @__PURE__ */_$.intersection(6, $scope => {
 const $x_effect = _$.effect("__tests__/tags/child.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/5", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -5,7 +5,7 @@ const $expr_input_extra_x = _$.intersection(6, ($scope) => {
   }),
   $x_effect = _$.effect("a0", ($scope, { 5: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(5, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/tags/child.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $x_effect = _$.effect("__tests__/tags/child.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 201 (min) 144 (brotli)
 const $x_effect = _$.effect("a0", ($scope, { 2: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(2, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 353 (min) 212 (brotli)
+// size: 355 (min) 213 (brotli)
 const $input_thing_selected = _$.value(5, ($scope, input_thing_selected) =>
     _$.classItem($scope[0], "selected", input_thing_selected),
   ),
@@ -12,7 +12,7 @@ const $input_thing_selected = _$.value(5, ($scope, input_thing_selected) =>
   $myThing = _$.value(3, ($scope, myThing) => $input_thing($scope[0], myThing)),
   $selected_effect = _$.effect("b1", ($scope, { 2: selected }) =>
     _$.on($scope[1], "click", function () {
-      $selected($scope, !selected);
+      $selected($scope, (selected = !selected));
     }),
   ),
   $selected = _$.state(2, ($scope, selected) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $myThing = /* @__PURE__ */_$.value("myThing", ($scope, myThing) => _child_
 const $selected_effect = _$.effect("__tests__/template.marko_0_selected", ($scope, {
   selected
 }) => _$.on($scope["#button/1"], "click", function () {
-  $selected($scope, !selected);
+  $selected($scope, selected = !selected);
 }));
 const $selected = /* @__PURE__ */_$.state("selected/2", ($scope, selected) => {
   $myThing($scope, {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.hydrate.js
@@ -4,7 +4,7 @@ const $myObj = _$.value(4, ($scope, myObj) =>
   ),
   $x_effect = _$.effect("a0", ($scope, { 3: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const $myObj = /* @__PURE__ */_$.value("myObj", ($scope, myObj) => _$.data($scop
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/2"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 441 (min) 247 (brotli)
+// size: 441 (min) 248 (brotli)
 const $a$define$content = _$.value(4, ($scope, a) => _$.data($scope[0], a)),
   $b$define$content = _$.value(5, ($scope, b) => _$.data($scope[1], b)),
   $c$define$content = _$.value(6, ($scope, c) => _$.data($scope[2], c)),
@@ -21,7 +21,7 @@ const $dynamicTag = _$.dynamicTag(0, 0, 0, 1),
   }),
   $x_effect = _$.effect("a1", ($scope, { 3: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/dom.expected/template.js
@@ -21,7 +21,7 @@ const $expr_x_MyTag = /* @__PURE__ */_$.intersection(5, $scope => {
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/2"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 363 (min) 225 (brotli)
+// size: 363 (min) 227 (brotli)
 const $number$define$content = _$.value(3, ($scope, number) =>
     _$.data($scope[0], number),
   ),
@@ -16,7 +16,7 @@ const $dynamicTag = _$.dynamicTag(),
   }),
   $x_effect = _$.effect("a1", ($scope, { 3: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/dom.expected/template.js
@@ -18,7 +18,7 @@ const $expr_x_MyTag = /* @__PURE__ */_$.intersection(5, $scope => {
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/2"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 195 (min) 130 (brotli)
+// size: 195 (min) 129 (brotli)
 const $x$define$content = _$.dynamicClosureRead(3, ($scope, x) =>
     _$.data($scope[0], x),
   ),
   $x_closure = _$.dynamicClosure($x$define$content),
   $x_effect = _$.effect("a1", ($scope, { 3: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $x_closure = /* @__PURE__ */_$.dynamicClosure($x$define$content);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/2"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 135 (min) 108 (brotli)
 const $y$define$content_effect = _$.effect("a1", ($scope, { 7: y }) =>
     _$.on($scope[2], "click", function () {
-      $y$define$content($scope, y + 1);
+      $y$define$content($scope, ++y);
     }),
   ),
   $y$define$content = _$.state(7, ($scope, y) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $y$define$content_effect = _$.effect("__tests__/template.marko_1_y", ($scope, {
   y
 }) => _$.on($scope["#button/2"], "click", function () {
-  $y$define$content($scope, y + 1), y;
+  $y$define$content($scope, ++y)
 }));
 const $y$define$content = /* @__PURE__ */_$.state("y/7", ($scope, y) => {
   _$.data($scope["#text/1"], y);

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 333 (min) 192 (brotli)
+// size: 335 (min) 197 (brotli)
 const $setup$if$content2 = ($scope) => {
     _$.data($scope[0], $scope.$global.x);
   },
@@ -15,7 +15,7 @@ const $setup$if$content2 = ($scope) => {
   $if2 = _$.conditional(1, $if_content2),
   $show_effect = _$.effect("a0", ($scope, { 3: show }) =>
     _$.on($scope[2], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(3, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ const $if2 = /* @__PURE__ */_$.conditional("#text/1", $if_content2);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/2"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/3", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 327 (min) 203 (brotli)
+// size: 327 (min) 210 (brotli)
 let sideEffect = 3;
 const $count$define$content = _$.dynamicClosureRead(1, ($scope, count) =>
   _$.data($scope[0], count),
@@ -13,7 +13,7 @@ const $expr_count_MyThing = _$.intersection(3, ($scope) => {
   $count_closure = _$.dynamicClosure($count$define$content),
   $count_effect = _$.effect("a1", ($scope, { 1: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(1, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/dom.expected/template.js
@@ -20,7 +20,7 @@ const $count_closure = /* @__PURE__ */_$.dynamicClosure($count$define$content);
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/1", $scope => {
   $expr_count_MyThing($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.hydrate.js
@@ -1,11 +1,11 @@
-// size: 122 (min) 104 (brotli)
+// size: 122 (min) 110 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 2: clickCount }) =>
     _$.on(
       $scope[0],
       "click",
       clickCount <= 1 &&
         (() => {
-          $clickCount($scope, clickCount + 1);
+          $clickCount($scope, ++clickCount);
         }),
     ),
   ),

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", clickCount <= 1 ? () => {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 } : false));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/2", ($scope, clickCount) => {
   _$.data($scope["#text/1"], clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 252 (min) 183 (brotli)
+// size: 254 (min) 180 (brotli)
 const $tagName_content = _$.registerContent("a0", "body content"),
   $dynamicTag = _$.dynamicTag(0, $tagName_content),
   $expr_tagName_className = _$.intersection(4, ($scope) => {
@@ -7,7 +7,7 @@ const $tagName_content = _$.registerContent("a0", "body content"),
   }),
   $tagName_effect = _$.effect("a1", ($scope, { 2: tagName }) =>
     _$.on($scope[1], "click", function () {
-      $tagName($scope, "span" === tagName ? "div" : "span");
+      $tagName($scope, (tagName = "span" === tagName ? "div" : "span"));
     }),
   ),
   $tagName = _$.state(2, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.expected/template.js
@@ -15,7 +15,7 @@ const $expr_tagName_className = /* @__PURE__ */_$.intersection(4, $scope => {
 const $tagName_effect = _$.effect("__tests__/template.marko_0_tagName", ($scope, {
   tagName
 }) => _$.on($scope["#button/1"], "click", function () {
-  $tagName($scope, tagName === "span" ? "div" : "span");
+  $tagName($scope, tagName = tagName === "span" ? "div" : "span");
 }));
 const $tagName = /* @__PURE__ */_$.state("tagName/2", $scope => {
   $expr_tagName_className($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 356 (min) 230 (brotli)
+// size: 356 (min) 220 (brotli)
 const $setup = () => {},
   $input = _$.value(2, ($scope, input) => {
     (_$.data($scope[0], input), _$.tagVarSignal($scope, input));
@@ -9,7 +9,7 @@ const tags = [
   $dynamicTag = _$.dynamicTag(2, 0, () => $y, 1),
   $x_effect = _$.effect("b0", ($scope, { 5: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(5, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/2", 0, () => $y, 1);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/5", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.hydrate.js
@@ -7,7 +7,7 @@ const tags = [_$.createTemplate("a", "<div> </div>", "D l", $setup, $input)],
   $dynamicTag = _$.dynamicTag(2, 0, 0, 1),
   $x_effect = _$.effect("b0", ($scope, { 6: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(6, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/2", 0, 0, 1);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/6", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 137 (min) 130 (brotli)
+// size: 139 (min) 128 (brotli)
 const $className_effect = _$.effect("a0", ($scope, { 2: className }) =>
     _$.on($scope[1], "click", function () {
-      $className($scope, "A" === className ? "B" : "A");
+      $className($scope, (className = "A" === className ? "B" : "A"));
     }),
   ),
   $className = _$.state(2, ($scope, className) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $className_effect = _$.effect("__tests__/template.marko_0_className", ($scope, {
   className
 }) => _$.on($scope["#button/1"], "click", function () {
-  $className($scope, className === "A" ? "B" : "A");
+  $className($scope, className = className === "A" ? "B" : "A");
 }));
 const $className = /* @__PURE__ */_$.state("className/2", ($scope, className) => {
   _$.classAttr($scope["#p/0"], className);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 303 (min) 210 (brotli)
+// size: 305 (min) 211 (brotli)
 const $setup = () => {},
   $id = _$.value(3, ($scope, id) => _$.data($scope[0], id)),
   $input = _$.value(2, ($scope, input) => $id($scope, input.id));
@@ -12,7 +12,7 @@ var child = _$.createTemplate(
 const $dynamicTag = _$.dynamicTag(1),
   $tagName_effect = _$.effect("b0", ($scope, { 2: tagName }) =>
     _$.on($scope[0], "click", function () {
-      $tagName($scope, tagName === child ? "div" : child);
+      $tagName($scope, (tagName = tagName === child ? "div" : child));
     }),
   ),
   $tagName = _$.state(2, ($scope, tagName) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/1");
 const $tagName_effect = _$.effect("__tests__/template.marko_0_tagName", ($scope, {
   tagName
 }) => _$.on($scope["#button/0"], "click", function () {
-  $tagName($scope, tagName === child ? "div" : child);
+  $tagName($scope, tagName = tagName === child ? "div" : child);
 }));
 const $tagName = /* @__PURE__ */_$.state("tagName/2", ($scope, tagName) => {
   $dynamicTag($scope, tagName, () => ({

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 496 (min) 251 (brotli)
+// size: 498 (min) 251 (brotli)
 const $setup$1 = () => {},
   $value$1 = _$.value(3, ($scope, value) => _$.data($scope[0], value)),
   $input$1 = _$.value(2, ($scope, input) => $value$1($scope, input.value));
@@ -26,7 +26,7 @@ const $dynamicTag = _$.dynamicTag(),
   }),
   $tagName_effect = _$.effect("c0", ($scope, { 2: tagName }) =>
     _$.on($scope[1], "click", function () {
-      $tagName($scope, tagName === child1 ? child2 : child1);
+      $tagName($scope, (tagName = tagName === child1 ? child2 : child1));
     }),
   ),
   $tagName = _$.state(2, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.expected/template.js
@@ -16,7 +16,7 @@ const $expr_tagName_val = /* @__PURE__ */_$.intersection(4, $scope => {
 const $tagName_effect = _$.effect("__tests__/template.marko_0_tagName", ($scope, {
   tagName
 }) => _$.on($scope["#button/1"], "click", function () {
-  $tagName($scope, tagName === child1 ? child2 : child1);
+  $tagName($scope, tagName = tagName === child1 ? child2 : child1);
 }));
 const $tagName = /* @__PURE__ */_$.state("tagName/2", $scope => {
   $expr_tagName_val($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.hydrate.js
@@ -7,7 +7,7 @@ const tags = [_$.createTemplate("a", "<div> </div>", "D l", $setup, $input)],
   $dynamicTag = _$.dynamicTag(2, 0, 0, 1),
   $x_effect = _$.effect("b0", ($scope, { 3: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/2", 0, 0, 1);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 182 (min) 139 (brotli)
+// size: 184 (min) 135 (brotli)
 const $x_content = _$.registerContent("a0", "Body Content"),
   $dynamicTag = _$.dynamicTag(0, $x_content),
   $x_effect = _$.effect("a1", ($scope, { 2: x }) =>
     _$.on($scope[1], "click", function () {
-      $x($scope, x ? null : "div");
+      $x($scope, (x = x ? null : "div"));
     }),
   ),
   $x = _$.state(2, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", $x_content);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x ? null : "div");
+  $x($scope, x = x ? null : "div");
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   $dynamicTag($scope, x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/tags/counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $x_effect = _$.effect("__tests__/tags/counter.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 457 (min) 249 (brotli)
+// size: 457 (min) 253 (brotli)
 const $x_effect = _$.effect("a1", ($scope, { 2: x }) =>
     _$.on($scope[0], "click", function () {
-      $x($scope, x + 1);
+      $x($scope, ++x);
     }),
   ),
   $x = _$.state(2, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/tags/counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/tags/counter.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 359 (min) 214 (brotli)
+// size: 361 (min) 216 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 2: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(2, ($scope, count) => {
@@ -20,7 +20,7 @@ const $tagName_content = _$.registerContent(
   $dynamicTag = _$.dynamicTag(0, $tagName_content),
   $tagName_effect = _$.effect("b1", ($scope, { 2: tagName }) =>
     _$.on($scope[1], "click", function () {
-      $tagName($scope, "span" === tagName ? "div" : "span");
+      $tagName($scope, (tagName = "span" === tagName ? "div" : "span"));
     }),
   ),
   $tagName = _$.state(2, ($scope, tagName) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.expected/template.js
@@ -10,7 +10,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0", $tagName_content);
 const $tagName_effect = _$.effect("__tests__/template.marko_0_tagName", ($scope, {
   tagName
 }) => _$.on($scope["#button/1"], "click", function () {
-  $tagName($scope, tagName === "span" ? "div" : "span");
+  $tagName($scope, tagName = tagName === "span" ? "div" : "span");
 }));
 const $tagName = /* @__PURE__ */_$.state("tagName/2", ($scope, tagName) => {
   $dynamicTag($scope, tagName);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 1062 (min) 355 (brotli)
+// size: 1064 (min) 353 (brotli)
 const getStringBy = $getStringBy,
   getFunctionBy = $getFunctionBy,
   getMissingBy = $getMissingBy,
@@ -49,7 +49,7 @@ const getStringBy = $getStringBy,
   $for5 = _$.loopOf(4, $for_content5),
   $items_effect = _$.effect("a3", ($scope, { 6: items }) =>
     _$.on($scope[5], "click", function () {
-      $items($scope, [...items.slice(1), items[0]]);
+      $items($scope, (items = [...items.slice(1), items[0]]));
     }),
   ),
   $items = _$.state(6, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/dom.expected/template.js
@@ -32,7 +32,7 @@ const $for5 = /* @__PURE__ */_$.loopOf("#div/4", $for_content5);
 const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => _$.on($scope["#button/5"], "click", function () {
-  $items($scope, [...items.slice(1), items[0]]);
+  $items($scope, items = [...items.slice(1), items[0]]);
 }));
 const $items = /* @__PURE__ */_$.state("items/6", ($scope, items) => {
   $for($scope, [items, "id"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 447 (min) 239 (brotli)
+// size: 451 (min) 242 (brotli)
 const $name$for$content = _$.value(4, ($scope, name) =>
     _$.data($scope[0], name),
   ),
@@ -21,13 +21,16 @@ const $name$for$content = _$.value(4, ($scope, name) =>
   $for = _$.loopOf(0, $for_content),
   $items_effect = _$.effect("a0", ($scope, { 3: items }) => {
     (_$.on($scope[1], "click", function () {
-      $items($scope, [
-        ...items,
-        { name: "JavaScript", description: "Java, but scriptier" },
-      ]);
+      $items(
+        $scope,
+        (items = [
+          ...items,
+          { name: "JavaScript", description: "Java, but scriptier" },
+        ]),
+      );
     }),
       _$.on($scope[2], "click", function () {
-        $items($scope, items.slice(0, -1));
+        $items($scope, (items = items.slice(0, -1)));
       }));
   }),
   $items = _$.state(3, ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/__snapshots__/dom.expected/template.js
@@ -15,13 +15,13 @@ const $items_effect = _$.effect("__tests__/template.marko_0_items", ($scope, {
   items
 }) => {
   _$.on($scope["#button/1"], "click", function () {
-    $items($scope, [...items, {
+    $items($scope, items = [...items, {
       name: "JavaScript",
       description: "Java, but scriptier"
     }]);
   });
   _$.on($scope["#button/2"], "click", function () {
-    $items($scope, items.slice(0, -1));
+    $items($scope, items = items.slice(0, -1));
   });
 });
 const $items = /* @__PURE__ */_$.state("items/3", ($scope, items) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 283 (min) 195 (brotli)
+// size: 283 (min) 196 (brotli)
 const $num$for$content_effect = _$.effect("a0", ($scope, { _: { 1: num } }) =>
     _$.on($scope[0], "click", function () {
-      $num($scope._, num + 1);
+      $num($scope._, ++num);
     }),
   ),
   $num$for$content = _$.loopClosure(1, 0, $num$for$content_effect),

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $num$for$content_effect = _$.effect("__tests__/template.marko_1_num", ($sc
     num
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $num($scope._, num + 1), num;
+  $num($scope._, ++num)
 }));
 const $num$for$content = /* @__PURE__ */_$.loopClosure("num", "#text/0", $num$for$content_effect);
 const $i$for$content = /* @__PURE__ */_$.value("i", ($scope, i) => _$.data($scope["#text/1"], i));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 220 (min) 155 (brotli)
+// size: 222 (min) 158 (brotli)
 const $for_content = _$.createRenderer("<div></div>"),
   $for = _$.loopOf(0, $for_content),
   $children_effect = _$.effect("a0", ($scope, { 1: children }) => {
-    1 === children.length && $children($scope, [...children, 2]);
+    1 === children.length && $children($scope, (children = [...children, 2]));
   }),
   $children = _$.state(1, ($scope, children) => {
     ($children_length($scope, children?.length),

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $children_effect = _$.effect("__tests__/template.marko_0_children", ($scop
   children
 }) => {
   if (children.length === 1) {
-    $children($scope, [...children, 2]);
+    $children($scope, children = [...children, 2]);
   }
 });
 const $children = /* @__PURE__ */_$.state("children/1", ($scope, children) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 214 (min) 153 (brotli)
+// size: 216 (min) 155 (brotli)
 const $for_content = _$.createRenderer("Child"),
   $for = _$.loopOf(1, $for_content),
   $children_effect = _$.effect("a0", ($scope, { 2: children }) => {
-    1 === children.length && $children($scope, [...children, 2]);
+    1 === children.length && $children($scope, (children = [...children, 2]));
   }),
   $children = _$.state(2, ($scope, children) => {
     ($children_length($scope, children?.length),

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/dom.expected/template.js
@@ -7,7 +7,7 @@ const $children_effect = _$.effect("__tests__/template.marko_0_children", ($scop
   children
 }) => {
   if (children.length === 1) {
-    $children($scope, [...children, 2]);
+    $children($scope, children = [...children, 2]);
   }
 });
 const $children = /* @__PURE__ */_$.state("children/2", ($scope, children) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/__snapshots__/dom.expected/template.hydrate.js
@@ -1,10 +1,10 @@
-// size: 168 (min) 129 (brotli)
+// size: 168 (min) 121 (brotli)
 const $count$for$content = _$.loopClosure(3, 0, ($scope, count) =>
     _$.data($scope[1], count),
   ),
   $count_effect = _$.effect("a0", ($scope, { 3: count }) =>
     _$.on($scope[1], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(3, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const $for_content = /* @__PURE__ */_$.createRenderer("<!>-<!>", /* replace, ove
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/1"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/3", ($scope, count) => {
   _$.data($scope["#text/2"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 156 (min) 120 (brotli)
+// size: 156 (min) 121 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 3: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(3, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/3", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 218 (min) 159 (brotli)
+// size: 218 (min) 157 (brotli)
 const $count_effect = _$.effect("a1", ($scope, { 2: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(2, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#script/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {
   _$.textContent($scope["#script/0"], `

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 165 (min) 133 (brotli)
 const $count_effect = _$.effect("a1", ($scope, { 1: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(1, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#style/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/1", ($scope, count) => {
   _$.textContent($scope["#style/0"], `

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 161 (min) 134 (brotli)
+// size: 163 (min) 135 (brotli)
 const $if_content = _$.createRenderer("hi"),
   $if = _$.conditional(1, $if_content),
   $show_effect = _$.effect("a0", ($scope, { 2: show }) =>
     _$.on($scope[0], "click", function () {
-      $show($scope, !show);
+      $show($scope, (show = !show));
     }),
   ),
   $show = _$.state(2, ($scope, show) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/1", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/0"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/2", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
@@ -5,7 +5,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $state_effect = _$.effect("__tests__/tags/child.marko_0_state", ($scope, {
   state
 }) => _$.on($scope["#button/0"], "click", function () {
-  $state($scope, state + 1), state;
+  $state($scope, ++state)
 }));
 const $state = /* @__PURE__ */_$.state("state/11", ($scope, state) => {
   _$.data($scope["#text/2"], state);
@@ -27,7 +27,7 @@ const $input_valueChange = /* @__PURE__ */_$.value("input_valueChange", $expr_in
 const $otherState_effect = _$.effect("__tests__/tags/child.marko_0_otherState", ($scope, {
   otherState
 }) => _$.on($scope["#button/3"], "click", function () {
-  $otherState($scope, otherState + 1), otherState;
+  $otherState($scope, ++otherState)
 }));
 const $otherState = /* @__PURE__ */_$.state("otherState/12", ($scope, otherState) => {
   _$.data($scope["#text/5"], otherState);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 563 (min) 259 (brotli)
+// size: 563 (min) 251 (brotli)
 const $state_effect = _$.effect("a0", ($scope, { 11: state }) =>
     _$.on($scope[0], "click", function () {
-      $state($scope, state + 1);
+      $state($scope, ++state);
     }),
   ),
   $state = _$.state(11, ($scope, state) => {
@@ -19,7 +19,7 @@ const $state_effect = _$.effect("a0", ($scope, { 11: state }) =>
   $input_valueChange = _$.value(9, $expr_input_value_input_valueChange),
   $otherState_effect = _$.effect("a1", ($scope, { 12: otherState }) =>
     _$.on($scope[3], "click", function () {
-      $otherState($scope, otherState + 1);
+      $otherState($scope, ++otherState);
     }),
   ),
   $otherState = _$.state(12, ($scope, otherState) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 346 (min) 189 (brotli)
+// size: 346 (min) 198 (brotli)
 const $y_effect = _$.effect("a1", ($scope, { 7: y }) =>
     _$.on($scope[0], "click", function () {
-      $y($scope, y + 1);
+      $y($scope, ++y);
     }),
   ),
   $y = _$.state(7, ($scope, y) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $y_effect = _$.effect("__tests__/template.marko_0_y", ($scope, {
   y
 }) => _$.on($scope["#button/0"], "click", function () {
-  $y($scope, y + 1), y;
+  $y($scope, ++y)
 }));
 const $y = /* @__PURE__ */_$.state("y/7", ($scope, y) => {
   _$.data($scope["#text/2"], y);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 272 (min) 168 (brotli)
+// size: 272 (min) 170 (brotli)
 const $y_effect = _$.effect("a1", ($scope, { 6: y }) =>
     _$.on($scope[0], "click", function () {
-      $y($scope, y + 1);
+      $y($scope, ++y);
     }),
   ),
   $y = _$.state(6, ($scope, y) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $y_effect = _$.effect("__tests__/template.marko_0_y", ($scope, {
   y
 }) => _$.on($scope["#button/0"], "click", function () {
-  $y($scope, y + 1), y;
+  $y($scope, ++y)
 }));
 const $y = /* @__PURE__ */_$.state("y/6", ($scope, y) => {
   _$.data($scope["#text/2"], y);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 231 (min) 146 (brotli)
+// size: 231 (min) 150 (brotli)
 const $y_effect = _$.effect("a1", ($scope, { 4: y }) =>
     _$.on($scope[0], "click", function () {
-      $y($scope, y + 1);
+      $y($scope, ++y);
     }),
   ),
   $y = _$.state(4, ($scope, y) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $y_effect = _$.effect("__tests__/template.marko_0_y", ($scope, {
   y
 }) => _$.on($scope["#button/0"], "click", function () {
-  $y($scope, y + 1), y;
+  $y($scope, ++y)
 }));
 const $y = /* @__PURE__ */_$.state("y/4", ($scope, y) => {
   _$.data($scope["#text/2"], y);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.hydrate.js
@@ -1,6 +1,6 @@
-// size: 116 (min) 105 (brotli)
+// size: 118 (min) 106 (brotli)
 const $b_effect = _$.effect("a0", ($scope, { 6: b }) =>
-    _$.on($scope[0], "click", () => ($b($scope, b + 1), b)),
+    _$.on($scope[0], "click", () => ($b($scope, ++b), b - 1)),
   ),
   $b = _$.state(6, ($scope, b) => {
     (_$.data($scope[2], b), $b_effect($scope));

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ export const $setup = () => {};
 import * as _$ from "@marko/runtime-tags/debug/dom";
 const $b_effect = _$.effect("__tests__/template.marko_0_b", ($scope, {
   b
-}) => _$.on($scope["#button/0"], "click", () => ($b($scope, b + 1), b)));
+}) => _$.on($scope["#button/0"], "click", () => ($b($scope, ++b), b - 1)));
 const $b = /* @__PURE__ */_$.state("b/6", ($scope, b) => {
   _$.data($scope["#text/2"], b);
   $b_effect($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.hydrate.js
@@ -1,6 +1,6 @@
-// size: 131 (min) 95 (brotli)
+// size: 133 (min) 99 (brotli)
 const $x_effect = _$.effect("a0", ($scope, { 2: x }) => {
-    ($y($scope, x), $x($scope, 2));
+    ($y($scope, x), $x($scope, (x = 2)));
   }),
   $x = _$.state(2, ($scope, x) => {
     (_$.data($scope[0], x), $x_effect($scope));

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => {
   $y($scope, x);
-  $x($scope, 2);
+  $x($scope, x = 2);
 });
 const $x = /* @__PURE__ */_$.state("x/2", ($scope, x) => {
   _$.data($scope["#text/0"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 304 (min) 191 (brotli)
+// size: 306 (min) 178 (brotli)
 const $a = _$.value(9, ($scope, a) => _$.data($scope[4], a)),
   $expr_y_z = _$.intersection(8, ($scope) => {
     const { 6: y, 7: z } = $scope;
@@ -11,7 +11,7 @@ const $a = _$.value(9, ($scope, a) => _$.data($scope[4], a)),
     (_$.data($scope[3], z), $expr_y_z($scope));
   }),
   $x_effect = _$.effect("a0", ($scope, { 5: x }) =>
-    _$.on($scope[0], "click", () => ($x($scope, x + 1), x)),
+    _$.on($scope[0], "click", () => ($x($scope, ++x), x - 1)),
   ),
   $x = _$.state(5, ($scope, x) => {
     (_$.data($scope[1], x),

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
@@ -19,7 +19,7 @@ const $z = /* @__PURE__ */_$.value("z", ($scope, z) => {
 });
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
-}) => _$.on($scope["#button/0"], "click", () => ($x($scope, x + 1), x)));
+}) => _$.on($scope["#button/0"], "click", () => ($x($scope, ++x), x - 1)));
 const $x = /* @__PURE__ */_$.state("x/5", ($scope, x) => {
   _$.data($scope["#text/1"], x);
   $y($scope, x + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,6 +1,6 @@
-// size: 185 (min) 136 (brotli)
+// size: 189 (min) 141 (brotli)
 const $expr_x_y_effect = _$.effect("a0", ($scope, { 3: x, 4: y }) =>
-    _$.on($scope[0], "click", () => $x($scope, $y($scope, x + y))),
+    _$.on($scope[0], "click", () => $x($scope, (x = $y($scope, (y = x + y))))),
   ),
   $expr_x_y = _$.intersection(5, $expr_x_y_effect),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $expr_x_y_effect = _$.effect("__tests__/template.marko_0_x_y", ($scope, {
   x,
   y
-}) => _$.on($scope["#button/0"], "click", () => $x($scope, $y($scope, x + y))));
+}) => _$.on($scope["#button/0"], "click", () => $x($scope, x = $y($scope, y = x + y))));
 const $expr_x_y = /* @__PURE__ */_$.intersection(5, $expr_x_y_effect);
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {
   _$.data($scope["#text/1"], x);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.hydrate.js
@@ -9,7 +9,7 @@ const $x_effect = _$.effect("a0", ($scope, { 3: x }) => {
       },
     }),
       _$.on($scope[2], "click", function () {
-        $x($scope, x + 1);
+        $x($scope, ++x);
       }));
   }),
   $x = _$.state(3, ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
     }
   });
   _$.on($scope["#button/2"], "click", function () {
-    $x($scope, x + 1), x;
+    $x($scope, ++x)
   });
 });
 const $x = /* @__PURE__ */_$.state("x/3", ($scope, x) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.expected/template.js
@@ -22,7 +22,7 @@ const $if_content = /* @__PURE__ */_$.createRenderer(0, 0, $setup$if$content);
 const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
   x
 }) => _$.on($scope["#button/1"], "click", function () {
-  $x($scope, x + 1), x;
+  $x($scope, ++x)
 }));
 const $x = /* @__PURE__ */_$.state("x/3", $scope => {
   $x$if$content($scope);
@@ -32,7 +32,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/0", $if_content);
 const $show_effect = _$.effect("__tests__/template.marko_0_show", ($scope, {
   show
 }) => _$.on($scope["#button/2"], "click", function () {
-  $show($scope, !show);
+  $show($scope, show = !show);
 }));
 const $show = /* @__PURE__ */_$.state("show/4", ($scope, show) => {
   $if($scope, show ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 251 (min) 179 (brotli)
+// size: 251 (min) 155 (brotli)
 const $x_effect = _$.effect("a0", ($scope, { 1: x }) => {
     (_$.lifecycle($scope, 2, {
       onMount: function () {
@@ -11,7 +11,7 @@ const $x_effect = _$.effect("a0", ($scope, { 1: x }) => {
       },
     }),
       _$.on($scope[0], "click", function () {
-        $x($scope, x + 1);
+        $x($scope, ++x);
       }));
   }),
   $x = _$.state(1, $x_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.expected/template.js
@@ -14,7 +14,7 @@ const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
     }
   });
   _$.on($scope["#button/0"], "click", function () {
-    $x($scope, x + 1), x;
+    $x($scope, ++x)
   });
 });
 const $x = /* @__PURE__ */_$.state("x/1", $x_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 264 (min) 134 (brotli)
+// size: 264 (min) 135 (brotli)
 const $x_effect = _$.effect("a0", ($scope, { 1: x }) => {
     (_$.lifecycle($scope, 2, {
       onMount: function () {
@@ -9,7 +9,7 @@ const $x_effect = _$.effect("a0", ($scope, { 1: x }) => {
       },
     }),
       _$.on($scope[0], "click", function () {
-        $x($scope, x + 1);
+        $x($scope, ++x);
       }));
   }),
   $x = _$.state(1, $x_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.expected/template.js
@@ -13,7 +13,7 @@ const $x_effect = _$.effect("__tests__/template.marko_0_x", ($scope, {
     }
   });
   _$.on($scope["#button/0"], "click", function () {
-    $x($scope, x + 1), x;
+    $x($scope, ++x)
   });
 });
 const $x = /* @__PURE__ */_$.state("x/1", $x_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/tags/2counters.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/tags/2counters.js
@@ -5,7 +5,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/tags/2counters.marko_0_count1", ($scope, {
   count1
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count1 + 1), count1;
+  $count($scope, ++count1)
 }));
 const $count = /* @__PURE__ */_$.state("count1/12", ($scope, count1) => {
   _$.data($scope["#text/1"], count1);
@@ -23,7 +23,7 @@ export const $input_count1Change = /* @__PURE__ */_$.value("input_count1Change",
 const $count2_effect = _$.effect("__tests__/tags/2counters.marko_0_count2", ($scope, {
   count2
 }) => _$.on($scope["#button/2"], "click", function () {
-  $count2($scope, count2 + 1), count2;
+  $count2($scope, ++count2)
 }));
 const $count2 = /* @__PURE__ */_$.state("count2/13", ($scope, count2) => {
   _$.data($scope["#text/3"], count2);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 560 (min) 237 (brotli)
+// size: 560 (min) 234 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 12: count1 }) =>
     _$.on($scope[0], "click", function () {
-      $count$1($scope, count1 + 1);
+      $count$1($scope, ++count1);
     }),
   ),
   $count$1 = _$.state(12, ($scope, count1) => {
@@ -14,7 +14,7 @@ const $count_effect = _$.effect("a0", ($scope, { 12: count1 }) =>
   $input_count = _$.value(6, $expr_input_count1_input_count1Change),
   $count2_effect = _$.effect("a1", ($scope, { 13: count2 }) =>
     _$.on($scope[2], "click", function () {
-      $count2$1($scope, count2 + 1);
+      $count2$1($scope, ++count2);
     }),
   ),
   $count2$1 = _$.state(13, ($scope, count2) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 688 (min) 328 (brotli)
+// size: 692 (min) 329 (brotli)
 const $Child_content2 = _$.registerContent("a0", "Hi"),
   $Child_content = _$.registerContent("a1", "Hi"),
   $setup$Parent$content = _$.dynamicClosureRead(10, ($scope, input_value) =>
@@ -17,7 +17,7 @@ const $Child_content2 = _$.registerContent("a0", "Hi"),
   $expr_Parent_Child = _$.intersection(13, $expr_Parent_Child_effect),
   $Parent_effect = _$.effect("a4", ($scope, { 11: Parent }) =>
     _$.on($scope[6], "click", function () {
-      $Parent($scope, "div" === Parent ? "svg" : "div");
+      $Parent($scope, (Parent = "div" === Parent ? "svg" : "div"));
     }),
   ),
   $Parent = _$.state(11, ($scope, Parent) => {
@@ -29,7 +29,7 @@ const $Child_content2 = _$.registerContent("a0", "Hi"),
   $dynamicTag2 = _$.dynamicTag(4, $Child_content2),
   $Child_effect = _$.effect("a5", ($scope, { 12: Child }) =>
     _$.on($scope[7], "click", function () {
-      $Child($scope, "a" === Child ? null : "a");
+      $Child($scope, (Child = "a" === Child ? null : "a"));
     }),
   ),
   $Child = _$.state(12, ($scope, Child) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.expected/template.js
@@ -23,7 +23,7 @@ const $expr_Parent_Child = /* @__PURE__ */_$.intersection(13, $expr_Parent_Child
 const $Parent_effect = _$.effect("__tests__/template.marko_0_Parent", ($scope, {
   Parent
 }) => _$.on($scope["#button/6"], "click", function () {
-  $Parent($scope, Parent === "div" ? "svg" : "div");
+  $Parent($scope, Parent = Parent === "div" ? "svg" : "div");
 }));
 const $Parent = /* @__PURE__ */_$.state("Parent/11", ($scope, Parent) => {
   $dynamicTag3($scope, Parent);
@@ -35,7 +35,7 @@ const $dynamicTag2 = /* @__PURE__ */_$.dynamicTag("#text/4", $Child_content2);
 const $Child_effect = _$.effect("__tests__/template.marko_0_Child", ($scope, {
   Child
 }) => _$.on($scope["#button/7"], "click", function () {
-  $Child($scope, Child === "a" ? null : "a");
+  $Child($scope, Child = Child === "a" ? null : "a");
 }));
 const $Child = /* @__PURE__ */_$.state("Child/12", ($scope, Child) => {
   $dynamicTag($scope, Child, () => ({

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 214 (min) 138 (brotli)
+// size: 216 (min) 138 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 4: clickCount }) =>
     _$.on($scope[0], "click", function () {
       const last = $lastCount(
         $scope,
-        ($clickCount($scope, clickCount + 1), clickCount),
+        ($clickCount($scope, ++clickCount), clickCount - 1),
       );
       $lastCount2($scope, last);
     }),

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  const last = $lastCount($scope, ($clickCount($scope, clickCount + 1), clickCount));
+  const last = $lastCount($scope, ($clickCount($scope, ++clickCount), clickCount - 1));
   $lastCount2($scope, last);
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/4", ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 846 (min) 405 (brotli)
+// size: 848 (min) 405 (brotli)
 const $setup$else$content_effect = _$.effect("a0", ($scope) =>
     _$.on($scope[0], "click", function () {
       $editing$for$content($scope._, !0);
@@ -28,11 +28,10 @@ const $setup$else$content_effect = _$.effect("a0", ($scope) =>
       },
     ) =>
       _$.on($scope[0], "click", function () {
-        ($counts($scope._._, [
-          ...counts.slice(0, i),
-          count + 1,
-          ...counts.slice(i + 1),
-        ]),
+        ($counts(
+          $scope._._,
+          (counts = [...counts.slice(0, i), count + 1, ...counts.slice(i + 1)]),
+        ),
           $editing$for$content($scope._, !1));
       }),
   ),

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.expected/template.js
@@ -19,7 +19,7 @@ const $expr_counts_count_i$if$content_effect = _$.effect("__tests__/template.mar
     i
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $counts($scope._._, [...counts.slice(0, i), count + 1, ...counts.slice(i + 1)]);
+  $counts($scope._._, counts = [...counts.slice(0, i), count + 1, ...counts.slice(i + 1)]);
   $editing$for$content($scope._, false);
 }));
 const $expr_counts_count_i$if$content = /* @__PURE__ */_$.intersection(2, $expr_counts_count_i$if$content_effect, 2);

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/.name-cache.json
@@ -1,0 +1,10 @@
+{
+  "vars": {
+    "props": {
+      "$_$": "t",
+      "$init": "o",
+      "$$clickCount_effect": "m",
+      "$$clickCount": "a"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,67 @@
+# Render
+```html
+<div>
+  <button>
+    0
+  </button>
+  <div />
+  <div />
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    1
+  </button>
+  <div>
+    0
+  </div>
+  <div>
+    1
+  </div>
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    2
+  </button>
+  <div>
+    1
+  </div>
+  <div>
+    2
+  </div>
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    3
+  </button>
+  <div>
+    2
+  </div>
+  <div>
+    3
+  </div>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/csr.expected.md
@@ -1,0 +1,94 @@
+# Render
+```html
+<div>
+  <button>
+    0
+  </button>
+  <div />
+  <div />
+</div>
+```
+
+# Mutations
+```
+INSERT div
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    1
+  </button>
+  <div>
+    0
+  </div>
+  <div>
+    1
+  </div>
+</div>
+```
+
+# Mutations
+```
+INSERT div/div0/#text
+INSERT div/div1/#text
+UPDATE div/button/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    2
+  </button>
+  <div>
+    1
+  </div>
+  <div>
+    2
+  </div>
+</div>
+```
+
+# Mutations
+```
+REMOVE #text in div/div0
+INSERT div/div0/#text
+REMOVE #text in div/div1
+INSERT div/div1/#text
+UPDATE div/button/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    3
+  </button>
+  <div>
+    2
+  </div>
+  <div>
+    3
+  </div>
+</div>
+```
+
+# Mutations
+```
+REMOVE #text in div/div0
+INSERT div/div0/#text
+REMOVE #text in div/div1
+INSERT div/div1/#text
+UPDATE div/button/#text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,12 @@
+// size: 158 (min) 121 (brotli)
+const $clickCount_effect = _$.effect("a0", ($scope, { 4: clickCount }) =>
+    _$.on($scope[0], "click", function () {
+      (($scope[2].innerHTML =
+        ($clickCount($scope, ++clickCount), clickCount - 1)),
+        ($scope[3].innerHTML = clickCount));
+    }),
+  ),
+  $clickCount = _$.state(4, ($scope, clickCount) => {
+    (_$.data($scope[1], clickCount), $clickCount_effect($scope));
+  });
+init();

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/dom.expected/template.js
@@ -1,0 +1,17 @@
+export const $template = "<div><button> </button><div></div><div></div></div>";
+export const $walks = /* next(1), get, next(1), get, out(1), get, over(1), get, out(1) */"D D l b l";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
+  clickCount
+}) => _$.on($scope["#button/0"], "click", function () {
+  $scope["#div/2"].innerHTML = ($clickCount($scope, ++clickCount), clickCount - 1);
+  $scope["#div/3"].innerHTML = clickCount;
+}));
+const $clickCount = /* @__PURE__ */_$.state("clickCount/4", ($scope, clickCount) => {
+  _$.data($scope["#text/1"], clickCount);
+  $clickCount_effect($scope);
+});
+export function $setup($scope) {
+  $clickCount($scope, 0);
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/html.expected/template.js
@@ -1,0 +1,15 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+export default _$.createTemplate("__tests__/template.marko", input => {
+  const $scope0_id = _$.nextScopeId();
+  let clickCount = 0;
+  const $a = _$.nodeRef();
+  const $b = _$.nodeRef();
+  _$.write(`<div><button>${_$.escapeXML(clickCount)}${_$.markResumeNode($scope0_id, "#text/1")}</button>${_$.markResumeNode($scope0_id, "#button/0")}<div></div>${_$.markResumeNode($scope0_id, "#div/2")}<div></div>${_$.markResumeNode($scope0_id, "#div/3")}</div>`);
+  _$.writeEffect($scope0_id, "__tests__/template.marko_0_clickCount");
+  _$.writeScope($scope0_id, {
+    clickCount
+  }, "__tests__/template.marko", 0, {
+    clickCount: "2:8"
+  });
+  _$.resumeClosestBranch($scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,67 @@
+# Render
+```html
+<div>
+  <button>
+    0
+  </button>
+  <div />
+  <div />
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    1
+  </button>
+  <div>
+    0
+  </div>
+  <div>
+    1
+  </div>
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    2
+  </button>
+  <div>
+    1
+  </div>
+  <div>
+    2
+  </div>
+</div>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    3
+  </button>
+  <div>
+    2
+  </div>
+  <div>
+    3
+  </div>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/resume.expected.md
@@ -1,0 +1,138 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button>
+        0
+        <!--M_*1 #text/1-->
+      </button>
+      <!--M_*1 #button/0-->
+      <div />
+      <!--M_*1 #div/2-->
+      <div />
+      <!--M_*1 #div/3-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button>
+        1
+        <!--M_*1 #text/1-->
+      </button>
+      <!--M_*1 #button/0-->
+      <div>
+        0
+      </div>
+      <!--M_*1 #div/2-->
+      <div>
+        1
+      </div>
+      <!--M_*1 #div/3-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div/div0/#text
+INSERT html/body/div/div1/#text
+UPDATE html/body/div/button/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button>
+        2
+        <!--M_*1 #text/1-->
+      </button>
+      <!--M_*1 #button/0-->
+      <div>
+        1
+      </div>
+      <!--M_*1 #div/2-->
+      <div>
+        2
+      </div>
+      <!--M_*1 #div/3-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE #text in html/body/div/div0
+INSERT html/body/div/div0/#text
+REMOVE #text in html/body/div/div1
+INSERT html/body/div/div1/#text
+UPDATE html/body/div/button/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button>
+        3
+        <!--M_*1 #text/1-->
+      </button>
+      <!--M_*1 #button/0-->
+      <div>
+        2
+      </div>
+      <!--M_*1 #div/2-->
+      <div>
+        3
+      </div>
+      <!--M_*1 #div/3-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE #text in html/body/div/div0
+INSERT html/body/div/div0/#text
+REMOVE #text in html/body/div/div1
+INSERT html/body/div/div1/#text
+UPDATE html/body/div/button/#text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,10 @@
+# Render End
+```html
+<div>
+  <button>
+    0
+  </button>
+  <div />
+  <div />
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/__snapshots__/ssr.expected.md
@@ -1,0 +1,45 @@
+# Write
+```html
+  <div><button>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><div></div><!--M_*1 #div/2--><div></div><!--M_*1 #div/3--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <button>
+        0
+        <!--M_*1 #text/1-->
+      </button>
+      <!--M_*1 #button/0-->
+      <div />
+      <!--M_*1 #div/2-->
+      <div />
+      <!--M_*1 #div/3-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.a=[0,{clickCount:0}]),"__tests__/template.marko_0_clickCount",1];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/div
+INSERT html/body/div/button
+INSERT html/body/div/button/#text
+INSERT html/body/div/button/#comment
+INSERT html/body/div/#comment0
+INSERT html/body/div/div0
+INSERT html/body/div/#comment1
+INSERT html/body/div/div1
+INSERT html/body/div/#comment2
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/template.marko
@@ -1,0 +1,10 @@
+<div>
+  <let/clickCount = 0/>
+  <button onClick() {
+    $a().innerHTML = clickCount++;
+    $b().innerHTML = clickCount;
+  }>${clickCount}</button>
+
+  <div/$a/>
+  <div/$b/>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/test.ts
@@ -1,0 +1,5 @@
+export const steps = [{}, click, click, click];
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,13 +1,13 @@
-// size: 233 (min) 124 (brotli)
+// size: 236 (min) 122 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 6: count }) => {
     (_$.on($scope[0], "click", function () {
-      $count($scope, count + 2);
+      $count($scope, (count += 2));
     }),
       _$.on($scope[2], "click", function () {
-        $count($scope, 3 * count);
+        $count($scope, (count *= 3));
       }),
       _$.on($scope[4], "click", function () {
-        $count($scope, count ** 3);
+        $count($scope, (count **= 3));
       }));
   }),
   $count = _$.state(6, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/__snapshots__/dom.expected/template.js
@@ -5,13 +5,13 @@ const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => {
   _$.on($scope["#button/0"], "click", function () {
-    $count($scope, count + 2);
+    $count($scope, count += 2);
   });
   _$.on($scope["#button/2"], "click", function () {
-    $count($scope, count * 3);
+    $count($scope, count *= 3);
   });
   _$.on($scope["#button/4"], "click", function () {
-    $count($scope, count ** 3);
+    $count($scope, count **= 3);
   });
 });
 const $count = /* @__PURE__ */_$.state("count/6", ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.hydrate.js
@@ -73,22 +73,22 @@ const $dynamicTag = _$.dynamicTag(0, 0, () => $onClickOnce2),
   );
 function $_return2($scope, { 2: value, 3: call } = $scope) {
   return function () {
-    call && ($call$define$content2($scope, call - 1), value());
+    call && ($call$define$content2($scope, --call), value());
   };
 }
 function $_return($scope, { 2: value, 3: call } = $scope) {
   return function () {
-    call && ($call$define$content($scope, call - 1), value());
+    call && ($call$define$content($scope, --call), value());
   };
 }
 function $onClickOnce($scope, { 9: clickOnceCount } = $scope) {
   return function () {
-    $clickOnceCount($scope, clickOnceCount + 1);
+    $clickOnceCount($scope, ++clickOnceCount);
   };
 }
 function $onClickTwice($scope, { 13: clickTwiceCount } = $scope) {
   return function () {
-    $clickTwiceCount($scope, clickTwiceCount + 1);
+    $clickTwiceCount($scope, ++clickTwiceCount);
   };
 }
 (_$.register("a2", $_return2),

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.expected/template.js
@@ -85,7 +85,7 @@ function $_return2($scope, {
 } = $scope) {
   return function () {
     if (call) {
-      $call$define$content2($scope, call - 1), call;
+      $call$define$content2($scope, --call)
       value();
     }
   };
@@ -96,7 +96,7 @@ function $_return($scope, {
 } = $scope) {
   return function () {
     if (call) {
-      $call$define$content($scope, call - 1), call;
+      $call$define$content($scope, --call)
       value();
     }
   };
@@ -105,14 +105,14 @@ function $onClickOnce($scope, {
   clickOnceCount
 } = $scope) {
   return function () {
-    $clickOnceCount($scope, clickOnceCount + 1), clickOnceCount;
+    $clickOnceCount($scope, ++clickOnceCount)
   };
 }
 function $onClickTwice($scope, {
   clickTwiceCount
 } = $scope) {
   return function () {
-    $clickTwiceCount($scope, clickTwiceCount + 1), clickTwiceCount;
+    $clickTwiceCount($scope, ++clickTwiceCount)
   };
 }
 _$.register("__tests__/template.marko_2/_return2", $_return2);

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.hydrate.js
@@ -3,7 +3,7 @@ const createWrapper = $createWrapper,
   $pattern2 = _$.value(4, ($scope, $pattern) => $a($scope, $pattern.a)),
   $count_effect = _$.effect("a1", ($scope, { 3: count }) =>
     _$.on($scope[0], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(3, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $pattern2 = /* @__PURE__ */_$.value("$pattern", ($scope, $pattern) => $a($
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/3", ($scope, count) => {
   $pattern2($scope, createWrapper(count));

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 454 (min) 163 (brotli)
+// size: 454 (min) 155 (brotli)
 const $count4_effect = _$.effect("a0", ($scope, { 8: count }) =>
     _$.on($scope[0], "click", function () {
-      $count4($scope, count + 1);
+      $count4($scope, ++count);
     }),
   ),
   $count4 = _$.state(8, ($scope, count) => {
@@ -9,7 +9,7 @@ const $count4_effect = _$.effect("a0", ($scope, { 8: count }) =>
   }),
   $count5_effect = _$.effect("a1", ($scope, { 9: $count }) =>
     _$.on($scope[2], "click", function () {
-      $count5($scope, $count + 1);
+      $count5($scope, ++$count);
     }),
   ),
   $count5 = _$.state(9, ($scope, $count) => {
@@ -17,7 +17,7 @@ const $count4_effect = _$.effect("a0", ($scope, { 8: count }) =>
   }),
   $count6_effect = _$.effect("a2", ($scope, { 10: $count2 }) =>
     _$.on($scope[4], "click", function () {
-      $count6($scope, $count2 + 1);
+      $count6($scope, ++$count2);
     }),
   ),
   $count6 = _$.state(10, ($scope, $count2) => {
@@ -25,7 +25,7 @@ const $count4_effect = _$.effect("a0", ($scope, { 8: count }) =>
   }),
   $count7_effect = _$.effect("a3", ($scope, { 11: $count3 }) =>
     _$.on($scope[6], "click", function () {
-      $count7($scope, $count3 + 1);
+      $count7($scope, ++$count3);
     }),
   ),
   $count7 = _$.state(11, ($scope, $count3) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count4_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count4($scope, count + 1), count;
+  $count4($scope, ++count)
 }));
 const $count4 = /* @__PURE__ */_$.state("count/8", ($scope, count) => {
   _$.data($scope["#text/1"], count);
@@ -13,7 +13,7 @@ const $count4 = /* @__PURE__ */_$.state("count/8", ($scope, count) => {
 const $count5_effect = _$.effect("__tests__/template.marko_0_$count", ($scope, {
   $count
 }) => _$.on($scope["#button/2"], "click", function () {
-  $count5($scope, $count + 1), $count;
+  $count5($scope, ++$count)
 }));
 const $count5 = /* @__PURE__ */_$.state("$count/9", ($scope, $count) => {
   _$.data($scope["#text/3"], $count);
@@ -22,7 +22,7 @@ const $count5 = /* @__PURE__ */_$.state("$count/9", ($scope, $count) => {
 const $count6_effect = _$.effect("__tests__/template.marko_0_$count2", ($scope, {
   $count2
 }) => _$.on($scope["#button/4"], "click", function () {
-  $count6($scope, $count2 + 1), $count2;
+  $count6($scope, ++$count2)
 }));
 const $count6 = /* @__PURE__ */_$.state("$count2/10", ($scope, $count2) => {
   _$.data($scope["#text/5"], $count2);
@@ -31,7 +31,7 @@ const $count6 = /* @__PURE__ */_$.state("$count2/10", ($scope, $count2) => {
 const $count7_effect = _$.effect("__tests__/template.marko_0_$count3", ($scope, {
   $count3
 }) => _$.on($scope["#button/6"], "click", function () {
-  $count7($scope, $count3 + 1), $count3;
+  $count7($scope, ++$count3)
 }));
 const $count7 = /* @__PURE__ */_$.state("$count3/11", ($scope, $count3) => {
   _$.data($scope["#text/7"], $count3);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
 // size: 120 (min) 102 (brotli)
 const $count_effect = _$.effect("a0", ($scope, { 2: count }) =>
     _$.on($scope[1], "click", function () {
-      $count($scope, count + 1);
+      $count($scope, ++count);
     }),
   ),
   $count = _$.state(2, ($scope, count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/1"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {
   _$.data($scope["#text/0"], count);

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 148 (min) 131 (brotli)
+// size: 150 (min) 120 (brotli)
 const $open_effect = _$.effect("a0", ($scope, { 2: open }) =>
     _$.on($scope[0], "click", function () {
-      $open($scope, !open);
+      $open($scope, (open = !open));
     }),
   ),
   $open = _$.state(2, ($scope, open) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $open_effect = _$.effect("__tests__/template.marko_0_open", ($scope, {
   open
 }) => _$.on($scope["#button/0"], "click", function () {
-  $open($scope, !open);
+  $open($scope, open = !open);
 }));
 const $open = /* @__PURE__ */_$.state("open/2", ($scope, open) => {
   _$.styleItem($scope["#div/1"], "display", open ? undefined : "none");

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.hydrate.js
@@ -1,8 +1,8 @@
-// size: 143 (min) 105 (brotli)
+// size: 143 (min) 104 (brotli)
 const $clickCount_effect = _$.effect("a0", ($scope, { 1: clickCount }) => {
     ((document.getElementById("button").textContent = clickCount),
       _$.on($scope[0], "click", function () {
-        $clickCount($scope, clickCount + 1);
+        $clickCount($scope, ++clickCount);
       }));
   }),
   $clickCount = _$.state(1, $clickCount_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.expected/template.js
@@ -6,7 +6,7 @@ const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($
 }) => {
   document.getElementById("button").textContent = clickCount;
   _$.on($scope["#button/0"], "click", function () {
-    $clickCount($scope, clickCount + 1), clickCount;
+    $clickCount($scope, ++clickCount)
   });
 });
 const $clickCount = /* @__PURE__ */_$.state("clickCount/1", $clickCount_effect);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 611 (min) 289 (brotli)
+// size: 615 (min) 298 (brotli)
 const $count$if$content_effect = _$.effect(
     "a0",
     (
@@ -10,7 +10,7 @@ const $count$if$content_effect = _$.effect(
       },
     ) =>
       _$.on($scope[0], "click", function () {
-        $count($scope._._, count + 1);
+        $count($scope._._, ++count);
       }),
   ),
   $count$if$content = _$.dynamicClosureRead(
@@ -29,7 +29,7 @@ const $count$if$content_effect = _$.effect(
   $if$if$content = _$.conditional(1, $if_content2),
   $inner$if$content_effect = _$.effect("a1", ($scope, { _: { 3: inner } }) =>
     _$.on($scope[0], "click", function () {
-      $inner($scope._, !inner);
+      $inner($scope._, (inner = !inner));
     }),
   ),
   $inner$if$content = _$.conditionalClosure(3, 1, 0, ($scope, inner) => {
@@ -44,7 +44,7 @@ const $count$if$content_effect = _$.effect(
   $if = _$.conditional(1, $if_content),
   $outer_effect = _$.effect("a2", ($scope, { 2: outer }) =>
     _$.on($scope[0], "click", function () {
-      $outer($scope, !outer);
+      $outer($scope, (outer = !outer));
     }),
   ),
   $outer = _$.state(2, ($scope, outer) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $count$if$content_effect = _$.effect("__tests__/template.marko_2_count", (
     }
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope._._, count + 1), count;
+  $count($scope._._, ++count)
 }));
 const $count$if$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);
@@ -22,7 +22,7 @@ const $inner$if$content_effect = _$.effect("__tests__/template.marko_1_inner", (
     inner
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $inner($scope._, !inner);
+  $inner($scope._, inner = !inner);
 }));
 const $inner$if$content = /* @__PURE__ */_$.conditionalClosure("inner", "#text/1", 0, ($scope, inner) => {
   $if$if$content($scope, inner ? 0 : 1);
@@ -34,7 +34,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/1", $if_content);
 const $outer_effect = _$.effect("__tests__/template.marko_0_outer", ($scope, {
   outer
 }) => _$.on($scope["#button/0"], "click", function () {
-  $outer($scope, !outer);
+  $outer($scope, outer = !outer);
 }));
 const $outer = /* @__PURE__ */_$.state("outer/2", ($scope, outer) => {
   $if($scope, outer ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.hydrate.js
@@ -1,4 +1,4 @@
-// size: 611 (min) 289 (brotli)
+// size: 615 (min) 298 (brotli)
 const $count$if$content_effect = _$.effect(
     "a0",
     (
@@ -10,7 +10,7 @@ const $count$if$content_effect = _$.effect(
       },
     ) =>
       _$.on($scope[0], "click", function () {
-        $count($scope._._, count + 1);
+        $count($scope._._, ++count);
       }),
   ),
   $count$if$content = _$.dynamicClosureRead(
@@ -29,7 +29,7 @@ const $count$if$content_effect = _$.effect(
   $if$if$content = _$.conditional(1, $if_content2),
   $inner$if$content_effect = _$.effect("a1", ($scope, { _: { 3: inner } }) =>
     _$.on($scope[0], "click", function () {
-      $inner($scope._, !inner);
+      $inner($scope._, (inner = !inner));
     }),
   ),
   $inner$if$content = _$.conditionalClosure(3, 1, 0, ($scope, inner) => {
@@ -44,7 +44,7 @@ const $count$if$content_effect = _$.effect(
   $if = _$.conditional(1, $if_content),
   $outer_effect = _$.effect("a2", ($scope, { 2: outer }) =>
     _$.on($scope[0], "click", function () {
-      $outer($scope, !outer);
+      $outer($scope, (outer = !outer));
     }),
   ),
   $outer = _$.state(2, ($scope, outer) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $count$if$content_effect = _$.effect("__tests__/template.marko_2_count", (
     }
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope._._, count + 1), count;
+  $count($scope._._, ++count)
 }));
 const $count$if$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);
@@ -22,7 +22,7 @@ const $inner$if$content_effect = _$.effect("__tests__/template.marko_1_inner", (
     inner
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $inner($scope._, !inner);
+  $inner($scope._, inner = !inner);
 }));
 const $inner$if$content = /* @__PURE__ */_$.conditionalClosure("inner", "#text/1", 0, ($scope, inner) => {
   $if$if$content($scope, inner ? 0 : 1);
@@ -34,7 +34,7 @@ const $if = /* @__PURE__ */_$.conditional("#text/1", $if_content);
 const $outer_effect = _$.effect("__tests__/template.marko_0_outer", ($scope, {
   outer
 }) => _$.on($scope["#button/0"], "click", function () {
-  $outer($scope, !outer);
+  $outer($scope, outer = !outer);
 }));
 const $outer = /* @__PURE__ */_$.state("outer/2", ($scope, outer) => {
   $if($scope, outer ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/tags/counter.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/tags/counter.js
@@ -5,7 +5,7 @@ const $expr_input_onCount_clickCount_effect = _$.effect("__tests__/tags/counter.
   input_onCount,
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  input_onCount($clickCount($scope, clickCount + 1));
+  input_onCount($clickCount($scope, ++clickCount));
 }));
 const $expr_input_onCount_clickCount = /* @__PURE__ */_$.intersection(6, $expr_input_onCount_clickCount_effect);
 const $clickCount = /* @__PURE__ */_$.state("clickCount/5", ($scope, clickCount) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.expected/template.hydrate.js
@@ -1,9 +1,9 @@
-// size: 568 (min) 328 (brotli)
+// size: 568 (min) 329 (brotli)
 const $expr_input_onCount_clickCount_effect = _$.effect(
     "a0",
     ($scope, { 4: input_onCount, 5: clickCount }) =>
       _$.on($scope[0], "click", function () {
-        input_onCount($clickCount($scope, clickCount + 1));
+        input_onCount($clickCount($scope, ++clickCount));
       }),
   ),
   $expr_input_onCount_clickCount = _$.intersection(

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.hydrate.js
@@ -1,7 +1,7 @@
-// size: 133 (min) 105 (brotli)
+// size: 135 (min) 107 (brotli)
 const $toggle_effect = _$.effect("a0", ($scope, { 2: toggle }) =>
     _$.on($scope[1], "click", function () {
-      $toggle($scope, !toggle);
+      $toggle($scope, (toggle = !toggle));
     }),
   ),
   $toggle = _$.state(2, ($scope, toggle) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $toggle_effect = _$.effect("__tests__/template.marko_0_toggle", ($scope, {
   toggle
 }) => _$.on($scope["#button/1"], "click", function () {
-  $toggle($scope, !toggle);
+  $toggle($scope, toggle = !toggle);
 }));
 const $toggle = /* @__PURE__ */_$.state("toggle/2", ($scope, toggle) => {
   _$.attr($scope["#body/0"], "data-toggle", toggle);

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.hydrate.js
@@ -38,7 +38,7 @@ const $await$try$content = _$.awaitTag(0, $await_content),
   $clickCount_closure = _$.dynamicClosure($clickCount$try$content),
   $clickCount_effect = _$.effect("a3", ($scope, { 3: clickCount }) =>
     _$.on($scope[0], "click", function () {
-      $clickCount($scope, clickCount + 1);
+      $clickCount($scope, ++clickCount);
     }),
   ),
   $clickCount = _$.state(3, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/dom.expected/template.js
@@ -28,7 +28,7 @@ const $clickCount_closure = /* @__PURE__ */_$.dynamicClosure($clickCount$try$con
 const $clickCount_effect = _$.effect("__tests__/template.marko_0_clickCount", ($scope, {
   clickCount
 }) => _$.on($scope["#button/0"], "click", function () {
-  $clickCount($scope, clickCount + 1), clickCount;
+  $clickCount($scope, ++clickCount)
 }));
 const $clickCount = /* @__PURE__ */_$.state("clickCount/3", $scope => {
   $clickCount_closure($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.hydrate.js
@@ -11,7 +11,7 @@ const $clickCount$try$content_effect = _$.effect(
     "a1",
     ($scope, { _: { 2: clickCount } }) => {
       (_$.on($scope[0], "click", function () {
-        $clickCount($scope._, clickCount + 1);
+        $clickCount($scope._, ++clickCount);
       }),
         ($scope._[0].textContent = clickCount));
     },

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.expected/template.js
@@ -11,7 +11,7 @@ const $clickCount$try$content_effect = _$.effect("__tests__/template.marko_1_cli
   }
 }) => {
   _$.on($scope["#button/0"], "click", function () {
-    $clickCount($scope._, clickCount + 1), clickCount;
+    $clickCount($scope._, ++clickCount)
   });
   $scope._["#div/0"].textContent = clickCount;
 });

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -379,11 +379,13 @@ function trackAssignment(
   >,
   binding: Binding,
 ) {
+  const fnRoot = getFnRoot(assignment);
+  const fnExtra = fnRoot && ((fnRoot.node.extra ??= {}) as FnExtra);
   const section = getOrCreateSection(assignment);
   setReferencesScope(assignment);
   forEachIdentifierPath(assignment, (id) => {
     if (id.node.name === binding.name) {
-      const extra = (id.node.extra ??= {});
+      const extra = (id.node.extra ??= {}) as AssignedBindingExtra;
 
       if (binding.upstreamAlias && binding.property !== undefined) {
         const changePropName = binding.property + "Change";
@@ -409,6 +411,7 @@ function trackAssignment(
       );
       extra.assignment = binding;
       extra.section = section;
+      extra.fnExtra = fnExtra;
     }
   });
 }
@@ -1236,6 +1239,7 @@ function addReadToExpression(
   if (fnRoot) {
     const readsByFn = getReadsByFunction();
     const fnExtra = (fnRoot.node.extra ??= {}) as FnExtra;
+    exprExtra.fnExtra = fnExtra;
     fnExtra.section = section;
     readsByFn.set(fnExtra, push(readsByFn.get(fnExtra), read));
   }
@@ -1574,6 +1578,7 @@ function isEventOrChangeHandler(prop: string) {
 
 export interface ReferencedExtra extends t.NodeExtra {
   section: Section;
+  fnExtra?: FnExtra;
 }
 export function isReferencedExtra(
   extra: t.NodeExtra | undefined,

--- a/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
+++ b/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.expected/components/custom-tag.js
@@ -5,8 +5,8 @@ const $expr_x_y_effect = _$.effect("__tests__/components/custom-tag.marko_0_x_y"
   x,
   y
 }) => _$.on($scope["#button/0"], "click", function () {
-  $x($scope, x + 1), x;
-  $y($scope, y + 1), y;
+  $x($scope, ++x)
+  $y($scope, ++y)
 }));
 const $expr_x_y = /* @__PURE__ */_$.intersection(9, $expr_x_y_effect);
 const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/3", 0, 0, 1);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/dom.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-class-to-tags/__snapshots__/dom.expected/components/tags-counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/components/tags-counter.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/5", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/dom.expected/template.js
@@ -8,7 +8,7 @@ const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/2");
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/3", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/components/tags-counter.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-to-tags-import/__snapshots__/dom.expected/components/tags-counter.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/components/tags-counter.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/5", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/components/tags-layout.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/7", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/components/tags-layout.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/6", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const $count$classlayout$content_effect = _$.effect("__tests__/template.marko_1_
     count
   }
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope._, count + 1), count;
+  $count($scope._, ++count)
 }));
 const $count$classlayout$content = /* @__PURE__ */_$.dynamicClosureRead("count", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/dom.expected/components/tags-layout.js
@@ -12,7 +12,7 @@ const $expr_input_content_count = /* @__PURE__ */_$.intersection(7, $scope => {
 const $count_effect = _$.effect("__tests__/components/tags-layout.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/6", ($scope, count) => {
   _$.data($scope["#text/1"], count);

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/dom.expected/template.js
@@ -19,7 +19,7 @@ const $multiplier$classlayout$content_effect = _$.effect("__tests__/template.mar
     multiplier
   }
 }) => _$.on($scope["#button/1"], "click", function () {
-  $multiplier($scope._, multiplier + 1), multiplier;
+  $multiplier($scope._, ++multiplier)
 }));
 const $multiplier$classlayout$content = /* @__PURE__ */_$.dynamicClosureRead("multiplier", ($scope, multiplier) => {
   _$.data($scope["#text/2"], multiplier);

--- a/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/dom.expected/template.js
+++ b/packages/translator-interop/src/__tests__/fixtures/let/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _$ from "@marko/runtime-tags/debug/dom";
 const $count_effect = _$.effect("__tests__/template.marko_0_count", ($scope, {
   count
 }) => _$.on($scope["#button/0"], "click", function () {
-  $count($scope, count + 1), count;
+  $count($scope, ++count)
 }));
 const $count = /* @__PURE__ */_$.state("count/2", ($scope, count) => {
   _$.data($scope["#text/1"], count);


### PR DESCRIPTION
## Description
Tag variables staying in the past after being written has been shown to be cumbersome, error prone, and confusing.

With that we decided to allow reading the "proposed" value after a tag variable has been written.
It is considered "proposed" because rendering logic, derivations and change handlers do not run eagerly when the assignment happens, however in the scope of the current expression you are able to read the last assigned to value of the tag variable.

```marko
<let/count=0>
<button onClick() {
  count++;
  console.log(count); // previously would be `0` on first click, now `1`
}/>
```

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
