### PR TITLE
chore: tell coderabbit to ignore snapshots and non-code files

### DIFF
--- a/.coderabbit.yml
+++ b/.coderabbit.yml
@@ -1,0 +1,3 @@
+path_filters:
+  - "!**/__snapshots__/**"
+  - "**/src/**"


### PR DESCRIPTION
CodeRabbit has many noisy comments related to code snapshots. Since this is a large part of our manual review process, it is okay for AI to ignore them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review configuration settings to optimize file filtering and review processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->