### PR TITLE
fix: scriptlets with comments

### DIFF
--- a/packages/compiler/src/babel-utils/parse.js
+++ b/packages/compiler/src/babel-utils/parse.js
@@ -134,9 +134,15 @@ function tryParse(
     parserOpts.startColumn = startColumn;
 
     try {
-      return isExpression
-        ? babelParser.parseExpression(code, parserOpts)
-        : babelParser.parse(code, parserOpts).program.body;
+      if (isExpression) {
+        return babelParser.parseExpression(code, parserOpts);
+      } else {
+        const { program } = babelParser.parse(code, parserOpts);
+        if (program.innerComments) {
+          return babelParser.parse(`;${code}`, parserOpts).program.body;
+        }
+        return program.body;
+      }
     } catch (err) {
       const parseError = createParseError(
         file,


### PR DESCRIPTION
Because of the way comments are handled in the babel AST, when a scriptlet contains _just_ comments and no statements they are lost at the compiler. This semi-hacky solution adds and empty statement when this is the case, which includes them as `trailingComments`