### PR TITLE
fix: static placeholders

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/.name-cache.json
@@ -1,0 +1,13 @@
+{
+  "vars": {
+    "props": {
+      "$_$": "o",
+      "$init": "t",
+      "$$mounted$if$content": "a",
+      "$$setup$if$content": "r",
+      "$$if_content": "e",
+      "$$if": "m",
+      "$$mounted": "i"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,12 @@
+# Render
+```html
+<div />
+```
+
+
+# Render ASYNC
+```html
+<div>
+  ABCD
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/csr.expected.md
@@ -1,0 +1,22 @@
+# Render
+```html
+<div />
+```
+
+# Mutations
+```
+INSERT div
+```
+
+# Render ASYNC
+```html
+<div>
+  ABCD
+</div>
+```
+
+# Mutations
+```
+INSERT div/#text0, div/#text1, div/#text2
+UPDATE div/#text1 "" => "C"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,11 @@
+// size: 193 (min) 147 (brotli)
+const $mounted$if$content = _$.conditionalClosure(1, 0, 0, ($scope, mounted) =>
+    _$.data($scope[0], mounted && "C"),
+  ),
+  $setup$if$content = $mounted$if$content,
+  $if_content = _$.createRenderer("AB<!>D", "b%c", $setup$if$content),
+  $if = _$.conditional(0, $if_content),
+  $mounted = _$.state(1, ($scope, mounted) => {
+    ($if($scope, mounted ? 0 : 1), $mounted$if$content($scope));
+  });
+(_$.effect("a0", ($scope) => $mounted($scope, !0)), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.expected/template.js
@@ -1,0 +1,17 @@
+export const $template = "<div></div>";
+export const $walks = /* get, over(1) */" b";
+import * as _$ from "@marko/runtime-tags/debug/dom";
+const $mounted$if$content = /* @__PURE__ */_$.conditionalClosure("mounted", "#div/0", 0, ($scope, mounted) => _$.data($scope["#text/0"], mounted && "C"));
+const $setup$if$content = $mounted$if$content;
+const $if_content = /* @__PURE__ */_$.createRenderer("AB<!>D", /* over(1), replace, over(2) */"b%c", $setup$if$content);
+const $if = /* @__PURE__ */_$.conditional("#div/0", $if_content);
+const $mounted = /* @__PURE__ */_$.state("mounted/1", ($scope, mounted) => {
+  $if($scope, mounted ? 0 : 1);
+  $mounted$if$content($scope);
+});
+const $setup_effect = _$.effect("__tests__/template.marko_0", $scope => $mounted($scope, true));
+export function $setup($scope) {
+  $mounted($scope, undefined);
+  $setup_effect($scope);
+}
+export default /* @__PURE__ */_$.createTemplate("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/html.expected/template.js
@@ -1,0 +1,23 @@
+import * as _$ from "@marko/runtime-tags/debug/html";
+export default _$.createTemplate("__tests__/template.marko", input => {
+  const $scope0_id = _$.nextScopeId();
+  let mounted = undefined;
+  _$.write("<div>");
+  _$.resumeConditional(() => {
+    if (mounted) {
+      const $scope1_id = _$.nextScopeId();
+      _$.write(`AB<!>${_$.escapeXML(mounted && "C")}${_$.markResumeNode($scope1_id, "#text/0")}D`);
+      _$.writeScope($scope1_id, {
+        _: _$.ensureScopeWithId($scope0_id)
+      }, "__tests__/template.marko", "4:3");
+      return 0;
+    }
+  }, $scope0_id, "#div/0", 1, /* state: mounted */1, "</div>");
+  _$.writeEffect($scope0_id, "__tests__/template.marko_0");
+  _$.writeScope($scope0_id, {
+    mounted
+  }, "__tests__/template.marko", 0, {
+    mounted: "1:5"
+  });
+  _$.resumeClosestBranch($scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,12 @@
+# Render
+```html
+<div />
+```
+
+
+# Render ASYNC
+```html
+<div>
+  ABCD
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume.expected.md
@@ -1,0 +1,51 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M_[2-->
+      <!--M_]1 #div/0-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.a = [0,
+        {}]),
+        "__tests__/template.marko_0",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render ASYNC
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M_[2-->
+      ABCD
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.a = [0,
+        {}]),
+        "__tests__/template.marko_0",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div/#text0, html/body/div/#text1, html/body/div/#text2
+REMOVE #comment after html/body/div/#text2
+UPDATE html/body/div/#text1 "" => "C"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,4 @@
+# Render End
+```html
+<div />
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr.expected.md
@@ -1,0 +1,38 @@
+# Write
+```html
+  <div><!--M_[2--><!--M_]1 #div/0--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{}]),"__tests__/template.marko_0",1];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <div>
+      <!--M_[2-->
+      <!--M_]1 #div/0-->
+    </div>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.a = [0,
+        {}]),
+        "__tests__/template.marko_0",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/div
+INSERT html/body/div/#comment0
+INSERT html/body/div/#comment1
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/template.marko
@@ -1,0 +1,5 @@
+let/mounted
+script -- mounted = true
+div
+  if=mounted
+    -- ${"A"}B${mounted && "C"}D

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/test.ts
@@ -1,0 +1,3 @@
+import { wait } from "../../utils/resolve";
+
+export const steps = [{}, wait(1)];

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -59,7 +59,10 @@ export default {
     if (confident && isVoid(computed)) return;
 
     if (isStaticText(node)) {
-      if (isStaticText(getPrev(placeholder))) {
+      if (
+        isStaticText(getPrev(placeholder)) ||
+        isStaticText(getNext(placeholder))
+      ) {
         (node.extra ??= {})[kSharedText] = true;
       }
     } else {
@@ -242,6 +245,19 @@ function getPrev(path: t.NodePath) {
   }
 
   return prev.node;
+}
+
+function getNext(path: t.NodePath) {
+  let next = path.getNextSibling();
+  while (
+    next.node &&
+    (next.isMarkoComment() ||
+      (next.isMarkoPlaceholder() && isEmptyPlaceholder(next.node)))
+  ) {
+    next = next.getNextSibling();
+  }
+
+  return next.node;
 }
 
 function isEmptyPlaceholder(placeholder: t.MarkoPlaceholder) {


### PR DESCRIPTION
In some cases, client-side rendered text nodes were broken when they had static content

```marko
-- ${"static"} rendered ${foo && "dynamic"} NOT rendered
```
