### PR TITLE
fix: dynamic tag content

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -7,23 +7,23 @@
     {
       "name": "*",
       "total": {
-        "min": 19311,
-        "brotli": 7353
+        "min": 19357,
+        "brotli": 7340
       }
     },
     {
       "name": "counter",
       "user": {
         "min": 184,
-        "brotli": 151
+        "brotli": 156
       },
       "runtime": {
         "min": 3960,
-        "brotli": 1760
+        "brotli": 1751
       },
       "total": {
         "min": 4144,
-        "brotli": 1911
+        "brotli": 1907
       }
     },
     {
@@ -34,11 +34,11 @@
       },
       "runtime": {
         "min": 2188,
-        "brotli": 1143
+        "brotli": 1142
       },
       "total": {
         "min": 2294,
-        "brotli": 1240
+        "brotli": 1239
       }
     },
     {
@@ -49,11 +49,11 @@
       },
       "runtime": {
         "min": 7019,
-        "brotli": 3005
+        "brotli": 2994
       },
       "total": {
         "min": 7912,
-        "brotli": 3463
+        "brotli": 3452
       }
     },
     {

--- a/.sizes/counter.csr/entry.js
+++ b/.sizes/counter.csr/entry.js
@@ -1,4 +1,4 @@
-// size: 184 (min) 151 (brotli)
+// size: 184 (min) 156 (brotli)
 const $clickCount_effect = effect("a0", ($scope, { 2: clickCount }) =>
     on($scope[0], "click", function () {
       $clickCount($scope, ++clickCount);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/resume.expected.md
@@ -24,13 +24,13 @@
       </option>
       <!--M_*3 #option/2-->
     </select>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <span>
       b
       <!--M_*1 #text/1-->
     </span>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ControlledType:#text/0":3,"ControlledValue:#text/0":"b","ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.a["ControlledHandler:#text/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"ControlledType:#select/0":3,"ControlledValue:#select/0":"b"},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.b["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
     </script>
   </body>
 </html>
@@ -71,13 +71,13 @@ select.dispatchEvent(new window.Event("input", {
       </option>
       <!--M_*3 #option/2-->
     </select>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <span>
       b
       <!--M_*1 #text/1-->
     </span>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ControlledType:#text/0":3,"ControlledValue:#text/0":"b","ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.a["ControlledHandler:#text/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"ControlledType:#select/0":3,"ControlledValue:#select/0":"b"},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.b["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
     </script>
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <select><option value=a>A</option><!--M_*3 #option/0--><option value=b selected>B</option><!--M_*3 #option/1--><option value=c>C</option><!--M_*3 #option/2--></select><!--M_|1 #text/0 2--><span>b<!--M_*1 #text/1--></span><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ControlledType:#text/0":3,"ControlledValue:#text/0":"b","ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.a["ControlledHandler:#text/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()</script>
+  <select><option value=a>A</option><!--M_*3 #option/0--><option value=b selected>B</option><!--M_*3 #option/1--><option value=c>C</option><!--M_*3 #option/2--></select><!--M_'1 #text/0 2--><span>b<!--M_*1 #text/1--></span><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"ControlledType:#select/0":3,"ControlledValue:#select/0":"b"},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.b["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()</script>
 ```
 
 # Render End
@@ -29,13 +29,13 @@
       </option>
       <!--M_*3 #option/2-->
     </select>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <span>
       b
       <!--M_*1 #text/1-->
     </span>
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ControlledType:#text/0":3,"ControlledValue:#text/0":"b","ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.a["ControlledHandler:#text/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"ControlledType:#select/0":3,"ControlledValue:#select/0":"b"},"ConditionalRenderer:#text/0":"select",tag:"select"},_.b,{}],_.b["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_1",3];M._.w()
     </script>
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
@@ -6,13 +6,15 @@
     <span
       class="A"
     >
+      <!--M_[3-->
       body content
+      <!--M_]2 #span/0-->
     </span>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -32,11 +34,11 @@ container.querySelector("button").click();
     >
       body content
     </div>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -63,11 +65,11 @@ container.querySelector("button").click();
     >
       body content
     </span>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <span class=A>body content</span><!--M_|1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <span class=A><!--M_[3-->body content<!--M_]2 #span/0--></span><!--M_'1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
@@ -11,13 +11,15 @@
     <span
       class="A"
     >
+      <!--M_[3-->
       body content
+      <!--M_]2 #span/0-->
     </span>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -29,7 +31,9 @@ INSERT html
 INSERT html/head
 INSERT html/body
 INSERT html/body/span
+INSERT html/body/span/#comment0
 INSERT html/body/span/#text
+INSERT html/body/span/#comment1
 INSERT html/body/#comment0
 INSERT html/body/button
 INSERT html/body/#comment1

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/.name-cache.json
@@ -1,0 +1,13 @@
+{
+  "vars": {
+    "props": {
+      "$_$": "r",
+      "$init": "t",
+      "$$dynamicTag$inputasdiv$content": "e",
+      "$$setup$inputasdiv$content": "o",
+      "$$dynamicTag": "n",
+      "$$expr_inputAs_inputClass_htmlInput_content": "a",
+      "$$content": "i"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div
+  class="foo"
+>
+  default
+</div>
+<span
+  class="foo"
+>
+  default
+</span>
+```
+
+
+# Render ASYNC
+```html
+<div
+  class="foo"
+>
+  Div
+</div>
+<span
+  class="foo"
+>
+  Span
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/csr.expected.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<!---->
+<!---->
+<div
+  class="foo"
+>
+  default
+</div>
+<!---->
+<!---->
+<span
+  class="foo"
+>
+  default
+</span>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+INSERT #comment0, #comment1, div, #comment2, #comment3, span, #comment4, #comment5
+```
+
+# Render ASYNC
+```html
+<!---->
+<!---->
+<div
+  class="foo"
+>
+  Div
+</div>
+<!---->
+<!---->
+<span
+  class="foo"
+>
+  Span
+</span>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+REMOVE #text in div
+INSERT div/#text
+REMOVE #text in span
+INSERT span/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected.1/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected.1/template.js
@@ -1,0 +1,18 @@
+export const $template = `<!>${_myTag_template}${_myTag_template}<!>`;
+export const $walks = /* beginChild, _myTag_walks, endChild, beginChild, _myTag_walks, endChild */`D/${_myTag_walks}&/${_myTag_walks}&D`;
+import { $setup as _myTag, $input as _myTag_input, $template as _myTag_template, $walks as _myTag_walks } from "./tags/my-tag.marko";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const $mytag_content2 = _$.registerContent("__tests__/template.marko_2_renderer", "Span");
+const $mytag_content = _$.registerContent("__tests__/template.marko_1_renderer", "Div");
+export function $setup($scope) {
+  _myTag($scope["#childScope/0"]);
+  _myTag_input($scope["#childScope/0"], {
+    content: $mytag_content($scope)
+  });
+  _myTag($scope["#childScope/1"]);
+  _myTag_input($scope["#childScope/1"], {
+    as: "span",
+    content: $mytag_content2($scope)
+  });
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/tags/my-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/tags/my-tag.js
@@ -1,0 +1,44 @@
+export const $template = "<!><!><!>";
+export const $walks = /* replace, over(1) */"D%bD";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const $define_content = /* @__PURE__ */_$.createContent("__tests__/tags/my-tag.marko_1_renderer", "default");
+const $dynamicTag = /* @__PURE__ */_$.dynamicTag("#text/0");
+const $expr_inputAs_inputClass_htmlInput_content = /* @__PURE__ */_$.intersection(9, $scope => {
+  const {
+    inputAs,
+    inputClass,
+    htmlInput,
+    content
+  } = $scope;
+  $dynamicTag($scope, inputAs || "div", () => ({
+    ...htmlInput,
+    class: ["foo", inputClass],
+    content: content
+  }));
+}, 3);
+const $content = /* @__PURE__ */_$.state("content/8", $expr_inputAs_inputClass_htmlInput_content);
+const $startContent = /* @__PURE__ */_$.value("startContent", $content);
+export function $setup($scope) {
+  $startContent($scope, {
+    content: $define_content($scope)
+  });
+}
+const $inputAs = /* @__PURE__ */_$.value("inputAs", $expr_inputAs_inputClass_htmlInput_content);
+const $inputClass = /* @__PURE__ */_$.value("inputClass", $expr_inputAs_inputClass_htmlInput_content);
+const $htmlInput = /* @__PURE__ */_$.value("htmlInput", $expr_inputAs_inputClass_htmlInput_content);
+const $inputContent_effect = _$.effect("__tests__/tags/my-tag.marko_0_inputContent", ($scope, {
+  inputContent
+}) => $content($scope, inputContent));
+const $inputContent = /* @__PURE__ */_$.value("inputContent", $inputContent_effect);
+export const $input = /* @__PURE__ */_$.value("input", ($scope, input) => {
+  (({
+    as,
+    class: $class,
+    content,
+    ...htmlInput
+  }) => $htmlInput($scope, htmlInput))(input);
+  $inputAs($scope, input.as);
+  $inputClass($scope, input.class);
+  $inputContent($scope, input.content);
+});
+export default /* @__PURE__ */_$.createTemplate("__tests__/tags/my-tag.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,21 @@
+// size: 242 (min) 175 (brotli)
+const $dynamicTag = _$.dynamicTag(0),
+  $expr_inputAs_inputClass_htmlInput_content = _$.intersection(
+    9,
+    ($scope) => {
+      const { 3: inputAs, 4: inputClass, 6: htmlInput, 8: content } = $scope;
+      $dynamicTag($scope, inputAs || "div", () => ({
+        ...htmlInput,
+        class: ["foo", inputClass],
+        content: content,
+      }));
+    },
+    3,
+  ),
+  $content = _$.state(8, $expr_inputAs_inputClass_htmlInput_content);
+(_$.effect("a1", ($scope, { 5: inputContent }) =>
+  $content($scope, inputContent),
+),
+  _$.registerContent("b0", "Span"),
+  _$.registerContent("b1", "Div"),
+  init());

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/dom.expected/template.js
@@ -1,0 +1,18 @@
+export const $template = `<!>${_myTag_template}${_myTag_template}<!>`;
+export const $walks = /* beginChild, _myTag_walks, endChild, beginChild, _myTag_walks, endChild */`D/${_myTag_walks}&/${_myTag_walks}&D`;
+import { $setup as _myTag, $input as _myTag_input, $template as _myTag_template, $walks as _myTag_walks } from "./tags/my-tag.marko";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const $mytag_content2 = _$.registerContent("__tests__/template.marko_2_renderer", "Span");
+const $mytag_content = _$.registerContent("__tests__/template.marko_1_renderer", "Div");
+export function $setup($scope) {
+  _myTag($scope["#childScope/0"]);
+  _myTag_input($scope["#childScope/0"], {
+    content: $mytag_content($scope)
+  });
+  _myTag($scope["#childScope/1"]);
+  _myTag_input($scope["#childScope/1"], {
+    as: "span",
+    content: $mytag_content2($scope)
+  });
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/html.expected/tags/my-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/html.expected/tags/my-tag.js
@@ -1,0 +1,37 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+export default _$.createTemplate("__tests__/tags/my-tag.marko", (input, $serialize) => {
+  const $scope0_id = _$.nextScopeId();
+  const {
+    as: inputAs,
+    class: inputClass,
+    content: inputContent,
+    ...htmlInput
+  } = input;
+  const startContent = {
+    content: _$.createContent("__tests__/tags/my-tag.marko_1_renderer", () => {
+      const $scope1_id = _$.nextScopeId();
+      _$.write("default");
+    })
+  };
+  let content = startContent;
+  _$.dynamicTag($scope0_id, "#text/0", inputAs || "div", {
+    ...htmlInput,
+    class: ["foo", inputClass],
+    content: content
+  });
+  _$.writeEffect($scope0_id, "__tests__/tags/my-tag.marko_0_inputContent");
+  _$.writeScope($scope0_id, {
+    inputAs,
+    inputClass,
+    inputContent,
+    htmlInput,
+    content: _$.serializeIf($serialize, /* input.as, input.class, input */3) && content
+  }, "__tests__/tags/my-tag.marko", 0, {
+    inputAs: "1:13",
+    inputClass: "1:29",
+    inputContent: "1:50",
+    htmlInput: "1:67",
+    content: "6:5"
+  });
+  _$.resumeClosestBranch($scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/html.expected/template.js
@@ -1,0 +1,18 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+import _myTag from "./tags/my-tag.marko";
+export default _$.createTemplate("__tests__/template.marko", input => {
+  const $scope0_id = _$.nextScopeId();
+  _myTag({
+    content: _$.registerContent("__tests__/template.marko_1_renderer", () => {
+      const $scope1_id = _$.nextScopeId();
+      _$.write("Div");
+    }, $scope0_id)
+  });
+  _myTag({
+    as: "span",
+    content: _$.registerContent("__tests__/template.marko_2_renderer", () => {
+      const $scope2_id = _$.nextScopeId();
+      _$.write("Span");
+    }, $scope0_id)
+  });
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div
+  class="foo"
+>
+  default
+</div>
+<span
+  class="foo"
+>
+  default
+</span>
+```
+
+
+# Render ASYNC
+```html
+<div
+  class="foo"
+>
+  Div
+</div>
+<span
+  class="foo"
+>
+  Span
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume.expected.md
@@ -1,0 +1,60 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <div
+      class="foo"
+    >
+      <!--M_[4-->
+      default
+      <!--M_]3 #div/0-->
+    </div>
+    <!--M_'2 #text/0 3-->
+    <span
+      class="foo"
+    >
+      <!--M_[7-->
+      default
+      <!--M_]6 #span/0-->
+    </span>
+    <!--M_'5 #text/0 6-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_renderer"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_renderer"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render ASYNC
+```html
+<html>
+  <head />
+  <body>
+    <div
+      class="foo"
+    >
+      Div
+    </div>
+    <!--M_'2 #text/0 3-->
+    <span
+      class="foo"
+    >
+      Span
+    </span>
+    <!--M_'5 #text/0 6-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_renderer"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_renderer"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE #comment, #text, #comment in html/body/div
+INSERT html/body/div/#text
+REMOVE #comment, #text, #comment in html/body/span
+INSERT html/body/span/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,13 @@
+# Render End
+```html
+<div
+  class="foo"
+>
+  default
+</div>
+<span
+  class="foo"
+>
+  default
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr.expected.md
@@ -1,0 +1,51 @@
+# Write
+```html
+  <div class=foo><!--M_[4-->default<!--M_]3 #div/0--></div><!--M_'2 #text/0 3--><span class=foo><!--M_[7-->default<!--M_]6 #span/0--></span><!--M_'5 #text/0 6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_renderer"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_renderer"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <div
+      class="foo"
+    >
+      <!--M_[4-->
+      default
+      <!--M_]3 #div/0-->
+    </div>
+    <!--M_'2 #text/0 3-->
+    <span
+      class="foo"
+    >
+      <!--M_[7-->
+      default
+      <!--M_]6 #span/0-->
+    </span>
+    <!--M_'5 #text/0 6-->
+    <script>
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_renderer"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_renderer"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_renderer"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/div
+INSERT html/body/div/#comment0
+INSERT html/body/div/#text
+INSERT html/body/div/#comment1
+INSERT html/body/#comment0
+INSERT html/body/span
+INSERT html/body/span/#comment0
+INSERT html/body/span/#text
+INSERT html/body/span/#comment1
+INSERT html/body/#comment1
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/tags/my-tag.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/tags/my-tag.marko
@@ -1,0 +1,11 @@
+const/{ as: inputAs, class: inputClass, content: inputContent, ...htmlInput }=input
+
+define/startContent
+  -- default
+
+let/content=startContent
+
+${inputAs || "div"} ...htmlInput class=["foo", inputClass] content=content
+
+script --
+  content = inputContent;

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/template.marko
@@ -1,0 +1,2 @@
+my-tag -- Div
+my-tag as="span" -- Span

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/test.ts
@@ -1,0 +1,3 @@
+import { wait } from "../../utils/resolve";
+
+export const steps = [{}, wait(1)];

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
@@ -4,6 +4,7 @@
   <head />
   <body>
     <div>
+      <!--M_[3-->
       <button
         id="count"
       >
@@ -11,14 +12,15 @@
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
+      <!--M_]2 #div/0-->
     </div>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button
       id="changeTag"
     />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -34,6 +36,7 @@ container.querySelector("#count").click();
   <head />
   <body>
     <div>
+      <!--M_[3-->
       <button
         id="count"
       >
@@ -41,14 +44,15 @@ container.querySelector("#count").click();
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
+      <!--M_]2 #div/0-->
     </div>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button
       id="changeTag"
     />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -74,13 +78,13 @@ container.querySelector("#changeTag").click();
         0
       </button>
     </span>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button
       id="changeTag"
     />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -109,13 +113,13 @@ container.querySelector("#count").click();
         1
       </button>
     </span>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button
       id="changeTag"
     />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><button id=count>0<!--M_*4 #text/1--></button><!--M_*4 #button/0--></div><!--M_|1 #text/0 2--><button id=changeTag></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <div><!--M_[3--><button id=count>0<!--M_*4 #text/1--></button><!--M_*4 #button/0--><!--M_]2 #div/0--></div><!--M_'1 #text/0 2--><button id=changeTag></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
@@ -9,6 +9,7 @@
   <head />
   <body>
     <div>
+      <!--M_[3-->
       <button
         id="count"
       >
@@ -16,14 +17,15 @@
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
+      <!--M_]2 #div/0-->
     </div>
-    <!--M_|1 #text/0 2-->
+    <!--M_'1 #text/0 2-->
     <button
       id="changeTag"
     />
     <!--M_*1 #button/1-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,1,{count:0,"#ClosestBranchId":2}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()
     </script>
   </body>
 </html>
@@ -35,10 +37,12 @@ INSERT html
 INSERT html/head
 INSERT html/body
 INSERT html/body/div
+INSERT html/body/div/#comment0
 INSERT html/body/div/button
 INSERT html/body/div/button/#text
 INSERT html/body/div/button/#comment
-INSERT html/body/div/#comment
+INSERT html/body/div/#comment1
+INSERT html/body/div/#comment2
 INSERT html/body/#comment0
 INSERT html/body/button
 INSERT html/body/#comment1

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/dom.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/template.marko:1:2
     > 1 | <buton/>
-        |  ^^^^^ Unable to find entry point for custom tag.
+        |  ^^^^^ Unable to find entry point for custom tag `<buton>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/html.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/template.marko:1:2
     > 1 | <buton/>
-        |  ^^^^^ Unable to find entry point for custom tag.
+        |  ^^^^^ Unable to find entry point for custom tag `<buton>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/resume.expected.md
@@ -14,9 +14,11 @@
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
+          <!--M_[3-->
           Hi
+          <!--M_]2 #a/0-->
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -27,17 +29,21 @@
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
+          <!--M_[5-->
           Hi
+          <!--M_]4 #a/0-->
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <div>
+        <!--M_[7-->
         <a
           href="#"
           ns="http://www.w3.org/1999/xhtml"
         />
+        <!--M_]6 #div/0-->
       </div>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -53,7 +59,7 @@
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -86,9 +92,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
+          <!--M_[3-->
           Hi
+          <!--M_]2 #a/0-->
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -99,9 +107,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
+          <!--M_[5-->
           Hi
+          <!--M_]4 #a/0-->
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <svg>
         <a
@@ -109,7 +119,7 @@ container.querySelector(".toggle-parent").click();
           ns="http://www.w3.org/2000/svg"
         />
       </svg>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -125,7 +135,7 @@ container.querySelector(".toggle-parent").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -159,9 +169,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
+          <!--M_[3-->
           Hi
+          <!--M_]2 #a/0-->
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -172,9 +184,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
+          <!--M_[5-->
           Hi
+          <!--M_]4 #a/0-->
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <div>
         <a
@@ -182,7 +196,7 @@ container.querySelector(".toggle-parent").click();
           ns="http://www.w3.org/1999/xhtml"
         />
       </div>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -198,7 +212,7 @@ container.querySelector(".toggle-parent").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -232,9 +246,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
+          <!--M_[3-->
           Hi
+          <!--M_]2 #a/0-->
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -245,9 +261,11 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
+          <!--M_[5-->
           Hi
+          <!--M_]4 #a/0-->
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <svg>
         <a
@@ -255,7 +273,7 @@ container.querySelector(".toggle-parent").click();
           ns="http://www.w3.org/2000/svg"
         />
       </svg>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -271,7 +289,7 @@ container.querySelector(".toggle-parent").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -302,7 +320,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/2000/svg"
         />
         Hi
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -310,7 +328,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/1998/Math/MathML"
         />
         Hi
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <svg>
         <a
@@ -318,7 +336,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/2000/svg"
         />
       </svg>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -334,7 +352,7 @@ container.querySelector(".toggle-child").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -368,7 +386,7 @@ container.querySelector(".toggle-child").click();
         >
           Hi
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -381,7 +399,7 @@ container.querySelector(".toggle-child").click();
         >
           Hi
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <svg>
         <a
@@ -389,7 +407,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/2000/svg"
         />
       </svg>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -405,7 +423,7 @@ container.querySelector(".toggle-child").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -440,7 +458,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/2000/svg"
         />
         Hi
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -448,7 +466,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/1998/Math/MathML"
         />
         Hi
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <svg>
         <a
@@ -456,7 +474,7 @@ container.querySelector(".toggle-child").click();
           ns="http://www.w3.org/2000/svg"
         />
       </svg>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -472,7 +490,7 @@ container.querySelector(".toggle-child").click();
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><svg><a href=#></a><a href=#bar>Hi</a><!--M_|1 #text/2 2--></svg><math><a href=#></a><a href=#bar>Hi</a><!--M_|1 #text/4 4--></math><div><a href=#></a></div><!--M_|1 #text/5 6--><button class=toggle-parent>Toggle Parent</button><!--M_*1 #button/6--><button class=toggle-child>Toggle Child</button><!--M_*1 #button/7--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#>\x3C/a>",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()</script>
+  <div><svg><a href=#></a><a href=#bar><!--M_[3-->Hi<!--M_]2 #a/0--></a><!--M_'1 #text/2 2--></svg><math><a href=#></a><a href=#bar><!--M_[5-->Hi<!--M_]4 #a/0--></a><!--M_'1 #text/4 4--></math><div><!--M_[7--><a href=#></a><!--M_]6 #div/0--></div><!--M_'1 #text/5 6--><button class=toggle-parent>Toggle Parent</button><!--M_*1 #button/6--><button class=toggle-child>Toggle Child</button><!--M_*1 #button/7--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#>\x3C/a>",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()</script>
 ```
 
 # Render End
@@ -16,9 +16,11 @@
         <a
           href="#bar"
         >
+          <!--M_[3-->
           Hi
+          <!--M_]2 #a/0-->
         </a>
-        <!--M_|1 #text/2 2-->
+        <!--M_'1 #text/2 2-->
       </svg>
       <math>
         <a
@@ -27,16 +29,20 @@
         <a
           href="#bar"
         >
+          <!--M_[5-->
           Hi
+          <!--M_]4 #a/0-->
         </a>
-        <!--M_|1 #text/4 4-->
+        <!--M_'1 #text/4 4-->
       </math>
       <div>
+        <!--M_[7-->
         <a
           href="#"
         />
+        <!--M_]6 #div/0-->
       </div>
-      <!--M_|1 #text/5 6-->
+      <!--M_'1 #text/5 6-->
       <button
         class="toggle-parent"
       >
@@ -52,7 +58,7 @@
     </div>
     <!--M_*1 #div/0-->
     <script>
-      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.d=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.b={},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.c={},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,1,_.b,1,_.c,{"#ClosestBranchId":6}]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
+      WALKER_RUNTIME("M")("_");M._.r=[_=&gt;(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_renderer"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_renderer"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_renderer"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#&gt;\x3C/a&gt;",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()
     </script>
   </body>
 </html>
@@ -67,15 +73,21 @@ INSERT html/body/div
 INSERT html/body/div/svg
 INSERT html/body/div/svg/a0
 INSERT html/body/div/svg/a1
+INSERT html/body/div/svg/a1/#comment0
 INSERT html/body/div/svg/a1/#text
+INSERT html/body/div/svg/a1/#comment1
 INSERT html/body/div/svg/#comment
 INSERT html/body/div/math
 INSERT html/body/div/math/a0
 INSERT html/body/div/math/a1
+INSERT html/body/div/math/a1/#comment0
 INSERT html/body/div/math/a1/#text
+INSERT html/body/div/math/a1/#comment1
 INSERT html/body/div/math/#comment
 INSERT html/body/div/div
+INSERT html/body/div/div/#comment0
 INSERT html/body/div/div/a
+INSERT html/body/div/div/#comment1
 INSERT html/body/div/#comment0
 INSERT html/body/div/button0
 INSERT html/body/div/button0/#text

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -31,6 +31,7 @@ export enum ResumeSymbol {
   BranchStart = "[",
   BranchEnd = "]",
   BranchSingleNode = "|",
+  BranchNativeTag = "'",
   BranchSingleNodeOnlyChildInParent = "=",
 }
 

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -8,7 +8,7 @@ import {
   NodeType,
   type Scope,
 } from "../common/types";
-import { attrs } from "./dom";
+import { attrs, attrsAndContent } from "./dom";
 import {
   caughtError,
   pendingEffects,
@@ -304,7 +304,7 @@ export let dynamicTag = function dynamicTag(
       const childScope = scope[childScopeAccessor] as Scope;
       const args = getInput?.();
       if (typeof normalizedRenderer === "string") {
-        attrs(
+        (getContent ? attrs : attrsAndContent)(
           childScope,
           MARKO_DEBUG ? `#${normalizedRenderer}/0` : 0,
           (inputIsArgs ? args[0] : args) || {},

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -7,6 +7,7 @@ import {
   type Scope,
 } from "../common/types";
 import type { Signal } from "./signals";
+import { getDebugKey } from "./walker";
 
 type Resumes = (number | Scope)[];
 type ResumeFn = (ctx: object) => Resumes;
@@ -114,6 +115,7 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
                   currentBranchId = branchStack.pop();
                 } else {
                   /**
+                   * visitToken === ResumeSymbol.BranchNativeTag ||
                    * visitToken === ResumeSymbol.BranchSingleNode ||
                    * visitToken === ResumeSymbol.BranchSingleNodeOnlyChildInParent
                    */
@@ -133,6 +135,15 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
                     );
                     curNode = endBranch(childScopeId, curNode).___endNode;
                     parentBranchIds.set(childScopeId, scopeId);
+
+                    if (visitToken === ResumeSymbol.BranchNativeTag) {
+                      const childBranch = scopeLookup[childScopeId];
+                      // const childTag = curNode.previousSibling as Element;
+                      childBranch[MARKO_DEBUG ? getDebugKey(0, curNode) : 0] =
+                        childBranch.___startNode =
+                        childBranch.___endNode =
+                          curNode;
+                    }
                   }
                 }
               },

--- a/packages/runtime-tags/src/dom/walker.ts
+++ b/packages/runtime-tags/src/dom/walker.ts
@@ -129,7 +129,7 @@ function walkInternal(
   }
 }
 
-function getDebugKey(index: number, node: Node | string) {
+export function getDebugKey(index: number, node: Node | string) {
   if (typeof node === "string") {
     return `${node}/${index}`;
   } else if (node.nodeType === NodeType.Text) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -352,11 +352,12 @@ export function getSignalFn(signal: Signal): t.Expression {
           const aliasId = t.identifier(alias.name);
           forEach(alias.excludeProperties, (name) => {
             const propId = toPropertyName(name);
-            const shorthand = propId.type === "Identifier";
+            const shorthand =
+              propId.type === "Identifier" && t.isValidIdentifier(name);
             props.push(
               t.objectProperty(
                 propId,
-                propId.type === "Identifier" ? propId : t.objectPattern([]),
+                shorthand ? propId : generateUidIdentifier(name),
                 false,
                 shorthand,
               ),

--- a/packages/runtime-tags/src/translator/util/translate-attrs.ts
+++ b/packages/runtime-tags/src/translator/util/translate-attrs.ts
@@ -130,13 +130,13 @@ export function translateAttrs(
   }
 
   if (!seen.has(contentKey) && usesExport(templateExports, contentKey)) {
-    seen.add(contentKey);
     const contentExpression = buildContent(tag.get("body"));
     if (contentExpression) {
       const contentProp = t.objectProperty(
         t.identifier(contentKey),
         contentExpression,
       );
+      seen.add(contentKey);
       contentProps.add(contentProp);
       properties.push(contentProp);
     }

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -115,7 +115,9 @@ export default {
         }
         throw tag
           .get("name")
-          .buildCodeFrameError("Unable to find entry point for custom tag.");
+          .buildCodeFrameError(
+            `Unable to find entry point for custom tag \`<${tagName}>\`.`,
+          );
       }
 
       const section = getOrCreateSection(tag);
@@ -522,7 +524,9 @@ export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
     }
     throw tag
       .get("name")
-      .buildCodeFrameError("Unable to find entry point for custom tag.");
+      .buildCodeFrameError(
+        `Unable to find entry point for custom tag \`<${tagName}>\`.`,
+      );
   }
 
   return relativePath;


### PR DESCRIPTION
- Fix a few `content`-related issues in dynamic tag
- Allow reserved keywords in destructure, like `<const/{ class }=input/>`
- Improve an unrelated error message

