### PR TITLE
fix issue 2721

### DIFF
--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -124,6 +124,10 @@ export function _attrs(
   nextAttrs: Record<string, unknown>,
 ) {
   const el = scope[nodeAccessor] as Element;
+  // Guard against undefined element (can happen in await tags before element is created)
+  if (!el) {
+    return;
+  }
   for (let i = el.attributes.length; i--; ) {
     const { name } = el.attributes.item(i)!;
     if (
@@ -168,6 +172,10 @@ export function _attrs_partial(
   skip: Record<string, 1>,
 ) {
   const el = scope[nodeAccessor] as Element;
+  // Guard against undefined element (can happen in await tags before element is created)
+  if (!el) {
+    return;
+  }
   const partial: Partial<typeof nextAttrs> = {};
 
   for (let i = el.attributes.length; i--; ) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Description of Changes
Added element existence checks in _attrs and _attrs_partial to prevent accessing attributes when the element is undefined.

Why This Change Is Required
Fixes issue #2721: components inside <await> tags that use input attributes can crash with TypeError: Cannot read properties of undefined (reading 'attributes') when the element doesn't exist yet. The guards return early if the element is undefined, preventing the crash while preserving correct behavior once the element is created.

link to issue - https://github.com/marko-js/marko/issues/2721

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ x] I have updated/added documentation affected by my changes.
- [ x] I have added tests to cover my changes.
