### PR TITLE
fix: avoid unhandled promise rejections when serializing promises

### DIFF
--- a/.changeset/deep-hands-sort.md
+++ b/.changeset/deep-hands-sort.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid unhandled promise rejections when serializing promises.

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/resume.expected.md
@@ -12,10 +12,14 @@
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
         {
-          promise: new Promise((f, r) =&gt; _.a = {
+          promise: (p =&gt; p = new Promise((f, r) =&gt; _.a = {
             f,
-            r
-          })
+            r(e)
+            {
+              p.catch(_ =&gt; 0);
+              r(e)
+            }
+          }))()
         }]), _ =&gt; (_.a.f("hello"), _.c = []),
         "__tests__/template.marko_0_promise",
         1
@@ -41,10 +45,14 @@
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
         {
-          promise: new Promise((f, r) =&gt; _.a = {
+          promise: (p =&gt; p = new Promise((f, r) =&gt; _.a = {
             f,
-            r
-          })
+            r(e)
+            {
+              p.catch(_ =&gt; 0);
+              r(e)
+            }
+          }))()
         }]), _ =&gt; (_.a.f("hello"), _.c = []),
         "__tests__/template.marko_0_promise",
         1

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <div id=ref>0</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{promise:new Promise((f,r)=>_.a={f,r})}]),_=>(_.a.f("hello"),_.c=[]),"__tests__/template.marko_0_promise",1];M._.w()</script>
+  <div id=ref>0</div><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,{promise:(p=>p=new Promise((f,r)=>_.a={f,r(e){p.catch(_=>0);r(e)}}))()}]),_=>(_.a.f("hello"),_.c=[]),"__tests__/template.marko_0_promise",1];M._.w()</script>
 ```
 
 # Render End
@@ -17,10 +17,14 @@
       WALKER_RUNTIME("M")("_");
       M._.r = [_ =&gt; (_.b = [0,
         {
-          promise: new Promise((f, r) =&gt; _.a = {
+          promise: (p =&gt; p = new Promise((f, r) =&gt; _.a = {
             f,
-            r
-          })
+            r(e)
+            {
+              p.catch(_ =&gt; 0);
+              r(e)
+            }
+          }))()
         }]), _ =&gt; (_.a.f("hello"), _.c = []),
         "__tests__/template.marko_0_promise",
         1

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -931,7 +931,7 @@ describe("serializer", () => {
       const promise = Promise.resolve(obj);
       const [result] = await serializer.assertStringify(
         promise,
-        `new Promise((f,r)=>_.a={f,r})`,
+        `(p=>p=new Promise((f,r)=>_.a={f,r(e){p.catch(_=>0);r(e)}}))()`,
         `_.a.f(_.a={x:1})`,
       );
       assert.deepEqual(serializer.get("a"), obj);
@@ -944,7 +944,7 @@ describe("serializer", () => {
       const promise = Promise.reject(error);
       const [result] = await serializer.assertStringify(
         promise,
-        `new Promise((f,r)=>_.a={f,r})`,
+        `(p=>p=new Promise((f,r)=>_.a={f,r(e){p.catch(_=>0);r(e)}}))()`,
         `_.a.r(_.a=new Error("test"))`,
       );
       assert.deepEqual(serializer.get("a"), error);

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -915,7 +915,9 @@ function writePromise(state: State, val: Promise<unknown>, ref: Reference) {
 
   const pId = nextRefAccess(state);
   const pRef = new Reference(ref, null, state.flush, null, pId);
-  state.buf.push("new Promise((f,r)=>" + pId + "={f,r})");
+  state.buf.push(
+    "(p=>p=new Promise((f,r)=>" + pId + "={f,r(e){p.catch(_=>0);r(e)}}))()",
+  );
   val.then(
     (v) => writeAsyncCall(state, boundary, pRef, "f", v, pId),
     (v) => writeAsyncCall(state, boundary, pRef, "r", v, pId),


### PR DESCRIPTION
Partial fix for #2791.
Promises serialized no longer contribute to unhandled rejections when unreferenced.