### PR TITLE
Improve resume walks

### DIFF
--- a/.changeset/yummy-doodles-burn.md
+++ b/.changeset/yummy-doodles-burn.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Improve resume walks to be easier to follow and more correct

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 19238,
-        "brotli": 7351
+        "min": 19091,
+        "brotli": 7284
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 103
       },
       "runtime": {
-        "min": 2191,
+        "min": 2199,
         "brotli": 1151
       },
       "total": {
-        "min": 2297,
-        "brotli": 1248
+        "min": 2305,
+        "brotli": 1254
       }
     },
     {
@@ -60,15 +60,15 @@
       "name": "comments 💧",
       "user": {
         "min": 142,
-        "brotli": 126
+        "brotli": 125
       },
       "runtime": {
-        "min": 2343,
-        "brotli": 1183
+        "min": 2351,
+        "brotli": 1194
       },
       "total": {
-        "min": 2485,
-        "brotli": 1306
+        "min": 2493,
+        "brotli": 1319
       }
     }
   ]

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 19225,
-        "brotli": 7339
+        "min": 19238,
+        "brotli": 7351
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 103
       },
       "runtime": {
-        "min": 2196,
-        "brotli": 1147
+        "min": 2191,
+        "brotli": 1151
       },
       "total": {
-        "min": 2302,
-        "brotli": 1250
+        "min": 2297,
+        "brotli": 1248
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 126
       },
       "runtime": {
-        "min": 2348,
-        "brotli": 1186
+        "min": 2343,
+        "brotli": 1183
       },
       "total": {
-        "min": 2490,
-        "brotli": 1312
+        "min": 2485,
+        "brotli": 1306
       }
     }
   ]

--- a/.sizes/comments.ssr/entry.js
+++ b/.sizes/comments.ssr/entry.js
@@ -1,4 +1,4 @@
-// size: 142 (min) 126 (brotli)
+// size: 142 (min) 125 (brotli)
 const $for_content__open__script = _script("a0", ($scope, { 12: open }) =>
     _on($scope[2], "click", function () {
       $for_content__open($scope, (open = !open));

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 19238 (min) 7351 (brotli)
+// size: 19091 (min) 7284 (brotli)
 var empty = [],
   rest = Symbol();
 function attrTag(attrs) {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/resume.expected.md
@@ -12,26 +12,26 @@
     <div
       data-level="4"
     >
-      <!--M_[4-->
+      <!--M_[-->
       <div
         data-level="3"
       >
-        <!--M_[8-->
+        <!--M_[-->
         <div
           data-level="2"
         >
-          <!--M_[13-->
+          <!--M_[-->
           <div
             data-level="1"
           >
-            <!--M_[17-->
-            <!--M_]16 #text/1-->
+            <!--M_[-->
+            <!--M_]16 #text/1 17-->
           </div>
-          <!--M_]12 #text/1-->
+          <!--M_]12 #text/1 13-->
         </div>
-        <!--M_]7 #text/1-->
+        <!--M_]7 #text/1 8-->
       </div>
-      <!--M_]3 #text/1-->
+      <!--M_]3 #text/1 4-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -88,4 +88,11 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/div/div/#text
+INSERT html/body/div/#text
+INSERT html/body/div/div/div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <div data-level=4><!--M_[4--><div data-level=3><!--M_[8--><!--M_!^b-->LOADING...<!--M_!b--><!--M_]7 #text/1--></div><!--M_]3 #text/1--></div><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{input_level:4},_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.a),_.c),_=>(_.f=[1,{input_level:3},_.d={"ConditionalScope:#text/1":_.e={"#BranchAccessor":"#text/1"}},_.e],_.e["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.d),_.f)];REORDER_RUNTIME(M._);M._.w()</script>
+  <div data-level=4><!--M_[--><div data-level=3><!--M_[--><!--M_!^b-->LOADING...<!--M_!b--><!--M_]7 #text/1 8--></div><!--M_]3 #text/1 4--></div><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{input_level:4},_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.a),_.c),_=>(_.f=[1,{input_level:3},_.d={"ConditionalScope:#text/1":_.e={"#BranchAccessor":"#text/1"}},_.e],_.e["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.d),_.f)];REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Write
 ```html
-  <t M_=c><div data-level=2><!--M_[13--><div data-level=1><!--M_[17--><!--M_!^d-->LOADING...<!--M_!d--><!--M_]16 #text/1--></div><!--M_]12 #text/1--></div></t><t M_=d><!--M_#e--></t><script>M._.r.push(_=>(_.i=[2,{input_level:2},_.g={"ConditionalScope:#text/1":_.h={"#BranchAccessor":"#text/1"}},_.h],_.h["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.g),_.i),_=>(_.l=[1,{input_level:1},_.j={"ConditionalScope:#text/1":_.k={"#BranchAccessor":"#text/1"}},_.k],_.k["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.j),_.l));M._.w()</script>
+  <t M_=c><div data-level=2><!--M_[--><div data-level=1><!--M_[--><!--M_!^d-->LOADING...<!--M_!d--><!--M_]16 #text/1 17--></div><!--M_]12 #text/1 13--></div></t><t M_=d><!--M_#e--></t><script>M._.r.push(_=>(_.i=[2,{input_level:2},_.g={"ConditionalScope:#text/1":_.h={"#BranchAccessor":"#text/1"}},_.h],_.h["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.g),_.i),_=>(_.l=[1,{input_level:1},_.j={"ConditionalScope:#text/1":_.k={"#BranchAccessor":"#text/1"}},_.k],_.k["#PlaceholderContent"]=_._["__tests__/tags/recurse.marko_4_content"](_.j),_.l));M._.w()</script>
 ```
 
 # Write
@@ -27,26 +27,26 @@
     <div
       data-level="4"
     >
-      <!--M_[4-->
+      <!--M_[-->
       <div
         data-level="3"
       >
-        <!--M_[8-->
+        <!--M_[-->
         <div
           data-level="2"
         >
-          <!--M_[13-->
+          <!--M_[-->
           <div
             data-level="1"
           >
-            <!--M_[17-->
-            <!--M_]16 #text/1-->
+            <!--M_[-->
+            <!--M_]16 #text/1 17-->
           </div>
-          <!--M_]12 #text/1-->
+          <!--M_]12 #text/1 13-->
         </div>
-        <!--M_]7 #text/1-->
+        <!--M_]7 #text/1 8-->
       </div>
-      <!--M_]3 #text/1-->
+      <!--M_]3 #text/1 4-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/__snapshots__/resume.expected.md
@@ -9,35 +9,35 @@
     </style>
   </head>
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div
       class="a"
       level="1"
     >
-      <!--M_[5-->
-      <!--M_[6-->
+      <!--M_[-->
+      <!--M_[-->
       <div
         class="a"
         level="2"
       >
-        <!--M_[7-->
+        <!--M_[-->
         <div
           class="b"
           level="3"
         >
-          <!--M_[10-->
+          <!--M_[-->
           <div
             class="b"
             level="4"
           />
-          <!--M_]9 #text/1-->
+          <!--M_]9 #text/1 10-->
         </div>
-        <!--M_]6 #text/1-->
+        <!--M_]6 #text/1 7-->
       </div>
-      <!--M_]5 #text/0-->
-      <!--M_]4 #text/1-->
+      <!--M_]5 #text/0 6-->
+      <!--M_]4 #text/1 5-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.d = [0, _.a = {
@@ -92,5 +92,9 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
-INSERT html/body/div/#text
+INSERT html/body/#text
+INSERT html/body/div/div/#text
+INSERT html/body/div/#text0
+INSERT html/body/div/#text1
+INSERT html/body/div/div/div/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/__snapshots__/ssr.expected.md
@@ -1,21 +1,21 @@
 # Write
 ```html
-  <!--M_[2--><!--M_!^b-->LOADING A1<!--M_!b--><!--M_]1 #text/0--><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"},promiseA:new Promise((f,r)=>_.c={f,r})},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_4_content"](_.a),_.d)];REORDER_RUNTIME(M._);M._.w()</script>
+  <!--M_[--><!--M_!^b-->LOADING A1<!--M_!b--><!--M_]1 #text/0 2--><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"},promiseA:new Promise((f,r)=>_.c={f,r})},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_4_content"](_.a),_.d)];REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Write
 ```html
-  <t M_=c><div class=a level=1><!--M_[5--><!--M_[6--><div class=a level=2><!--M_[7--><!--M_!^d-->LOADING B1<!--M_!d--><!--M_]6 #text/1--></div><!--M_]5 #text/0--><!--M_]4 #text/1--></div></t><t M_=d><!--M_#e--></t><script>M._.r.push(_=>(_.g=[1,_.e={"ConditionalScope:#text/1":_.f={"#BranchAccessor":"#text/1"}},_.f],_.f["#PlaceholderContent"]=_._["__tests__/template.marko_5_content"](_.e),_.g),_=>(_.c.f("a"),_.h=[]),_=>(_.l=[_.i={"ConditionalScope:#text/1":_.j={"#BranchAccessor":"#text/1"},promiseB:new Promise((f,r)=>_.k={f,r})},_.j],_.j["#PlaceholderContent"]=_._["__tests__/template.marko_10_content"](_.i),(_.f["ConditionalScope:#text/0"]=_.i),_.l));M._.w()</script>
+  <t M_=c><div class=a level=1><!--M_[--><!--M_[--><div class=a level=2><!--M_[--><!--M_!^d-->LOADING B1<!--M_!d--><!--M_]6 #text/1 7--></div><!--M_]5 #text/0 6--><!--M_]4 #text/1 5--></div></t><t M_=d><!--M_#e--></t><script>M._.r.push(_=>(_.g=[1,_.e={"ConditionalScope:#text/1":_.f={"#BranchAccessor":"#text/1"}},_.f],_.f["#PlaceholderContent"]=_._["__tests__/template.marko_5_content"](_.e),_.g),_=>(_.c.f("a"),_.h=[]),_=>(_.l=[_.i={"ConditionalScope:#text/1":_.j={"#BranchAccessor":"#text/1"},promiseB:new Promise((f,r)=>_.k={f,r})},_.j],_.j["#PlaceholderContent"]=_._["__tests__/template.marko_10_content"](_.i),(_.f["ConditionalScope:#text/0"]=_.i),_.l));M._.w()</script>
 ```
 
 # Write
 ```html
-  <t M_=e><div class=b level=3><!--M_[10--><div class=b level=4></div><!--M_]9 #text/1--></div></t><script>M._.r.push(_=>(_.o=[1,_.m={"ConditionalScope:#text/1":_.n={"#BranchAccessor":"#text/1"}},_.n],_.n["#PlaceholderContent"]=_._["__tests__/template.marko_11_content"](_.m),_.o),_=>(_.k.f("b"),_.p=[]));M._.w()</script>
+  <t M_=e><div class=b level=3><!--M_[--><div class=b level=4></div><!--M_]9 #text/1 10--></div></t><script>M._.r.push(_=>(_.o=[1,_.m={"ConditionalScope:#text/1":_.n={"#BranchAccessor":"#text/1"}},_.n],_.n["#PlaceholderContent"]=_._["__tests__/template.marko_11_content"](_.m),_.o),_=>(_.k.f("b"),_.p=[]));M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head>
     <style
@@ -29,30 +29,30 @@
       class="a"
       level="1"
     >
-      <!--M_[5-->
-      <!--M_[6-->
+      <!--M_[-->
+      <!--M_[-->
       <div
         class="a"
         level="2"
       >
-        <!--M_[7-->
+        <!--M_[-->
         <div
           class="b"
           level="3"
         >
-          <!--M_[10-->
+          <!--M_[-->
           <div
             class="b"
             level="4"
           />
-          <!--M_]9 #text/1-->
+          <!--M_]9 #text/1 10-->
         </div>
-        <!--M_]6 #text/1-->
+        <!--M_]6 #text/1 7-->
       </div>
-      <!--M_]5 #text/0-->
-      <!--M_]4 #text/1-->
+      <!--M_]5 #text/0 6-->
+      <!--M_]4 #text/1 5-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.d = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/resume.expected.md
@@ -13,12 +13,12 @@
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -48,6 +48,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text1
 ```
 
@@ -69,12 +70,12 @@ container.querySelector("button").click();
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -119,9 +120,7 @@ container.querySelector("button").click();
     </button>
     <!--M_*1 #button/0-->
     LOADING...
-    <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -151,10 +150,14 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-INSERT html/body/#text0
-REMOVE #document-fragment/#comment0 after html/body/#text0
-REMOVE #document-fragment/#comment1 after html/body/#text0
-REMOVE #document-fragment/#text after html/body/#text0
+INSERT html/body/#text
+REMOVE #document-fragment/#comment0 after html/body/#text
+REMOVE #document-fragment/#comment1 after html/body/#text
+REMOVE #document-fragment/#text0 after html/body/#text
+REMOVE #document-fragment/#comment2 after html/body/#text
+REMOVE #document-fragment/#text1 after html/body/#text
+REMOVE #document-fragment/#comment3 after html/body/#text
+REMOVE #document-fragment/#text2 after html/body/#text
 ```
 
 # Render ASYNC
@@ -172,12 +175,12 @@ REMOVE #document-fragment/#text after html/body/#text0
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     1
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -207,8 +210,8 @@ REMOVE #document-fragment/#text after html/body/#text0
 
 # Mutations
 ```
-INSERT html/body/#comment1, html/body/#comment2, html/body/#text0
-REMOVE #text after html/body/#text0
+INSERT html/body/#comment1, html/body/#comment2, html/body/#text0, html/body/#comment3, html/body/#text1, html/body/#comment4, html/body/#text2
+REMOVE #text after html/body/#text2
 ```
 
 # Render
@@ -229,12 +232,12 @@ container.querySelector("button").click();
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     1
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -279,9 +282,7 @@ container.querySelector("button").click();
     </button>
     <!--M_*1 #button/0-->
     LOADING...
-    <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -311,10 +312,14 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-INSERT html/body/#text0
-REMOVE #document-fragment/#comment0 after html/body/#text0
-REMOVE #document-fragment/#comment1 after html/body/#text0
-REMOVE #document-fragment/#text after html/body/#text0
+INSERT html/body/#text
+REMOVE #document-fragment/#comment0 after html/body/#text
+REMOVE #document-fragment/#comment1 after html/body/#text
+REMOVE #document-fragment/#text0 after html/body/#text
+REMOVE #document-fragment/#comment2 after html/body/#text
+REMOVE #document-fragment/#text1 after html/body/#text
+REMOVE #document-fragment/#comment3 after html/body/#text
+REMOVE #document-fragment/#text2 after html/body/#text
 ```
 
 # Render ASYNC
@@ -332,12 +337,12 @@ REMOVE #document-fragment/#text after html/body/#text0
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     2
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -367,6 +372,6 @@ REMOVE #document-fragment/#text after html/body/#text0
 
 # Mutations
 ```
-INSERT html/body/#comment1, html/body/#comment2, html/body/#text0
-REMOVE #text after html/body/#text0
+INSERT html/body/#comment1, html/body/#comment2, html/body/#text0, html/body/#comment3, html/body/#text1, html/body/#comment4, html/body/#text2
+REMOVE #text after html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <button>inc</button><!--M_*1 #button/0--><!--M_[2--><!--M_!^b-->LOADING...<!--M_!b--><!--M_]1 #text/1--><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/1"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_0_clickCount",1];REORDER_RUNTIME(M._);M._.w()</script>
+  <button>inc</button><!--M_*1 #button/0--><!--M_[--><!--M_!^b-->LOADING...<!--M_!b--><!--M_]1 #text/1 2--><style M_>t{display:none}</style><t M_=b><!--M_#c--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/1"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_0_clickCount",1];REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Write
 ```html
-  <t M_=c><!--M_[4-->0<!--M_*4 #text/0--><!--M_]2 #text/0--></t><script>M._.r.push(_=>(_.e=[1,_.f={}],(_.b["ConditionalScope:#text/0"]=_.f),_.e));M._.w()</script>
+  <t M_=c><!--M_[-->0<!--M_*4 #text/0--><!--M_]2 #text/0 4--></t><script>M._.r.push(_=>(_.e=[1,_.f={}],(_.b["ConditionalScope:#text/0"]=_.f),_.e));M._.w()</script>
 ```
 
 # Render End
@@ -23,12 +23,12 @@
       inc
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
-    <!--M_[4-->
+    <!--M_[-->
+    <!--M_[-->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]2 #text/0 4-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/resume.expected.md
@@ -3,12 +3,12 @@
 <html>
   <head />
   <body>
-    <!--M_[3-->
+    <!--M_[-->
     y: 
     <!---->
     1
     <!--M_*3 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 3-->
     <button>
       Toggle
     </button>
@@ -36,6 +36,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text2
 ```
 
 # Render
@@ -46,8 +47,7 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_]2 #text/0-->
-    <!--M_*3 #text/0-->
+    <!--M_]2 #text/0 3-->
     <button>
       Toggle
     </button>
@@ -73,8 +73,10 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE html/body/#comment0 after html/body/#comment1
+REMOVE html/body/#comment0 after #text
 INSERT html/body/#comment0
+REMOVE #comment after html/body/#comment0
+REMOVE #text after html/body/#comment0
 REMOVE #comment after html/body/#comment0
 REMOVE #text after html/body/#comment0
 REMOVE #comment after html/body/#comment0
@@ -90,7 +92,6 @@ container.querySelector("button").click();
   <head />
   <body>
     y: 1
-    <!--M_*3 #text/0-->
     <button>
       Toggle
     </button>
@@ -129,8 +130,7 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_]2 #text/0-->
-    <!--M_*3 #text/0-->
+    <!--M_]2 #text/0 3-->
     <button>
       Toggle
     </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[3-->y: <!>1<!--M_*3 #text/0--><!--M_]2 #text/0--><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{x:!0,"#childScope/0":_.a={"ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content"}},_.a,_.b]),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <!--M_[-->y: <!>1<!--M_*3 #text/0--><!--M_]2 #text/0 3--><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{x:!0,"#childScope/0":_.a={"ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content"}},_.a,_.b]),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[3-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -13,7 +13,7 @@
     <!---->
     1
     <!--M_*3 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 3-->
     <button>
       Toggle
     </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/resume.expected.md
@@ -4,12 +4,12 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Got: a 
       <!---->
       0
       <!--M_*2 #text/1-->
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <script>
         WALKER_RUNTIME("M")("_");
         M._.r = [_ =&gt; (_.a = [0,
@@ -30,18 +30,18 @@
         }], (_.d).add(_.g), (_.b["ConditionalScope:#text/2"] = _.g), _.f));
         M._.w()
       </script>
-      <!--M_[4-->
+      <!--M_[-->
       Got: b 
       <!---->
       0
       <!--M_*4 #text/1-->
-      <!--M_]1 #text/1-->
-      <!--M_[3-->
+      <!--M_]1 #text/1 4-->
+      <!--M_[-->
       Got: c 
       <!---->
       0
       <!--M_*3 #text/1-->
-      <!--M_]1 #text/2-->
+      <!--M_]1 #text/2 3-->
       <button>
         Inc
       </button>
@@ -70,12 +70,12 @@ container.querySelector("button").click();
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Got: a 
       <!---->
       1
       <!--M_*2 #text/1-->
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <script>
         WALKER_RUNTIME("M")("_");
         M._.r = [_ =&gt; (_.a = [0,
@@ -96,18 +96,18 @@ container.querySelector("button").click();
         }], (_.d).add(_.g), (_.b["ConditionalScope:#text/2"] = _.g), _.f));
         M._.w()
       </script>
-      <!--M_[4-->
+      <!--M_[-->
       Got: b 
       <!---->
       1
       <!--M_*4 #text/1-->
-      <!--M_]1 #text/1-->
-      <!--M_[3-->
+      <!--M_]1 #text/1 4-->
+      <!--M_[-->
       Got: c 
       <!---->
       1
       <!--M_*3 #text/1-->
-      <!--M_]1 #text/2-->
+      <!--M_]1 #text/2 3-->
       <button>
         Inc
       </button>
@@ -142,12 +142,12 @@ container.querySelector("button").click();
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Got: a 
       <!---->
       2
       <!--M_*2 #text/1-->
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <script>
         WALKER_RUNTIME("M")("_");
         M._.r = [_ =&gt; (_.a = [0,
@@ -168,18 +168,18 @@ container.querySelector("button").click();
         }], (_.d).add(_.g), (_.b["ConditionalScope:#text/2"] = _.g), _.f));
         M._.w()
       </script>
-      <!--M_[4-->
+      <!--M_[-->
       Got: b 
       <!---->
       2
       <!--M_*4 #text/1-->
-      <!--M_]1 #text/1-->
-      <!--M_[3-->
+      <!--M_]1 #text/1 4-->
+      <!--M_[-->
       Got: c 
       <!---->
       2
       <!--M_*3 #text/1-->
-      <!--M_]1 #text/2-->
+      <!--M_]1 #text/2 3-->
       <button>
         Inc
       </button>
@@ -214,12 +214,12 @@ container.querySelector("button").click();
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Got: a 
       <!---->
       3
       <!--M_*2 #text/1-->
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <script>
         WALKER_RUNTIME("M")("_");
         M._.r = [_ =&gt; (_.a = [0,
@@ -240,18 +240,18 @@ container.querySelector("button").click();
         }], (_.d).add(_.g), (_.b["ConditionalScope:#text/2"] = _.g), _.f));
         M._.w()
       </script>
-      <!--M_[4-->
+      <!--M_[-->
       Got: b 
       <!---->
       3
       <!--M_*4 #text/1-->
-      <!--M_]1 #text/1-->
-      <!--M_[3-->
+      <!--M_]1 #text/1 4-->
+      <!--M_[-->
       Got: c 
       <!---->
       3
       <!--M_*3 #text/1-->
-      <!--M_]1 #text/2-->
+      <!--M_]1 #text/2 3-->
       <button>
         Inc
       </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><!--M_[2-->Got: a <!>0<!--M_*2 #text/1--><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{count:0,"ClosureScopes:count":new Set}]),_=>(_.c=[_.e={_:_.b=_.a[1],"ClosureSignalIndex:count":0}],(_.d=_.b["ClosureScopes:count"]).add(_.e),(_.b["ConditionalScope:#text/0"]=_.e),_.c)];M._.w()</script>
+  <div><!--M_[-->Got: a <!>0<!--M_*2 #text/1--><!--M_]1 #text/0 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{count:0,"ClosureScopes:count":new Set}]),_=>(_.c=[_.e={_:_.b=_.a[1],"ClosureSignalIndex:count":0}],(_.d=_.b["ClosureScopes:count"]).add(_.e),(_.b["ConditionalScope:#text/0"]=_.e),_.c)];M._.w()</script>
 ```
 
 # Write
@@ -10,7 +10,7 @@
 
 # Write
 ```html
-  <!--M_[4-->Got: b <!>0<!--M_*4 #text/1--><!--M_]1 #text/1--><!--M_[3-->Got: c <!>0<!--M_*3 #text/1--><!--M_]1 #text/2--><button>Inc</button><!--M_*1 #button/3--></div><script>M._.r.push(_=>(_.h=[_.i={_:_.b,"ClosureSignalIndex:count":1}],(_.d).add(_.i),(_.b["ConditionalScope:#text/1"]=_.i),_.h),"__tests__/template.marko_0_count",1);M._.w()</script>
+  <!--M_[-->Got: b <!>0<!--M_*4 #text/1--><!--M_]1 #text/1 4--><!--M_[-->Got: c <!>0<!--M_*3 #text/1--><!--M_]1 #text/2 3--><button>Inc</button><!--M_*1 #button/3--></div><script>M._.r.push(_=>(_.h=[_.i={_:_.b,"ClosureSignalIndex:count":1}],(_.d).add(_.i),(_.b["ConditionalScope:#text/1"]=_.i),_.h),"__tests__/template.marko_0_count",1);M._.w()</script>
 ```
 
 # Render End
@@ -19,12 +19,12 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Got: a 
       <!---->
       0
       <!--M_*2 #text/1-->
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <script>
         WALKER_RUNTIME("M")("_");
         M._.r = [_ =&gt; (_.a = [0,
@@ -45,18 +45,18 @@
         }], (_.d).add(_.g), (_.b["ConditionalScope:#text/2"] = _.g), _.f));
         M._.w()
       </script>
-      <!--M_[4-->
+      <!--M_[-->
       Got: b 
       <!---->
       0
       <!--M_*4 #text/1-->
-      <!--M_]1 #text/1-->
-      <!--M_[3-->
+      <!--M_]1 #text/1 4-->
+      <!--M_[-->
       Got: c 
       <!---->
       0
       <!--M_*3 #text/1-->
-      <!--M_]1 #text/2-->
+      <!--M_]1 #text/2 3-->
       <button>
         Inc
       </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/resume.expected.md
@@ -11,12 +11,12 @@
       class="toggle"
     />
     <!--M_*1 #button/1-->
-    <!--M_[2-->
+    <!--M_[-->
     The count is 
     <!---->
     0
     <!--M_*2 #text/0-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -36,6 +36,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text2
+```
 
 # Render
 ```js
@@ -53,12 +57,12 @@ container.querySelector("button.inc").click();
       class="toggle"
     />
     <!--M_*1 #button/1-->
-    <!--M_[2-->
+    <!--M_[-->
     The count is 
     <!---->
     1
     <!--M_*2 #text/0-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -99,8 +103,7 @@ container.querySelector("button.toggle").click();
       class="toggle"
     />
     <!--M_*1 #button/1-->
-    <!--M_]1 #text/2-->
-    <!--M_*2 #text/0-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -122,8 +125,10 @@ container.querySelector("button.toggle").click();
 
 # Mutations
 ```
-REMOVE html/body/#comment2 after html/body/#comment3
+REMOVE html/body/#comment2 after #text
 INSERT html/body/#comment2
+REMOVE #comment after html/body/#comment2
+REMOVE #text after html/body/#comment2
 REMOVE #comment after html/body/#comment2
 REMOVE #text after html/body/#comment2
 REMOVE #comment after html/body/#comment2
@@ -146,8 +151,7 @@ container.querySelector("button.inc").click();
       class="toggle"
     />
     <!--M_*1 #button/1-->
-    <!--M_]1 #text/2-->
-    <!--M_*2 #text/0-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -185,7 +189,6 @@ container.querySelector("button.toggle").click();
     />
     <!--M_*1 #button/1-->
     The count is 2
-    <!--M_*2 #text/0-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -229,7 +232,6 @@ container.querySelector("button.inc").click();
     />
     <!--M_*1 #button/1-->
     The count is 3
-    <!--M_*2 #text/0-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button class=inc></button><!--M_*1 #button/0--><button class=toggle></button><!--M_*1 #button/1--><!--M_[2-->The count is <!>0<!--M_*2 #text/0--><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0,count:0},_.b],_.b._=_.a,_.c),"__tests__/template.marko_0_show",1,"__tests__/template.marko_0_count",1];M._.w()</script>
+  <button class=inc></button><!--M_*1 #button/0--><button class=toggle></button><!--M_*1 #button/1--><!--M_[-->The count is <!>0<!--M_*2 #text/0--><!--M_]1 #text/2 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0,count:0},_.b],_.b._=_.a,_.c),"__tests__/template.marko_0_show",1,"__tests__/template.marko_0_count",1];M._.w()</script>
 ```
 
 # Render End
@@ -16,12 +16,12 @@
       class="toggle"
     />
     <!--M_*1 #button/1-->
-    <!--M_[2-->
+    <!--M_[-->
     The count is 
     <!---->
     0
     <!--M_*2 #text/0-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/resume.expected.md
@@ -7,7 +7,7 @@
       Push
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       0.0
       <!--M_*4 #text/0-->
@@ -17,84 +17,8 @@
       <!--M_*6 #text/0-->
     </div>
     <!--M_|2 #text/0 5 3-->
-    <!--M_[7 -->
-    <div>
-      1.0
-      <!--M_*9 #text/0-->
-    </div>
-    <div>
-      1.1
-      <!--M_*11 #text/0-->
-    </div>
-    <!--M_|7 #text/0 10 8-->
-    <!--M_]1 #text/1-->
-    <script>
-      WALKER_RUNTIME("M")("_");
-      M._.r = [_ =&gt; (_.o = [0, _.f = {
-            "LoopScopeMap:#text/1": new Map(_.a = [
-              [0, _.c = {
-                "LoopScopeMap:#text/0": new Map(_.b = [
-                  [0, _.d = {
-                    "#childScope/0": _.k = {}
-                  }],
-                  [1, _.e = {
-                    "#childScope/0": _.l = {}
-                  }]
-                ]),
-                outer: 0
-              }],
-              [1, _.h = {
-                "LoopScopeMap:#text/0": new Map(_.g = [
-                  [0, _.i = {
-                    "#childScope/0": _.m = {}
-                  }],
-                  [1, _.j = {
-                    "#childScope/0": _.n = {}
-                  }]
-                ]),
-                outer: 1
-              }]
-            ]),
-            items: [0, 1]
-          }, _.c, _.d, _.k, _.e, _.l, _.h, _.i, _.m, _.j, _.n], _.d._ = _.e
-          ._ = _.c, _.c._ = _.h._ = _.f, _.i._ = _.j._ = _.h, _.o),
-        "__tests__/template.marko_0_items",
-        1
-      ];
-      M._.w()
-    </script>
-  </body>
-</html>
-```
-
-
-# Render
-```js
-container.querySelector("button").click();
-```
-```html
-<html>
-  <head />
-  <body>
-    <button>
-      Push
-    </button>
-    <!--M_*1 #button/0-->
     <!--M_[2-->
     <div>
-      0.0
-      <!--M_*4 #text/0-->
-    </div>
-    <div>
-      0.1
-      <!--M_*6 #text/0-->
-    </div>
-    <div>
-      0.2
-    </div>
-    <!--M_|2 #text/0 5 3-->
-    <!--M_[7 -->
-    <div>
       1.0
       <!--M_*9 #text/0-->
     </div>
@@ -102,22 +26,8 @@ container.querySelector("button").click();
       1.1
       <!--M_*11 #text/0-->
     </div>
-    <div>
-      1.2
-    </div>
-    <!---->
-    <div>
-      2.0
-    </div>
-    <div>
-      2.1
-    </div>
-    <div>
-      2.2
-    </div>
-    <!---->
     <!--M_|7 #text/0 10 8-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 7-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.o = [0, _.f = {
@@ -159,10 +69,105 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-INSERT html/body/#comment4, #text, html/body/#comment5
+INSERT html/body/#text0
+INSERT html/body/#text1
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      Push
+    </button>
+    <!--M_*1 #button/0-->
+    <!--M_[-->
+    <div>
+      0.0
+      <!--M_*4 #text/0-->
+    </div>
+    <div>
+      0.1
+      <!--M_*6 #text/0-->
+    </div>
+    <div>
+      0.2
+    </div>
+    <!--M_|2 #text/0 5 3-->
+    <!--M_[2-->
+    <div>
+      1.0
+      <!--M_*9 #text/0-->
+    </div>
+    <div>
+      1.1
+      <!--M_*11 #text/0-->
+    </div>
+    <div>
+      1.2
+    </div>
+    <!--M_|7 #text/0 10 8-->
+    <!---->
+    <div>
+      2.0
+    </div>
+    <div>
+      2.1
+    </div>
+    <div>
+      2.2
+    </div>
+    <!---->
+    <!--M_]1 #text/1 7-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.o = [0, _.f = {
+            "LoopScopeMap:#text/1": new Map(_.a = [
+              [0, _.c = {
+                "LoopScopeMap:#text/0": new Map(_.b = [
+                  [0, _.d = {
+                    "#childScope/0": _.k = {}
+                  }],
+                  [1, _.e = {
+                    "#childScope/0": _.l = {}
+                  }]
+                ]),
+                outer: 0
+              }],
+              [1, _.h = {
+                "LoopScopeMap:#text/0": new Map(_.g = [
+                  [0, _.i = {
+                    "#childScope/0": _.m = {}
+                  }],
+                  [1, _.j = {
+                    "#childScope/0": _.n = {}
+                  }]
+                ]),
+                outer: 1
+              }]
+            ]),
+            items: [0, 1]
+          }, _.c, _.d, _.k, _.e, _.l, _.h, _.i, _.m, _.j, _.n], _.d._ = _.e
+          ._ = _.c, _.c._ = _.h._ = _.f, _.i._ = _.j._ = _.h, _.o),
+        "__tests__/template.marko_0_items",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/#comment5, #text, html/body/#comment6
 INSERT html/body/div2
 INSERT html/body/div5
-REMOVE #text after html/body/#comment4
+REMOVE #text after html/body/#comment5
 INSERT html/body/div6
 INSERT html/body/div7
 INSERT html/body/div8

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Push</button><!--M_*1 #button/0--><!--M_[2--><div>0.0<!--M_*4 #text/0--></div><div>0.1<!--M_*6 #text/0--></div><!--M_|2 #text/0 5 3--><!--M_[7 --><div>1.0<!--M_*9 #text/0--></div><div>1.1<!--M_*11 #text/0--></div><!--M_|7 #text/0 10 8--><!--M_]1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.o=[0,_.f={"LoopScopeMap:#text/1":new Map(_.a=[[0,_.c={"LoopScopeMap:#text/0":new Map(_.b=[[0,_.d={"#childScope/0":_.k={}}],[1,_.e={"#childScope/0":_.l={}}]]),outer:0}],[1,_.h={"LoopScopeMap:#text/0":new Map(_.g=[[0,_.i={"#childScope/0":_.m={}}],[1,_.j={"#childScope/0":_.n={}}]]),outer:1}]]),items:[0,1]},_.c,_.d,_.k,_.e,_.l,_.h,_.i,_.m,_.j,_.n],_.d._=_.e._=_.c,_.c._=_.h._=_.f,_.i._=_.j._=_.h,_.o),"__tests__/template.marko_0_items",1];M._.w()</script>
+  <button>Push</button><!--M_*1 #button/0--><!--M_[--><div>0.0<!--M_*4 #text/0--></div><div>0.1<!--M_*6 #text/0--></div><!--M_|2 #text/0 5 3--><!--M_[2--><div>1.0<!--M_*9 #text/0--></div><div>1.1<!--M_*11 #text/0--></div><!--M_|7 #text/0 10 8--><!--M_]1 #text/1 7--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.o=[0,_.f={"LoopScopeMap:#text/1":new Map(_.a=[[0,_.c={"LoopScopeMap:#text/0":new Map(_.b=[[0,_.d={"#childScope/0":_.k={}}],[1,_.e={"#childScope/0":_.l={}}]]),outer:0}],[1,_.h={"LoopScopeMap:#text/0":new Map(_.g=[[0,_.i={"#childScope/0":_.m={}}],[1,_.j={"#childScope/0":_.n={}}]]),outer:1}]]),items:[0,1]},_.c,_.d,_.k,_.e,_.l,_.h,_.i,_.m,_.j,_.n],_.d._=_.e._=_.c,_.c._=_.h._=_.f,_.i._=_.j._=_.h,_.o),"__tests__/template.marko_0_items",1];M._.w()</script>
 ```
 
 # Render End
@@ -12,7 +12,7 @@
       Push
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       0.0
       <!--M_*4 #text/0-->
@@ -22,7 +22,7 @@
       <!--M_*6 #text/0-->
     </div>
     <!--M_|2 #text/0 5 3-->
-    <!--M_[7 -->
+    <!--M_[2-->
     <div>
       1.0
       <!--M_*9 #text/0-->
@@ -32,7 +32,7 @@
       <!--M_*11 #text/0-->
     </div>
     <!--M_|7 #text/0 10 8-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 7-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.o = [0, _.f = {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/resume.expected.md
@@ -8,9 +8,9 @@
     </button>
     <!--M_*1 #button/0-->
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <div>
-        <!--M_[5-->
+        <!--M_[-->
         <div>
           1
           <!--M_*5 #text/0-->
@@ -19,9 +19,9 @@
           2
           <!--M_*5 #text/1-->
         </div>
-        <!--M_]4 #text/0-->
+        <!--M_]4 #text/0 5-->
       </div>
-      <!--M_]2 #text/0-->
+      <!--M_]2 #text/0 3-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -57,6 +57,11 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/div/#text
+INSERT html/body/div/#text
+```
 
 # Render
 ```js
@@ -71,9 +76,9 @@ container.querySelector("button").click();
     </button>
     <!--M_*1 #button/0-->
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <div>
-        <!--M_[5-->
+        <!--M_[-->
         <div>
           2
           <!--M_*5 #text/0-->
@@ -82,9 +87,9 @@ container.querySelector("button").click();
           2
           <!--M_*5 #text/1-->
         </div>
-        <!--M_]4 #text/0-->
+        <!--M_]4 #text/0 5-->
       </div>
-      <!--M_]2 #text/0-->
+      <!--M_]2 #text/0 3-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -138,9 +143,9 @@ container.querySelector("button").click();
     </button>
     <!--M_*1 #button/0-->
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <div>
-        <!--M_[5-->
+        <!--M_[-->
         <div>
           3
           <!--M_*5 #text/0-->
@@ -149,9 +154,9 @@ container.querySelector("button").click();
           2
           <!--M_*5 #text/1-->
         </div>
-        <!--M_]4 #text/0-->
+        <!--M_]4 #text/0 5-->
       </div>
-      <!--M_]2 #text/0-->
+      <!--M_]2 #text/0 3-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -205,9 +210,9 @@ container.querySelector("button").click();
     </button>
     <!--M_*1 #button/0-->
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <div>
-        <!--M_[5-->
+        <!--M_[-->
         <div>
           4
           <!--M_*5 #text/0-->
@@ -216,9 +221,9 @@ container.querySelector("button").click();
           2
           <!--M_*5 #text/1-->
         </div>
-        <!--M_]4 #text/0-->
+        <!--M_]4 #text/0 5-->
       </div>
-      <!--M_]2 #text/0-->
+      <!--M_]2 #text/0 3-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Inc</button><!--M_*1 #button/0--><div><!--M_[3--><div><!--M_[5--><div>1<!--M_*5 #text/0-->.<!>2<!--M_*5 #text/1--></div><!--M_]4 #text/0--></div><!--M_]2 #text/0--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={x:1,y:2,"ClosureScopes:y":_.h=new Set,"#childScope/1":_.e={"ConditionalScope:#text/0":_.b={outer:1,"ClosureScopes:outer":_.g=new Set,"#childScope/0":_.d={"ConditionalScope:#text/0":_.c={"ClosureSignalIndex:outer":0},"ConditionalRenderer:#text/0":"__tests__/template.marko_2_content"},"ClosureSignalIndex:y":0},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content"}},_.e,_.b,_.d,_.c],_.b._=_.a,_.c._=_.b,_.d.content=_._["__tests__/template.marko_2_content"](_.b),_.e.content=_._["__tests__/template.marko_1_content"](_.a),(_.g).add(_.c),(_.h).add(_.b),_.f),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <button>Inc</button><!--M_*1 #button/0--><div><!--M_[--><div><!--M_[--><div>1<!--M_*5 #text/0-->.<!>2<!--M_*5 #text/1--></div><!--M_]4 #text/0 5--></div><!--M_]2 #text/0 3--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={x:1,y:2,"ClosureScopes:y":_.h=new Set,"#childScope/1":_.e={"ConditionalScope:#text/0":_.b={outer:1,"ClosureScopes:outer":_.g=new Set,"#childScope/0":_.d={"ConditionalScope:#text/0":_.c={"ClosureSignalIndex:outer":0},"ConditionalRenderer:#text/0":"__tests__/template.marko_2_content"},"ClosureSignalIndex:y":0},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content"}},_.e,_.b,_.d,_.c],_.b._=_.a,_.c._=_.b,_.d.content=_._["__tests__/template.marko_2_content"](_.b),_.e.content=_._["__tests__/template.marko_1_content"](_.a),(_.g).add(_.c),(_.h).add(_.b),_.f),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
@@ -13,9 +13,9 @@
     </button>
     <!--M_*1 #button/0-->
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <div>
-        <!--M_[5-->
+        <!--M_[-->
         <div>
           1
           <!--M_*5 #text/0-->
@@ -24,9 +24,9 @@
           2
           <!--M_*5 #text/1-->
         </div>
-        <!--M_]4 #text/0-->
+        <!--M_]4 #text/0 5-->
       </div>
-      <!--M_]2 #text/0-->
+      <!--M_]2 #text/0 3-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/resume.expected.md
@@ -16,7 +16,7 @@
         3
         <!--M_*4 #text/0-->
       </li>
-      <!--M_=1 #ul/0 4 3 2-->
+      <!--M_}1 #ul/0 4 3 2-->
     </ul>
     <button
       id="toggle"
@@ -77,7 +77,7 @@ container.querySelector("#toggle").click();
         3
         <!--M_*4 #text/0-->
       </li>
-      <!--M_=1 #ul/0 4 3 2-->
+      <!--M_}1 #ul/0 4 3 2-->
     </ul>
     <button
       id="toggle"
@@ -140,7 +140,7 @@ container.querySelector("#toggle").click();
         3
         <!--M_*4 #text/0-->
       </li>
-      <!--M_=1 #ul/0 4 3 2-->
+      <!--M_}1 #ul/0 4 3 2-->
     </ul>
     <button
       id="toggle"
@@ -203,7 +203,7 @@ container.querySelector("#reverse").click();
         1
         <!--M_*2 #text/0-->
       </li>
-      <!--M_=1 #ul/0 4 3 2-->
+      <!--M_}1 #ul/0 4 3 2-->
     </ul>
     <button
       id="toggle"

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <ul><li>1<!--M_*2 #text/0--></li><li>2<!--M_*3 #text/0--></li><li>3<!--M_*4 #text/0--></li><!--M_=1 #ul/0 4 3 2--></ul><button id=toggle>Toggle</button><!--M_*1 #button/1--><button id=reverse>Reverse</button><!--M_*1 #button/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.e=[0,{"LoopScopeMap:#ul/0":new Map(_.a=[[1,_.b={}],[2,_.c={}],[3,_.d={}]]),open:!0,list:[1,2,3]},_.b,_.c,_.d]),"__tests__/template.marko_0_list",1,"__tests__/template.marko_0_open",1];M._.w()</script>
+  <ul><li>1<!--M_*2 #text/0--></li><li>2<!--M_*3 #text/0--></li><li>3<!--M_*4 #text/0--></li><!--M_}1 #ul/0 4 3 2--></ul><button id=toggle>Toggle</button><!--M_*1 #button/1--><button id=reverse>Reverse</button><!--M_*1 #button/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.e=[0,{"LoopScopeMap:#ul/0":new Map(_.a=[[1,_.b={}],[2,_.c={}],[3,_.d={}]]),open:!0,list:[1,2,3]},_.b,_.c,_.d]),"__tests__/template.marko_0_list",1,"__tests__/template.marko_0_open",1];M._.w()</script>
 ```
 
 # Render End
@@ -21,7 +21,7 @@
         3
         <!--M_*4 #text/0-->
       </li>
-      <!--M_=1 #ul/0 4 3 2-->
+      <!--M_}1 #ul/0 4 3 2-->
     </ul>
     <button
       id="toggle"

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/resume.expected.md
@@ -4,9 +4,9 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Hello!
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <button>
         Toggle
       </button>
@@ -29,6 +29,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text1
+```
 
 # Render
 ```js
@@ -39,7 +43,7 @@ container.querySelector("button").click();
   <head />
   <body>
     <div>
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <button>
         Toggle
       </button>
@@ -67,6 +71,7 @@ container.querySelector("button").click();
 REMOVE html/body/div/#comment0 after #text
 INSERT html/body/div/#comment0
 REMOVE #comment after html/body/div/#comment0
+REMOVE #text after html/body/div/#comment0
 REMOVE #text after html/body/div/#comment0
 ```
 
@@ -117,7 +122,7 @@ container.querySelector("button").click();
   <head />
   <body>
     <div>
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <button>
         Toggle
       </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><!--M_[2-->Hello!<!--M_]1 #text/0--><button>Toggle</button><!--M_*1 #button/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalRenderer:#text/0":0,"ConditionalScope:#text/0":_.a={},show:!0},_.a]),"__tests__/template.marko_0_show",1];M._.w()</script>
+  <div><!--M_[-->Hello!<!--M_]1 #text/0 2--><button>Toggle</button><!--M_*1 #button/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalRenderer:#text/0":0,"ConditionalScope:#text/0":_.a={},show:!0},_.a]),"__tests__/template.marko_0_show",1];M._.w()</script>
 ```
 
 # Render End
@@ -9,9 +9,9 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
       Hello!
-      <!--M_]1 #text/0-->
+      <!--M_]1 #text/0 2-->
       <button>
         Toggle
       </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/resume.expected.md
@@ -4,10 +4,10 @@
   <head />
   <body>
     <button>
-      <!--M_[3-->
+      <!--M_[-->
       0
       <!--M_*3 #text/0-->
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </button>
     <!--M_*2 #button/0-->
     <script>
@@ -35,6 +35,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/button/#text1
+```
 
 # Render
 ```js
@@ -45,10 +49,10 @@ container.querySelector("button").click();
   <head />
   <body>
     <button>
-      <!--M_[3-->
+      <!--M_[-->
       1
       <!--M_*3 #text/0-->
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </button>
     <!--M_*2 #button/0-->
     <script>
@@ -78,7 +82,7 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-UPDATE html/body/button/#text "0" => "1"
+UPDATE html/body/button/#text0 "0" => "1"
 ```
 
 # Render
@@ -90,10 +94,10 @@ container.querySelector("button").click();
   <head />
   <body>
     <button>
-      <!--M_[3-->
+      <!--M_[-->
       2
       <!--M_*3 #text/0-->
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </button>
     <!--M_*2 #button/0-->
     <script>
@@ -123,7 +127,7 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-UPDATE html/body/button/#text "1" => "2"
+UPDATE html/body/button/#text0 "1" => "2"
 ```
 
 # Render
@@ -135,10 +139,10 @@ container.querySelector("button").click();
   <head />
   <body>
     <button>
-      <!--M_[3-->
+      <!--M_[-->
       3
       <!--M_*3 #text/0-->
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </button>
     <!--M_*2 #button/0-->
     <script>
@@ -168,5 +172,5 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-UPDATE html/body/button/#text "2" => "3"
+UPDATE html/body/button/#text0 "2" => "3"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button><!--M_[3-->0<!--M_*3 #text/0--><!--M_]2 #text/1--></button><!--M_*2 #button/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={clickCount:0,"ClosureScopes:clickCount":_.g=new Set,"#childScope/0":_.e={"EventAttributes:#button/0":_.b={},"ConditionalScope:#text/1":_.c={"ClosureSignalIndex:clickCount":0},"ConditionalRenderer:#text/1":"__tests__/template.marko_1_content",attrs:_.d={}}},_.e,_.c],_.c._=_.a,_.b.click=_.d.onClick=_._["__tests__/template.marko_0/onClick"](_.a),(_.g).add(_.c),_.f),"__tests__/tags/FancyButton.marko_0_attrs",2];M._.w()</script>
+  <button><!--M_[-->0<!--M_*3 #text/0--><!--M_]2 #text/1 3--></button><!--M_*2 #button/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={clickCount:0,"ClosureScopes:clickCount":_.g=new Set,"#childScope/0":_.e={"EventAttributes:#button/0":_.b={},"ConditionalScope:#text/1":_.c={"ClosureSignalIndex:clickCount":0},"ConditionalRenderer:#text/1":"__tests__/template.marko_1_content",attrs:_.d={}}},_.e,_.c],_.c._=_.a,_.b.click=_.d.onClick=_._["__tests__/template.marko_0/onClick"](_.a),(_.g).add(_.c),_.f),"__tests__/tags/FancyButton.marko_0_attrs",2];M._.w()</script>
 ```
 
 # Render End
@@ -9,10 +9,10 @@
   <head />
   <body>
     <button>
-      <!--M_[3-->
+      <!--M_[-->
       0
       <!--M_*3 #text/0-->
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </button>
     <!--M_*2 #button/0-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/resume.expected.md
@@ -10,10 +10,10 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*4 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     def
     <script>
       M._.r.push(_ =&gt; (_.d = [1,
@@ -23,4 +23,9 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  a<!--M_[2--><!--M_!^b-->b<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  a<!--M_[--><!--M_!^b-->b<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Write
 ```html
-  <!--M_!b--><!--M_]1 #text/0-->def<style M_>t{display:none}</style><t M_=b>ERROR!<!--M_*4 #text/0--></t><script>M._.r.push(_=>(_.d=[1,{}]));REORDER_RUNTIME(M._);M._.w()</script>
+  <!--M_!b--><!--M_]1 #text/0 2-->def<style M_>t{display:none}</style><t M_=b>ERROR!<!--M_*4 #text/0--></t><script>M._.r.push(_=>(_.d=[1,{}]));REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Render End
@@ -20,10 +20,10 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*4 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     def
     <script>
       M._.r.push(_ =&gt; (_.d = [1,

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/__snapshots__/resume.expected.md
@@ -4,7 +4,7 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
     b
     <script>
@@ -19,8 +19,13 @@
     </script>
     cd
     <!--M_!b-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     fgh
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text3
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  a<!--M_[2--><!--M_!^b-->b<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  a<!--M_[--><!--M_!^b-->b<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Write
 ```html
-  cd<!--M_!b--><!--M_]1 #text/0-->fgh
+  cd<!--M_!b--><!--M_]1 #text/0 2-->fgh
 ```
 
 # Render End
@@ -14,7 +14,7 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
     b
     <script>
@@ -29,7 +29,7 @@
     </script>
     cd
     <!--M_!b-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     fgh
   </body>
 </html>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/__snapshots__/resume.expected.md
@@ -4,9 +4,9 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     b
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     c
     <script>
       WALKER_RUNTIME("M")("_");
@@ -20,4 +20,9 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  a<!--M_[2-->b<!--M_]1 #text/0-->c<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  a<!--M_[-->b<!--M_]1 #text/0 2-->c<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Render End
@@ -9,9 +9,9 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     b
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     c
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/resume.expected.md
@@ -4,10 +4,10 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     d
     <script>
       WALKER_RUNTIME("M")("_");
@@ -22,4 +22,9 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  a<!--M_[2-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/0-->d<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  a<!--M_[-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/0 2-->d<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Render End
@@ -9,10 +9,10 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     d
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/resume.expected.md
@@ -14,7 +14,7 @@ mounted 2
 mounted 3
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*3 #text/0-->
@@ -27,7 +27,7 @@ mounted 3
       1
       <!--M_*3 #text/2-->
     </p>
-    <!--M_[4 -->
+    <!--M_[2-->
     <div>
       2
       <!--M_*5 #text/0-->
@@ -40,7 +40,7 @@ mounted 3
       2
       <!--M_*5 #text/2-->
     </p>
-    <!--M_[6 -->
+    <!--M_[4-->
     <div>
       3
       <!--M_*7 #text/0-->
@@ -53,7 +53,7 @@ mounted 3
       3
       <!--M_*7 #text/2-->
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.b = {
@@ -95,6 +95,9 @@ mounted 3
 
 # Mutations
 ```
+INSERT html/body/#text0
+INSERT html/body/#text1
+INSERT html/body/#text2
 INSERT #text
 REMOVE #text in html/body/div0
 INSERT #text
@@ -122,7 +125,7 @@ mounted 3
 destroyed 3
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*3 #text/0-->
@@ -135,7 +138,7 @@ destroyed 3
       1
       <!--M_*3 #text/2-->
     </p>
-    <!--M_[4 -->
+    <!--M_[2-->
     <div>
       2
       <!--M_*5 #text/0-->
@@ -148,7 +151,7 @@ destroyed 3
       2
       <!--M_*5 #text/2-->
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.b = {
@@ -192,10 +195,11 @@ destroyed 3
 ```
 REMOVE #text in html/body/div0
 INSERT html/body/div0/#text
-REMOVE #comment after html/body/p1
-REMOVE div after html/body/p1
-REMOVE span after html/body/p1
-REMOVE p after html/body/p1
+REMOVE #comment after html/body/#text1
+REMOVE div after html/body/#text1
+REMOVE span after html/body/#text1
+REMOVE p after html/body/#text1
+REMOVE #text after html/body/#text1
 ```
 
 # Render
@@ -219,7 +223,7 @@ destroyed 3
 destroyed 2
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*3 #text/0-->
@@ -232,7 +236,7 @@ destroyed 2
       1
       <!--M_*3 #text/2-->
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.b = {
@@ -276,10 +280,11 @@ destroyed 2
 ```
 REMOVE #text in html/body/div0
 INSERT html/body/div0/#text
-REMOVE #comment after html/body/p
-REMOVE div after html/body/p
-REMOVE span after html/body/p
-REMOVE p after html/body/p
+REMOVE #comment after html/body/#text
+REMOVE div after html/body/#text
+REMOVE span after html/body/#text
+REMOVE p after html/body/#text
+REMOVE #text after html/body/#text
 ```
 
 # Render
@@ -304,7 +309,7 @@ destroyed 2
 destroyed 1
     </div>
     <!--M_*1 #div/1-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.b = {
@@ -346,7 +351,7 @@ destroyed 1
 
 # Mutations
 ```
-REMOVE html/body/#comment2 after p
+REMOVE html/body/#comment2 after #text
 INSERT html/body/#comment2
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
@@ -354,6 +359,7 @@ REMOVE #comment after html/body/#comment1
 REMOVE div after html/body/#comment1
 REMOVE span after html/body/#comment1
 REMOVE p after html/body/#comment1
+REMOVE #text after html/body/#comment1
 ```
 
 # Render

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Toggle</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[2--><div>1<!--M_*3 #text/0--></div><span>1<!--M_*3 #text/1--></span><p>1<!--M_*3 #text/2--></p><!--M_[4 --><div>2<!--M_*5 #text/0--></div><span>2<!--M_*5 #text/1--></span><p>2<!--M_*5 #text/2--></p><!--M_[6 --><div>3<!--M_*7 #text/0--></div><span>3<!--M_*7 #text/1--></span><p>3<!--M_*7 #text/2--></p><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.i=[0,_.b={"LoopScopeMap:#text/2":new Map(_.a=[[0,_.f={"#childScope/0":_.c={name:1,"#ClosestBranchId":2}}],[1,_.g={"#childScope/0":_.d={name:2,"#ClosestBranchId":4}}],[2,_.h={"#childScope/0":_.e={name:3,"#ClosestBranchId":6}}]]),items:[1,2,3]},_.f,_.c,_.g,_.d,_.h,_.e],_.c.write=_.d.write=_.e.write=_.b.write=_._["__tests__/template.marko_0/write"](_.b),_.i),"__tests__/tags/child.marko_0_name_write",3,5,7,"__tests__/template.marko_0_items",1];M._.w()</script>
+  <button>Toggle</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[--><div>1<!--M_*3 #text/0--></div><span>1<!--M_*3 #text/1--></span><p>1<!--M_*3 #text/2--></p><!--M_[2--><div>2<!--M_*5 #text/0--></div><span>2<!--M_*5 #text/1--></span><p>2<!--M_*5 #text/2--></p><!--M_[4--><div>3<!--M_*7 #text/0--></div><span>3<!--M_*7 #text/1--></span><p>3<!--M_*7 #text/2--></p><!--M_]1 #text/2 6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.i=[0,_.b={"LoopScopeMap:#text/2":new Map(_.a=[[0,_.f={"#childScope/0":_.c={name:1,"#ClosestBranchId":2}}],[1,_.g={"#childScope/0":_.d={name:2,"#ClosestBranchId":4}}],[2,_.h={"#childScope/0":_.e={name:3,"#ClosestBranchId":6}}]]),items:[1,2,3]},_.f,_.c,_.g,_.d,_.h,_.e],_.c.write=_.d.write=_.e.write=_.b.write=_._["__tests__/template.marko_0/write"](_.b),_.i),"__tests__/tags/child.marko_0_name_write",3,5,7,"__tests__/template.marko_0_items",1];M._.w()</script>
 ```
 
 # Render End
@@ -14,7 +14,7 @@
     <!--M_*1 #button/0-->
     <div />
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*3 #text/0-->
@@ -27,7 +27,7 @@
       1
       <!--M_*3 #text/2-->
     </p>
-    <!--M_[4 -->
+    <!--M_[2-->
     <div>
       2
       <!--M_*5 #text/0-->
@@ -40,7 +40,7 @@
       2
       <!--M_*5 #text/2-->
     </p>
-    <!--M_[6 -->
+    <!--M_[4-->
     <div>
       3
       <!--M_*7 #text/0-->
@@ -53,7 +53,7 @@
       3
       <!--M_*7 #text/2-->
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.b = {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/resume.expected.md
@@ -48,7 +48,7 @@ Inner mounted
         <p>
           Middle a
         </p>
-        <!--M_[6-->
+        <!--M_[-->
         <div>
           Inner a
         </div>
@@ -58,7 +58,7 @@ Inner mounted
         <p>
           Inner a
         </p>
-        <!--M_]4 #text/1-->
+        <!--M_]4 #text/1 6-->
       </div>
       <!--M_|2 #text/1 4-->
     </div>
@@ -109,6 +109,7 @@ Inner mounted
 
 # Mutations
 ```
+INSERT html/body/div/div1/#text
 INSERT #text
 REMOVE #text in html/body/pre
 INSERT #text
@@ -170,7 +171,7 @@ Inner destroyed
         <p>
           Middle a
         </p>
-        <!--M_]4 #text/1-->
+        <!--M_]4 #text/1 6-->
       </div>
       <!--M_|2 #text/1 4-->
     </div>
@@ -221,7 +222,7 @@ Inner destroyed
 
 # Mutations
 ```
-REMOVE html/body/div/div1/#comment after p
+REMOVE html/body/div/div1/#comment after #text
 INSERT html/body/div/div1/#comment
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
@@ -229,6 +230,7 @@ REMOVE #comment after html/body/div/div1/#comment
 REMOVE div after html/body/div/div1/#comment
 REMOVE span after html/body/div/div1/#comment
 REMOVE p after html/body/div/div1/#comment
+REMOVE #text after html/body/div/div1/#comment
 ```
 
 # Render

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button id=outer>Toggle Outer</button><!--M_*1 #button/0--><button id=middle>Toggle Middle</button><!--M_*1 #button/1--><button id=inner>Toggle Inner</button><!--M_*1 #button/2--><pre></pre><!--M_*1 #pre/3--><div><div>Outer a</div><span>Outer a</span><p>Outer a</p><div><div>Middle a</div><span>Middle a</span><p>Middle a</p><!--M_[6--><div>Inner a</div><span>Inner a</span><p>Inner a</p><!--M_]4 #text/1--></div><!--M_|2 #text/1 4--></div><!--M_|1 #text/4 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.h=[0,_.c={"ConditionalRenderer:#text/4":0,"ConditionalScope:#text/4":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.f={},"ClosureSignalIndex:showInner":0}},showOuter:!0,showMiddle:!0,showInner:!0,"ClosureScopes:showInner":_.i=new Set},_.a,_.d={name:"Outer","#ClosestBranchId":2},_.b,_.e={name:"Middle","#ClosestBranchId":4},_.f,_.g={name:"Inner","#ClosestBranchId":6}],_.b._=_.a,_.a._=_.c,_.c.write=_.d.write=_.e.write=_.g.write=_._["__tests__/template.marko_0/write"](_.c),(_.i).add(_.b),_.h),"__tests__/tags/child.marko_0_name_write",3,5,7,"__tests__/template.marko_0_showInner",1,"__tests__/template.marko_0_showMiddle",1,"__tests__/template.marko_0_showOuter",1];M._.w()</script>
+  <button id=outer>Toggle Outer</button><!--M_*1 #button/0--><button id=middle>Toggle Middle</button><!--M_*1 #button/1--><button id=inner>Toggle Inner</button><!--M_*1 #button/2--><pre></pre><!--M_*1 #pre/3--><div><div>Outer a</div><span>Outer a</span><p>Outer a</p><div><div>Middle a</div><span>Middle a</span><p>Middle a</p><!--M_[--><div>Inner a</div><span>Inner a</span><p>Inner a</p><!--M_]4 #text/1 6--></div><!--M_|2 #text/1 4--></div><!--M_|1 #text/4 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.h=[0,_.c={"ConditionalRenderer:#text/4":0,"ConditionalScope:#text/4":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.f={},"ClosureSignalIndex:showInner":0}},showOuter:!0,showMiddle:!0,showInner:!0,"ClosureScopes:showInner":_.i=new Set},_.a,_.d={name:"Outer","#ClosestBranchId":2},_.b,_.e={name:"Middle","#ClosestBranchId":4},_.f,_.g={name:"Inner","#ClosestBranchId":6}],_.b._=_.a,_.a._=_.c,_.c.write=_.d.write=_.e.write=_.g.write=_._["__tests__/template.marko_0/write"](_.c),(_.i).add(_.b),_.h),"__tests__/tags/child.marko_0_name_write",3,5,7,"__tests__/template.marko_0_showInner",1,"__tests__/template.marko_0_showMiddle",1,"__tests__/template.marko_0_showOuter",1];M._.w()</script>
 ```
 
 # Render End
@@ -48,7 +48,7 @@
         <p>
           Middle a
         </p>
-        <!--M_[6-->
+        <!--M_[-->
         <div>
           Inner a
         </div>
@@ -58,7 +58,7 @@
         <p>
           Inner a
         </p>
-        <!--M_]4 #text/1-->
+        <!--M_]4 #text/1 6-->
       </div>
       <!--M_|2 #text/1 4-->
     </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/resume.expected.md
@@ -12,7 +12,7 @@
 mounted
     </pre>
     <!--M_*1 #pre/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       a
     </div>
@@ -22,7 +22,7 @@ mounted
     <p>
       c
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -43,6 +43,7 @@ mounted
 
 # Mutations
 ```
+INSERT html/body/#text
 INSERT html/body/pre/#text
 ```
 
@@ -64,7 +65,7 @@ mounted
 destroyed
     </pre>
     <!--M_*1 #pre/1-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -85,7 +86,7 @@ destroyed
 
 # Mutations
 ```
-REMOVE html/body/#comment2 after p
+REMOVE html/body/#comment2 after #text
 INSERT html/body/#comment2
 REMOVE #text in html/body/pre
 INSERT html/body/pre/#text
@@ -93,6 +94,7 @@ REMOVE #comment after html/body/#comment2
 REMOVE div after html/body/#comment2
 REMOVE span after html/body/#comment2
 REMOVE p after html/body/#comment2
+REMOVE #text after html/body/#comment2
 ```
 
 # Render
@@ -169,7 +171,7 @@ mounted
 destroyed
     </pre>
     <!--M_*1 #pre/1-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Toggle</button><!--M_*1 #button/0--><pre></pre><!--M_*1 #pre/1--><!--M_[2--><div>a</div><span>b</span><p>c</p><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0},_.b],_.b._=_.a,_.c),"__tests__/template.marko_1",2,"__tests__/template.marko_0_show",1];M._.w()</script>
+  <button>Toggle</button><!--M_*1 #button/0--><pre></pre><!--M_*1 #pre/1--><!--M_[--><div>a</div><span>b</span><p>c</p><!--M_]1 #text/2 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0},_.b],_.b._=_.a,_.c),"__tests__/template.marko_1",2,"__tests__/template.marko_0_show",1];M._.w()</script>
 ```
 
 # Render End
@@ -14,7 +14,7 @@
     <!--M_*1 #button/0-->
     <pre />
     <!--M_*1 #pre/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       a
     </div>
@@ -24,7 +24,7 @@
     <p>
       c
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/resume.expected.md
@@ -11,7 +11,7 @@
       mounted
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       a
     </div>
@@ -21,7 +21,7 @@
     <p>
       c
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -51,6 +51,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text
 INSERT html/body/div0/#text
 ```
 
@@ -70,7 +71,7 @@ container.querySelector("button").click();
       destroyed
     </div>
     <!--M_*1 #div/1-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -100,7 +101,7 @@ container.querySelector("button").click();
 
 # Mutations
 ```
-REMOVE html/body/#comment2 after p
+REMOVE html/body/#comment2 after #text
 INSERT html/body/#comment2
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
@@ -108,6 +109,7 @@ REMOVE #comment after html/body/#comment2
 REMOVE div after html/body/#comment2
 REMOVE span after html/body/#comment2
 REMOVE p after html/body/#comment2
+REMOVE #text after html/body/#comment2
 ```
 
 # Render
@@ -186,7 +188,7 @@ container.querySelector("button").click();
       destroyed
     </div>
     <!--M_*1 #div/1-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Toggle</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[2--><div>a</div><span>b</span><p>c</p><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0},_.b,{input:{write:_._["__tests__/template.marko_1/write"](_.b)},"#ClosestBranchId":2}],_.b._=_.a,_.c),"__tests__/tags/child.marko_0_input",3,"__tests__/template.marko_0_show",1];M._.w()</script>
+  <button>Toggle</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[--><div>a</div><span>b</span><p>c</p><!--M_]1 #text/2 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#text/2":0,"ConditionalScope:#text/2":_.b={},show:!0},_.b,{input:{write:_._["__tests__/template.marko_1/write"](_.b)},"#ClosestBranchId":2}],_.b._=_.a,_.c),"__tests__/tags/child.marko_0_input",3,"__tests__/template.marko_0_show",1];M._.w()</script>
 ```
 
 # Render End
@@ -14,7 +14,7 @@
     <!--M_*1 #button/0-->
     <div />
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       a
     </div>
@@ -24,7 +24,7 @@
     <p>
       c
     </p>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/resume.expected.md
@@ -5,7 +5,7 @@
   <body>
     <table>
       <tbody>
-        <!--M_=1 #tbody/0-->
+        <!--M_}1 #tbody/0-->
       </tbody>
     </table>
     <button>
@@ -38,7 +38,7 @@ container.querySelector("button").click();
   <body>
     <table>
       <tbody>
-        <!--M_=1 #tbody/0-->
+        <!--M_}1 #tbody/0-->
         <tr>
           <td>
             Hi

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <table><tbody><!--M_=1 #tbody/0--></tbody></table><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{show:!1}]),"__tests__/template.marko_0_show",1];M._.w()</script>
+  <table><tbody><!--M_}1 #tbody/0--></tbody></table><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{show:!1}]),"__tests__/template.marko_0_show",1];M._.w()</script>
 ```
 
 # Render End
@@ -10,7 +10,7 @@
   <body>
     <table>
       <tbody>
-        <!--M_=1 #tbody/0-->
+        <!--M_}1 #tbody/0-->
       </tbody>
     </table>
     <button>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/resume.expected.md
@@ -27,7 +27,7 @@
           <!--M_*4 #text/1-->
         </option>
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
       </select>
       <button
         type="reset"
@@ -104,7 +104,7 @@ container.querySelector(".remove").click();
           <!--M_*4 #text/1-->
         </option>
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
       </select>
       <button
         type="reset"
@@ -180,7 +180,7 @@ container.querySelector(".remove").click();
           <!--M_*4 #text/1-->
         </option>
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
       </select>
       <button
         type="reset"
@@ -249,7 +249,7 @@ container.querySelector(".remove").click();
         <!--M_*2 #option/0-->
         <!--M_*3 #option/0-->
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
       </select>
       <button
         type="reset"
@@ -318,7 +318,7 @@ container.querySelector(".add").click();
         <!--M_*2 #option/0-->
         <!--M_*3 #option/0-->
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
         <option
           selected=""
           value="3"
@@ -393,7 +393,7 @@ container.querySelector(".add").click();
         <!--M_*2 #option/0-->
         <!--M_*3 #option/0-->
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
         <option
           value="2"
         >
@@ -472,7 +472,7 @@ container.querySelector(".add").click();
         <!--M_*2 #option/0-->
         <!--M_*3 #option/0-->
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
         <option
           value="1"
         >

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <form><select><option value=1 selected>1<!--M_*2 #text/1--></option><!--M_*2 #option/0--><option value=2>2<!--M_*3 #text/1--></option><!--M_*3 #option/0--><option value=3>3<!--M_*4 #text/1--></option><!--M_*4 #option/0--><!--M_=1 #select/0 4 3 2--></select><button type=reset>reset</button></form><div>1<!--M_*1 #text/1--></div><button class=remove>Remove option</button><!--M_*1 #button/2--><button class=add>Add option</button><!--M_*1 #button/3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={"ControlledType:#select/0":3,"ControlledValue:#select/0":1,"LoopScopeMap:#select/0":new Map(_.b=[[1,_.c={}],[2,_.d={}],[3,_.e={}]]),options:[1,2,3],value:1},_.c,_.d,_.e],_.a["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.f),"__tests__/template.marko_0_options",1,"__tests__/template.marko_0",1];M._.w()</script>
+  <form><select><option value=1 selected>1<!--M_*2 #text/1--></option><!--M_*2 #option/0--><option value=2>2<!--M_*3 #text/1--></option><!--M_*3 #option/0--><option value=3>3<!--M_*4 #text/1--></option><!--M_*4 #option/0--><!--M_}1 #select/0 4 3 2--></select><button type=reset>reset</button></form><div>1<!--M_*1 #text/1--></div><button class=remove>Remove option</button><!--M_*1 #button/2--><button class=add>Add option</button><!--M_*1 #button/3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={"ControlledType:#select/0":3,"ControlledValue:#select/0":1,"LoopScopeMap:#select/0":new Map(_.b=[[1,_.c={}],[2,_.d={}],[3,_.e={}]]),options:[1,2,3],value:1},_.c,_.d,_.e],_.a["ControlledHandler:#select/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.f),"__tests__/template.marko_0_options",1,"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
@@ -32,7 +32,7 @@
           <!--M_*4 #text/1-->
         </option>
         <!--M_*4 #option/0-->
-        <!--M_=1 #select/0 4 3 2-->
+        <!--M_}1 #select/0 4 3 2-->
       </select>
       <button
         type="reset"

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/resume.expected.md
@@ -14,7 +14,7 @@
       <!--M_*2 #text/2-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Counts: 
       <!---->
@@ -25,7 +25,7 @@
       10
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/3-->
+    <!--M_]2 #text/3 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -47,6 +47,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -67,7 +71,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/2-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Counts: 
       <!---->
@@ -78,7 +82,7 @@ container.querySelector("button").click();
       11
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/3-->
+    <!--M_]2 #text/3 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -127,7 +131,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/2-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Counts: 
       <!---->
@@ -138,7 +142,7 @@ container.querySelector("button").click();
       12
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/3-->
+    <!--M_]2 #text/3 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -187,7 +191,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/2-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Counts: 
       <!---->
@@ -198,7 +202,7 @@ container.querySelector("button").click();
       13
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/3-->
+    <!--M_]2 #text/3 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button class=inc>1<!--M_*2 #text/1-->,<!>10<!--M_*2 #text/2--></button><!--M_*2 #button/0--><!--M_[3--><div>Counts: <!>1<!--M_*3 #text/0-->,<!>10<!--M_*3 #text/1--></div><!--M_]2 #text/3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/3":_.b={},"ConditionalRenderer:#text/3":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),x:1,y:10},_.b]),"__tests__/tags/custom-tag.marko_0_x_y",2];M._.w()</script>
+  <button class=inc>1<!--M_*2 #text/1-->,<!>10<!--M_*2 #text/2--></button><!--M_*2 #button/0--><!--M_[--><div>Counts: <!>1<!--M_*3 #text/0-->,<!>10<!--M_*3 #text/1--></div><!--M_]2 #text/3 3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/3":_.b={},"ConditionalRenderer:#text/3":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),x:1,y:10},_.b]),"__tests__/tags/custom-tag.marko_0_x_y",2];M._.w()</script>
 ```
 
 # Render End
@@ -19,7 +19,7 @@
       <!--M_*2 #text/2-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Counts: 
       <!---->
@@ -30,7 +30,7 @@
       10
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/3-->
+    <!--M_]2 #text/3 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/resume.expected.md
@@ -10,7 +10,7 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count (
       <!---->
@@ -21,7 +21,7 @@
       1
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -43,6 +43,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -59,7 +63,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count (
       <!---->
@@ -70,7 +74,7 @@ container.querySelector("button").click();
       2
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -113,7 +117,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count (
       <!---->
@@ -124,7 +128,7 @@ container.querySelector("button").click();
       3
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -167,7 +171,7 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count (
       <!---->
@@ -178,7 +182,7 @@ container.querySelector("button").click();
       4
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_[3--><div>Count (<!>hello<!--M_*3 #text/0-->): <!>1<!--M_*3 #text/1--></div><!--M_]2 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),input_name:"hello",x:1},_.b]),"__tests__/tags/custom-tag.marko_0_x",2];M._.w()</script>
+  <button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_[--><div>Count (<!>hello<!--M_*3 #text/0-->): <!>1<!--M_*3 #text/1--></div><!--M_]2 #text/2 3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),input_name:"hello",x:1},_.b]),"__tests__/tags/custom-tag.marko_0_x",2];M._.w()</script>
 ```
 
 # Render End
@@ -15,7 +15,7 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count (
       <!---->
@@ -26,7 +26,7 @@
       1
       <!--M_*3 #text/1-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/resume.expected.md
@@ -10,14 +10,14 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count: 
       <!---->
       1
       <!--M_*3 #text/0-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -38,6 +38,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -54,14 +58,14 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count: 
       <!---->
       2
       <!--M_*3 #text/0-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -103,14 +107,14 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count: 
       <!---->
       3
       <!--M_*3 #text/0-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,
@@ -152,14 +156,14 @@ container.querySelector("button").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count: 
       <!---->
       4
       <!--M_*3 #text/0-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_[3--><div>Count: <!>1<!--M_*3 #text/0--></div><!--M_]2 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),x:1},_.b]),"__tests__/tags/custom-tag.marko_0_x",2];M._.w()</script>
+  <button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_[--><div>Count: <!>1<!--M_*3 #text/0--></div><!--M_]2 #text/2 3--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,1,{"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/template.marko_1_content",input_content:_._["__tests__/template.marko_1_content"](_.a={}),x:1},_.b]),"__tests__/tags/custom-tag.marko_0_x",2];M._.w()</script>
 ```
 
 # Render End
@@ -15,14 +15,14 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       Count: 
       <!---->
       1
       <!--M_*3 #text/0-->
     </div>
-    <!--M_]2 #text/2-->
+    <!--M_]2 #text/2 3-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/resume.expected.md
@@ -4,11 +4,11 @@
   <head />
   <body>
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <span>
         The thing
       </span>
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </div>
     <!--M_*2 #div/0-->
     <button>
@@ -34,6 +34,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text
+```
 
 # Render
 ```js
@@ -46,11 +50,11 @@ container.querySelector("button").click();
     <div
       class="selected"
     >
-      <!--M_[3-->
+      <!--M_[-->
       <span>
         The thing
       </span>
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </div>
     <!--M_*2 #div/0-->
     <button>
@@ -92,11 +96,11 @@ container.querySelector("button").click();
     <div
       class=""
     >
-      <!--M_[3-->
+      <!--M_[-->
       <span>
         The thing
       </span>
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </div>
     <!--M_*2 #div/0-->
     <button>
@@ -138,11 +142,11 @@ container.querySelector("button").click();
     <div
       class="selected"
     >
-      <!--M_[3-->
+      <!--M_[-->
       <span>
         The thing
       </span>
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </div>
     <!--M_*2 #div/0-->
     <button>

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><!--M_[3--><span>The thing</span><!--M_]2 #text/1--></div><!--M_*2 #div/0--><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{selected:!1,"#childScope/0":_.a={"ConditionalScope:#text/1":_.b={},"ConditionalRenderer:#text/1":"__tests__/template.marko_1_content"}},_.a,_.b]),"__tests__/template.marko_0_selected",1];M._.w()</script>
+  <div><!--M_[--><span>The thing</span><!--M_]2 #text/1 3--></div><!--M_*2 #div/0--><button>Toggle</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{selected:!1,"#childScope/0":_.a={"ConditionalScope:#text/1":_.b={},"ConditionalRenderer:#text/1":"__tests__/template.marko_1_content"}},_.a,_.b]),"__tests__/template.marko_0_selected",1];M._.w()</script>
 ```
 
 # Render End
@@ -9,11 +9,11 @@
   <head />
   <body>
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <span>
         The thing
       </span>
-      <!--M_]2 #text/1-->
+      <!--M_]2 #text/1 3-->
     </div>
     <!--M_*2 #div/0-->
     <button>

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/resume.expected.md
@@ -3,7 +3,7 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
@@ -16,7 +16,7 @@
       1
       <!--M_*2 #text/2-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       1
       <!--M_*1 #text/2-->
@@ -45,6 +45,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text
 ```
 
 # Render
@@ -55,7 +56,7 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
@@ -68,7 +69,7 @@ container.querySelector("button").click();
       2
       <!--M_*2 #text/2-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       2
       <!--M_*1 #text/2-->
@@ -107,7 +108,7 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
@@ -120,7 +121,7 @@ container.querySelector("button").click();
       3
       <!--M_*2 #text/2-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       3
       <!--M_*1 #text/2-->
@@ -159,7 +160,7 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
@@ -172,7 +173,7 @@ container.querySelector("button").click();
       4
       <!--M_*2 #text/2-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       4
       <!--M_*1 #text/2-->

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[2--><div>1<!--M_*2 #text/0-->|<!>Hello<!--M_*2 #text/1-->|<!>1<!--M_*2 #text/2--></div><!--M_]1 #text/0--><button>1<!--M_*1 #text/2--></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content",x:1,MyTag:_.b={}},_.c],_.b.content=_._["__tests__/template.marko_1_content"](_.a),_.d),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <!--M_[--><div>1<!--M_*2 #text/0-->|<!>Hello<!--M_*2 #text/1-->|<!>1<!--M_*2 #text/2--></div><!--M_]1 #text/0 2--><button>1<!--M_*1 #text/2--></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content",x:1,MyTag:_.b={}},_.c],_.b.content=_._["__tests__/template.marko_1_content"](_.a),_.d),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -21,7 +21,7 @@
       1
       <!--M_*2 #text/2-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       1
       <!--M_*1 #text/2-->

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/resume.expected.md
@@ -3,12 +3,12 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       1
       <!--M_*1 #text/2-->
@@ -37,6 +37,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text
 ```
 
 # Render
@@ -47,12 +48,12 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       2
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       2
       <!--M_*1 #text/2-->
@@ -91,12 +92,12 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       3
       <!--M_*1 #text/2-->
@@ -135,12 +136,12 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       4
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       4
       <!--M_*1 #text/2-->

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[2--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/0--><button>1<!--M_*1 #text/2--></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content",x:1,MyTag:_.b={}},_.c],_.b.content=_._["__tests__/template.marko_1_content"](_.a),_.d),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <!--M_[--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/0 2--><button>1<!--M_*1 #text/2--></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content",x:1,MyTag:_.b={}},_.c],_.b.content=_._["__tests__/template.marko_1_content"](_.a),_.d),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -13,7 +13,7 @@
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button>
       1
       <!--M_*1 #text/2-->

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/resume.expected.md
@@ -6,9 +6,9 @@
     <span
       class="A"
     >
-      <!--M_[3-->
+      <!--M_[-->
       body content
-      <!--M_]2 #span/0-->
+      <!--M_]2 #span/0 3-->
     </span>
     <!--M_'1 #text/0 2-->
     <button />
@@ -34,6 +34,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/span/#text1
+```
 
 # Render
 ```js

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <span class=A><!--M_[3-->body content<!--M_]2 #span/0--></span><!--M_'1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <span class=A><!--M_[-->body content<!--M_]2 #span/0 3--></span><!--M_'1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#span/0":_.b={},"ConditionalRenderer:#span/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/0":"span",tagName:"span",className:"A"},_.a,_.b]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
@@ -11,9 +11,9 @@
     <span
       class="A"
     >
-      <!--M_[3-->
+      <!--M_[-->
       body content
-      <!--M_]2 #span/0-->
+      <!--M_]2 #span/0 3-->
     </span>
     <!--M_'1 #text/0 2-->
     <button />

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/resume.expected.md
@@ -10,14 +10,14 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child: 
       <!---->
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       Parent: 
       <!---->
@@ -43,6 +43,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -59,14 +63,14 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child: 
       <!---->
       2
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       Parent: 
       <!---->
@@ -114,14 +118,14 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child: 
       <!---->
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       Parent: 
       <!---->
@@ -169,14 +173,14 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child: 
       <!---->
       4
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       Parent: 
       <!---->

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[2--><div>Child: <!>1<!--M_*2 #text/0--></div><!--M_]1 #text/2--><div>Parent: <!>1<!--M_*1 #text/4--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko","#scopeOffset/3":3,x:1},_.b],_.b["#TagVariable"]=_._["__tests__/template.marko_0_y/var"](_.a),_.c),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[--><div>Child: <!>1<!--M_*2 #text/0--></div><!--M_]1 #text/2 2--><div>Parent: <!>1<!--M_*1 #text/4--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/2":_.b={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko","#scopeOffset/3":3,x:1},_.b],_.b["#TagVariable"]=_._["__tests__/template.marko_0_y/var"](_.a),_.c),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
@@ -15,14 +15,14 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child: 
       <!---->
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       Parent: 
       <!---->

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/resume.expected.md
@@ -10,12 +10,12 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       false
     </div>
@@ -42,6 +42,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -58,12 +62,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       2
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       false
     </div>
@@ -111,12 +115,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       false
     </div>
@@ -164,12 +168,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       4
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       false
     </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[2--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/2--><div>false</div><div>true</div><div>"spread1"</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko",x:1},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/2 2--><div>false</div><div>true</div><div>"spread1"</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko",x:1},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
@@ -15,12 +15,12 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <div>
       false
     </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/resume.expected.md
@@ -5,14 +5,14 @@
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Id is 
       <!---->
       dynamic
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -32,6 +32,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -46,7 +50,7 @@ container.querySelector("button").click();
     <div
       id="dynamic"
     />
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -71,6 +75,7 @@ container.querySelector("button").click();
 INSERT html/body/div
 REMOVE #comment after html/body/div
 REMOVE div after html/body/div
+REMOVE #text after html/body/div
 UPDATE html/body/div[id] null => "dynamic"
 ```
 
@@ -87,7 +92,7 @@ container.querySelector("button").click();
     <div>
       Id is dynamic
     </div>
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button></button><!--M_*1 #button/0--><!--M_[2--><div>Id is <!>dynamic<!--M_*2 #text/0--></div><!--M_]1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/1":_.a={},"ConditionalRenderer:#text/1":"__tests__/tags/child.marko",tagName:_._["__tests__/tags/child.marko"]},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <button></button><!--M_*1 #button/0--><!--M_[--><div>Id is <!>dynamic<!--M_*2 #text/0--></div><!--M_]1 #text/1 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/1":_.a={},"ConditionalRenderer:#text/1":"__tests__/tags/child.marko",tagName:_._["__tests__/tags/child.marko"]},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
@@ -10,14 +10,14 @@
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Id is 
       <!---->
       dynamic
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/resume.expected.md
@@ -3,14 +3,14 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       Child 1 has 
       <!---->
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
@@ -37,6 +37,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text
 ```
 
 # Render
@@ -50,7 +51,7 @@ container.querySelector("button").click();
     <div>
       Child 2 has 3
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
@@ -78,6 +79,7 @@ container.querySelector("button").click();
 INSERT html/body/div
 REMOVE #comment after html/body/div
 REMOVE div after html/body/div
+REMOVE #text after html/body/div
 UPDATE html/body/div/#text1 "" => "3"
 ```
 
@@ -92,7 +94,7 @@ container.querySelector("button").click();
     <div>
       Child 1 has 3
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[2--><div>Child 1 has <!>3<!--M_*2 #text/0--></div><!--M_]1 #text/0--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"__tests__/tags/child1.marko",tagName:_._["__tests__/tags/child1.marko"],val:3},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <!--M_[--><div>Child 1 has <!>3<!--M_*2 #text/0--></div><!--M_]1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"__tests__/tags/child1.marko",tagName:_._["__tests__/tags/child1.marko"],val:3},_.a]),"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -15,7 +15,7 @@
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/resume.expected.md
@@ -6,17 +6,17 @@
     <div
       class="foo"
     >
-      <!--M_[4-->
+      <!--M_[-->
       default
-      <!--M_]3 #div/0-->
+      <!--M_]3 #div/0 4-->
     </div>
     <!--M_'2 #text/0 3-->
     <span
       class="foo"
     >
-      <!--M_[7-->
+      <!--M_[-->
       default
-      <!--M_]6 #span/0-->
+      <!--M_]6 #span/0 7-->
     </span>
     <!--M_'5 #text/0 6-->
     <script>
@@ -56,6 +56,11 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text1
+INSERT html/body/span/#text1
+```
 
 # Render ASYNC
 ```html
@@ -113,8 +118,8 @@
 
 # Mutations
 ```
-REMOVE #comment, #text, #comment in html/body/div
+REMOVE #comment, #text, #text, #comment in html/body/div
 INSERT html/body/div/#text
-REMOVE #comment, #text, #comment in html/body/span
+REMOVE #comment, #text, #text, #comment in html/body/span
 INSERT html/body/span/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div class=foo><!--M_[4-->default<!--M_]3 #div/0--></div><!--M_'2 #text/0 3--><span class=foo><!--M_[7-->default<!--M_]6 #span/0--></span><!--M_'5 #text/0 6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_content"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_content"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_content"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_content"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()</script>
+  <div class=foo><!--M_[-->default<!--M_]3 #div/0 4--></div><!--M_'2 #text/0 3--><span class=foo><!--M_[-->default<!--M_]6 #span/0 7--></span><!--M_'5 #text/0 6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,1,{"ConditionalScope:#text/0":_.b={"ConditionalScope:#div/0":_.c={},"ConditionalRenderer:#div/0":"__tests__/tags/my-tag.marko_1_content"},"ConditionalRenderer:#text/0":"div",inputContent:_._["__tests__/template.marko_1_content"](_.a={}),htmlInput:{}},_.b,_.c,{"ConditionalScope:#text/0":_.d={"ConditionalScope:#span/0":_.e={},"ConditionalRenderer:#span/0":"__tests__/tags/my-tag.marko_1_content"},"ConditionalRenderer:#text/0":"span",inputAs:"span",inputContent:_._["__tests__/template.marko_2_content"](_.a),htmlInput:{}},_.d,_.e]),"__tests__/tags/my-tag.marko_0_inputContent",2,5];M._.w()</script>
 ```
 
 # Render End
@@ -11,17 +11,17 @@
     <div
       class="foo"
     >
-      <!--M_[4-->
+      <!--M_[-->
       default
-      <!--M_]3 #div/0-->
+      <!--M_]3 #div/0 4-->
     </div>
     <!--M_'2 #text/0 3-->
     <span
       class="foo"
     >
-      <!--M_[7-->
+      <!--M_[-->
       default
-      <!--M_]6 #span/0-->
+      <!--M_]6 #span/0 7-->
     </span>
     <!--M_'5 #text/0 6-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/resume.expected.md
@@ -10,12 +10,12 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -33,6 +33,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/#text
+```
 
 # Render
 ```js
@@ -49,12 +53,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       2
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -93,12 +97,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       3
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -137,12 +141,12 @@ container.querySelector("button").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       4
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[2--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko",x:1},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <button>Count: <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[--><div>1<!--M_*2 #text/0--></div><!--M_]1 #text/2 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":"__tests__/tags/custom-tag.marko",x:1},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
@@ -15,12 +15,12 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       1
       <!--M_*2 #text/0-->
     </div>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/resume.expected.md
@@ -3,9 +3,9 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     Body Content
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
@@ -28,6 +28,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text1
 ```
 
 # Render
@@ -41,7 +42,7 @@ container.querySelector("button").click();
     <div>
       Body Content
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>
@@ -65,6 +66,7 @@ container.querySelector("button").click();
 INSERT html/body/div
 REMOVE #comment after html/body/div
 REMOVE #text after html/body/div
+REMOVE #text after html/body/div
 INSERT html/body/div/#text
 ```
 
@@ -77,7 +79,7 @@ container.querySelector("button").click();
   <head />
   <body>
     Body Content
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/ssr.expected.md
@@ -1,16 +1,16 @@
 # Write
 ```html
-  <!--M_[2-->Body Content<!--M_]1 #text/0--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},x:null},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
+  <!--M_[-->Body Content<!--M_]1 #text/0 2--><button></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},x:null},_.a]),"__tests__/template.marko_0_x",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
     Body Content
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button />
     <!--M_*1 #button/1-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/resume.expected.md
@@ -3,7 +3,7 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       class="inc"
     >
@@ -11,7 +11,7 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >
@@ -46,6 +46,7 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text
 ```
 
 # Render
@@ -56,7 +57,7 @@ container.querySelector("button.inc").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       class="inc"
     >
@@ -64,7 +65,7 @@ container.querySelector("button.inc").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >
@@ -108,7 +109,7 @@ container.querySelector("button.inc").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       class="inc"
     >
@@ -116,7 +117,7 @@ container.querySelector("button.inc").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >
@@ -160,7 +161,7 @@ container.querySelector("button.reset").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       class="inc"
     >
@@ -168,7 +169,7 @@ container.querySelector("button.reset").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >
@@ -212,7 +213,7 @@ container.querySelector("button.inc").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       class="inc"
     >
@@ -220,7 +221,7 @@ container.querySelector("button.inc").click();
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[2--><button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_]1 #text/0--><button class=reset>reset</button><!--M_*1 #button/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={x:1},"ConditionalRenderer:#text/0":"__tests__/tags/counter.marko","#scopeOffset/1":3},_.a],_.a["#TagVariableChange"]=_._["__tests__/tags/counter.marko_0/valueChange"](_.a),_.a["#TagVariable"]=_._["__tests__/template.marko_0_count/var"](_.b),_.c),"__tests__/tags/counter.marko_0_x",2,"__tests__/template.marko_0",1];M._.w()</script>
+  <!--M_[--><button class=inc>1<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_]1 #text/0 2--><button class=reset>reset</button><!--M_*1 #button/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={x:1},"ConditionalRenderer:#text/0":"__tests__/tags/counter.marko","#scopeOffset/1":3},_.a],_.a["#TagVariableChange"]=_._["__tests__/tags/counter.marko_0/valueChange"](_.a),_.a["#TagVariable"]=_._["__tests__/template.marko_0_count/var"](_.b),_.c),"__tests__/tags/counter.marko_0_x",2,"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -16,7 +16,7 @@
       <!--M_*2 #text/1-->
     </button>
     <!--M_*2 #button/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <button
       class="reset"
     >

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/resume.expected.md
@@ -4,7 +4,7 @@
   <head />
   <body>
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <button
         id="count"
       >
@@ -12,7 +12,7 @@
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
-      <!--M_]2 #div/0-->
+      <!--M_]2 #div/0 3-->
     </div>
     <!--M_'1 #text/0 2-->
     <button
@@ -45,6 +45,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text
+```
 
 # Render
 ```js
@@ -55,7 +59,7 @@ container.querySelector("#count").click();
   <head />
   <body>
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <button
         id="count"
       >
@@ -63,7 +67,7 @@ container.querySelector("#count").click();
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
-      <!--M_]2 #div/0-->
+      <!--M_]2 #div/0 3-->
     </div>
     <!--M_'1 #text/0 2-->
     <button

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><!--M_[3--><button id=count>0<!--M_*4 #text/1--></button><!--M_*4 #button/0--><!--M_]2 #div/0--></div><!--M_'1 #text/0 2--><button id=changeTag></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()</script>
+  <div><!--M_[--><button id=count>0<!--M_*4 #text/1--></button><!--M_*4 #button/0--><!--M_]2 #div/0 3--></div><!--M_'1 #text/0 2--><button id=changeTag></button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"ConditionalScope:#text/0":_.a={"ConditionalScope:#div/0":_.b={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/0":"div",tagName:"div"},_.a,_.b,{count:0,"#ClosestBranchId":3}]),"__tests__/tags/counter.marko_0_count",4,"__tests__/template.marko_0_tagName",1];M._.w()</script>
 ```
 
 # Render End
@@ -9,7 +9,7 @@
   <head />
   <body>
     <div>
-      <!--M_[3-->
+      <!--M_[-->
       <button
         id="count"
       >
@@ -17,7 +17,7 @@
         <!--M_*4 #text/1-->
       </button>
       <!--M_*4 #button/0-->
-      <!--M_]2 #div/0-->
+      <!--M_]2 #div/0 3-->
     </div>
     <!--M_'1 #text/0 2-->
     <button

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/resume.expected.md
@@ -13,7 +13,7 @@
         <!--M_*3 #text/0-->
         third
         <!--M_*4 #text/0-->
-        <!--M_=1 #div/0 4 3 2-->
+        <!--M_}1 #div/0 4 3 2-->
       </div>
       <div
         class="by-function"
@@ -24,7 +24,7 @@
         <!--M_*6 #text/0-->
         third
         <!--M_*7 #text/0-->
-        <!--M_=1 #div/1 7 6 5-->
+        <!--M_}1 #div/1 7 6 5-->
       </div>
       <div
         class="by-unknown-string"
@@ -35,7 +35,7 @@
         <!--M_*9 #text/0-->
         third
         <!--M_*10 #text/0-->
-        <!--M_=1 #div/2 10 9 8-->
+        <!--M_}1 #div/2 10 9 8-->
       </div>
       <div
         class="by-unknown-function"
@@ -46,7 +46,7 @@
         <!--M_*12 #text/0-->
         third
         <!--M_*13 #text/0-->
-        <!--M_=1 #div/3 13 12 11-->
+        <!--M_}1 #div/3 13 12 11-->
       </div>
       <div
         class="by-unknown-missing"
@@ -57,7 +57,7 @@
         <!--M_*15 #text/0-->
         third
         <!--M_*16 #text/0-->
-        <!--M_=1 #div/4 16 15 14-->
+        <!--M_}1 #div/4 16 15 14-->
       </div>
       <button>
         Rotate
@@ -136,7 +136,7 @@ container.querySelector("button").click();
         <!--M_*3 #text/0-->
         third
         <!--M_*4 #text/0-->
-        <!--M_=1 #div/0 4 3 2-->
+        <!--M_}1 #div/0 4 3 2-->
         first
       </div>
       <div
@@ -147,7 +147,7 @@ container.querySelector("button").click();
         <!--M_*6 #text/0-->
         third
         <!--M_*7 #text/0-->
-        <!--M_=1 #div/1 7 6 5-->
+        <!--M_}1 #div/1 7 6 5-->
         first
       </div>
       <div
@@ -158,7 +158,7 @@ container.querySelector("button").click();
         <!--M_*9 #text/0-->
         third
         <!--M_*10 #text/0-->
-        <!--M_=1 #div/2 10 9 8-->
+        <!--M_}1 #div/2 10 9 8-->
         first
       </div>
       <div
@@ -169,7 +169,7 @@ container.querySelector("button").click();
         <!--M_*12 #text/0-->
         third
         <!--M_*13 #text/0-->
-        <!--M_=1 #div/3 13 12 11-->
+        <!--M_}1 #div/3 13 12 11-->
         first
       </div>
       <div
@@ -181,7 +181,7 @@ container.querySelector("button").click();
         <!--M_*15 #text/0-->
         first
         <!--M_*16 #text/0-->
-        <!--M_=1 #div/4 16 15 14-->
+        <!--M_}1 #div/4 16 15 14-->
       </div>
       <button>
         Rotate
@@ -273,7 +273,7 @@ container.querySelector("button").click();
         <!--M_*3 #text/0-->
         third
         <!--M_*4 #text/0-->
-        <!--M_=1 #div/0 4 3 2-->
+        <!--M_}1 #div/0 4 3 2-->
         firstsecond
       </div>
       <div
@@ -283,7 +283,7 @@ container.querySelector("button").click();
         <!--M_*6 #text/0-->
         third
         <!--M_*7 #text/0-->
-        <!--M_=1 #div/1 7 6 5-->
+        <!--M_}1 #div/1 7 6 5-->
         firstsecond
       </div>
       <div
@@ -293,7 +293,7 @@ container.querySelector("button").click();
         <!--M_*9 #text/0-->
         third
         <!--M_*10 #text/0-->
-        <!--M_=1 #div/2 10 9 8-->
+        <!--M_}1 #div/2 10 9 8-->
         firstsecond
       </div>
       <div
@@ -303,7 +303,7 @@ container.querySelector("button").click();
         <!--M_*12 #text/0-->
         third
         <!--M_*13 #text/0-->
-        <!--M_=1 #div/3 13 12 11-->
+        <!--M_}1 #div/3 13 12 11-->
         firstsecond
       </div>
       <div
@@ -315,7 +315,7 @@ container.querySelector("button").click();
         <!--M_*15 #text/0-->
         second
         <!--M_*16 #text/0-->
-        <!--M_=1 #div/4 16 15 14-->
+        <!--M_}1 #div/4 16 15 14-->
       </div>
       <button>
         Rotate
@@ -406,7 +406,7 @@ container.querySelector("button").click();
         <!--M_*2 #text/0-->
         <!--M_*3 #text/0-->
         <!--M_*4 #text/0-->
-        <!--M_=1 #div/0 4 3 2-->
+        <!--M_}1 #div/0 4 3 2-->
         firstsecondthird
       </div>
       <div
@@ -415,7 +415,7 @@ container.querySelector("button").click();
         <!--M_*5 #text/0-->
         <!--M_*6 #text/0-->
         <!--M_*7 #text/0-->
-        <!--M_=1 #div/1 7 6 5-->
+        <!--M_}1 #div/1 7 6 5-->
         firstsecondthird
       </div>
       <div
@@ -424,7 +424,7 @@ container.querySelector("button").click();
         <!--M_*8 #text/0-->
         <!--M_*9 #text/0-->
         <!--M_*10 #text/0-->
-        <!--M_=1 #div/2 10 9 8-->
+        <!--M_}1 #div/2 10 9 8-->
         firstsecondthird
       </div>
       <div
@@ -433,7 +433,7 @@ container.querySelector("button").click();
         <!--M_*11 #text/0-->
         <!--M_*12 #text/0-->
         <!--M_*13 #text/0-->
-        <!--M_=1 #div/3 13 12 11-->
+        <!--M_}1 #div/3 13 12 11-->
         firstsecondthird
       </div>
       <div
@@ -445,7 +445,7 @@ container.querySelector("button").click();
         <!--M_*15 #text/0-->
         third
         <!--M_*16 #text/0-->
-        <!--M_=1 #div/4 16 15 14-->
+        <!--M_}1 #div/4 16 15 14-->
       </div>
       <button>
         Rotate

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><div class=by-string>first<!--M_*2 #text/0-->second<!--M_*3 #text/0-->third<!--M_*4 #text/0--><!--M_=1 #div/0 4 3 2--></div><div class=by-function>first<!--M_*5 #text/0-->second<!--M_*6 #text/0-->third<!--M_*7 #text/0--><!--M_=1 #div/1 7 6 5--></div><div class=by-unknown-string>first<!--M_*8 #text/0-->second<!--M_*9 #text/0-->third<!--M_*10 #text/0--><!--M_=1 #div/2 10 9 8--></div><div class=by-unknown-function>first<!--M_*11 #text/0-->second<!--M_*12 #text/0-->third<!--M_*13 #text/0--><!--M_=1 #div/3 13 12 11--></div><div class=by-unknown-missing>first<!--M_*14 #text/0-->second<!--M_*15 #text/0-->third<!--M_*16 #text/0--><!--M_=1 #div/4 16 15 14--></div><button>Rotate</button><!--M_*1 #button/5--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.u=[0,{"LoopScopeMap:#div/0":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"LoopScopeMap:#div/1":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"LoopScopeMap:#div/2":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"LoopScopeMap:#div/3":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"LoopScopeMap:#div/4":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]]),items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}]},_.f,_.g,_.h,_.i,_.j,_.k,_.l,_.m,_.n,_.o,_.p,_.q,_.r,_.s,_.t]),"__tests__/template.marko_0_items",1];M._.w()</script>
+  <div><div class=by-string>first<!--M_*2 #text/0-->second<!--M_*3 #text/0-->third<!--M_*4 #text/0--><!--M_}1 #div/0 4 3 2--></div><div class=by-function>first<!--M_*5 #text/0-->second<!--M_*6 #text/0-->third<!--M_*7 #text/0--><!--M_}1 #div/1 7 6 5--></div><div class=by-unknown-string>first<!--M_*8 #text/0-->second<!--M_*9 #text/0-->third<!--M_*10 #text/0--><!--M_}1 #div/2 10 9 8--></div><div class=by-unknown-function>first<!--M_*11 #text/0-->second<!--M_*12 #text/0-->third<!--M_*13 #text/0--><!--M_}1 #div/3 13 12 11--></div><div class=by-unknown-missing>first<!--M_*14 #text/0-->second<!--M_*15 #text/0-->third<!--M_*16 #text/0--><!--M_}1 #div/4 16 15 14--></div><button>Rotate</button><!--M_*1 #button/5--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.u=[0,{"LoopScopeMap:#div/0":new Map(_.a=[[0,_.f={}],[1,_.g={}],[2,_.h={}]]),"LoopScopeMap:#div/1":new Map(_.b=[[0,_.i={}],[1,_.j={}],[2,_.k={}]]),"LoopScopeMap:#div/2":new Map(_.c=[[0,_.l={}],[1,_.m={}],[2,_.n={}]]),"LoopScopeMap:#div/3":new Map(_.d=[[0,_.o={}],[1,_.p={}],[2,_.q={}]]),"LoopScopeMap:#div/4":new Map(_.e=[[0,_.r={}],[1,_.s={}],[2,_.t={}]]),items:[{id:0,text:"first"},{id:1,text:"second"},{id:2,text:"third"}]},_.f,_.g,_.h,_.i,_.j,_.k,_.l,_.m,_.n,_.o,_.p,_.q,_.r,_.s,_.t]),"__tests__/template.marko_0_items",1];M._.w()</script>
 ```
 
 # Render End
@@ -18,7 +18,7 @@
         <!--M_*3 #text/0-->
         third
         <!--M_*4 #text/0-->
-        <!--M_=1 #div/0 4 3 2-->
+        <!--M_}1 #div/0 4 3 2-->
       </div>
       <div
         class="by-function"
@@ -29,7 +29,7 @@
         <!--M_*6 #text/0-->
         third
         <!--M_*7 #text/0-->
-        <!--M_=1 #div/1 7 6 5-->
+        <!--M_}1 #div/1 7 6 5-->
       </div>
       <div
         class="by-unknown-string"
@@ -40,7 +40,7 @@
         <!--M_*9 #text/0-->
         third
         <!--M_*10 #text/0-->
-        <!--M_=1 #div/2 10 9 8-->
+        <!--M_}1 #div/2 10 9 8-->
       </div>
       <div
         class="by-unknown-function"
@@ -51,7 +51,7 @@
         <!--M_*12 #text/0-->
         third
         <!--M_*13 #text/0-->
-        <!--M_=1 #div/3 13 12 11-->
+        <!--M_}1 #div/3 13 12 11-->
       </div>
       <div
         class="by-unknown-missing"
@@ -62,7 +62,7 @@
         <!--M_*15 #text/0-->
         third
         <!--M_*16 #text/0-->
-        <!--M_=1 #div/4 16 15 14-->
+        <!--M_}1 #div/4 16 15 14-->
       </div>
       <button>
         Rotate

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/resume.expected.md
@@ -7,7 +7,7 @@
       data-children="1"
     >
       <div />
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -37,7 +37,7 @@
       data-children="2"
     >
       <div />
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
       <div />
     </div>
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div data-children=1><div></div><!--M_=1 #div/0 2--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"LoopScopeMap:#div/0":new Map(_.a=[[0,_.b={}]]),children:[1]},_.b]),"__tests__/template.marko_0_children",1];M._.w()</script>
+  <div data-children=1><div></div><!--M_}1 #div/0 2--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"LoopScopeMap:#div/0":new Map(_.a=[[0,_.b={}]]),children:[1]},_.b]),"__tests__/template.marko_0_children",1];M._.w()</script>
 ```
 
 # Render End
@@ -12,7 +12,7 @@
       data-children="1"
     >
       <div />
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/resume.expected.md
@@ -7,9 +7,9 @@
       data-children="1"
     >
       Before 
-      <!--M_[2-->
+      <!--M_[-->
       Child
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <!--M_*1 #div/0-->
     <script>
@@ -30,6 +30,10 @@
 </html>
 ```
 
+# Mutations
+```
+INSERT html/body/div/#text2
+```
 
 # Render ASYNC
 ```html
@@ -40,9 +44,9 @@
       data-children="2"
     >
       Before 
-      <!--M_[2-->
+      <!--M_[-->
       ChildChild
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <!--M_*1 #div/0-->
     <script>
@@ -66,5 +70,5 @@
 # Mutations
 ```
 UPDATE html/body/div[data-children] "1" => "2"
-INSERT html/body/div/#text2
+INSERT html/body/div/#text3
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div data-children=1>Before <!--M_[2-->Child<!--M_]1 #text/1--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"LoopScopeMap:#text/1":new Map(_.a=[[0,_.b={}]]),children:[1]},_.b]),"__tests__/template.marko_0_children",1];M._.w()</script>
+  <div data-children=1>Before <!--M_[-->Child<!--M_]1 #text/1 2--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,{"LoopScopeMap:#text/1":new Map(_.a=[[0,_.b={}]]),children:[1]},_.b]),"__tests__/template.marko_0_children",1];M._.w()</script>
 ```
 
 # Render End
@@ -12,9 +12,9 @@
       data-children="1"
     >
       Before 
-      <!--M_[2-->
+      <!--M_[-->
       Child
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <!--M_*1 #div/0-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/resume.expected.md
@@ -4,43 +4,43 @@
 <html>
   <head />
   <body>
-    <!--M_[4-->
+    <!--M_[-->
     <div>
       Hoist from custom tag
     </div>
     <!--M_*4 #div/0-->
-    <!--M_]3 #text/0-->
-    <!--M_[7-->
+    <!--M_]3 #text/0 4-->
+    <!--M_[-->
     <div>
       Hoist from custom tag
     </div>
     <!--M_*7 #div/0-->
-    <!--M_]6 #text/0-->
-    <!--M_[13-->
+    <!--M_]6 #text/0 7-->
+    <!--M_[-->
     <div>
       Hoist from dynamic tag
     </div>
     <!--M_*13 #div/0-->
-    <!--M_]12 #text/0-->
-    <!--M_[16-->
+    <!--M_]12 #text/0 13-->
+    <!--M_[-->
     <div />
     <!--M_*16 #div/0-->
-    <!--M_]15 #text/0-->
-    <!--M_[21-->
+    <!--M_]15 #text/0 16-->
+    <!--M_[-->
     <div />
     <!--M_*21 #div/0-->
-    <!--M_]20 #text/0-->
-    <!--M_[24-->
+    <!--M_]20 #text/0 21-->
+    <!--M_[-->
     <div />
     <!--M_*24 #div/0-->
-    <!--M_]23 #text/0-->
+    <!--M_]23 #text/0 24-->
     <section>
-      <!--M_[28-->
+      <!--M_[-->
       <div>
         Hoist from dynamic tag
       </div>
       <!--M_*28 #div/0-->
-      <!--M_]27 #text/0-->
+      <!--M_]27 #text/0 28-->
     </section>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -128,6 +128,13 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text0
+INSERT html/body/#text1
+INSERT html/body/#text2
+INSERT html/body/#text3
+INSERT html/body/#text4
+INSERT html/body/#text5
+INSERT html/body/section/#text
 INSERT html/body/div2/#text
 INSERT html/body/section/div/#text
 INSERT html/body/div0/#text

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/ssr.expected.md
@@ -1,42 +1,42 @@
 # Write
 ```html
-  <!--M_[4--><div></div><!--M_*4 #div/0--><!--M_]3 #text/0--><!--M_[7--><div></div><!--M_*7 #div/0--><!--M_]6 #text/0--><!--M_[13--><div></div><!--M_*13 #div/0--><!--M_]12 #text/0--><!--M_[16--><div></div><!--M_*16 #div/0--><!--M_]15 #text/0--><!--M_[21--><div></div><!--M_*21 #div/0--><!--M_]20 #text/0--><!--M_[24--><div></div><!--M_*24 #div/0--><!--M_]23 #text/0--><section><!--M_[28--><div></div><!--M_*28 #div/0--><!--M_]27 #text/0--></section><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.p=[0,_.a={"ClosureScopes:1":_.q=new Set,"ClosureScopes:2":_.s=new Set,"ClosureScopes:4":_.w=new Set},1,_.b={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":5},_.c,1,_.d={"ConditionalScope:#text/0":_.e={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":8},_.e,2,_.t={"ClosureScopes:3":_.r=new Set},1,_.f={"ConditionalScope:#text/0":_.g={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":14},_.g,1,_.h={"ConditionalScope:#text/0":_.i={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":17},_.i,1,_.v={"ClosureScopes:3":_.u=new Set},1,_.j={"ConditionalScope:#text/0":_.k={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":22},_.k,1,_.l={"ConditionalScope:#text/0":_.m={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":25},_.m,2,_.n={"ConditionalScope:#text/0":_.o={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":29},_.o],_.a.$hoisted_setHtml=_._["__tests__/template.marko_0_$hoisted_setHtml/hoist"](_.a),_.c["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.b),_.b.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.c),_.e["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.d),_.d.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.e),_.g["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.f),_.f.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.g),_.i["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.h),_.h.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.i),_.k["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.j),_.j.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.k),_.m["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.l),_.l.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.m),_.o["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.n),_.n.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.o),(_.q).add(_.b),(_.q).add(_.d),(_.r).add(_.f),(_.r).add(_.h),(_.s).add(_.t),(_.u).add(_.j),(_.u).add(_.l),(_.s).add(_.v),(_.w).add(_.n),_.p),"__tests__/template.marko_0",1,"__tests__/template.marko_0_$hoisted_setHtml",1];M._.w()</script>
+  <!--M_[--><div></div><!--M_*4 #div/0--><!--M_]3 #text/0 4--><!--M_[--><div></div><!--M_*7 #div/0--><!--M_]6 #text/0 7--><!--M_[--><div></div><!--M_*13 #div/0--><!--M_]12 #text/0 13--><!--M_[--><div></div><!--M_*16 #div/0--><!--M_]15 #text/0 16--><!--M_[--><div></div><!--M_*21 #div/0--><!--M_]20 #text/0 21--><!--M_[--><div></div><!--M_*24 #div/0--><!--M_]23 #text/0 24--><section><!--M_[--><div></div><!--M_*28 #div/0--><!--M_]27 #text/0 28--></section><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.p=[0,_.a={"ClosureScopes:1":_.q=new Set,"ClosureScopes:2":_.s=new Set,"ClosureScopes:4":_.w=new Set},1,_.b={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":5},_.c,1,_.d={"ConditionalScope:#text/0":_.e={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":8},_.e,2,_.t={"ClosureScopes:3":_.r=new Set},1,_.f={"ConditionalScope:#text/0":_.g={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":14},_.g,1,_.h={"ConditionalScope:#text/0":_.i={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":17},_.i,1,_.v={"ClosureScopes:3":_.u=new Set},1,_.j={"ConditionalScope:#text/0":_.k={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":22},_.k,1,_.l={"ConditionalScope:#text/0":_.m={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":25},_.m,2,_.n={"ConditionalScope:#text/0":_.o={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":29},_.o],_.a.$hoisted_setHtml=_._["__tests__/template.marko_0_$hoisted_setHtml/hoist"](_.a),_.c["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.b),_.b.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.c),_.e["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.d),_.d.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.e),_.g["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.f),_.f.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.g),_.i["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.h),_.h.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.i),_.k["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.j),_.j.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.k),_.m["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.l),_.l.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.m),_.o["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.n),_.n.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.o),(_.q).add(_.b),(_.q).add(_.d),(_.r).add(_.f),(_.r).add(_.h),(_.s).add(_.t),(_.u).add(_.j),(_.u).add(_.l),(_.s).add(_.v),(_.w).add(_.n),_.p),"__tests__/template.marko_0",1,"__tests__/template.marko_0_$hoisted_setHtml",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[4-->
+<!--M_[-->
 <html>
   <head />
   <body>
     <div />
     <!--M_*4 #div/0-->
-    <!--M_]3 #text/0-->
-    <!--M_[7-->
+    <!--M_]3 #text/0 4-->
+    <!--M_[-->
     <div />
     <!--M_*7 #div/0-->
-    <!--M_]6 #text/0-->
-    <!--M_[13-->
+    <!--M_]6 #text/0 7-->
+    <!--M_[-->
     <div />
     <!--M_*13 #div/0-->
-    <!--M_]12 #text/0-->
-    <!--M_[16-->
+    <!--M_]12 #text/0 13-->
+    <!--M_[-->
     <div />
     <!--M_*16 #div/0-->
-    <!--M_]15 #text/0-->
-    <!--M_[21-->
+    <!--M_]15 #text/0 16-->
+    <!--M_[-->
     <div />
     <!--M_*21 #div/0-->
-    <!--M_]20 #text/0-->
-    <!--M_[24-->
+    <!--M_]20 #text/0 21-->
+    <!--M_[-->
     <div />
     <!--M_*24 #div/0-->
-    <!--M_]23 #text/0-->
+    <!--M_]23 #text/0 24-->
     <section>
-      <!--M_[28-->
+      <!--M_[-->
       <div />
       <!--M_*28 #div/0-->
-      <!--M_]27 #text/0-->
+      <!--M_]27 #text/0 28-->
     </section>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/resume.expected.md
@@ -4,160 +4,160 @@
 <html>
   <head />
   <body>
-    <!--M_[3-->
+    <!--M_[-->
     <div>
       First Only
     </div>
     <!--M_*3 #div/0-->
-    <!--M_]2 #text/0-->
-    <!--M_[6-->
+    <!--M_]2 #text/0 3-->
+    <!--M_[-->
     <div />
     <!--M_*6 #div/0-->
-    <!--M_]5 #text/0-->
-    <!--M_[9-->
+    <!--M_]5 #text/0 6-->
+    <!--M_[-->
     <div />
     <!--M_*9 #div/0-->
-    <!--M_]8 #text/0-->
-    <!--M_[12-->
+    <!--M_]8 #text/0 9-->
+    <!--M_[-->
     <div />
     <!--M_*12 #div/0-->
-    <!--M_]11 #text/0-->
-    <!--M_[15-->
+    <!--M_]11 #text/0 12-->
+    <!--M_[-->
     <div />
     <!--M_*15 #div/0-->
-    <!--M_]14 #text/0-->
-    <!--M_[18-->
+    <!--M_]14 #text/0 15-->
+    <!--M_[-->
     <div />
     <!--M_*18 #div/0-->
-    <!--M_]17 #text/0-->
+    <!--M_]17 #text/0 18-->
     <hr />
-    <!--M_[20-->
-    <!--M_[21-->
+    <!--M_[-->
+    <!--M_[-->
     <div>
       First Only
     </div>
     <!--M_*21 #div/0-->
-    <!--M_]20 #text/0-->
-    <!--M_[23 -->
-    <!--M_[24-->
+    <!--M_]20 #text/0 21-->
+    <!--M_[20-->
+    <!--M_[-->
     <div />
     <!--M_*24 #div/0-->
-    <!--M_]23 #text/0-->
-    <!--M_[26 -->
-    <!--M_[27-->
+    <!--M_]23 #text/0 24-->
+    <!--M_[23-->
+    <!--M_[-->
     <div />
     <!--M_*27 #div/0-->
-    <!--M_]26 #text/0-->
-    <!--M_[29 -->
-    <!--M_[30-->
+    <!--M_]26 #text/0 27-->
+    <!--M_[26-->
+    <!--M_[-->
     <div />
     <!--M_*30 #div/0-->
-    <!--M_]29 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]29 #text/0 30-->
+    <!--M_]1 #text/1 29-->
     <hr />
     <ul>
-      <!--M_[34-->
+      <!--M_[-->
       <div>
         All (0)
       </div>
       <!--M_*34 #div/0-->
-      <!--M_]33 #text/0-->
-      <!--M_[37-->
+      <!--M_]33 #text/0 34-->
+      <!--M_[-->
       <div>
         All (1)
       </div>
       <!--M_*37 #div/0-->
-      <!--M_]36 #text/0-->
-      <!--M_[40-->
+      <!--M_]36 #text/0 37-->
+      <!--M_[-->
       <div>
         All (2)
       </div>
       <!--M_*40 #div/0-->
-      <!--M_]39 #text/0-->
-      <!--M_[43-->
+      <!--M_]39 #text/0 40-->
+      <!--M_[-->
       <div>
         All (3)
       </div>
       <!--M_*43 #div/0-->
-      <!--M_]42 #text/0-->
+      <!--M_]42 #text/0 43-->
     </ul>
     <ul>
-      <!--M_[47-->
+      <!--M_[-->
       <div>
         All (4)
       </div>
       <!--M_*47 #div/0-->
-      <!--M_]46 #text/0-->
-      <!--M_[50-->
+      <!--M_]46 #text/0 47-->
+      <!--M_[-->
       <div>
         All (5)
       </div>
       <!--M_*50 #div/0-->
-      <!--M_]49 #text/0-->
-      <!--M_[53-->
+      <!--M_]49 #text/0 50-->
+      <!--M_[-->
       <div>
         All (6)
       </div>
       <!--M_*53 #div/0-->
-      <!--M_]52 #text/0-->
-      <!--M_[56-->
+      <!--M_]52 #text/0 53-->
+      <!--M_[-->
       <div>
         All (7)
       </div>
       <!--M_*56 #div/0-->
-      <!--M_]55 #text/0-->
+      <!--M_]55 #text/0 56-->
     </ul>
     <ul>
-      <!--M_[60-->
+      <!--M_[-->
       <div>
         All (8)
       </div>
       <!--M_*60 #div/0-->
-      <!--M_]59 #text/0-->
-      <!--M_[63-->
+      <!--M_]59 #text/0 60-->
+      <!--M_[-->
       <div>
         All (9)
       </div>
       <!--M_*63 #div/0-->
-      <!--M_]62 #text/0-->
-      <!--M_[66-->
+      <!--M_]62 #text/0 63-->
+      <!--M_[-->
       <div>
         All (10)
       </div>
       <!--M_*66 #div/0-->
-      <!--M_]65 #text/0-->
-      <!--M_[69-->
+      <!--M_]65 #text/0 66-->
+      <!--M_[-->
       <div>
         All (11)
       </div>
       <!--M_*69 #div/0-->
-      <!--M_]68 #text/0-->
+      <!--M_]68 #text/0 69-->
     </ul>
     <ul>
-      <!--M_[73-->
+      <!--M_[-->
       <div>
         All (12)
       </div>
       <!--M_*73 #div/0-->
-      <!--M_]72 #text/0-->
-      <!--M_[76-->
+      <!--M_]72 #text/0 73-->
+      <!--M_[-->
       <div>
         All (13)
       </div>
       <!--M_*76 #div/0-->
-      <!--M_]75 #text/0-->
-      <!--M_[79-->
+      <!--M_]75 #text/0 76-->
+      <!--M_[-->
       <div>
         All (14)
       </div>
       <!--M_*79 #div/0-->
-      <!--M_]78 #text/0-->
-      <!--M_[82-->
+      <!--M_]78 #text/0 79-->
+      <!--M_[-->
       <div>
         All (15)
       </div>
       <!--M_*82 #div/0-->
-      <!--M_]81 #text/0-->
+      <!--M_]81 #text/0 82-->
     </ul>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -446,6 +446,32 @@ INSERT html/body/#text0
 INSERT html/body/#text1
 INSERT html/body/#text2
 INSERT html/body/#text3
+INSERT html/body/#text4
+INSERT html/body/#text5
+INSERT html/body/#text6
+INSERT html/body/#text7
+INSERT html/body/#text8
+INSERT html/body/#text9
+INSERT html/body/#text10
+INSERT html/body/#text11
+INSERT html/body/#text12
+INSERT html/body/#text13
+INSERT html/body/ul0/#text0
+INSERT html/body/ul0/#text1
+INSERT html/body/ul0/#text2
+INSERT html/body/ul0/#text3
+INSERT html/body/ul1/#text0
+INSERT html/body/ul1/#text1
+INSERT html/body/ul1/#text2
+INSERT html/body/ul1/#text3
+INSERT html/body/ul2/#text0
+INSERT html/body/ul2/#text1
+INSERT html/body/ul2/#text2
+INSERT html/body/ul2/#text3
+INSERT html/body/ul3/#text0
+INSERT html/body/ul3/#text1
+INSERT html/body/ul3/#text2
+INSERT html/body/ul3/#text3
 INSERT html/body/ul0/div0/#text
 INSERT html/body/ul0/div1/#text
 INSERT html/body/ul0/div2/#text

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/ssr.expected.md
@@ -1,131 +1,131 @@
 # Write
 ```html
-  <!--M_[3--><div></div><!--M_*3 #div/0--><!--M_]2 #text/0--><!--M_[6--><div></div><!--M_*6 #div/0--><!--M_]5 #text/0--><!--M_[9--><div></div><!--M_*9 #div/0--><!--M_]8 #text/0--><!--M_[12--><div></div><!--M_*12 #div/0--><!--M_]11 #text/0--><!--M_[15--><div></div><!--M_*15 #div/0--><!--M_]14 #text/0--><!--M_[18--><div></div><!--M_*18 #div/0--><!--M_]17 #text/0--><hr><!--M_[20--><!--M_[21--><div></div><!--M_*21 #div/0--><!--M_]20 #text/0--><!--M_[23 --><!--M_[24--><div></div><!--M_*24 #div/0--><!--M_]23 #text/0--><!--M_[26 --><!--M_[27--><div></div><!--M_*27 #div/0--><!--M_]26 #text/0--><!--M_[29 --><!--M_[30--><div></div><!--M_*30 #div/0--><!--M_]29 #text/0--><!--M_]1 #text/1--><hr><ul><!--M_[34--><div></div><!--M_*34 #div/0--><!--M_]33 #text/0--><!--M_[37--><div></div><!--M_*37 #div/0--><!--M_]36 #text/0--><!--M_[40--><div></div><!--M_*40 #div/0--><!--M_]39 #text/0--><!--M_[43--><div></div><!--M_*43 #div/0--><!--M_]42 #text/0--></ul><ul><!--M_[47--><div></div><!--M_*47 #div/0--><!--M_]46 #text/0--><!--M_[50--><div></div><!--M_*50 #div/0--><!--M_]49 #text/0--><!--M_[53--><div></div><!--M_*53 #div/0--><!--M_]52 #text/0--><!--M_[56--><div></div><!--M_*56 #div/0--><!--M_]55 #text/0--></ul><ul><!--M_[60--><div></div><!--M_*60 #div/0--><!--M_]59 #text/0--><!--M_[63--><div></div><!--M_*63 #div/0--><!--M_]62 #text/0--><!--M_[66--><div></div><!--M_*66 #div/0--><!--M_]65 #text/0--><!--M_[69--><div></div><!--M_*69 #div/0--><!--M_]68 #text/0--></ul><ul><!--M_[73--><div></div><!--M_*73 #div/0--><!--M_]72 #text/0--><!--M_[76--><div></div><!--M_*76 #div/0--><!--M_]75 #text/0--><!--M_[79--><div></div><!--M_*79 #div/0--><!--M_]78 #text/0--><!--M_[82--><div></div><!--M_*82 #div/0--><!--M_]81 #text/0--></ul><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.lb=[0,_.gb={"LoopScopeMap:#text/0":new Map(_.a=[[0,_.b={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":4}],[1,_.d={"ConditionalScope:#text/0":_.e={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":7}],[2,_.f={"ConditionalScope:#text/0":_.g={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":10}],[3,_.h={"ConditionalScope:#text/0":_.i={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":13}],[4,_.j={"ConditionalScope:#text/0":_.k={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":16}],[5,_.l={"ConditionalScope:#text/0":_.m={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":19}]]),"LoopScopeMap:#text/1":new Map(_.n=[[0,_.o={"ConditionalScope:#text/0":_.p={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":22}],[1,_.q={"ConditionalScope:#text/0":_.r={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":25}],[2,_.s={"ConditionalScope:#text/0":_.t={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":28}],[3,_.u={"ConditionalScope:#text/0":_.v={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":31}]]),"LoopScopeMap:#text/2":new Map(_.w=[[0,_.hb={"LoopScopeMap:#ul/0":new Map(_.x=[[0,_.y={"ConditionalScope:#text/0":_.z={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":35}],[1,_.A={"ConditionalScope:#text/0":_.B={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":38}],[2,_.C={"ConditionalScope:#text/0":_.D={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":41}],[3,_.E={"ConditionalScope:#text/0":_.F={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":44}]])}],[1,_.ib={"LoopScopeMap:#ul/0":new Map(_.G=[[0,_.H={"ConditionalScope:#text/0":_.I={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":48}],[1,_.J={"ConditionalScope:#text/0":_.K={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":51}],[2,_.L={"ConditionalScope:#text/0":_.M={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":54}],[3,_.N={"ConditionalScope:#text/0":_.O={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":57}]])}],[2,_.jb={"LoopScopeMap:#ul/0":new Map(_.P=[[0,_.Q={"ConditionalScope:#text/0":_.R={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":61}],[1,_.S={"ConditionalScope:#text/0":_.T={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":64}],[2,_.U={"ConditionalScope:#text/0":_.V={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":67}],[3,_.W={"ConditionalScope:#text/0":_.X={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":70}]])}],[3,_.kb={"LoopScopeMap:#ul/0":new Map(_.Y=[[0,_.Z={"ConditionalScope:#text/0":_.$={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":74}],[1,_.ab={"ConditionalScope:#text/0":_.bb={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":77}],[2,_.cb={"ConditionalScope:#text/0":_.db={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":80}],[3,_.eb={"ConditionalScope:#text/0":_.fb={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":83}]])}]])},_.b,_.c,1,_.d,_.e,1,_.f,_.g,1,_.h,_.i,1,_.j,_.k,1,_.l,_.m,1,_.o,_.p,1,_.q,_.r,1,_.s,_.t,1,_.u,_.v,1,_.hb,_.y,_.z,1,_.A,_.B,1,_.C,_.D,1,_.E,_.F,1,_.ib,_.H,_.I,1,_.J,_.K,1,_.L,_.M,1,_.N,_.O,1,_.jb,_.Q,_.R,1,_.S,_.T,1,_.U,_.V,1,_.W,_.X,1,_.kb,_.Z,_.$,1,_.ab,_.bb,1,_.cb,_.db,1,_.eb,_.fb],_.c["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.b),_.b.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.c),_.e["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.d),_.d.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.e),_.g["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.f),_.f.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.g),_.i["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.h),_.h.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.i),_.k["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.j),_.j.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.k),_.m["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.l),_.l.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.m),_.p["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.o),_.o.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.p),_.r["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.q),_.q.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.r),_.t["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.s),_.s.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.t),_.v["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.u),_.u.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.v),_.z["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.y),_.y.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.z),_.B["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.A),_.A.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.B),_.D["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.C),_.C.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.D),_.F["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.E),_.E.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.F),_.I["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.H),_.H.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.I),_.K["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.J),_.J.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.K),_.M["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.L),_.L.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.M),_.O["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.N),_.N.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.O),_.R["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.Q),_.Q.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.R),_.T["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.S),_.S.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.T),_.V["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.U),_.U.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.V),_.X["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.W),_.W.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.X),_.$["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.Z),_.Z.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.$),_.bb["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.ab),_.ab.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.bb),_.db["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.cb),_.cb.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.db),_.fb["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.eb),_.eb.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.fb),_.gb.$hoisted_setHtml3=_._["__tests__/template.marko_0_$hoisted_setHtml3/hoist"](_.gb),_.lb),"__tests__/template.marko_0_$hoisted_setHtml3",1,"__tests__/template.marko_0",1];M._.w()</script>
+  <!--M_[--><div></div><!--M_*3 #div/0--><!--M_]2 #text/0 3--><!--M_[--><div></div><!--M_*6 #div/0--><!--M_]5 #text/0 6--><!--M_[--><div></div><!--M_*9 #div/0--><!--M_]8 #text/0 9--><!--M_[--><div></div><!--M_*12 #div/0--><!--M_]11 #text/0 12--><!--M_[--><div></div><!--M_*15 #div/0--><!--M_]14 #text/0 15--><!--M_[--><div></div><!--M_*18 #div/0--><!--M_]17 #text/0 18--><hr><!--M_[--><!--M_[--><div></div><!--M_*21 #div/0--><!--M_]20 #text/0 21--><!--M_[20--><!--M_[--><div></div><!--M_*24 #div/0--><!--M_]23 #text/0 24--><!--M_[23--><!--M_[--><div></div><!--M_*27 #div/0--><!--M_]26 #text/0 27--><!--M_[26--><!--M_[--><div></div><!--M_*30 #div/0--><!--M_]29 #text/0 30--><!--M_]1 #text/1 29--><hr><ul><!--M_[--><div></div><!--M_*34 #div/0--><!--M_]33 #text/0 34--><!--M_[--><div></div><!--M_*37 #div/0--><!--M_]36 #text/0 37--><!--M_[--><div></div><!--M_*40 #div/0--><!--M_]39 #text/0 40--><!--M_[--><div></div><!--M_*43 #div/0--><!--M_]42 #text/0 43--></ul><ul><!--M_[--><div></div><!--M_*47 #div/0--><!--M_]46 #text/0 47--><!--M_[--><div></div><!--M_*50 #div/0--><!--M_]49 #text/0 50--><!--M_[--><div></div><!--M_*53 #div/0--><!--M_]52 #text/0 53--><!--M_[--><div></div><!--M_*56 #div/0--><!--M_]55 #text/0 56--></ul><ul><!--M_[--><div></div><!--M_*60 #div/0--><!--M_]59 #text/0 60--><!--M_[--><div></div><!--M_*63 #div/0--><!--M_]62 #text/0 63--><!--M_[--><div></div><!--M_*66 #div/0--><!--M_]65 #text/0 66--><!--M_[--><div></div><!--M_*69 #div/0--><!--M_]68 #text/0 69--></ul><ul><!--M_[--><div></div><!--M_*73 #div/0--><!--M_]72 #text/0 73--><!--M_[--><div></div><!--M_*76 #div/0--><!--M_]75 #text/0 76--><!--M_[--><div></div><!--M_*79 #div/0--><!--M_]78 #text/0 79--><!--M_[--><div></div><!--M_*82 #div/0--><!--M_]81 #text/0 82--></ul><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.lb=[0,_.gb={"LoopScopeMap:#text/0":new Map(_.a=[[0,_.b={"ConditionalScope:#text/0":_.c={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":4}],[1,_.d={"ConditionalScope:#text/0":_.e={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":7}],[2,_.f={"ConditionalScope:#text/0":_.g={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":10}],[3,_.h={"ConditionalScope:#text/0":_.i={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":13}],[4,_.j={"ConditionalScope:#text/0":_.k={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":16}],[5,_.l={"ConditionalScope:#text/0":_.m={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":19}]]),"LoopScopeMap:#text/1":new Map(_.n=[[0,_.o={"ConditionalScope:#text/0":_.p={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":22}],[1,_.q={"ConditionalScope:#text/0":_.r={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":25}],[2,_.s={"ConditionalScope:#text/0":_.t={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":28}],[3,_.u={"ConditionalScope:#text/0":_.v={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":31}]]),"LoopScopeMap:#text/2":new Map(_.w=[[0,_.hb={"LoopScopeMap:#ul/0":new Map(_.x=[[0,_.y={"ConditionalScope:#text/0":_.z={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":35}],[1,_.A={"ConditionalScope:#text/0":_.B={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":38}],[2,_.C={"ConditionalScope:#text/0":_.D={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":41}],[3,_.E={"ConditionalScope:#text/0":_.F={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":44}]])}],[1,_.ib={"LoopScopeMap:#ul/0":new Map(_.G=[[0,_.H={"ConditionalScope:#text/0":_.I={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":48}],[1,_.J={"ConditionalScope:#text/0":_.K={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":51}],[2,_.L={"ConditionalScope:#text/0":_.M={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":54}],[3,_.N={"ConditionalScope:#text/0":_.O={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":57}]])}],[2,_.jb={"LoopScopeMap:#ul/0":new Map(_.P=[[0,_.Q={"ConditionalScope:#text/0":_.R={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":61}],[1,_.S={"ConditionalScope:#text/0":_.T={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":64}],[2,_.U={"ConditionalScope:#text/0":_.V={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":67}],[3,_.W={"ConditionalScope:#text/0":_.X={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":70}]])}],[3,_.kb={"LoopScopeMap:#ul/0":new Map(_.Y=[[0,_.Z={"ConditionalScope:#text/0":_.$={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":74}],[1,_.ab={"ConditionalScope:#text/0":_.bb={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":77}],[2,_.cb={"ConditionalScope:#text/0":_.db={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":80}],[3,_.eb={"ConditionalScope:#text/0":_.fb={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":83}]])}]])},_.b,_.c,1,_.d,_.e,1,_.f,_.g,1,_.h,_.i,1,_.j,_.k,1,_.l,_.m,1,_.o,_.p,1,_.q,_.r,1,_.s,_.t,1,_.u,_.v,1,_.hb,_.y,_.z,1,_.A,_.B,1,_.C,_.D,1,_.E,_.F,1,_.ib,_.H,_.I,1,_.J,_.K,1,_.L,_.M,1,_.N,_.O,1,_.jb,_.Q,_.R,1,_.S,_.T,1,_.U,_.V,1,_.W,_.X,1,_.kb,_.Z,_.$,1,_.ab,_.bb,1,_.cb,_.db,1,_.eb,_.fb],_.c["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.b),_.b.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.c),_.e["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.d),_.d.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.e),_.g["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.f),_.f.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.g),_.i["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.h),_.h.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.i),_.k["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.j),_.j.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.k),_.m["#TagVariable"]=_._["__tests__/template.marko_1_setHtml/var"](_.l),_.l.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.m),_.p["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.o),_.o.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.p),_.r["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.q),_.q.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.r),_.t["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.s),_.s.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.t),_.v["#TagVariable"]=_._["__tests__/template.marko_2_setHtml2/var"](_.u),_.u.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.v),_.z["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.y),_.y.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.z),_.B["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.A),_.A.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.B),_.D["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.C),_.C.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.D),_.F["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.E),_.E.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.F),_.I["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.H),_.H.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.I),_.K["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.J),_.J.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.K),_.M["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.L),_.L.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.M),_.O["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.N),_.N.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.O),_.R["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.Q),_.Q.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.R),_.T["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.S),_.S.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.T),_.V["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.U),_.U.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.V),_.X["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.W),_.W.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.X),_.$["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.Z),_.Z.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.$),_.bb["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.ab),_.ab.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.bb),_.db["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.cb),_.cb.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.db),_.fb["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.eb),_.eb.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.fb),_.gb.$hoisted_setHtml3=_._["__tests__/template.marko_0_$hoisted_setHtml3/hoist"](_.gb),_.lb),"__tests__/template.marko_0_$hoisted_setHtml3",1,"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[3-->
+<!--M_[-->
 <html>
   <head />
   <body>
     <div />
     <!--M_*3 #div/0-->
-    <!--M_]2 #text/0-->
-    <!--M_[6-->
+    <!--M_]2 #text/0 3-->
+    <!--M_[-->
     <div />
     <!--M_*6 #div/0-->
-    <!--M_]5 #text/0-->
-    <!--M_[9-->
+    <!--M_]5 #text/0 6-->
+    <!--M_[-->
     <div />
     <!--M_*9 #div/0-->
-    <!--M_]8 #text/0-->
-    <!--M_[12-->
+    <!--M_]8 #text/0 9-->
+    <!--M_[-->
     <div />
     <!--M_*12 #div/0-->
-    <!--M_]11 #text/0-->
-    <!--M_[15-->
+    <!--M_]11 #text/0 12-->
+    <!--M_[-->
     <div />
     <!--M_*15 #div/0-->
-    <!--M_]14 #text/0-->
-    <!--M_[18-->
+    <!--M_]14 #text/0 15-->
+    <!--M_[-->
     <div />
     <!--M_*18 #div/0-->
-    <!--M_]17 #text/0-->
+    <!--M_]17 #text/0 18-->
     <hr />
-    <!--M_[20-->
-    <!--M_[21-->
+    <!--M_[-->
+    <!--M_[-->
     <div />
     <!--M_*21 #div/0-->
-    <!--M_]20 #text/0-->
-    <!--M_[23 -->
-    <!--M_[24-->
+    <!--M_]20 #text/0 21-->
+    <!--M_[20-->
+    <!--M_[-->
     <div />
     <!--M_*24 #div/0-->
-    <!--M_]23 #text/0-->
-    <!--M_[26 -->
-    <!--M_[27-->
+    <!--M_]23 #text/0 24-->
+    <!--M_[23-->
+    <!--M_[-->
     <div />
     <!--M_*27 #div/0-->
-    <!--M_]26 #text/0-->
-    <!--M_[29 -->
-    <!--M_[30-->
+    <!--M_]26 #text/0 27-->
+    <!--M_[26-->
+    <!--M_[-->
     <div />
     <!--M_*30 #div/0-->
-    <!--M_]29 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]29 #text/0 30-->
+    <!--M_]1 #text/1 29-->
     <hr />
     <ul>
-      <!--M_[34-->
+      <!--M_[-->
       <div />
       <!--M_*34 #div/0-->
-      <!--M_]33 #text/0-->
-      <!--M_[37-->
+      <!--M_]33 #text/0 34-->
+      <!--M_[-->
       <div />
       <!--M_*37 #div/0-->
-      <!--M_]36 #text/0-->
-      <!--M_[40-->
+      <!--M_]36 #text/0 37-->
+      <!--M_[-->
       <div />
       <!--M_*40 #div/0-->
-      <!--M_]39 #text/0-->
-      <!--M_[43-->
+      <!--M_]39 #text/0 40-->
+      <!--M_[-->
       <div />
       <!--M_*43 #div/0-->
-      <!--M_]42 #text/0-->
+      <!--M_]42 #text/0 43-->
     </ul>
     <ul>
-      <!--M_[47-->
+      <!--M_[-->
       <div />
       <!--M_*47 #div/0-->
-      <!--M_]46 #text/0-->
-      <!--M_[50-->
+      <!--M_]46 #text/0 47-->
+      <!--M_[-->
       <div />
       <!--M_*50 #div/0-->
-      <!--M_]49 #text/0-->
-      <!--M_[53-->
+      <!--M_]49 #text/0 50-->
+      <!--M_[-->
       <div />
       <!--M_*53 #div/0-->
-      <!--M_]52 #text/0-->
-      <!--M_[56-->
+      <!--M_]52 #text/0 53-->
+      <!--M_[-->
       <div />
       <!--M_*56 #div/0-->
-      <!--M_]55 #text/0-->
+      <!--M_]55 #text/0 56-->
     </ul>
     <ul>
-      <!--M_[60-->
+      <!--M_[-->
       <div />
       <!--M_*60 #div/0-->
-      <!--M_]59 #text/0-->
-      <!--M_[63-->
+      <!--M_]59 #text/0 60-->
+      <!--M_[-->
       <div />
       <!--M_*63 #div/0-->
-      <!--M_]62 #text/0-->
-      <!--M_[66-->
+      <!--M_]62 #text/0 63-->
+      <!--M_[-->
       <div />
       <!--M_*66 #div/0-->
-      <!--M_]65 #text/0-->
-      <!--M_[69-->
+      <!--M_]65 #text/0 66-->
+      <!--M_[-->
       <div />
       <!--M_*69 #div/0-->
-      <!--M_]68 #text/0-->
+      <!--M_]68 #text/0 69-->
     </ul>
     <ul>
-      <!--M_[73-->
+      <!--M_[-->
       <div />
       <!--M_*73 #div/0-->
-      <!--M_]72 #text/0-->
-      <!--M_[76-->
+      <!--M_]72 #text/0 73-->
+      <!--M_[-->
       <div />
       <!--M_*76 #div/0-->
-      <!--M_]75 #text/0-->
-      <!--M_[79-->
+      <!--M_]75 #text/0 76-->
+      <!--M_[-->
       <div />
       <!--M_*79 #div/0-->
-      <!--M_]78 #text/0-->
-      <!--M_[82-->
+      <!--M_]78 #text/0 79-->
+      <!--M_[-->
       <div />
       <!--M_*82 #div/0-->
-      <!--M_]81 #text/0-->
+      <!--M_]81 #text/0 82-->
     </ul>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/resume.expected.md
@@ -4,24 +4,24 @@
 <html>
   <head />
   <body>
-    <!--M_[4-->
+    <!--M_[-->
     <div>
       Hello world
     </div>
     <!--M_*4 #div/0-->
-    <!--M_]3 #text/0-->
-    <!--M_[8-->
+    <!--M_]3 #text/0 4-->
+    <!--M_[-->
     <div>
       Hello world
     </div>
     <!--M_*8 #div/0-->
-    <!--M_]7 #text/0-->
-    <!--M_[11-->
+    <!--M_]7 #text/0 8-->
+    <!--M_[-->
     <div>
       Hello world
     </div>
     <!--M_*11 #div/0-->
-    <!--M_]10 #text/0-->
+    <!--M_]10 #text/0 11-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.j = [0, _.g = {
@@ -78,6 +78,9 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text0
+INSERT html/body/#text1
+INSERT html/body/#text2
 INSERT html/body/div2/#text
 INSERT html/body/div0/#text
 INSERT html/body/div1/#text

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/ssr.expected.md
@@ -1,25 +1,25 @@
 # Write
 ```html
-  <!--M_[4--><div></div><!--M_*4 #div/0--><!--M_]3 #text/0--><!--M_[8--><div></div><!--M_*8 #div/0--><!--M_]7 #text/0--><!--M_[11--><div></div><!--M_*11 #div/0--><!--M_]10 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.j=[0,_.g={"ConditionalScope:#text/0":_.i={"ConditionalScope:#text/0":_.a={"ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":5}},"ConditionalScope:#text/2":_.c={"ConditionalScope:#text/0":_.d={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":9},"ConditionalScope:#text/3":_.e={"ConditionalScope:#text/0":_.f={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":12},"#childScope/1":_.h={}},_.i,_.a,_.b,1,_.h,_.c,_.d,1,_.e,_.f,1,{_:_.g}],_.b["#TagVariable"]=_._["__tests__/template.marko_2_setHtml/var"](_.a),_.a.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.b),_.d["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.c),_.c.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.d),_.f["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.e),_.e.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.f),_.h.input_value=_._["__tests__/template.marko_0_$hoisted_setHtml/hoist"](_.g),_.j),"__tests__/tags/thing.marko_0_input_value",6,"__tests__/template.marko_5",13,"__tests__/template.marko_0",1];M._.w()</script>
+  <!--M_[--><div></div><!--M_*4 #div/0--><!--M_]3 #text/0 4--><!--M_[--><div></div><!--M_*8 #div/0--><!--M_]7 #text/0 8--><!--M_[--><div></div><!--M_*11 #div/0--><!--M_]10 #text/0 11--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.j=[0,_.g={"ConditionalScope:#text/0":_.i={"ConditionalScope:#text/0":_.a={"ConditionalScope:#text/0":_.b={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":5}},"ConditionalScope:#text/2":_.c={"ConditionalScope:#text/0":_.d={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":9},"ConditionalScope:#text/3":_.e={"ConditionalScope:#text/0":_.f={},"ConditionalRenderer:#text/0":"__tests__/tags/child.marko","#scopeOffset/1":12},"#childScope/1":_.h={}},_.i,_.a,_.b,1,_.h,_.c,_.d,1,_.e,_.f,1,{_:_.g}],_.b["#TagVariable"]=_._["__tests__/template.marko_2_setHtml/var"](_.a),_.a.setHtml=_._["__tests__/tags/child.marko_0/_return"](_.b),_.d["#TagVariable"]=_._["__tests__/template.marko_3_setHtml2/var"](_.c),_.c.setHtml2=_._["__tests__/tags/child.marko_0/_return"](_.d),_.f["#TagVariable"]=_._["__tests__/template.marko_4_setHtml3/var"](_.e),_.e.setHtml3=_._["__tests__/tags/child.marko_0/_return"](_.f),_.h.input_value=_._["__tests__/template.marko_0_$hoisted_setHtml/hoist"](_.g),_.j),"__tests__/tags/thing.marko_0_input_value",6,"__tests__/template.marko_5",13,"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[4-->
+<!--M_[-->
 <html>
   <head />
   <body>
     <div />
     <!--M_*4 #div/0-->
-    <!--M_]3 #text/0-->
-    <!--M_[8-->
+    <!--M_]3 #text/0 4-->
+    <!--M_[-->
     <div />
     <!--M_*8 #div/0-->
-    <!--M_]7 #text/0-->
-    <!--M_[11-->
+    <!--M_]7 #text/0 8-->
+    <!--M_[-->
     <div />
     <!--M_*11 #div/0-->
-    <!--M_]10 #text/0-->
+    <!--M_]10 #text/0 11-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.j = [0, _.g = {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/resume.expected.md
@@ -5,7 +5,7 @@
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_]1 #text/1-->
     <script>
       WALKER_RUNTIME("M")("_");
@@ -33,7 +33,7 @@ container.querySelector("button").click();
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     hi
     <script>
       WALKER_RUNTIME("M")("_");
@@ -66,7 +66,7 @@ container.querySelector("button").click();
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_]1 #text/1-->
     <script>
       WALKER_RUNTIME("M")("_");
@@ -99,7 +99,7 @@ container.querySelector("button").click();
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     hi
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button></button><!--M_*1 #button/0--><!--M_[2--><!--M_]1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{show:!1}]),"__tests__/template.marko_0_show",1];M._.w()</script>
+  <button></button><!--M_*1 #button/0--><!--M_[--><!--M_]1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{show:!1}]),"__tests__/template.marko_0_show",1];M._.w()</script>
 ```
 
 # Render End
@@ -10,7 +10,7 @@
   <body>
     <button />
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_]1 #text/1-->
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/resume.expected.md
@@ -3,11 +3,11 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <div>
       baz
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -24,4 +24,5 @@
 ```
 REMOVE html/body/#comment0 before html
 INSERT html/body/#comment0
+INSERT html/body/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/ssr.expected.md
@@ -1,18 +1,18 @@
 # Write
 ```html
-  <!--M_[2--><div>baz</div><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"__tests__/tags/baz.marko"},_.a])]</script>
+  <!--M_[--><div>baz</div><!--M_]1 #text/0 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={},"ConditionalRenderer:#text/0":"__tests__/tags/baz.marko"},_.a])]</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
     <div>
       baz
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/resume.expected.md
@@ -14,9 +14,9 @@
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
-          <!--M_[3-->
+          <!--M_[-->
           Hi
-          <!--M_]2 #a/0-->
+          <!--M_]2 #a/0 3-->
         </a>
         <!--M_'1 #text/2 2-->
       </svg>
@@ -29,19 +29,19 @@
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
-          <!--M_[5-->
+          <!--M_[-->
           Hi
-          <!--M_]4 #a/0-->
+          <!--M_]4 #a/0 5-->
         </a>
         <!--M_'1 #text/4 4-->
       </math>
       <div>
-        <!--M_[7-->
+        <!--M_[-->
         <a
           href="#"
           ns="http://www.w3.org/1999/xhtml"
         />
-        <!--M_]6 #div/0-->
+        <!--M_]6 #div/0 7-->
       </div>
       <!--M_'1 #text/5 6-->
       <button
@@ -96,6 +96,9 @@
 
 # Mutations
 ```
+INSERT html/body/div/svg/a1/#text1
+INSERT html/body/div/math/a1/#text1
+INSERT html/body/div/div/#text
 UPDATE html/body/div/svg/a0[ns] null => "http://www.w3.org/2000/svg"
 UPDATE html/body/div/svg/a1[ns] null => "http://www.w3.org/2000/svg"
 UPDATE html/body/div/math/a0[ns] null => "http://www.w3.org/1998/Math/MathML"
@@ -121,9 +124,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
-          <!--M_[3-->
+          <!--M_[-->
           Hi
-          <!--M_]2 #a/0-->
+          <!--M_]2 #a/0 3-->
         </a>
         <!--M_'1 #text/2 2-->
       </svg>
@@ -136,9 +139,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
-          <!--M_[5-->
+          <!--M_[-->
           Hi
-          <!--M_]4 #a/0-->
+          <!--M_]4 #a/0 5-->
         </a>
         <!--M_'1 #text/4 4-->
       </math>
@@ -227,9 +230,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
-          <!--M_[3-->
+          <!--M_[-->
           Hi
-          <!--M_]2 #a/0-->
+          <!--M_]2 #a/0 3-->
         </a>
         <!--M_'1 #text/2 2-->
       </svg>
@@ -242,9 +245,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
-          <!--M_[5-->
+          <!--M_[-->
           Hi
-          <!--M_]4 #a/0-->
+          <!--M_]4 #a/0 5-->
         </a>
         <!--M_'1 #text/4 4-->
       </math>
@@ -333,9 +336,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/2000/svg"
         >
-          <!--M_[3-->
+          <!--M_[-->
           Hi
-          <!--M_]2 #a/0-->
+          <!--M_]2 #a/0 3-->
         </a>
         <!--M_'1 #text/2 2-->
       </svg>
@@ -348,9 +351,9 @@ container.querySelector(".toggle-parent").click();
           href="#bar"
           ns="http://www.w3.org/1998/Math/MathML"
         >
-          <!--M_[5-->
+          <!--M_[-->
           Hi
-          <!--M_]4 #a/0-->
+          <!--M_]4 #a/0 5-->
         </a>
         <!--M_'1 #text/4 4-->
       </math>

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><svg><a href=#></a><a href=#bar><!--M_[3-->Hi<!--M_]2 #a/0--></a><!--M_'1 #text/2 2--></svg><math><a href=#></a><a href=#bar><!--M_[5-->Hi<!--M_]4 #a/0--></a><!--M_'1 #text/4 4--></math><div><!--M_[7--><a href=#></a><!--M_]6 #div/0--></div><!--M_'1 #text/5 6--><button class=toggle-parent>Toggle Parent</button><!--M_*1 #button/6--><button class=toggle-child>Toggle Child</button><!--M_*1 #button/7--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_content"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_content"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#>\x3C/a>",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()</script>
+  <div><svg><a href=#></a><a href=#bar><!--M_[-->Hi<!--M_]2 #a/0 3--></a><!--M_'1 #text/2 2--></svg><math><a href=#></a><a href=#bar><!--M_[-->Hi<!--M_]4 #a/0 5--></a><!--M_'1 #text/4 4--></math><div><!--M_[--><a href=#></a><!--M_]6 #div/0 7--></div><!--M_'1 #text/5 6--><button class=toggle-parent>Toggle Parent</button><!--M_*1 #button/6--><button class=toggle-child>Toggle Child</button><!--M_*1 #button/7--></div><!--M_*1 #div/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.g=[0,{"ConditionalScope:#text/2":_.a={"ConditionalScope:#a/0":_.b={},"ConditionalRenderer:#a/0":"__tests__/template.marko_2_content"},"ConditionalRenderer:#text/2":"a","ConditionalScope:#text/4":_.c={"ConditionalScope:#a/0":_.d={},"ConditionalRenderer:#a/0":"__tests__/template.marko_3_content"},"ConditionalRenderer:#text/4":"a","ConditionalScope:#text/5":_.e={"ConditionalScope:#div/0":_.f={},"ConditionalRenderer:#div/0":"__tests__/template.marko_1_content"},"ConditionalRenderer:#text/5":"div",input_value:"\x3Ca href=#>\x3C/a>",Parent:"div",Child:"a"},_.a,_.b,_.c,_.d,_.e,_.f]),"__tests__/template.marko_0_Parent_Child",1,"__tests__/template.marko_0_Child",1,"__tests__/template.marko_0_Parent",1];M._.w()</script>
 ```
 
 # Render End
@@ -16,9 +16,9 @@
         <a
           href="#bar"
         >
-          <!--M_[3-->
+          <!--M_[-->
           Hi
-          <!--M_]2 #a/0-->
+          <!--M_]2 #a/0 3-->
         </a>
         <!--M_'1 #text/2 2-->
       </svg>
@@ -29,18 +29,18 @@
         <a
           href="#bar"
         >
-          <!--M_[5-->
+          <!--M_[-->
           Hi
-          <!--M_]4 #a/0-->
+          <!--M_]4 #a/0 5-->
         </a>
         <!--M_'1 #text/4 4-->
       </math>
       <div>
-        <!--M_[7-->
+        <!--M_[-->
         <a
           href="#"
         />
-        <!--M_]6 #div/0-->
+        <!--M_]6 #div/0 7-->
       </div>
       <!--M_'1 #text/5 6-->
       <button

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/resume.expected.md
@@ -1,9 +1,9 @@
 # Render
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Increment 
       <!---->
@@ -12,7 +12,7 @@
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 
       <!---->
@@ -21,7 +21,7 @@
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 
       <!---->
@@ -30,7 +30,7 @@
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -69,6 +69,8 @@
 
 # Mutations
 ```
+REMOVE html/body/#comment0 before html
+INSERT html/body/#comment0
 INSERT html/body/#text0
 INSERT html/body/#text1
 INSERT html/body/#text2
@@ -80,16 +82,16 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 
       <!---->
@@ -98,7 +100,7 @@ buttonIndex = (buttonIndex + 1) % 3;
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 
       <!---->
@@ -107,7 +109,7 @@ buttonIndex = (buttonIndex + 1) % 3;
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -157,22 +159,22 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Confirm 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 
       <!---->
@@ -181,7 +183,7 @@ buttonIndex = (buttonIndex + 1) % 3;
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -231,28 +233,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Confirm 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Confirm 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -302,28 +304,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Increment 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Confirm 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Confirm 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -373,28 +375,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Increment 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Confirm 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -444,28 +446,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Increment 1
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -515,28 +517,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 2
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 1
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -586,28 +588,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 2
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Confirm 2
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 1
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {
@@ -657,28 +659,28 @@ container.querySelectorAll("button")[buttonIndex].click();
 buttonIndex = (buttonIndex + 1) % 3;
 ```
 ```html
-<!--M_[2-->
 <html>
   <head />
   <body>
+    <!--M_[-->
     <button>
       Confirm 2
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Confirm 2
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Confirm 2
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <!--M_[2--><button>Increment <!>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/0 3--><!--M_[4 --><button>Increment <!>0<!--M_*5 #text/1--></button><!--M_*5 #button/0--><!--M_|4 #text/0 5--><!--M_[6 --><button>Increment <!>0<!--M_*7 #text/1--></button><!--M_*7 #button/0--><!--M_|6 #text/0 7--><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.i=[0,_.d={"LoopScopeMap:#text/0":new Map(_.a=[[0,_.b={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.c={},count:0,i:0}],[1,_.e={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.f={},count:0,i:1}],[2,_.g={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.h={},count:0,i:2}]]),counts:[0,0,0],"ClosureScopes:counts":new Set},_.b,_.c,_.e,_.f,_.g,_.h],_.c._=_.b,_.b._=_.e._=_.g._=_.d,_.f._=_.e,_.h._=_.g,_.i),"__tests__/template.marko_3",3,5,7];M._.w()</script>
+  <!--M_[--><button>Increment <!>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/0 3--><!--M_[2--><button>Increment <!>0<!--M_*5 #text/1--></button><!--M_*5 #button/0--><!--M_|4 #text/0 5--><!--M_[4--><button>Increment <!>0<!--M_*7 #text/1--></button><!--M_*7 #button/0--><!--M_|6 #text/0 7--><!--M_]1 #text/0 6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.i=[0,_.d={"LoopScopeMap:#text/0":new Map(_.a=[[0,_.b={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.c={},count:0,i:0}],[1,_.e={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.f={},count:0,i:1}],[2,_.g={"ConditionalRenderer:#text/0":1,"ConditionalScope:#text/0":_.h={},count:0,i:2}]]),counts:[0,0,0],"ClosureScopes:counts":new Set},_.b,_.c,_.e,_.f,_.g,_.h],_.c._=_.b,_.b._=_.e._=_.g._=_.d,_.f._=_.e,_.h._=_.g,_.i),"__tests__/template.marko_3",3,5,7];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
+<!--M_[-->
 <html>
   <head />
   <body>
@@ -17,7 +17,7 @@
     </button>
     <!--M_*3 #button/0-->
     <!--M_|2 #text/0 3-->
-    <!--M_[4 -->
+    <!--M_[2-->
     <button>
       Increment 
       <!---->
@@ -26,7 +26,7 @@
     </button>
     <!--M_*5 #button/0-->
     <!--M_|4 #text/0 5-->
-    <!--M_[6 -->
+    <!--M_[4-->
     <button>
       Increment 
       <!---->
@@ -35,7 +35,7 @@
     </button>
     <!--M_*7 #button/0-->
     <!--M_|6 #text/0 7-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 6-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.i = [0, _.d = {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/__snapshots__/resume.expected.md
@@ -10,9 +10,9 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     bcd
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     e
     <script>
       WALKER_RUNTIME("M")("_");
@@ -32,4 +32,9 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text4
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  a<!--M_[2--><!--M_!^b-->_A_<!--M_!b--><!--M_]1 #text/0-->e<style M_>t{display:none}</style><t M_=b>b<!--M_#c-->d</t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)];REORDER_RUNTIME(M._);M._.w()</script>
+  a<!--M_[--><!--M_!^b-->_A_<!--M_!b--><!--M_]1 #text/0 2-->e<style M_>t{display:none}</style><t M_=b>b<!--M_#c-->d</t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)];REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Write
@@ -25,9 +25,9 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     bcd
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     e
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/__snapshots__/resume.expected.md
@@ -4,9 +4,9 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     b
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     c
     <script>
       WALKER_RUNTIME("M")("_");
@@ -21,4 +21,9 @@
     de
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  a<!--M_[2-->b<!--M_]1 #text/0-->c<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  a<!--M_[-->b<!--M_]1 #text/0 2-->c<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Write
@@ -14,9 +14,9 @@
   <head />
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     b
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     c
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/resume.expected.md
@@ -4,8 +4,8 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
-      <!--M_]1 #div/0-->
+      <!--M_[-->
+      <!--M_)1 #div/0-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -27,7 +27,8 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
+      <!--M_[-->
+      <!--M_)1 #div/0-->
       ABCD
     </div>
     <script>
@@ -46,6 +47,5 @@
 # Mutations
 ```
 INSERT html/body/div/#text0, html/body/div/#text1, html/body/div/#text2
-REMOVE #comment after html/body/div/#text2
 UPDATE html/body/div/#text1 "" => "C"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><!--M_[2--><!--M_]1 #div/0--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{}]),"__tests__/template.marko_0",1];M._.w()</script>
+  <div><!--M_[--><!--M_)1 #div/0--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{}]),"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
@@ -9,8 +9,8 @@
   <head />
   <body>
     <div>
-      <!--M_[2-->
-      <!--M_]1 #div/0-->
+      <!--M_[-->
+      <!--M_)1 #div/0-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/__snapshots__/resume.expected.md
@@ -10,12 +10,12 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     bcd
-    <!--M_[3-->
+    <!--M_[-->
     efg
-    <!--M_]2 #text/1-->
-    <!--M_]1 #text/0-->
+    <!--M_]2 #text/1 3-->
+    <!--M_]1 #text/0 2-->
     h
     <script>
       WALKER_RUNTIME("M")("_");
@@ -47,5 +47,6 @@
 
 # Mutations
 ```
+INSERT html/body/#text8
 INSERT html/body/#text7
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  a<!--M_[2--><!--M_!^b-->_B_<!--M_!b--><!--M_]1 #text/0-->h<style M_>t{display:none}</style><t M_=b>b<!--M_#c-->d<!--M_[3--><!--M_!^d-->_A_<!--M_!d--><!--M_]2 #text/1--></t><t M_=d>e<!--M_#e-->g</t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalScope:#text/0":_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"},"#BranchAccessor":"#text/0"}},_.a,_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_5_content"](_.a),_.a["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.c),_.d)];REORDER_RUNTIME(M._);M._.w()</script>
+  a<!--M_[--><!--M_!^b-->_B_<!--M_!b--><!--M_]1 #text/0 2-->h<style M_>t{display:none}</style><t M_=b>b<!--M_#c-->d<!--M_[--><!--M_!^d-->_A_<!--M_!d--><!--M_]2 #text/1 3--></t><t M_=d>e<!--M_#e-->g</t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalScope:#text/0":_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"},"#BranchAccessor":"#text/0"}},_.a,_.b],_.b["#PlaceholderContent"]=_._["__tests__/template.marko_5_content"](_.a),_.a["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.c),_.d)];REORDER_RUNTIME(M._);M._.w()</script>
 ```
 
 # Write
@@ -30,12 +30,12 @@
   </head>
   <body>
     a
-    <!--M_[2-->
+    <!--M_[-->
     bcd
-    <!--M_[3-->
+    <!--M_[-->
     efg
-    <!--M_]2 #text/1-->
-    <!--M_]1 #text/0-->
+    <!--M_]2 #text/1 3-->
+    <!--M_]1 #text/0 2-->
     h
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/.name-cache.json
@@ -1,0 +1,19 @@
+{
+  "vars": {
+    "props": {
+      "$_": "o",
+      "$init": "t",
+      "$$if_content": "r",
+      "$$for_content__if": "_",
+      "$$for_content__items_length": "n",
+      "$$for_content__setup": "c",
+      "$$for_content": "i",
+      "$$itemId__OR__items__script": "m",
+      "$$itemId__OR__items": "a",
+      "$$itemId": "e",
+      "$$for": "f",
+      "$$items": "s",
+      "$$items_length": "d"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,61 @@
+# Render
+```html
+<div>
+  a
+</div>
+<button>
+  More
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<button>
+  More
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<button>
+  More
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/csr.expected.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<!---->
+<div>
+  a
+</div>
+<!---->
+<button>
+  More
+</button>
+```
+
+# Mutations
+```
+INSERT #comment0, div, #text, #comment1, button
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<!---->
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<!---->
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<!---->
+<button>
+  More
+</button>
+```
+
+# Mutations
+```
+INSERT div2, #text, #comment2
+INSERT div1
+REMOVE #text after div1
+INSERT div3
+REMOVE #text after div3
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<!---->
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<!---->
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<!---->
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<!---->
+<button>
+  More
+</button>
+```
+
+# Mutations
+```
+INSERT div4, #text, #comment3
+INSERT div5
+REMOVE #text after div5
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,29 @@
+// size: 357 (min) 226 (brotli)
+const $if_content = _._content_branch("<div>b</div>", "b"),
+  $for_content__if = _._if(0, $if_content),
+  $for_content__items_length = _._for_closure(5, 0, ($scope, items_length) =>
+    $for_content__if($scope, items_length > 1 ? 0 : 1),
+  ),
+  $for_content__setup = $for_content__items_length,
+  $for_content = _._content_branch(
+    "<div>a</div><!><!>",
+    "b%c",
+    $for_content__setup,
+  ),
+  $itemId__OR__items__script = _._script(
+    "a0",
+    ($scope, { 2: itemId, 3: items }) =>
+      _._on($scope[1], "click", function () {
+        $items($scope, (items = [...items, $itemId($scope, ++itemId)]));
+      }),
+  ),
+  $itemId__OR__items = _._or(4, $itemId__OR__items__script),
+  $itemId = _._let(2, $itemId__OR__items),
+  $for = _._for_of(0, $for_content),
+  $items = _._let(3, ($scope, items) => {
+    ($items_length($scope, items?.length),
+      $for($scope, [items]),
+      $itemId__OR__items($scope));
+  }),
+  $items_length = _._const(5, $for_content__items_length);
+init();

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.js
@@ -1,0 +1,28 @@
+export const $template = "<!><!><button>More</button>";
+export const $walks = /* over(1), replace, over(1), get, over(1) */"b%b b";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $if_content = /* @__PURE__ */_._content_branch("<div>b</div>", /* over(1) */"b");
+const $for_content__if = /* @__PURE__ */_._if("#text/0", $if_content);
+const $for_content__items_length = /* @__PURE__ */_._for_closure("items_length", "#text/0", ($scope, items_length) => $for_content__if($scope, items_length > 1 ? 0 : 1));
+const $for_content__setup = $for_content__items_length;
+const $for_content = /* @__PURE__ */_._content_branch("<div>a</div><!><!>", /* over(1), replace, over(2) */"b%c", $for_content__setup);
+const $itemId__OR__items__script = _._script("__tests__/template.marko_0_itemId_items", ($scope, {
+  itemId,
+  items
+}) => _._on($scope["#button/1"], "click", function () {
+  $items($scope, items = [...items, $itemId($scope, ++itemId)]);
+}));
+const $itemId__OR__items = /* @__PURE__ */_._or(4, $itemId__OR__items__script);
+const $itemId = /* @__PURE__ */_._let("itemId/2", $itemId__OR__items);
+const $for = /* @__PURE__ */_._for_of("#text/0", $for_content);
+const $items = /* @__PURE__ */_._let("items/3", ($scope, items) => {
+  $items_length($scope, items?.length);
+  $for($scope, [items]);
+  $itemId__OR__items($scope);
+});
+export function $setup($scope) {
+  $itemId($scope, 0);
+  $items($scope, [0]);
+}
+const $items_length = /* @__PURE__ */_._const("items_length", $for_content__items_length);
+export default /* @__PURE__ */_._template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/html.expected/template.js
@@ -1,0 +1,33 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/template.marko", input => {
+  const $scope0_id = _._scope_id();
+  let itemId = 0;
+  let items = [0];
+  _._for_of(items, () => {
+    const $scope1_id = _._scope_id();
+    _._html("<div>a</div>");
+    _._if(() => {
+      if (items.length > 1) {
+        const $scope2_id = _._scope_id();
+        _._html("<div>b</div>");
+        _._scope($scope2_id, {}, "__tests__/template.marko", "6:4");
+        return 0;
+      }
+    }, $scope1_id, "#text/0", 1, /* state: items.length */1, 0, 1);
+    _._scope($scope1_id, {
+      _: _._scope_with_id($scope0_id)
+    }, "__tests__/template.marko", "4:2");
+  }, 0, $scope0_id, "#text/0");
+  _._html(`<button>More</button>${_._el_resume($scope0_id, "#button/1")}`);
+  _._script($scope0_id, "__tests__/template.marko_0_itemId_items");
+  _._scope($scope0_id, {
+    itemId,
+    items,
+    items_length: items?.length
+  }, "__tests__/template.marko", 0, {
+    itemId: "1:6",
+    items: "2:6",
+    items_length: ["items.length", "2:6"]
+  });
+  _._resume_branch($scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,61 @@
+# Render
+```html
+<div>
+  a
+</div>
+<button>
+  More
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<button>
+  More
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<div>
+  a
+</div>
+<div>
+  b
+</div>
+<button>
+  More
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/resume.expected.md
@@ -1,0 +1,155 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <!--M_[-->
+    <div>
+      a
+    </div>
+    <!--M_|2 #text/0-->
+    <!--M_]1 #text/0 2-->
+    <button>
+      More
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.d = [0, _.b = {
+          "LoopScopeMap:#text/0": new Map(_.a = [
+            [0, _.c = {}]
+          ]),
+          itemId: 0,
+          items: [0],
+          items_length: 1
+        }, _.c], _.c._ = _.b, _.d),
+        "__tests__/template.marko_0_itemId_items",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE html/body/#comment0 before html
+INSERT html/body/#comment0
+INSERT html/body/#text
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <!--M_[-->
+    <div>
+      a
+    </div>
+    <div>
+      b
+    </div>
+    <div>
+      a
+    </div>
+    <div>
+      b
+    </div>
+    <!---->
+    <!--M_]1 #text/0 2-->
+    <button>
+      More
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.d = [0, _.b = {
+          "LoopScopeMap:#text/0": new Map(_.a = [
+            [0, _.c = {}]
+          ]),
+          itemId: 0,
+          items: [0],
+          items_length: 1
+        }, _.c], _.c._ = _.b, _.d),
+        "__tests__/template.marko_0_itemId_items",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div2, #text, html/body/#comment1
+INSERT html/body/div1
+REMOVE #comment after html/body/div1
+INSERT html/body/div3
+REMOVE #text after html/body/div3
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <!--M_[-->
+    <div>
+      a
+    </div>
+    <div>
+      b
+    </div>
+    <div>
+      a
+    </div>
+    <div>
+      b
+    </div>
+    <!---->
+    <div>
+      a
+    </div>
+    <div>
+      b
+    </div>
+    <!---->
+    <!--M_]1 #text/0 2-->
+    <button>
+      More
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.d = [0, _.b = {
+          "LoopScopeMap:#text/0": new Map(_.a = [
+            [0, _.c = {}]
+          ]),
+          itemId: 0,
+          items: [0],
+          items_length: 1
+        }, _.c], _.c._ = _.b, _.d),
+        "__tests__/template.marko_0_itemId_items",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html/body/div4, #text, html/body/#comment2
+INSERT html/body/div5
+REMOVE #text after html/body/div5
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,9 @@
+# Render End
+```html
+<div>
+  a
+</div>
+<button>
+  More
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/ssr.expected.md
@@ -1,0 +1,55 @@
+# Write
+```html
+  <!--M_[--><div>a</div><!--M_|2 #text/0--><!--M_]1 #text/0 2--><button>More</button><!--M_*1 #button/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.b={"LoopScopeMap:#text/0":new Map(_.a=[[0,_.c={}]]),itemId:0,items:[0],items_length:1},_.c],_.c._=_.b,_.d),"__tests__/template.marko_0_itemId_items",1];M._.w()</script>
+```
+
+# Render End
+```html
+<!--M_[-->
+<html>
+  <head />
+  <body>
+    <div>
+      a
+    </div>
+    <!--M_|2 #text/0-->
+    <!--M_]1 #text/0 2-->
+    <button>
+      More
+    </button>
+    <!--M_*1 #button/1-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.d = [0, _.b = {
+          "LoopScopeMap:#text/0": new Map(_.a = [
+            [0, _.c = {}]
+          ]),
+          itemId: 0,
+          items: [0],
+          items_length: 1
+        }, _.c], _.c._ = _.b, _.d),
+        "__tests__/template.marko_0_itemId_items",
+        1
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT #comment
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/div
+INSERT html/body/div/#text
+INSERT html/body/#comment0
+INSERT html/body/#comment1
+INSERT html/body/button
+INSERT html/body/button/#text
+INSERT html/body/#comment2
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/template.marko
@@ -1,0 +1,13 @@
+<let/itemId=0>
+<let/items=[0]>
+
+<for of=items>
+  <div>a</div>
+  <if=(items.length > 1)>
+    <div>b</div>
+  </if>
+</for>
+
+<button onClick() { items = [...items, ++itemId] }>
+  More
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/test.ts
@@ -1,0 +1,5 @@
+const click = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+export const steps = [{}, click, click];

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/resume.expected.md
@@ -1,7 +1,7 @@
 # Render
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -12,8 +12,8 @@
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >
@@ -72,8 +72,8 @@
 container.querySelector("button.once").click();
 ```
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -84,8 +84,8 @@ container.querySelector("button.once").click();
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >
@@ -148,8 +148,8 @@ UPDATE html/body/button0/#text "0" => "1"
 container.querySelector("button.once").click();
 ```
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -160,8 +160,8 @@ container.querySelector("button.once").click();
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >
@@ -220,8 +220,8 @@ container.querySelector("button.once").click();
 container.querySelector("button.twice").click();
 ```
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -232,8 +232,8 @@ container.querySelector("button.twice").click();
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >
@@ -296,8 +296,8 @@ UPDATE html/body/button1/#text "0" => "1"
 container.querySelector("button.twice").click();
 ```
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -308,8 +308,8 @@ container.querySelector("button.twice").click();
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >
@@ -372,8 +372,8 @@ UPDATE html/body/button1/#text "1" => "2"
 container.querySelector("button.twice").click();
 ```
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -384,8 +384,8 @@ container.querySelector("button.twice").click();
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/ssr.expected.md
@@ -1,12 +1,12 @@
 # Write
 ```html
-  <!--M_[2--><!--M_]1 #text/0--><button class=once>0<!--M_*1 #text/3--></button><!--M_*1 #button/2--><!--M_[4--><!--M_]1 #text/4--><button class=twice>0<!--M_*1 #text/7--></button><!--M_*1 #button/6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={"ConditionalScope:#text/0":_.b={call:1},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content","#scopeOffset/1":3,"ConditionalScope:#text/4":_.c={call:2},"ConditionalRenderer:#text/4":"__tests__/template.marko_2_content","#scopeOffset/5":5,Once:_.d={},clickOnceCount:0,Twice:_.e={},clickTwiceCount:0},_.b,1,_.c],_.b.value=_._["__tests__/template.marko_0/onClickOnce"](_.a),_.b["#TagVariable"]=_._["__tests__/template.marko_0_onClickOnce/var"](_.a),_.c.value=_._["__tests__/template.marko_0/onClickTwice"](_.a),_.c["#TagVariable"]=_._["__tests__/template.marko_0_onClickTwice/var"](_.a),_.d.content=_._["__tests__/template.marko_1_content"](_.a),_.a.onClickOnce=_._["__tests__/template.marko_1/_return"](_.b),_.e.content=_._["__tests__/template.marko_2_content"](_.a),_.a.onClickTwice=_._["__tests__/template.marko_2/_return2"](_.c),_.f),"__tests__/template.marko_0_onClickTwice",1,"__tests__/template.marko_0_onClickOnce",1];M._.w()</script>
+  <!--M_[--><!--M_]1 #text/0 2--><button class=once>0<!--M_*1 #text/3--></button><!--M_*1 #button/2--><!--M_[--><!--M_]1 #text/4 4--><button class=twice>0<!--M_*1 #text/7--></button><!--M_*1 #button/6--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.f=[0,_.a={"ConditionalScope:#text/0":_.b={call:1},"ConditionalRenderer:#text/0":"__tests__/template.marko_1_content","#scopeOffset/1":3,"ConditionalScope:#text/4":_.c={call:2},"ConditionalRenderer:#text/4":"__tests__/template.marko_2_content","#scopeOffset/5":5,Once:_.d={},clickOnceCount:0,Twice:_.e={},clickTwiceCount:0},_.b,1,_.c],_.b.value=_._["__tests__/template.marko_0/onClickOnce"](_.a),_.b["#TagVariable"]=_._["__tests__/template.marko_0_onClickOnce/var"](_.a),_.c.value=_._["__tests__/template.marko_0/onClickTwice"](_.a),_.c["#TagVariable"]=_._["__tests__/template.marko_0_onClickTwice/var"](_.a),_.d.content=_._["__tests__/template.marko_1_content"](_.a),_.a.onClickOnce=_._["__tests__/template.marko_1/_return"](_.b),_.e.content=_._["__tests__/template.marko_2_content"](_.a),_.a.onClickTwice=_._["__tests__/template.marko_2/_return2"](_.c),_.f),"__tests__/template.marko_0_onClickTwice",1,"__tests__/template.marko_0_onClickOnce",1];M._.w()</script>
 ```
 
 # Render End
 ```html
-<!--M_[2-->
-<!--M_]1 #text/0-->
+<!--M_[-->
+<!--M_]1 #text/0 2-->
 <html>
   <head />
   <body>
@@ -17,8 +17,8 @@
       <!--M_*1 #text/3-->
     </button>
     <!--M_*1 #button/2-->
-    <!--M_[4-->
-    <!--M_]1 #text/4-->
+    <!--M_[-->
+    <!--M_]1 #text/4 4-->
     <button
       class="twice"
     >

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/resume.expected.md
@@ -8,7 +8,7 @@
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -21,7 +21,7 @@
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -69,7 +69,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -82,7 +82,7 @@ container.querySelector("#count").click();
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -130,7 +130,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -143,7 +143,7 @@ container.querySelector("#count").click();
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -191,14 +191,14 @@ container.querySelector("#inner").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
       <!--M_*2 #button/0-->
       <!--M_|2 #text/1 3-->
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -248,7 +248,7 @@ container.querySelector("#inner").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -259,7 +259,7 @@ container.querySelector("#inner").click();
         2
       </button>
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -309,7 +309,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -320,7 +320,7 @@ container.querySelector("#count").click();
         3
       </button>
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");
@@ -368,7 +368,7 @@ container.querySelector("#outer").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><button id=outer></button><!--M_*1 #button/0--><!--M_[2--><button id=inner></button><!--M_*2 #button/0--><button id=count>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/1 3--><!--M_]1 #text/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:count":0}},outer:!0,inner:!0,count:0,"ClosureScopes:count":_.e=new Set},_.a,_.b],_.b._=_.a,_.a._=_.c,(_.e).add(_.b),_.d),"__tests__/template.marko_2_count",3,"__tests__/template.marko_1_inner",2,"__tests__/template.marko_0_outer",1];M._.w()</script>
+  <div><button id=outer></button><!--M_*1 #button/0--><!--M_[--><button id=inner></button><!--M_*2 #button/0--><button id=count>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/1 3--><!--M_]1 #text/1 2--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:count":0}},outer:!0,inner:!0,count:0,"ClosureScopes:count":_.e=new Set},_.a,_.b],_.b._=_.a,_.a._=_.c,(_.e).add(_.b),_.d),"__tests__/template.marko_2_count",3,"__tests__/template.marko_1_inner",2,"__tests__/template.marko_0_outer",1];M._.w()</script>
 ```
 
 # Render End
@@ -13,7 +13,7 @@
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -26,7 +26,7 @@
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/resume.expected.md
@@ -8,7 +8,7 @@
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -21,7 +21,7 @@
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -70,7 +70,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -83,7 +83,7 @@ container.querySelector("#count").click();
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -132,7 +132,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -145,7 +145,7 @@ container.querySelector("#count").click();
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -194,14 +194,14 @@ container.querySelector("#inner").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
       <!--M_*2 #button/0-->
       <!--M_|2 #text/1 3-->
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -252,7 +252,7 @@ container.querySelector("#inner").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -263,7 +263,7 @@ container.querySelector("#inner").click();
         2
       </button>
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -314,7 +314,7 @@ container.querySelector("#count").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -325,7 +325,7 @@ container.querySelector("#count").click();
         3
       </button>
       <!--M_*3 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>
@@ -374,7 +374,7 @@ container.querySelector("#outer").click();
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><button id=outer></button><!--M_*1 #button/0--><!--M_[2--><button id=inner></button><!--M_*2 #button/0--><button id=count>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/1 3--><!--M_]1 #text/1--> hello</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:count":0}},outer:!0,inner:!0,count:0,"ClosureScopes:count":_.e=new Set},_.a,_.b],_.b._=_.a,_.a._=_.c,(_.e).add(_.b),_.d),"__tests__/template.marko_2_count",3,"__tests__/template.marko_1_inner",2,"__tests__/template.marko_0_outer",1];M._.w()</script>
+  <div><button id=outer></button><!--M_*1 #button/0--><!--M_[--><button id=inner></button><!--M_*2 #button/0--><button id=count>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--M_|2 #text/1 3--><!--M_]1 #text/1 2--> hello</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.c={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.a={"ConditionalRenderer:#text/1":0,"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:count":0}},outer:!0,inner:!0,count:0,"ClosureScopes:count":_.e=new Set},_.a,_.b],_.b._=_.a,_.a._=_.c,(_.e).add(_.b),_.d),"__tests__/template.marko_2_count",3,"__tests__/template.marko_1_inner",2,"__tests__/template.marko_0_outer",1];M._.w()</script>
 ```
 
 # Render End
@@ -13,7 +13,7 @@
         id="outer"
       />
       <!--M_*1 #button/0-->
-      <!--M_[2-->
+      <!--M_[-->
       <button
         id="inner"
       />
@@ -26,7 +26,7 @@
       </button>
       <!--M_*3 #button/0-->
       <!--M_|2 #text/1 3-->
-      <!--M_]1 #text/1-->
+      <!--M_]1 #text/1 2-->
        hello
     </div>
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/resume.expected.md
@@ -9,7 +9,7 @@
         Hello
         <!--M_*2 #text/0-->
       </span>
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <input
       value="Hello"

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><span>Hello<!--M_*2 #text/0--></span><!--M_=1 #div/0 2--></div><input value=Hello><!--M_*1 #input/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#div/0":0,"ConditionalScope:#div/0":_.b={},"ControlledType:#input/1":2,value:"Hello"},_.b],_.b._=_.a,_.a["ControlledHandler:#input/1"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_0",1];M._.w()</script>
+  <div><span>Hello<!--M_*2 #text/0--></span><!--M_}1 #div/0 2--></div><input value=Hello><!--M_*1 #input/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalRenderer:#div/0":0,"ConditionalScope:#div/0":_.b={},"ControlledType:#input/1":2,value:"Hello"},_.b],_.b._=_.a,_.a["ControlledHandler:#input/1"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.c),"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
@@ -13,7 +13,7 @@
         Hello
         <!--M_*2 #text/0-->
       </span>
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <input
       value="Hello"

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/resume.expected.md
@@ -11,7 +11,7 @@
         </button>
         <!--M_*3 #button/0-->
       </div>
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div><div><button>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--></div><!--M_=1 #div/0 2--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalRenderer:#div/0":0,"ConditionalScope:#div/0":_.b={}},_.b,_.c={clickCount:0,"#ClosestBranchId":2}],_.a.onCount=_.c.input_onCount=_._["__tests__/template.marko_0/onCount"](_.a),_.d),"__tests__/tags/counter.marko_0_input_onCount_clickCount",3];M._.w()</script>
+  <div><div><button>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--></div><!--M_}1 #div/0 2--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.d=[0,_.a={"ConditionalRenderer:#div/0":0,"ConditionalScope:#div/0":_.b={}},_.b,_.c={clickCount:0,"#ClosestBranchId":2}],_.a.onCount=_.c.input_onCount=_._["__tests__/template.marko_0/onCount"](_.a),_.d),"__tests__/tags/counter.marko_0_input_onCount_clickCount",3];M._.w()</script>
 ```
 
 # Render End
@@ -16,7 +16,7 @@
         </button>
         <!--M_*3 #button/0-->
       </div>
-      <!--M_=1 #div/0 2-->
+      <!--M_}1 #div/0 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/resume.expected.md
@@ -17,16 +17,16 @@
       0
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
-    <!--M_[4-->
+    <!--M_[-->
     Async: 
     <!---->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 4-->
     <!--M_!b-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -64,6 +64,8 @@
 
 # Mutations
 ```
+INSERT html/body/#text3
+INSERT html/body/#text2
 INSERT html/body/div/#text
 ```
 
@@ -89,16 +91,16 @@ container.querySelector("button").click();
       0
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
-    <!--M_[4-->
+    <!--M_[-->
     Async: 
     <!---->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 4-->
     <!--M_!b-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -155,7 +157,7 @@ container.querySelector("button").click();
     </div>
     <!--M_*1 #div/1-->
     LOADING...
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -201,8 +203,10 @@ REMOVE #document-fragment/#text0 after html/body/#text
 REMOVE #document-fragment/#comment3 after html/body/#text
 REMOVE #document-fragment/#text1 after html/body/#text
 REMOVE #document-fragment/#comment4 after html/body/#text
+REMOVE #document-fragment/#text2 after html/body/#text
 REMOVE #document-fragment/#comment5 after html/body/#text
 REMOVE #document-fragment/#comment6 after html/body/#text
+REMOVE #document-fragment/#text3 after html/body/#text
 ```
 
 # Render ASYNC
@@ -224,16 +228,16 @@ REMOVE #document-fragment/#comment6 after html/body/#text
       1
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
-    <!--M_[4-->
+    <!--M_[-->
     Async: 
     <!---->
     1
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 4-->
     <!--M_!b-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -271,8 +275,8 @@ REMOVE #document-fragment/#comment6 after html/body/#text
 
 # Mutations
 ```
-INSERT html/body/#comment2, html/body/#comment3, html/body/#comment4, html/body/#text0, html/body/#comment5, html/body/#text1, html/body/#comment6, html/body/#comment7, html/body/#comment8
-REMOVE #text after html/body/#comment8
+INSERT html/body/#comment2, html/body/#comment3, html/body/#comment4, html/body/#text0, html/body/#comment5, html/body/#text1, html/body/#comment6, html/body/#text2, html/body/#comment7, html/body/#comment8, html/body/#text3
+REMOVE #text after html/body/#text3
 REMOVE #text in html/body/div
 INSERT html/body/div/#text
 ```
@@ -299,16 +303,16 @@ container.querySelector("button").click();
       1
     </div>
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
-    <!--M_[4-->
+    <!--M_[-->
     Async: 
     <!---->
     1
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 4-->
     <!--M_!b-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -365,7 +369,7 @@ container.querySelector("button").click();
     </div>
     <!--M_*1 #div/1-->
     LOADING...
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -411,8 +415,10 @@ REMOVE #document-fragment/#text0 after html/body/#text
 REMOVE #document-fragment/#comment3 after html/body/#text
 REMOVE #document-fragment/#text1 after html/body/#text
 REMOVE #document-fragment/#comment4 after html/body/#text
+REMOVE #document-fragment/#text2 after html/body/#text
 REMOVE #document-fragment/#comment5 after html/body/#text
 REMOVE #document-fragment/#comment6 after html/body/#text
+REMOVE #document-fragment/#text3 after html/body/#text
 ```
 
 # Render ASYNC
@@ -435,7 +441,7 @@ REMOVE #document-fragment/#comment6 after html/body/#text
     </div>
     <!--M_*1 #div/1-->
     Error: ERROR!
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/ssr.expected.md
@@ -1,11 +1,11 @@
 # Write
 ```html
-  <button>inc</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[2--><!--M_!^b--><!--M_!^c-->LOADING...<!--M_!c--><!--M_!b--><!--M_]1 #text/2--><style M_>t{display:none}</style><t M_=c><!--M_#d--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/2":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/2"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#CatchContent"]=_._["__tests__/template.marko_3_content"](_.a),_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_0_clickCount",1];REORDER_RUNTIME(M._);M._.j.c=_=>{_.push("__tests__/template.marko_1_clickCount",2)};M._.w()</script>
+  <button>inc</button><!--M_*1 #button/0--><div></div><!--M_*1 #div/1--><!--M_[--><!--M_!^b--><!--M_!^c-->LOADING...<!--M_!c--><!--M_!b--><!--M_]1 #text/2 2--><style M_>t{display:none}</style><t M_=c><!--M_#d--></t><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/2":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/2"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#CatchContent"]=_._["__tests__/template.marko_3_content"](_.a),_.b["#PlaceholderContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_0_clickCount",1];REORDER_RUNTIME(M._);M._.j.c=_=>{_.push("__tests__/template.marko_1_clickCount",2)};M._.w()</script>
 ```
 
 # Write
 ```html
-  <t M_=d><!--M_[4-->Async: <!>0<!--M_*4 #text/0--><!--M_]2 #text/0--></t><script>M._.r.push(_=>(_.e=[1,_.f={}],(_.b["ConditionalScope:#text/0"]=_.f),_.e));M._.w()</script>
+  <t M_=d><!--M_[-->Async: <!>0<!--M_*4 #text/0--><!--M_]2 #text/0 4--></t><script>M._.r.push(_=>(_.e=[1,_.f={}],(_.b["ConditionalScope:#text/0"]=_.f),_.e));M._.w()</script>
 ```
 
 # Render End
@@ -25,16 +25,16 @@
     <!--M_*1 #button/0-->
     <div />
     <!--M_*1 #div/1-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M_!^b-->
-    <!--M_[4-->
+    <!--M_[-->
     Async: 
     <!---->
     0
     <!--M_*4 #text/0-->
-    <!--M_]2 #text/0-->
+    <!--M_]2 #text/0 4-->
     <!--M_!b-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/resume.expected.md
@@ -7,7 +7,7 @@
       0
     </div>
     <!--M_*1 #div/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button>
       inc
     </button>
@@ -16,7 +16,7 @@
     <!---->
     ‍
     <!--M_*2 #text/1-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -40,6 +40,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/div/#text
 ```
 
@@ -55,7 +56,7 @@ container.querySelector("button").click();
       1
     </div>
     <!--M_*1 #div/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button>
       inc
     </button>
@@ -64,7 +65,7 @@ container.querySelector("button").click();
     <!---->
     ‍
     <!--M_*2 #text/1-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -105,8 +106,7 @@ container.querySelector("button").click();
     </div>
     <!--M_*1 #div/0-->
     Error: ERROR!
-    <!--M_*2 #text/1-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {
@@ -133,6 +133,8 @@ container.querySelector("button").click();
 INSERT html/body/#text
 REMOVE #comment after html/body/#text
 REMOVE button after html/body/#text
+REMOVE #comment after html/body/#text
+REMOVE #text after html/body/#text
 REMOVE #comment after html/body/#text
 REMOVE #text after html/body/#text
 REMOVE #comment after html/body/#text

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div></div><!--M_*1 #div/0--><!--M_[2--><button>inc</button><!--M_*2 #button/0--> -- <!>&zwj;<!--M_*2 #text/1--><!--M_]1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/1"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_1_clickCount",2];M._.w()</script>
+  <div></div><!--M_*1 #div/0--><!--M_[--><button>inc</button><!--M_*2 #button/0--> -- <!>&zwj;<!--M_*2 #text/1--><!--M_]1 #text/1 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"ClosureSignalIndex:clickCount":0,"#BranchAccessor":"#text/1"},clickCount:0,"ClosureScopes:clickCount":_.d=new Set},_.b],_.b._=_.a,_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),(_.d).add(_.b),_.c),"__tests__/template.marko_1_clickCount",2];M._.w()</script>
 ```
 
 # Render End
@@ -10,7 +10,7 @@
   <body>
     <div />
     <!--M_*1 #div/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button>
       inc
     </button>
@@ -19,7 +19,7 @@
     <!---->
     ‍
     <!--M_*2 #text/1-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.a = {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/resume.expected.md
@@ -5,10 +5,10 @@
   <body>
     <div />
     <!--M_*1 #div/0-->
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <div>
       This is good
     </div>
@@ -34,5 +34,6 @@
 
 # Mutations
 ```
+INSERT html/body/#text1
 INSERT html/body/div1/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div></div><!--M_*1 #div/0--><!--M_[2-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/1--><div></div><!--M_*1 #div/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c),"__tests__/template.marko_0",1];M._.w()</script>
+  <div></div><!--M_*1 #div/0--><!--M_[-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/1 2--><div></div><!--M_*1 #div/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/1":_.b={"#BranchAccessor":"#text/1"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c),"__tests__/template.marko_0",1];M._.w()</script>
 ```
 
 # Render End
@@ -10,10 +10,10 @@
   <body>
     <div />
     <!--M_*1 #div/0-->
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/1-->
+    <!--M_]1 #text/1 2-->
     <div />
     <!--M_*1 #div/2-->
     <script>

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/resume.expected.md
@@ -4,10 +4,10 @@
   <head />
   <body>
     Before
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     After
     <script>
       WALKER_RUNTIME("M")("_");
@@ -22,4 +22,9 @@
     </script>
   </body>
 </html>
+```
+
+# Mutations
+```
+INSERT html/body/#text2
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  Before<!--M_[2-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/0-->After<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
+  Before<!--M_[-->ERROR!<!--M_*3 #text/0--><!--M_]1 #text/0 2-->After<script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.a={"ConditionalScope:#text/0":_.b={"#BranchAccessor":"#text/0"}},_.b,{}],_.b["#CatchContent"]=_._["__tests__/template.marko_2_content"](_.a),_.c)]</script>
 ```
 
 # Render End
@@ -9,10 +9,10 @@
   <head />
   <body>
     Before
-    <!--M_[2-->
+    <!--M_[-->
     ERROR!
     <!--M_*3 #text/0-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     After
     <script>
       WALKER_RUNTIME("M")("_");

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -30,9 +30,10 @@ export enum ResumeSymbol {
   Node = "*",
   BranchStart = "[",
   BranchEnd = "]",
-  BranchSingleNode = "|",
-  BranchNativeTag = "'",
-  BranchSingleNodeOnlyChildInParent = "=",
+  BranchEndNativeTag = "'",
+  BranchEndSingleNode = "|",
+  BranchEndOnlyChildInParent = ")",
+  BranchEndSingleNodeOnlyChildInParent = "}",
 }
 
 export { AccessorPrefix, AccessorProp } from "./accessor.debug";

--- a/packages/runtime-tags/src/html/dynamic-tag.ts
+++ b/packages/runtime-tags/src/html/dynamic-tag.ts
@@ -45,12 +45,14 @@ export let _dynamic_tag = (
 
   const state = getState()!;
   const branchId = _peek_scope_id();
+  let rendered = false;
   let result: unknown;
 
   if (typeof renderer === "string") {
     const input = ((inputIsArgs
       ? (inputOrArgs as unknown[])[0]
       : inputOrArgs) || {}) as Record<string, unknown>;
+    rendered = true;
     _scope_id();
     _html(
       `<${renderer}${_attrs(input, MARKO_DEBUG ? `#${renderer}/0` : 0, branchId, renderer)}>`,
@@ -113,7 +115,7 @@ export let _dynamic_tag = (
     if (shouldResume) {
       _html(
         state.mark(
-          ResumeSymbol.BranchNativeTag,
+          ResumeSymbol.BranchEndNativeTag,
           scopeId + " " + accessor + " " + branchId,
         ),
       );
@@ -122,7 +124,7 @@ export let _dynamic_tag = (
     // TODO: this needs to set result the element getter
   } else {
     if (shouldResume) {
-      _html(state.mark(ResumeSymbol.BranchStart, branchId + ""));
+      _html(state.mark(ResumeSymbol.BranchStart, ""));
     }
 
     const render = () => {
@@ -150,13 +152,18 @@ export let _dynamic_tag = (
       }
     };
     result = shouldResume ? withBranchId(branchId, render) : render();
+    rendered = _peek_scope_id() !== branchId;
 
     if (shouldResume) {
-      _html(state.mark(ResumeSymbol.BranchEnd, scopeId + " " + accessor));
+      _html(
+        state.mark(
+          ResumeSymbol.BranchEnd,
+          scopeId + " " + accessor + (rendered ? " " + branchId : ""),
+        ),
+      );
     }
   }
 
-  const rendered = _peek_scope_id() !== branchId;
   if (rendered) {
     if (shouldResume) {
       _scope(scopeId, {

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -254,7 +254,7 @@ export function _for_of(
   const { state } = $chunk.boundary;
   const resumeBranch = serializeBranch !== 0;
   const resumeMarker = serializeMarker !== 0;
-  let singleNodeBranchIds = "";
+  let flushBranchIds = "";
 
   if (resumeBranch) {
     const loopScopes = new Map<unknown, ScopeInternals>();
@@ -262,11 +262,12 @@ export function _for_of(
       const branchId = _peek_scope_id();
       if (resumeMarker) {
         if (singleNode) {
-          singleNodeBranchIds = " " + branchId + singleNodeBranchIds;
+          flushBranchIds = " " + branchId + flushBranchIds;
         } else {
           $chunk.writeHTML(
-            state.mark(ResumeSymbol.BranchStart, branchId + (index ? " " : "")),
+            state.mark(ResumeSymbol.BranchStart, flushBranchIds),
           );
+          flushBranchIds = branchId + "";
         }
       }
 
@@ -288,18 +289,11 @@ export function _for_of(
   writeBranchEnd(
     scopeId,
     accessor,
+    resumeBranch,
     resumeMarker,
     parentEndTag,
-    resumeMarker &&
-      (!parentEndTag || resumeBranch) &&
-      (singleNode
-        ? state.mark(
-            parentEndTag
-              ? ResumeSymbol.BranchSingleNodeOnlyChildInParent
-              : ResumeSymbol.BranchSingleNode,
-            scopeId + " " + accessor + singleNodeBranchIds,
-          )
-        : state.mark(ResumeSymbol.BranchEnd, scopeId + " " + accessor)),
+    singleNode,
+    singleNode ? flushBranchIds : flushBranchIds ? " " + flushBranchIds : "",
   );
 }
 
@@ -317,21 +311,20 @@ export function _for_in(
   const { state } = $chunk.boundary;
   const resumeBranch = serializeBranch !== 0;
   const resumeMarker = serializeMarker !== 0;
-  let singleNodeBranchIds = "";
+  let flushBranchIds = "";
 
   if (resumeBranch) {
     const loopScopes = new Map<unknown, ScopeInternals>();
-    let sep = "";
     forIn(obj, (key, value) => {
       const branchId = _peek_scope_id();
       if (resumeMarker) {
         if (singleNode) {
-          singleNodeBranchIds = " " + branchId + singleNodeBranchIds;
+          flushBranchIds = " " + branchId + flushBranchIds;
         } else {
           $chunk.writeHTML(
-            state.mark(ResumeSymbol.BranchStart, branchId + sep),
+            state.mark(ResumeSymbol.BranchStart, flushBranchIds),
           );
-          sep = " ";
+          flushBranchIds = branchId + "";
         }
       }
 
@@ -353,18 +346,11 @@ export function _for_in(
   writeBranchEnd(
     scopeId,
     accessor,
+    resumeBranch,
     resumeMarker,
     parentEndTag,
-    resumeMarker &&
-      (!parentEndTag || resumeBranch) &&
-      (singleNode
-        ? state.mark(
-            parentEndTag
-              ? ResumeSymbol.BranchSingleNodeOnlyChildInParent
-              : ResumeSymbol.BranchSingleNode,
-            scopeId + " " + accessor + singleNodeBranchIds,
-          )
-        : state.mark(ResumeSymbol.BranchEnd, scopeId + " " + accessor)),
+    singleNode,
+    singleNode ? flushBranchIds : flushBranchIds ? " " + flushBranchIds : "",
   );
 }
 
@@ -384,21 +370,20 @@ export function _for_to(
   const { state } = $chunk.boundary;
   const resumeBranch = serializeBranch !== 0;
   const resumeMarker = serializeMarker !== 0;
-  let singleNodeBranchIds = "";
+  let flushBranchIds = "";
 
   if (resumeBranch) {
     const loopScopes = new Map<unknown, ScopeInternals>();
-    let sep = "";
     forTo(to, from, step, (i) => {
       const branchId = _peek_scope_id();
       if (resumeMarker) {
         if (singleNode) {
-          singleNodeBranchIds = " " + branchId + singleNodeBranchIds;
+          flushBranchIds = " " + branchId + flushBranchIds;
         } else {
           $chunk.writeHTML(
-            state.mark(ResumeSymbol.BranchStart, branchId + sep),
+            state.mark(ResumeSymbol.BranchStart, flushBranchIds),
           );
-          sep = " ";
+          flushBranchIds = branchId + "";
         }
       }
 
@@ -420,18 +405,11 @@ export function _for_to(
   writeBranchEnd(
     scopeId,
     accessor,
+    resumeBranch,
     resumeMarker,
     parentEndTag,
-    resumeMarker &&
-      (!parentEndTag || resumeBranch) &&
-      (singleNode
-        ? state.mark(
-            parentEndTag
-              ? ResumeSymbol.BranchSingleNodeOnlyChildInParent
-              : ResumeSymbol.BranchSingleNode,
-            scopeId + " " + accessor + singleNodeBranchIds,
-          )
-        : state.mark(ResumeSymbol.BranchEnd, scopeId + " " + accessor)),
+    singleNode,
+    singleNode ? flushBranchIds : flushBranchIds ? " " + flushBranchIds : "",
   );
 }
 
@@ -449,7 +427,7 @@ export function _if(
   const resumeMarker = serializeMarker !== 0;
   const branchId = _peek_scope_id();
   if (resumeMarker && resumeBranch && !singleNode) {
-    $chunk.writeHTML(state.mark(ResumeSymbol.BranchStart, branchId + ""));
+    $chunk.writeHTML(state.mark(ResumeSymbol.BranchStart, ""));
   }
 
   const branchIndex = resumeBranch ? withBranchId(branchId, cb) : cb();
@@ -467,34 +445,40 @@ export function _if(
   writeBranchEnd(
     scopeId,
     accessor,
+    resumeBranch,
     resumeMarker,
     parentEndTag,
-    resumeMarker &&
-      (!parentEndTag || resumeBranch) &&
-      (singleNode
-        ? state.mark(
-            parentEndTag
-              ? ResumeSymbol.BranchSingleNodeOnlyChildInParent
-              : ResumeSymbol.BranchSingleNode,
-            scopeId +
-              " " +
-              accessor +
-              (shouldWriteBranch ? " " + branchId : ""),
-          )
-        : state.mark(ResumeSymbol.BranchEnd, scopeId + " " + accessor)),
+    singleNode,
+    shouldWriteBranch ? " " + branchId : "",
   );
 }
 
 function writeBranchEnd(
   scopeId: number,
   accessor: Accessor,
+  resumeBranch: boolean,
   resumeMarker: boolean,
   parentEndTag: string | undefined | 0,
-  mark: string | undefined | false,
+  singleNode?: 1,
+  branchIds?: string,
 ) {
   const endTag = parentEndTag || "";
   if (resumeMarker) {
-    if (mark) {
+    if (!parentEndTag || resumeBranch) {
+      const { state } = $chunk.boundary;
+      const mark = singleNode
+        ? state.mark(
+            parentEndTag
+              ? ResumeSymbol.BranchEndSingleNodeOnlyChildInParent
+              : ResumeSymbol.BranchEndSingleNode,
+            scopeId + " " + accessor + (branchIds || ""),
+          )
+        : state.mark(
+            parentEndTag
+              ? ResumeSymbol.BranchEndOnlyChildInParent
+              : ResumeSymbol.BranchEnd,
+            scopeId + " " + accessor + (branchIds || ""),
+          );
       $chunk.writeHTML(mark + endTag);
     } else {
       $chunk.writeHTML(endTag + _el_resume(scopeId, accessor));
@@ -587,7 +571,7 @@ export function _await<T>(
     if (resumeMarker) {
       const branchId = _peek_scope_id();
       $chunk.writeHTML(
-        $chunk.boundary.state.mark(ResumeSymbol.BranchStart, branchId + ""),
+        $chunk.boundary.state.mark(ResumeSymbol.BranchStart, ""),
       );
       content(promise);
       writeScope(scopeId, {
@@ -596,7 +580,7 @@ export function _await<T>(
       $chunk.writeHTML(
         $chunk.boundary.state.mark(
           ResumeSymbol.BranchEnd,
-          scopeId + " " + accessor,
+          scopeId + " " + accessor + " " + branchId,
         ),
       );
     } else {
@@ -623,10 +607,7 @@ export function _await<T>(
             if (resumeMarker) {
               const branchId = _peek_scope_id();
               $chunk.writeHTML(
-                $chunk.boundary.state.mark(
-                  ResumeSymbol.BranchStart,
-                  branchId + "",
-                ),
+                $chunk.boundary.state.mark(ResumeSymbol.BranchStart, ""),
               );
               content(value);
               boundary.state.serializer.writeAssign(
@@ -637,7 +618,7 @@ export function _await<T>(
               $chunk.writeHTML(
                 $chunk.boundary.state.mark(
                   ResumeSymbol.BranchEnd,
-                  scopeId + " " + accessor,
+                  scopeId + " " + accessor + " " + branchId,
                 ),
               );
             } else {
@@ -665,9 +646,7 @@ export function _try(
   },
 ) {
   const branchId = _peek_scope_id();
-  $chunk.writeHTML(
-    $chunk.boundary.state.mark(ResumeSymbol.BranchStart, branchId + ""),
-  );
+  $chunk.writeHTML($chunk.boundary.state.mark(ResumeSymbol.BranchStart, ""));
 
   const catchContent = normalizeDynamicRenderer(input.catch) as
     | ServerRenderer
@@ -701,7 +680,7 @@ export function _try(
   $chunk.writeHTML(
     $chunk.boundary.state.mark(
       ResumeSymbol.BranchEnd,
-      scopeId + " " + accessor,
+      scopeId + " " + accessor + " " + branchId,
     ),
   );
 }

--- a/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <button class=inc>1<!--Ms*1 #text/1-->,<!>10<!--Ms*1 #text/2--></button><!--Ms*1 #button/0--><!--Ms[2--><div>Counts: 1,10</div><!--Ms]1 #text/3--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{"ConditionalScope:#text/3":_.a={},"ConditionalRenderer:#text/3":_._.$compat_renderBody,input_content:_._.$compat_renderBody,x:1,y:10},_.a]),"__tests__/components/custom-tag.marko_0_x_y",1];M.s.w()</script>
+  <button class=inc>1<!--Ms*1 #text/1-->,<!>10<!--Ms*1 #text/2--></button><!--Ms*1 #button/0--><!--Ms[--><div>Counts: 1,10</div><!--Ms]1 #text/3 2--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{"ConditionalScope:#text/3":_.a={},"ConditionalRenderer:#text/3":_._.$compat_renderBody,input_content:_._.$compat_renderBody,x:1,y:10},_.a]),"__tests__/components/custom-tag.marko_0_x_y",1];M.s.w()</script>
 
 # Render End
 ```html
@@ -17,11 +17,11 @@
       <!--Ms*1 #text/2-->
     </button>
     <!--Ms*1 #button/0-->
-    <!--Ms[2-->
+    <!--Ms[-->
     <div>
       Counts: 1,10
     </div>
-    <!--Ms]1 #text/3-->
+    <!--Ms]1 #text/3 2-->
     <script>
       WALKER_RUNTIME("M")("s");
       M.s.r = [_ =&gt; (_.b = [0,

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/resume.expected.md
@@ -10,14 +10,14 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="0"
       id="class"
     >
       0
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -58,6 +58,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment1
@@ -79,14 +80,14 @@ container.querySelector("#tags").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="1"
       id="class"
     >
       0
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -146,14 +147,14 @@ container.querySelector("#class").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="1"
       id="class"
     >
       1
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -212,14 +213,14 @@ container.querySelector("#tags").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="2"
       id="class"
     >
       1
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -279,14 +280,14 @@ container.querySelector("#class").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="2"
       id="class"
     >
       2
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
@@ -345,14 +346,14 @@ container.querySelector("#tags").click();
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-parent="3"
       id="class"
     >
       2
     </button>
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-basic-tags-to-class/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <button id=tags>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[2--><!--M#_0--><button id=class data-parent=0>0</button><!--M/--><!--M_]1 #text/2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={m5c:"_0"},"ConditionalRenderer:#text/2":_._.$compat_renderer(_._["__tests__/components/class-counter.marko"]),count:0},_.a])];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{"count":0},{"f":1}]],"t":["__tests__/components/class-counter.marko"]});M._.r.push("$compat_setScope",2,"__tests__/template.marko_0_count",1);M._.w()</script>
+  <button id=tags>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[--><!--M#_0--><button id=class data-parent=0>0</button><!--M/--><!--M_]1 #text/2 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/2":_.a={m5c:"_0"},"ConditionalRenderer:#text/2":_._.$compat_renderer(_._["__tests__/components/class-counter.marko"]),count:0},_.a])];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{"count":0},{"f":1}]],"t":["__tests__/components/class-counter.marko"]});M._.r.push("$compat_setScope",2,"__tests__/template.marko_0_count",1);M._.w()</script>
 
 # Render End
 ```html
@@ -13,7 +13,7 @@
       <!--M_*1 #text/1-->
     </button>
     <!--M_*1 #button/0-->
-    <!--M_[2-->
+    <!--M_[-->
     <!--M#_0-->
     <button
       data-parent="0"
@@ -22,7 +22,7 @@
       0
     </button>
     <!--M/-->
-    <!--M_]1 #text/2-->
+    <!--M_]1 #text/2 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-in-components-in-tags-dir/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-in-components-in-tags-dir/__snapshots__/resume.expected.md
@@ -3,11 +3,11 @@
 <html>
   <head />
   <body>
-    <!--Ms[2-->
+    <!--Ms[-->
     <h1>
       Hello world
     </h1>
-    <!--Ms]1 #text/0-->
+    <!--Ms]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("s");
       M.s.r = [_ =&gt; (_.b = [0,
@@ -40,6 +40,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment0

--- a/packages/translator-interop/src/__tests__/fixtures/interop-class-in-components-in-tags-dir/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-class-in-components-in-tags-dir/__snapshots__/ssr.expected.md
@@ -1,18 +1,18 @@
 # Write
-  <!--Ms[2--><!--M#s1--><h1>Hello world</h1><!--M/--><!--Ms]1 #text/0--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={m5c:"s1"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/tags/components/hello-internal.marko"])},_.a]),"$compat_setScope",2];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s1",0,{},{"f":1}]],"t":["__tests__/tags/components/hello-internal.marko"]})</script>
+  <!--Ms[--><!--M#s1--><h1>Hello world</h1><!--M/--><!--Ms]1 #text/0 2--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={m5c:"s1"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/tags/components/hello-internal.marko"])},_.a]),"$compat_setScope",2];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s1",0,{},{"f":1}]],"t":["__tests__/tags/components/hello-internal.marko"]})</script>
 
 # Render End
 ```html
 <html>
   <head />
   <body>
-    <!--Ms[2-->
+    <!--Ms[-->
     <!--M#s1-->
     <h1>
       Hello world
     </h1>
     <!--M/-->
-    <!--Ms]1 #text/0-->
+    <!--Ms]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("s");
       M.s.r = [_ =&gt; (_.b = [0,

--- a/packages/translator-interop/src/__tests__/fixtures/interop-event-handler-render-body-tags-to-class/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-event-handler-render-body-tags-to-class/__snapshots__/resume.expected.md
@@ -3,14 +3,14 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-marko="{\"onclick\":\"emit _0 false 0\"}"
     >
       0
       <!--M_*3 #text/0-->
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -66,6 +66,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment0
@@ -88,14 +89,14 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-marko="{\"onclick\":\"emit _0 false 0\"}"
     >
       1
       <!--M_*3 #text/0-->
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -162,14 +163,14 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-marko="{\"onclick\":\"emit _0 false 0\"}"
     >
       2
       <!--M_*3 #text/0-->
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -236,14 +237,14 @@ container.querySelector("button").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       data-marko="{\"onclick\":\"emit _0 false 0\"}"
     >
       3
       <!--M_*3 #text/0-->
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-event-handler-render-body-tags-to-class/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-event-handler-render-body-tags-to-class/__snapshots__/ssr.expected.md
@@ -1,12 +1,12 @@
 # Write
-  <!--M_[2--><!--M#_0--><button data-marko='{"onclick":"emit _0 false 0"}'><!--F#1-->0<!--M_*3 #text/0--><!--F/--></button><!--M/--><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/my-button.marko"]),count:0,"ClosureScopes:count":_.d=new Set},_.a,_.e={m5c:"_0-1",_:_.b,"ClosureSignalIndex:count":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{},{"b":[["click"]],"e":[["click",["__tests__/template.marko_0/onClick",1]]],"f":1,"r":["__tests__/template.marko_1_content",1]}]],"t":["__tests__/components/my-button.marko"]});M._.r.push("$compat_setScope",2);M._.w()</script>
+  <!--M_[--><!--M#_0--><button data-marko='{"onclick":"emit _0 false 0"}'><!--F#1-->0<!--M_*3 #text/0--><!--F/--></button><!--M/--><!--M_]1 #text/0 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/my-button.marko"]),count:0,"ClosureScopes:count":_.d=new Set},_.a,_.e={m5c:"_0-1",_:_.b,"ClosureSignalIndex:count":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{},{"b":[["click"]],"e":[["click",["__tests__/template.marko_0/onClick",1]]],"f":1,"r":["__tests__/template.marko_1_content",1]}]],"t":["__tests__/components/my-button.marko"]});M._.r.push("$compat_setScope",2);M._.w()</script>
 
 # Render End
 ```html
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <!--M#_0-->
     <button
       data-marko="{\"onclick\":\"emit _0 false 0\"}"
@@ -17,7 +17,7 @@
       <!--F/-->
     </button>
     <!--M/-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/resume.expected.md
@@ -3,13 +3,13 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class-api"
     >
       0
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <div
       id="tags-api"
     >
@@ -57,6 +57,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment0
@@ -71,13 +72,13 @@ container.querySelector("#class-api").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class-api"
     >
       1
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <div
       id="tags-api"
     >
@@ -137,13 +138,13 @@ container.querySelector("#class-api").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class-api"
     >
       2
     </button>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <div
       id="tags-api"
     >

--- a/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-events-tags-to-class/__snapshots__/ssr.expected.md
@@ -1,12 +1,12 @@
 # Write
-  <!--M_[2--><!--M#_0--><button id=class-api>0</button><!--M/--><!--M_]1 #text/0--><div id=tags-api>0<!--M_*1 #text/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-counter.marko"])},_.a]),_=>(_.d=[-2,_.c=_.b[1]])];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{},{"e":[["count",["__tests__/template.marko_0/onCount",1]]],"f":1}]],"t":["__tests__/components/class-counter.marko"]});M._.r.push("$compat_setScope",2);M._.w()</script>
+  <!--M_[--><!--M#_0--><button id=class-api>0</button><!--M/--><!--M_]1 #text/0 2--><div id=tags-api>0<!--M_*1 #text/1--></div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-counter.marko"])},_.a]),_=>(_.d=[-2,_.c=_.b[1]])];M._.w();$MC=(window.$MC||[]).concat({"p":"_","w":[["_0",0,{},{"e":[["count",["__tests__/template.marko_0/onCount",1]]],"f":1}]],"t":["__tests__/components/class-counter.marko"]});M._.r.push("$compat_setScope",2);M._.w()</script>
 
 # Render End
 ```html
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <!--M#_0-->
     <button
       id="class-api"
@@ -14,7 +14,7 @@
       0
     </button>
     <!--M/-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <div
       id="tags-api"
     >

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/resume.expected.md
@@ -16,7 +16,7 @@
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -51,6 +51,7 @@
 
 # Mutations
 ```
+INSERT #text
 INSERT html/body/#text0
 INSERT html/body/#text5
 REMOVE #comment before html/body/#text0
@@ -58,6 +59,7 @@ REMOVE #comment after html/body/#text5
 INSERT html/body/div/#text0, html/body/div/#text3
 REMOVE #comment after html/body/div/#text3
 REMOVE button after html/body/div/#text3
+REMOVE #text after html/body/div/#text3
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -93,7 +95,7 @@ container.querySelector("#tags").click();
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -152,7 +154,7 @@ container.querySelector("#class").click();
       >
         1
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -220,7 +222,7 @@ container.querySelector("#tags").click();
       >
         1
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -279,7 +281,7 @@ container.querySelector("#class").click();
       >
         2
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -347,7 +349,7 @@ container.querySelector("#tags").click();
       >
         2
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-attr-tags-class-to-tags/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[2--><button id=class>0</button><!--Ms]1 #text/2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
+  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[--><button id=class>0</button><!--Ms]1 #text/2 2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
 
 # Render End
 ```html
@@ -16,13 +16,13 @@
     </button>
     <!--Ms*1 #button/0-->
     <div>
-      <!--Ms[2-->
+      <!--Ms[-->
       <button
         id="class"
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <!--F/-->
     <!--M/-->

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/resume.expected.md
@@ -16,7 +16,7 @@
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -51,6 +51,7 @@
 
 # Mutations
 ```
+INSERT #text
 INSERT html/body/#text0
 INSERT html/body/#text5
 REMOVE #comment before html/body/#text0
@@ -58,6 +59,7 @@ REMOVE #comment after html/body/#text5
 INSERT html/body/div/#text0, html/body/div/#text3
 REMOVE #comment after html/body/div/#text3
 REMOVE button after html/body/div/#text3
+REMOVE #text after html/body/div/#text3
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -93,7 +95,7 @@ container.querySelector("#tags").click();
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -152,7 +154,7 @@ container.querySelector("#class").click();
       >
         1
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -220,7 +222,7 @@ container.querySelector("#tags").click();
       >
         1
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -279,7 +281,7 @@ container.querySelector("#class").click();
       >
         2
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -347,7 +349,7 @@ container.querySelector("#tags").click();
       >
         2
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-class-to-tags/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[2--><button id=class>0</button><!--Ms]1 #text/2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
+  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[--><button id=class>0</button><!--Ms]1 #text/2 2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
 
 # Render End
 ```html
@@ -16,13 +16,13 @@
     </button>
     <!--Ms*1 #button/0-->
     <div>
-      <!--Ms[2-->
+      <!--Ms[-->
       <button
         id="class"
       >
         0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <!--F/-->
     <!--M/-->

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/resume.expected.md
@@ -3,7 +3,7 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -18,7 +18,7 @@
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -76,6 +76,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment0
@@ -98,7 +99,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -113,7 +114,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -182,7 +183,7 @@ container.querySelector("#class").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -197,7 +198,7 @@ container.querySelector("#class").click();
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -266,7 +267,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -281,7 +282,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -350,7 +351,7 @@ container.querySelector("#class").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -365,7 +366,7 @@ container.querySelector("#class").click();
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -434,7 +435,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -449,7 +450,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/0-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-nested-tags-to-class/__snapshots__/ssr.expected.md
@@ -1,12 +1,12 @@
 # Write
-  <!--M_[2--><!--M#_0--><button id=class>0</button><div><!--F#1--><button id=tags>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--F/--></div><!--M/--><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-layout.marko"]),count:0,"ClosureScopes:count":_.d=new Set},_.a,_.e={m5c:"_0-2",_:_.b,"ClosureSignalIndex:count":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3,"__tests__/template.marko_1_count",3];M._.w();$MC=(window.$MC||[]).concat({"o":{"p":"_","w":[["_0",0,{"renderBody":["__tests__/template.marko_1_content",1]},{"f":1}]],"t":["__tests__/components/class-layout.marko"]},"$$":[{"l":["w",0,3,"r"],"r":["w",0,2,"renderBody"]}]});M._.r.push("$compat_setScope",2);M._.w()</script>
+  <!--M_[--><!--M#_0--><button id=class>0</button><div><!--F#1--><button id=tags>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--><!--F/--></div><!--M/--><!--M_]1 #text/0 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-layout.marko"]),count:0,"ClosureScopes:count":_.d=new Set},_.a,_.e={m5c:"_0-2",_:_.b,"ClosureSignalIndex:count":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3,"__tests__/template.marko_1_count",3];M._.w();$MC=(window.$MC||[]).concat({"o":{"p":"_","w":[["_0",0,{"renderBody":["__tests__/template.marko_1_content",1]},{"f":1}]],"t":["__tests__/components/class-layout.marko"]},"$$":[{"l":["w",0,3,"r"],"r":["w",0,2,"renderBody"]}]});M._.r.push("$compat_setScope",2);M._.w()</script>
 
 # Render End
 ```html
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <!--M#_0-->
     <button
       id="class"
@@ -25,7 +25,7 @@
       <!--F/-->
     </div>
     <!--M/-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/resume.expected.md
@@ -19,7 +19,7 @@
       >
         1 * 0 = 0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -55,6 +55,7 @@
 
 # Mutations
 ```
+INSERT #text
 INSERT html/body/#text0
 INSERT html/body/#text5
 REMOVE #comment before html/body/#text0
@@ -63,6 +64,7 @@ INSERT html/body/div/#text0, html/body/div/#text3
 REMOVE #comment after html/body/div/#text3
 REMOVE h1 after html/body/div/#text3
 REMOVE button after html/body/div/#text3
+REMOVE #text after html/body/div/#text3
 INSERT html/body/#text1
 INSERT html/body/#text4
 INSERT html/body/#text2
@@ -107,7 +109,7 @@ container.querySelector("#tags").click();
       >
         1 * 1 = 1
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -172,7 +174,7 @@ container.querySelector("#class").click();
       >
         2 * 1 = 2
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -251,7 +253,7 @@ container.querySelector("#tags").click();
       >
         2 * 2 = 4
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -316,7 +318,7 @@ container.querySelector("#class").click();
       >
         3 * 2 = 6
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");
@@ -395,7 +397,7 @@ container.querySelector("#tags").click();
       >
         3 * 3 = 9
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <script>
       WALKER_RUNTIME("M")("s");

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-class-to-tags/__snapshots__/ssr.expected.md
@@ -1,5 +1,5 @@
 # Write
-  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[2--><h1>hello</h1><button id=class>1 * 0 = 0</button><!--Ms]1 #text/2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,input_content:_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
+  <!--M#s0--><!--F#1--><button id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><div><!--Ms[--><h1>hello</h1><button id=class>1 * 0 = 0</button><!--Ms]1 #text/2 2--></div><!--F/--><!--M/--><script>WALKER_RUNTIME("M")("s");M.s.r=[_=>(_.b=[0,{m5c:"s0-0","ConditionalScope:#text/2":_.a={},"ConditionalRenderer:#text/2":_._.$compat_renderBody,input_content:_._.$compat_renderBody,count:0},_.a]),"$compat_setScope",1,"__tests__/components/tags-layout.marko_0_count",1];M.s.w();$MC=(window.$MC||[]).concat({"w":[["s0",0,{},{"f":1}]],"t":["__tests__/template.marko"]})</script>
 
 # Render End
 ```html
@@ -16,7 +16,7 @@
     </button>
     <!--Ms*1 #button/0-->
     <div>
-      <!--Ms[2-->
+      <!--Ms[-->
       <h1>
         hello
       </h1>
@@ -25,7 +25,7 @@
       >
         1 * 0 = 0
       </button>
-      <!--Ms]1 #text/2-->
+      <!--Ms]1 #text/2 2-->
     </div>
     <!--F/-->
     <!--M/-->

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/resume.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/resume.expected.md
@@ -3,7 +3,7 @@
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -30,7 +30,7 @@
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -89,6 +89,7 @@
 
 # Mutations
 ```
+INSERT html/body/#text2
 INSERT html/body/#text0
 INSERT html/body/#text1
 REMOVE #comment after html/body/#comment0
@@ -111,7 +112,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -138,7 +139,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -208,7 +209,7 @@ container.querySelector("#class").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -235,7 +236,7 @@ container.querySelector("#class").click();
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -307,7 +308,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -334,7 +335,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -405,7 +406,7 @@ container.querySelector("#class").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -432,7 +433,7 @@ container.querySelector("#class").click();
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {
@@ -504,7 +505,7 @@ container.querySelector("#tags").click();
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <button
       id="class"
     >
@@ -531,7 +532,7 @@ container.querySelector("#tags").click();
       </button>
       <!--M_*3 #button/1-->
     </div>
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {

--- a/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/ssr.expected.md
+++ b/packages/translator-interop/src/__tests__/fixtures/interop-tag-params-tags-to-class/__snapshots__/ssr.expected.md
@@ -1,12 +1,12 @@
 # Write
-  <!--M_[2--><!--M#_0--><button id=class>0</button><div><!--F#1--><h1>hello<!--M_*3 #text/0--></h1><button id=tags>1<!--M_*3 #text/2--> * <!>0<!--M_*3 #text/3--> = <!>0<!--M_*3 #text/4--></button><!--M_*3 #button/1--><!--F/--></div><!--M/--><!--M_]1 #text/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-layout.marko"]),multiplier:1,"ClosureScopes:multiplier":_.d=new Set},_.a,_.e={m5c:"_0-2",baseCount:0,_:_.b,"ClosureSignalIndex:multiplier":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3,"__tests__/template.marko_1_multiplier",3];M._.w();$MC=(window.$MC||[]).concat({"o":{"p":"_","w":[["_0",0,{"renderBody":["__tests__/template.marko_1_content",1]},{"f":1}]],"t":["__tests__/components/class-layout.marko"]},"$$":[{"l":["w",0,3,"r"],"r":["w",0,2,"renderBody"]}]});M._.r.push("$compat_setScope",2);M._.w()</script>
+  <!--M_[--><!--M#_0--><button id=class>0</button><div><!--F#1--><h1>hello<!--M_*3 #text/0--></h1><button id=tags>1<!--M_*3 #text/2--> * <!>0<!--M_*3 #text/3--> = <!>0<!--M_*3 #text/4--></button><!--M_*3 #button/1--><!--F/--></div><!--M/--><!--M_]1 #text/0 2--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"ConditionalScope:#text/0":_.a={m5c:"_0"},"ConditionalRenderer:#text/0":_._.$compat_renderer(_._["__tests__/components/class-layout.marko"]),multiplier:1,"ClosureScopes:multiplier":_.d=new Set},_.a,_.e={m5c:"_0-2",baseCount:0,_:_.b,"ClosureSignalIndex:multiplier":0}],(_.d).add(_.e),_.c),_=>(_.f=[-3,_.b]),"$compat_setScope",3,"__tests__/template.marko_1_multiplier",3];M._.w();$MC=(window.$MC||[]).concat({"o":{"p":"_","w":[["_0",0,{"renderBody":["__tests__/template.marko_1_content",1]},{"f":1}]],"t":["__tests__/components/class-layout.marko"]},"$$":[{"l":["w",0,3,"r"],"r":["w",0,2,"renderBody"]}]});M._.r.push("$compat_setScope",2);M._.w()</script>
 
 # Render End
 ```html
 <html>
   <head />
   <body>
-    <!--M_[2-->
+    <!--M_[-->
     <!--M#_0-->
     <button
       id="class"
@@ -37,7 +37,7 @@
       <!--F/-->
     </div>
     <!--M/-->
-    <!--M_]1 #text/0-->
+    <!--M_]1 #text/0 2-->
     <script>
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.c = [0, _.b = {


### PR DESCRIPTION
This PR improves resume walks to be more correct and easy to follow. All branch IDs are now on the branch end marker. It adds a new branch end marker for only child branches which were not optimized previously.

Fixes #2773.