### PR TITLE
feat: include links to docs in error messages

### DIFF
--- a/.changeset/wise-signs-make.md
+++ b/.changeset/wise-signs-make.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Add links to the docs in error messages

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/template.marko:1:2
     > 1 | <const/x=1 y=2/>
-        |  ^^^^^ The `const` tag only supports the `value` attribute.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/template.marko:1:2
     > 1 | <const/x=1 y=2/>
-        |  ^^^^^ The `const` tag only supports the `value` attribute.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/template.marko:1:2
     > 1 | <const/x/>
-        |  ^^^^^ The `const` tag requires a value.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/template.marko:1:2
     > 1 | <const/x/>
-        |  ^^^^^ The `const` tag requires a value.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The `const` tag requires a tag variable.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The `const` tag requires a tag variable.
+        |  ^^^^^ The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/__snapshots__/dom.expected/template.error.txt
@@ -3,4 +3,4 @@
       1 | static const myTag = "div"
       2 |
     > 3 | <myTag/>
-        |  ^^^^^ Local variables must be in a dynamic tag unless they are PascalCase. Use `<${myTag}/>` or rename to `MyTag`.
+        |  ^^^^^ Local variables must be in a [dynamic tag](https://next.markojs.com/docs/reference/language#dynamic-tags) unless they are PascalCase. Use `<${myTag}/>` or rename to `MyTag`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/__snapshots__/html.expected/template.error.txt
@@ -3,4 +3,4 @@
       1 | static const myTag = "div"
       2 |
     > 3 | <myTag/>
-        |  ^^^^^ Local variables must be in a dynamic tag unless they are PascalCase. Use `<${myTag}/>` or rename to `MyTag`.
+        |  ^^^^^ Local variables must be in a [dynamic tag](https://next.markojs.com/docs/reference/language#dynamic-tags) unless they are PascalCase. Use `<${myTag}/>` or rename to `MyTag`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/dom.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/template.marko:1:2
     > 1 | <buton/>
-        |  ^^^^^ Unable to find entry point for custom tag `<buton>`.
+        |  ^^^^^ Unable to find entry point for [custom tag](https://next.markojs.com/docs/reference/custom-tag#relative-custom-tags) `<buton>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/__snapshots__/html.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/template.marko:1:2
     > 1 | <buton/>
-        |  ^^^^^ Unable to find entry point for custom tag `<buton>`.
+        |  ^^^^^ Unable to find entry point for [custom tag](https://next.markojs.com/docs/reference/custom-tag#relative-custom-tags) `<buton>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/template.marko:2:2
       1 | <const/x=0/>
     > 2 | <debug=x y=1/>
-        |  ^^^^^ The `debug` tag only supports the `value` attribute.
+        |  ^^^^^ The [`<debug>` tag](https://next.markojs.com/docs/reference/core-tag#debug) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/template.marko:2:2
       1 | <const/x=0/>
     > 2 | <debug=x y=1/>
-        |  ^^^^^ The `debug` tag only supports the `value` attribute.
+        |  ^^^^^ The [`<debug>` tag](https://next.markojs.com/docs/reference/core-tag#debug) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/template.marko:1:2
     > 1 | <define>Hello!</define>
-        |  ^^^^^^ The `define` tag requires a tag variable.
+        |  ^^^^^^ The [`<define>` tag](https://next.markojs.com/docs/reference/core-tag#define) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/template.marko:1:2
     > 1 | <define>Hello!</define>
-        |  ^^^^^^ The `define` tag requires a tag variable.
+        |  ^^^^^^ The [`<define>` tag](https://next.markojs.com/docs/reference/core-tag#define) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The `effect` tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://next.markojs.com/docs/reference/core-tag#effect) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The `effect` tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://next.markojs.com/docs/reference/core-tag#effect) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/template.marko:1:20
     > 1 | <script=(() => {}) y=1/>
-        |                    ^^^ The `script` tag does not support html attributes. For a native html `script` tag use the `html-script` core tag instead.
+        |                    ^^^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support html attributes. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/template.marko:1:20
     > 1 | <script=(() => {}) y=1/>
-        |                    ^^^ The `script` tag does not support html attributes. For a native html `script` tag use the `html-script` core tag instead.
+        |                    ^^^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support html attributes. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/template.marko:1:9
     > 1 | <script/x=(() => {})/>
-        |         ^ The `script` tag does not support a tag variable reference. For a native html `script` tag use the `html-script` core tag instead.
+        |         ^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support a tag variable reference. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/template.marko:1:9
     > 1 | <script/x=(() => {})/>
-        |         ^ The `script` tag does not support a tag variable reference. For a native html `script` tag use the `html-script` core tag instead.
+        |         ^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support a tag variable reference. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/template.marko:2:21
       1 | <if=false>Skipped</if>
     > 2 | <else if=input.show y=2>Hello World</else>
-        |                     ^^^ The `else` tag only supports an `if=` attribute.
+        |                     ^^^ The [`else` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports an `if=` attribute.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/template.marko:2:21
       1 | <if=false>Skipped</if>
     > 2 | <else if=input.show y=2>Hello World</else>
-        |                     ^^^ The `else` tag only supports an `if=` attribute.
+        |                     ^^^ The [`else` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports an `if=` attribute.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else />
-        |  ^^^^ The `else` tag requires body content.
+        |  ^^^^ The [`else` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else />
-        |  ^^^^ The `else` tag requires body content.
+        |  ^^^^ The [`else` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/template.marko:2:21
       1 | <if=false>Skipped</if>
     > 2 | <else-if=input.show y=2>Hello World</else-if>
-        |                     ^^^ The `else-if` tag only supports the `value` attribute.
+        |                     ^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/template.marko:2:21
       1 | <if=false>Skipped</if>
     > 2 | <else-if=input.show y=2>Hello World</else-if>
-        |                     ^^^ The `else-if` tag only supports the `value` attribute.
+        |                     ^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else-if=input.show />
-        |  ^^^^^^^ The `else-if` tag requires body content.
+        |  ^^^^^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else-if=input.show />
-        |  ^^^^^^^ The `else-if` tag requires body content.
+        |  ^^^^^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else-if>Hello World</else-if>
-        |  ^^^^^^^ The `else-if` tag requires a value.
+        |  ^^^^^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/template.marko:2:2
       1 | <if=false>Skipped</if>
     > 2 | <else-if>Hello World</else-if>
-        |  ^^^^^^^ The `else-if` tag requires a value.
+        |  ^^^^^^^ The [`else-if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/template.marko:1:5
     > 1 | <id/{ firstNameId }/>
-        |     ^^^^^^^^^^^^^^^ The `id` tag cannot be destructured
+        |     ^^^^^^^^^^^^^^^ The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) cannot be destructured.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/template.marko:1:5
     > 1 | <id/{ firstNameId }/>
-        |     ^^^^^^^^^^^^^^^ The `id` tag cannot be destructured
+        |     ^^^^^^^^^^^^^^^ The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) cannot be destructured.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/template.marko:1:2
     > 1 | <id/>
-        |  ^^ The `id` tag requires a tag variable.
+        |  ^^ The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/template.marko:1:2
     > 1 | <id/>
-        |  ^^ The `id` tag requires a tag variable.
+        |  ^^ The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/template.marko:1:16
     > 1 | <if=input.show y=2>Hello World</if>
-        |                ^^^ The `if` tag only supports the `value` attribute.
+        |                ^^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/template.marko:1:16
     > 1 | <if=input.show y=2>Hello World</if>
-        |                ^^^ The `if` tag only supports the `value` attribute.
+        |                ^^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/template.marko:1:2
     > 1 | <if=input.show />
-        |  ^^ The `if` tag requires body content.
+        |  ^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/template.marko:1:2
     > 1 | <if=input.show />
-        |  ^^ The `if` tag requires body content.
+        |  ^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/template.marko:1:2
     > 1 | <if>Hello World</if>
-        |  ^^ The `if` tag requires a value.
+        |  ^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/template.marko:1:2
     > 1 | <if>Hello World</if>
-        |  ^^ The `if` tag requires a value.
+        |  ^^ The [`if` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/template.marko:1:14
     > 1 | <let/count=0 y=3/>
-        |              ^^^ The `let` tag only supports the `value` attribute and its change handler.
+        |              ^^^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value) and its change handler.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/template.marko:1:14
     > 1 | <let/count=0 y=3/>
-        |              ^^^ The `let` tag only supports the `value` attribute and its change handler.
+        |              ^^^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value) and its change handler.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The `let` tag requires a tag variable.
+        |  ^^^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The `let` tag requires a tag variable.
+        |  ^^^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/template.marko:1:12
     > 1 | <let/count ...{ value: 1, valueChange() {} }/>
-        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `let` tag does not support `...spread` attributes.
+        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<let>`](https://next.markojs.com/docs/reference/core-tag#let) tag does not support `...spread` attributes.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/template.marko:1:12
     > 1 | <let/count ...{ value: 1, valueChange() {} }/>
-        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `let` tag does not support `...spread` attributes.
+        |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<let>`](https://next.markojs.com/docs/reference/core-tag#let) tag does not support `...spread` attributes.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/__snapshots__/dom.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/template.marko:1:2
     > 1 | <lifecycle />
-        |  ^^^^^^^^^ The `lifecycle` tag requires at least one attribute.
+        |  ^^^^^^^^^ The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) requires at least one attribute.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/__snapshots__/html.expected/template.error.txt
@@ -1,4 +1,4 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/template.marko:1:2
     > 1 | <lifecycle />
-        |  ^^^^^^^^^ The `lifecycle` tag requires at least one attribute.
+        |  ^^^^^^^^^ The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) requires at least one attribute.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/template.marko:1:2
     > 1 | <lifecycle ...{
-        |  ^^^^^^^^^ The `lifecycle` tag does not support `...spread` attributes.
+        |  ^^^^^^^^^ The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) does not support [`...spread` attributes](https://next.markojs.com/docs/reference/language#spread-attributes).
       2 |   onMount() {},
       3 |   onUpdate() {},
       4 |   onDestroy() {}

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/__snapshots__/html.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/template.marko:1:2
     > 1 | <lifecycle ...{
-        |  ^^^^^^^^^ The `lifecycle` tag does not support `...spread` attributes.
+        |  ^^^^^^^^^ The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) does not support [`...spread` attributes](https://next.markojs.com/docs/reference/language#spread-attributes).
       2 |   onMount() {},
       3 |   onUpdate() {},
       4 |   onDestroy() {}

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/template.marko:1:2
     > 1 | <log="Hello" y=1/>
-        |  ^^^ The `log` tag only supports the `value` attribute.
+        |  ^^^ The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/template.marko:1:2
     > 1 | <log="Hello" y=1/>
-        |  ^^^ The `log` tag only supports the `value` attribute.
+        |  ^^^ The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/template.marko:1:2
     > 1 | <log/>
-        |  ^^^ The `log` tag requires a value.
+        |  ^^^ The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/template.marko:1:2
     > 1 | <log/>
-        |  ^^^ The `log` tag requires a value.
+        |  ^^^ The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/dom.expected/template.error.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:2:4
       1 | <if=input.show>
     > 2 |   <return=1/>
-        |    ^^^^^^ The `return` tag can not be used under an `"if"` tag.
+        |    ^^^^^^ The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) can not be used under the `<"if">` tag.
       3 | </if>
       4 | <else>
       5 |   <return=2/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/html.expected/template.error.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:2:4
       1 | <if=input.show>
     > 2 |   <return=1/>
-        |    ^^^^^^ The `return` tag can not be used under an `"if"` tag.
+        |    ^^^^^^ The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) can not be used under the `<"if">` tag.
       3 | </if>
       4 | <else>
       5 |   <return=2/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/__snapshots__/dom.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/template.marko:2:2
       1 | <return=1/>
     > 2 | <return=2/>
-        |  ^^^^^^ Cannot have multiple `return` tags for the template.
+        |  ^^^^^^ Cannot have multiple [`<return>` tags](https://next.markojs.com/docs/reference/core-tag#return) for the template.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/__snapshots__/html.expected/template.error.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/template.marko:2:2
       1 | <return=1/>
     > 2 | <return=2/>
-        |  ^^^^^^ Cannot have multiple `return` tags for the template.
+        |  ^^^^^^ Cannot have multiple [`<return>` tags](https://next.markojs.com/docs/reference/core-tag#return) for the template.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/__snapshots__/dom.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/template.marko:1:2
     > 1 | <return/>
-        |  ^^^^^^ The `return` tag requires a value.
+        |  ^^^^^^ The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/__snapshots__/html.expected/template.error.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/template.marko:1:2
     > 1 | <return/>
-        |  ^^^^^^ The `return` tag requires a value.
+        |  ^^^^^^ The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/dom.expected/error-script-placeholder/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/dom.expected/error-script-placeholder/template.error.txt
@@ -2,6 +2,6 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/error-script-placeholder/template.marko:2:3
       1 | <script>
     > 2 |   ${"Hello <b> </script>"}
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in `script` tag. Only javascript and typescript is supported. For a native html `script` tag use the `html-script` core tag instead.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script). Only javascript and typescript is supported. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/dom.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/template.marko:1:9
     > 1 | <script blocking="render">
-        |         ^^^^^^^^^^^^^^^^^ The `script` tag does not support html attributes. For a native html `script` tag use the `html-script` core tag instead.
+        |         ^^^^^^^^^^^^^^^^^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support html attributes. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |   console.log("hi")
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/html.expected/error-script-placeholder/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/html.expected/error-script-placeholder/template.error.txt
@@ -2,6 +2,6 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/error-script-placeholder/template.marko:2:3
       1 | <script>
     > 2 |   ${"Hello <b> </script>"}
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in `script` tag. Only javascript and typescript is supported. For a native html `script` tag use the `html-script` core tag instead.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script). Only javascript and typescript is supported. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/__snapshots__/html.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/template.marko:1:9
     > 1 | <script blocking="render">
-        |         ^^^^^^^^^^^^^^^^^ The `script` tag does not support html attributes. For a native html `script` tag use the `html-script` core tag instead.
+        |         ^^^^^^^^^^^^^^^^^ The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support html attributes. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       2 |   console.log("hi")
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/__snapshots__/dom.expected/template.error.txt
@@ -2,6 +2,6 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/template.marko:2:3
       1 | <script>
     > 2 |   ${"Hello <b> </script>"}
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in `script` tag. Only javascript and typescript is supported. For a native html `script` tag use the `html-script` core tag instead.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script). Only javascript and typescript is supported. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/__snapshots__/html.expected/template.error.txt
@@ -2,6 +2,6 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/template.marko:2:3
       1 | <script>
     > 2 |   ${"Hello <b> </script>"}
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in `script` tag. Only javascript and typescript is supported. For a native html `script` tag use the `html-script` core tag instead.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^ Unexpected content in [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script). Only javascript and typescript is supported. For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.
       3 | </script>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/__snapshots__/dom.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/template.marko:1:17
     > 1 | <style blocking="render">
-        |                 ^^^^^^^^ The `style` does not support html attributes. For a native html `style` tag use the `html-style` core tag instead.
+        |                 ^^^^^^^^ The `style` does not support html attributes. For a native html [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) use the `html-style` core tag instead.
       2 |   body {
       3 |     color: green;
       4 |   }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/__snapshots__/html.expected/template.error.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/template.marko:1:17
     > 1 | <style blocking="render">
-        |                 ^^^^^^^^ The `style` does not support html attributes. For a native html `style` tag use the `html-style` core tag instead.
+        |                 ^^^^^^^^ The `style` does not support html attributes. For a native html [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) use the `html-style` core tag instead.
       2 |   body {
       3 |     color: green;
       4 |   }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/__snapshots__/dom.expected/template.error.txt
@@ -3,7 +3,7 @@
       1 | <style>
       2 |   body {
     > 3 |     color: ${"green"}
-        |            ^^^^^^^^^^ The `style` tag currently only supports static content. For a native html `style` tag use the `html-style` core tag instead.
+        |            ^^^^^^^^^^ The [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) currently only supports static content. For a native html [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) use the `html-style` core tag instead.
       4 |   }
       5 | </style>
       6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/__snapshots__/html.expected/template.error.txt
@@ -3,7 +3,7 @@
       1 | <style>
       2 |   body {
     > 3 |     color: ${"green"}
-        |            ^^^^^^^^^^ The `style` tag currently only supports static content. For a native html `style` tag use the `html-style` core tag instead.
+        |            ^^^^^^^^^^ The [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) currently only supports static content. For a native html [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) use the `html-style` core tag instead.
       4 |   }
       5 | </style>
       6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/__snapshots__/dom.expected/template.error.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/template.marko:2:22
       1 | <let/x=1/>
     > 2 | <let/y=x valueChange=5 />
-        |                      ^ The `let` tag `valueChange` attribute must be a function.
+        |                      ^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) [`valueChange=` attribute](https://next.markojs.com/docs/reference/core-tag#controllable-let) must be a function.
       3 | <button onClick() { y++; }>
       4 |   ${x}|${y}
       5 | </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/__snapshots__/html.expected/template.error.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/template.marko:2:22
       1 | <let/x=1/>
     > 2 | <let/y=x valueChange=5 />
-        |                      ^ The `let` tag `valueChange` attribute must be a function.
+        |                      ^ The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) [`valueChange=` attribute](https://next.markojs.com/docs/reference/core-tag#controllable-let) must be a function.
       3 | <button onClick() { y++; }>
       4 |   ${x}|${y}
       5 | </button>

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -63,7 +63,9 @@ export default {
     if (!valueAttr) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `await` tag requires a value.");
+        .buildCodeFrameError(
+          "The [`<await>` tag](https://next.markojs.com/docs/reference/core-tag#await) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
+        );
     }
 
     if (
@@ -74,14 +76,16 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `await` tag only supports the `value` attribute.",
+          "The [`<await>` tag](https://next.markojs.com/docs/reference/core-tag#await) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
         );
     }
 
     if (!node.body.body.length) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `await` tag requires body content.");
+        .buildCodeFrameError(
+          "The [`<await>` tag](https://next.markojs.com/docs/reference/core-tag#await) requires [content](https://next.markojs.com/docs/reference/language#tag-content).",
+        );
     }
 
     if (
@@ -91,7 +95,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `await` tag only supports a single parameter.",
+          "The [`<await>` tag](https://next.markojs.com/docs/reference/core-tag#await) only supports a single parameter.",
         );
     }
 
@@ -201,7 +205,8 @@ export default {
   autocomplete: [
     {
       description: "Use to consume asynchronous an data.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#await",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#await",
     },
   ],
   types: runtimeInfo.name + "/tags/await.d.marko",

--- a/packages/runtime-tags/src/translator/core/const.ts
+++ b/packages/runtime-tags/src/translator/core/const.ts
@@ -29,13 +29,17 @@ export default {
     if (!node.var) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `const` tag requires a tag variable.");
+        .buildCodeFrameError(
+          "The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).",
+        );
     }
 
     if (!valueAttr) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `const` tag requires a value.");
+        .buildCodeFrameError(
+          "The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
+        );
     }
 
     if (
@@ -46,7 +50,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `const` tag only supports the `value` attribute.",
+          "The [`<const>` tag](https://next.markojs.com/docs/reference/core-tag#const) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
         );
     }
 
@@ -94,7 +98,8 @@ export default {
   autocomplete: [
     {
       description: "Use to create an constant binding.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#const",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#const",
     },
   ],
   types: runtimeInfo.name + "/tags/const.d.marko",

--- a/packages/runtime-tags/src/translator/core/debug.ts
+++ b/packages/runtime-tags/src/translator/core/debug.ts
@@ -30,7 +30,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `debug` tag only supports the `value` attribute.",
+          "The [`<debug>` tag](https://next.markojs.com/docs/reference/core-tag#debug) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
         );
     }
   },
@@ -58,7 +58,8 @@ export default {
   autocomplete: [
     {
       description: "Debug on value change.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#debug",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#debug",
     },
   ],
   types: runtimeInfo.name + "/tags/debug.d.marko",

--- a/packages/runtime-tags/src/translator/core/define.ts
+++ b/packages/runtime-tags/src/translator/core/define.ts
@@ -29,7 +29,9 @@ export default {
     if (!tag.node.var) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `define` tag requires a tag variable.");
+        .buildCodeFrameError(
+          "The [`<define>` tag](https://next.markojs.com/docs/reference/core-tag#define) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).",
+        );
     }
 
     const tagBody = tag.get("body");
@@ -101,7 +103,8 @@ export default {
     {
       description:
         "Use to create a constant object binding that can be rendered.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#define",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#define",
     },
   ],
   types: runtimeInfo.name + "/tags/define.d.marko",

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -80,7 +80,7 @@ export default {
         break;
       default:
         throw tag.buildCodeFrameError(
-          "Invalid `for` tag, missing an `of=`, `in=`, `to=` attribute.",
+          "The [`<for>` tag](https://next.markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.",
         );
     }
 
@@ -333,17 +333,17 @@ export default {
       description:
         "Use to iterate over lists, object properties, or between ranges.",
       descriptionMoreURL:
-        "https://markojs.com/docs/core-tags/#iterating-over-a-list",
+        "https://next.markojs.com/docs/reference/core-tag#for",
     },
     {
       snippet: "for|${1:name, value}| in=${3:object}",
       descriptionMoreURL:
-        "https://markojs.com/docs/core-tags/#iterating-over-an-objects-properties",
+        "https://next.markojs.com/docs/reference/core-tag#for",
     },
     {
       snippet: "for|${1:index}| to=${2:number}",
       descriptionMoreURL:
-        "https://markojs.com/docs/core-tags/#iterating-between-a-range-of-numbers",
+        "https://next.markojs.com/docs/reference/core-tag#for",
     },
   ],
 } satisfies Tag;

--- a/packages/runtime-tags/src/translator/core/html-comment.ts
+++ b/packages/runtime-tags/src/translator/core/html-comment.ts
@@ -63,7 +63,7 @@ export default {
         throw tag
           .get("var")
           .buildCodeFrameError(
-            "The `html-comment` tag variable cannot be destructured.",
+            "The [`<html-comment>` tag](https://next.markojs.com/docs/reference/core-tag#html-comment) tag variable cannot be destructured.",
           );
       }
       needsBinding = true;
@@ -243,7 +243,8 @@ export default {
     {
       description:
         "Use to create an html comment that is not stripped from the output.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#html-comment",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#html-comment",
     },
   ],
 } as Tag;

--- a/packages/runtime-tags/src/translator/core/html-script.ts
+++ b/packages/runtime-tags/src/translator/core/html-script.ts
@@ -479,6 +479,14 @@ export default {
     text: true,
     preserveWhitespace: true,
   },
+  autocomplete: [
+    {
+      description:
+        "Use instead of `<script>` to render a native tag directly, without processing by Marko.",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#html-script--html-style",
+    },
+  ],
 } as Tag;
 
 function getUsedAttrs(tag: t.MarkoTag) {

--- a/packages/runtime-tags/src/translator/core/html-style.ts
+++ b/packages/runtime-tags/src/translator/core/html-style.ts
@@ -474,6 +474,14 @@ export default {
     text: true,
     preserveWhitespace: true,
   },
+  autocomplete: [
+    {
+      description:
+        "Use instead of `<style>` to render a native tag directly, without processing by Marko.",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#html-script--html-style",
+    },
+  ],
 } as Tag;
 
 function getUsedAttrs(tag: t.MarkoTag) {

--- a/packages/runtime-tags/src/translator/core/id.ts
+++ b/packages/runtime-tags/src/translator/core/id.ts
@@ -32,13 +32,17 @@ export default {
     if (!node.var) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `id` tag requires a tag variable.");
+        .buildCodeFrameError(
+          "The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).",
+        );
     }
 
     if (!t.isIdentifier(node.var)) {
       throw tag
         .get("var")
-        .buildCodeFrameError("The `id` tag cannot be destructured");
+        .buildCodeFrameError(
+          "The [`<id>` tag](https://next.markojs.com/docs/reference/core-tag#id) cannot be destructured.",
+        );
     }
 
     const binding = trackVarReferences(tag, BindingType.derived);
@@ -73,7 +77,7 @@ export default {
       displayText: "id/<name>",
       description: "Use to create a unique identifier.",
       snippet: "id/${1:name}",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#id",
+      descriptionMoreURL: "https://next.markojs.com/docs/reference/core-tag#id",
     },
   ],
   types: runtimeInfo.name + "/tags/id.d.marko",

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -308,7 +308,8 @@ export const IfTag = {
     {
       snippet: "if=${1:condition}",
       description: "Use to display content only if the condition is met.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#if-else-if-else",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#if--else",
     },
   ],
 } satisfies Tag;
@@ -320,7 +321,8 @@ export const ElseIfTag = {
       snippet: "else-if=${1:condition}",
       description:
         "Use after an <if> or <else-if> tag to display content if those conditions do not match and this one does.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#if-else-if-else",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#if--else",
     },
   ],
 };
@@ -331,7 +333,8 @@ export const ElseTag = {
     {
       description:
         "Use after an <if> or <else-if> tag to display content if those conditions do not match.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#if-else-if-else",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#if--else",
     },
   ],
 };
@@ -367,7 +370,7 @@ function assertHasPrecedingCondition(tag: t.NodePath<t.MarkoTag>) {
     (getTagName(prev) !== "else" && !prev.node.attributes.length)
   ) {
     throw tag.buildCodeFrameError(
-      `The \`<${getTagName(tag)}>\` must have a preceding \`<if=cond>\`, \`<else-if=cond>\`, or \`<else if=cond>\`.`,
+      `The [\`<${getTagName(tag)}>\` tag](https://next.markojs.com/docs/reference/core-tag#if--else) must have a preceding \`<if=cond>\` or \`<else if=cond>\`.`,
     );
   }
 }
@@ -377,7 +380,7 @@ function assertHasBody(tag: t.NodePath<t.MarkoTag>) {
     throw tag
       .get("name")
       .buildCodeFrameError(
-        `The \`${getTagName(tag)}\` tag requires body content.`,
+        `The [\`${getTagName(tag)}\` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).`,
       );
   }
 }
@@ -389,13 +392,15 @@ function assertHasValueAttribute(tag: t.NodePath<t.MarkoTag>) {
   if (!t.isMarkoAttribute(valueAttr) || !valueAttr.default) {
     throw tag
       .get("name")
-      .buildCodeFrameError(`The \`${getTagName(tag)}\` tag requires a value.`);
+      .buildCodeFrameError(
+        `The [\`${getTagName(tag)}\` tag](https://next.markojs.com/docs/reference/core-tag#if--else) requires a [\`value=\` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).`,
+      );
   }
 
   if (node.attributes.length > 1) {
     const start = node.attributes[1].loc?.start;
     const end = node.attributes[node.attributes.length - 1].loc?.end;
-    const msg = `The \`${getTagName(tag)}\` tag only supports the \`value\` attribute.`;
+    const msg = `The [\`${getTagName(tag)}\` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports the [\`value=\` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).`;
 
     if (start == null || end == null) {
       throw tag.get("name").buildCodeFrameError(msg);
@@ -419,7 +424,7 @@ function assertOptionalIfAttribute(tag: t.NodePath<t.MarkoTag>) {
   ) {
     const start = node.attributes[1].loc?.start;
     const end = node.attributes[node.attributes.length - 1].loc?.end;
-    const msg = `The \`${getTagName(tag)}\` tag only supports an \`if=\` attribute.`;
+    const msg = `The [\`${getTagName(tag)}\` tag](https://next.markojs.com/docs/reference/core-tag#if--else) only supports an \`if=\` attribute.`;
 
     if (start == null || end == null) {
       throw tag.get("name").buildCodeFrameError(msg);

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -48,7 +48,7 @@ export default {
           const start = attr.loc?.start;
           const end = attr.loc?.end;
           const msg =
-            "The `let` tag only supports the `value` attribute and its change handler.";
+            "The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value) and its change handler.";
 
           if (start == null || end == null) {
             throw tag.get("name").buildCodeFrameError(msg);
@@ -71,13 +71,17 @@ export default {
     if (!tagVar) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `let` tag requires a tag variable.");
+        .buildCodeFrameError(
+          "The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://next.markojs.com/docs/reference/language#tag-variables).",
+        );
     }
 
     if (!t.isIdentifier(tagVar)) {
       throw tag
         .get("var")
-        .buildCodeFrameError("The `let` tag variable cannot be destructured.");
+        .buildCodeFrameError(
+          "The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) variable cannot be destructured.",
+        );
     }
 
     if (valueChangeAttr && computeNode(valueChangeAttr.value)) {
@@ -86,7 +90,7 @@ export default {
         .find((attr) => attr.node === valueChangeAttr)!
         .get("value")
         .buildCodeFrameError(
-          "The `let` tag `valueChange` attribute must be a function.",
+          "The [`<let>` tag](https://next.markojs.com/docs/reference/core-tag#let) [`valueChange=` attribute](https://next.markojs.com/docs/reference/core-tag#controllable-let) must be a function.",
         );
     }
 
@@ -162,7 +166,8 @@ export default {
   autocomplete: [
     {
       description: "Use to create a mutable binding.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#let",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#let",
     },
   ],
   types: runtimeInfo.name + "/tags/let.d.marko",

--- a/packages/runtime-tags/src/translator/core/lifecycle.ts
+++ b/packages/runtime-tags/src/translator/core/lifecycle.ts
@@ -58,7 +58,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `lifecycle` tag requires at least one attribute.",
+          "The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) requires at least one attribute.",
         );
     }
 
@@ -67,7 +67,7 @@ export default {
         throw tag
           .get("name")
           .buildCodeFrameError(
-            "The `lifecycle` tag does not support `...spread` attributes.",
+            "The [`<lifecycle>` tag](https://next.markojs.com/docs/reference/core-tag#lifecycle) does not support [`...spread` attributes](https://next.markojs.com/docs/reference/language#spread-attributes).",
           );
       }
       (attr.value.extra ??= {}).isEffect = true;
@@ -116,7 +116,8 @@ export default {
   autocomplete: [
     {
       description: "Use to create a side effects.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#effect",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#lifecycle",
     },
   ],
   types: runtimeInfo.name + "/tags/lifecycle.d.marko",

--- a/packages/runtime-tags/src/translator/core/log.ts
+++ b/packages/runtime-tags/src/translator/core/log.ts
@@ -23,7 +23,9 @@ export default {
     if (!valueAttr) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `log` tag requires a value.");
+        .buildCodeFrameError(
+          "The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
+        );
     }
 
     if (
@@ -34,7 +36,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The `log` tag only supports the `value` attribute.",
+          "The [`<log>` tag](https://next.markojs.com/docs/reference/core-tag#log) only supports the [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
         );
     }
   },
@@ -68,7 +70,8 @@ export default {
   autocomplete: [
     {
       description: "Use to log a value to the console.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#log",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#log",
     },
   ],
   types: runtimeInfo.name + "/tags/log.d.marko",

--- a/packages/runtime-tags/src/translator/core/return.ts
+++ b/packages/runtime-tags/src/translator/core/return.ts
@@ -42,13 +42,13 @@ export default {
         throw tag
           .get("name")
           .buildCodeFrameError(
-            "The `return` tag can not be used in a native tag.",
+            "The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) can not be used in a [native tag](https://next.markojs.com/docs/reference/native-tag).",
           );
       } else if (isControlFlowTag(parentTag)) {
         throw tag
           .get("name")
           .buildCodeFrameError(
-            `The \`return\` tag can not be used under an \`${parentTag.get("name").toString()}\` tag.`,
+            `The [\`<return>\` tag](https://next.markojs.com/docs/reference/core-tag#return) can not be used under the \`<${parentTag.get("name").toString()}>\` tag.`,
           );
       }
     }
@@ -57,7 +57,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          `Cannot have multiple \`return\` tags ${tag.parent.type === "Program" ? "for the template" : "within a tag's body content"}.`,
+          `Cannot have multiple [\`<return>\` tags](https://next.markojs.com/docs/reference/core-tag#return) ${tag.parent.type === "Program" ? "for the template" : "within a tag's body content"}.`,
         );
     } else {
       tagsWithReturn.add(tag.parentPath);
@@ -67,7 +67,9 @@ export default {
     if (!attrs.value) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `return` tag requires a value.");
+        .buildCodeFrameError(
+          "The [`<return>` tag](https://next.markojs.com/docs/reference/core-tag#return) requires a [`value=` attribute](https://next.markojs.com/docs/reference/language#shorthand-value).",
+        );
     }
 
     if (attrs.valueChange) {
@@ -150,7 +152,8 @@ export default {
       displayText: "return=<value>",
       description: "Provides a value for use in a parent template.",
       snippet: "return=${1:value}",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#return",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#return",
     },
   ],
 } as Tag;

--- a/packages/runtime-tags/src/translator/core/script.ts
+++ b/packages/runtime-tags/src/translator/core/script.ts
@@ -18,7 +18,7 @@ import { skip, traverseContains } from "../util/traverse";
 import { scopeIdentifier } from "../visitors/program";
 
 const htmlScriptTagAlternateMsg =
-  " For a native html `script` tag use the `html-script` core tag instead.";
+  " For a native html [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) use the `html-script` core tag instead.";
 
 export default {
   parse(tag) {
@@ -30,7 +30,7 @@ export default {
         if (child.type !== "MarkoText") {
           throw tag.hub.file.hub.buildError(
             child,
-            "Unexpected content in `script` tag. Only javascript and typescript is supported." +
+            "Unexpected content in [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script). Only javascript and typescript is supported." +
               htmlScriptTagAlternateMsg,
             SyntaxError,
           );
@@ -63,7 +63,7 @@ export default {
     if (node.var) {
       throw tag.hub.buildError(
         node.var,
-        "The `script` tag does not support a tag variable reference." +
+        "The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support a tag variable reference." +
           htmlScriptTagAlternateMsg,
       );
     }
@@ -80,7 +80,7 @@ export default {
       } else {
         throw tag.hub.buildError(
           attr,
-          "The `script` tag does not support html attributes." +
+          "The [`<script>` tag](https://next.markojs.com/docs/reference/core-tag#script) does not support html attributes." +
             htmlScriptTagAlternateMsg,
         );
       }

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -16,7 +16,7 @@ import { getMarkoOpts } from "../util/marko-config";
 
 const STYLE_EXT_REG = /^style((?:\.[a-zA-Z0-9$_-]+)+)?/;
 const htmlStyleTagAlternateMsg =
-  " For a native html `style` tag use the `html-style` core tag instead.";
+  " For a native html [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) use the `html-style` core tag instead.";
 
 export default {
   analyze(tag) {
@@ -48,7 +48,7 @@ export default {
       if (child.type !== "MarkoText") {
         throw tag.hub.buildError(
           child,
-          "The `style` tag currently only supports static content." +
+          "The [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) currently only supports static content." +
             htmlStyleTagAlternateMsg,
         );
       }
@@ -57,7 +57,7 @@ export default {
     if (node.body.body.length > 1) {
       throw tag.hub.buildError(
         node.name,
-        "The `style` tag currently only supports static content." +
+        "The [`<style>` tag](https://next.markojs.com/docs/reference/core-tag#style) currently only supports static content." +
           htmlStyleTagAlternateMsg,
       );
     }

--- a/packages/runtime-tags/src/translator/core/try.ts
+++ b/packages/runtime-tags/src/translator/core/try.ts
@@ -71,7 +71,9 @@ export default {
     if (!tag.node.body.body.length) {
       throw tag
         .get("name")
-        .buildCodeFrameError("The `try` tag requires body content.");
+        .buildCodeFrameError(
+          "The [`<try>` tag](https://next.markojs.com/docs/reference/core-tag#try) requires [body content](https://next.markojs.com/docs/reference/language#tag-content).",
+        );
     }
 
     startSection(tag.get("body"));
@@ -195,7 +197,8 @@ export default {
     {
       description:
         "Used to capture errors and display placeholders for nested content.",
-      descriptionMoreURL: "https://markojs.com/docs/core-tags/#try",
+      descriptionMoreURL:
+        "https://next.markojs.com/docs/reference/core-tag#try",
     },
   ],
   types: runtimeInfo.name + "/tags/try.d.marko",

--- a/packages/runtime-tags/src/translator/util/assert.ts
+++ b/packages/runtime-tags/src/translator/util/assert.ts
@@ -3,8 +3,9 @@ import type { types as t } from "@marko/compiler";
 export function assertNoSpreadAttrs(tag: t.NodePath<t.MarkoTag>) {
   for (const attr of tag.get("attributes")) {
     if (attr.isMarkoSpreadAttribute()) {
+      const tagName = (tag.get("name").node as t.StringLiteral).value;
       throw attr.buildCodeFrameError(
-        `The \`${(tag.get("name").node as t.StringLiteral).value}\` tag does not support \`...spread\` attributes.`,
+        `The [\`<${tagName}>\`](https://next.markojs.com/docs/reference/core-tag#${tagName}) tag does not support \`...spread\` attributes.`,
       );
     }
   }
@@ -12,10 +13,10 @@ export function assertNoSpreadAttrs(tag: t.NodePath<t.MarkoTag>) {
 
 export function assertNoBodyContent(tag: t.NodePath<t.MarkoTag>) {
   if (tag.node.body.body.length) {
-    throw tag
-      .get("name")
-      .buildCodeFrameError(
-        `The \`${(tag.get("name").node as t.StringLiteral).value}\` tag does not support body content.`,
-      );
+    const tagName = tag.get("name");
+    const tagNameLiteral = (tagName.node as t.StringLiteral).value;
+    throw tagName.buildCodeFrameError(
+      `The [\`<${tagNameLiteral}>\`](https://next.markojs.com/docs/reference/core-tag#${tagNameLiteral}) tag does not support body content.`,
+    );
   }
 }

--- a/packages/runtime-tags/src/translator/util/writer.ts
+++ b/packages/runtime-tags/src/translator/util/writer.ts
@@ -113,7 +113,7 @@ export function markNode(
 ) {
   if (nodeBinding.type !== BindingType.dom) {
     throw path.buildCodeFrameError(
-      "Tried to mark a node that was not determined to need a mark during analyze.",
+      "POTENTIAL MARKO BUG: Tried to mark a node that was not determined to need a mark during analyze.",
     );
   }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/attribute-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/attribute-tag.ts
@@ -23,7 +23,9 @@ export default {
       if (!findParentTag(tag)) {
         throw tag
           .get("name")
-          .buildCodeFrameError("@tags must be nested within another tag.");
+          .buildCodeFrameError(
+            "[Attribute tags](https://next.markojs.com/docs/reference/language#attribute-tags) must be nested within another tag.",
+          );
       }
     },
   },

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -117,13 +117,13 @@ export default {
           throw tag
             .get("name")
             .buildCodeFrameError(
-              `Local variables must be in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
+              `Local variables must be in a [dynamic tag](https://next.markojs.com/docs/reference/language#dynamic-tags) unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
             );
         }
         throw tag
           .get("name")
           .buildCodeFrameError(
-            `Unable to find entry point for custom tag \`<${tagName}>\`.`,
+            `Unable to find entry point for [custom tag](https://next.markojs.com/docs/reference/custom-tag#relative-custom-tags) \`<${tagName}>\`.`,
           );
       }
 
@@ -525,13 +525,13 @@ export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          `Local variables must be in a dynamic tag unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
+          `Local variables must be in a [dynamic tag](https://next.markojs.com/docs/reference/language#dynamic-tags) unless they are PascalCase. Use \`<\${${tagName}}/>\` or rename to \`${tagName.charAt(0).toUpperCase() + tagName.slice(1)}\`.`,
         );
     }
     throw tag
       .get("name")
       .buildCodeFrameError(
-        `Unable to find entry point for custom tag \`<${tagName}>\`.`,
+        `Unable to find entry point for [custom tag](https://next.markojs.com/docs/reference/custom-tag#relative-custom-tags) \`<${tagName}>\`.`,
       );
   }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -125,7 +125,7 @@ export default {
         throw tag
           .get("var")
           .buildCodeFrameError(
-            "Tag variables on native elements cannot be destructured.",
+            "Tag variables on [native tags](https://next.markojs.com/docs/reference/native-tag) cannot be destructured.",
           );
       }
 


### PR DESCRIPTION
Error messages now include links to the docs. Also cleaned up a few inconsistencies.