### PR TITLE
fix: allow import helper outside of translate

### DIFF
--- a/.changeset/tender-areas-read.md
+++ b/.changeset/tender-areas-read.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"marko": patch
+"@marko/runtime-tags": patch
+---
+
+Allow compiler import helper to be used outside of translate.

--- a/packages/compiler/src/babel-utils/imports.js
+++ b/packages/compiler/src/babel-utils/imports.js
@@ -127,9 +127,6 @@ export function importStar(file, request, nameHint) {
 }
 
 function getImports(file) {
-  if (file.___compileStage !== "translate") {
-    throw new Error("Unable to add an import outside of translate");
-  }
   let imports = file.metadata.marko[IMPORTS_KEY];
 
   if (!imports) {


### PR DESCRIPTION
Resolves #2866

Reverting the compiler stage check for the import helper to resolve the above, and some other similar usage.