### PR TITLE
fix: store section with scope reads

### DIFF
--- a/.changeset/eager-rabbits-live.md
+++ b/.changeset/eager-rabbits-live.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix cases where compiler was not storing section information with scope reads.

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/.name-cache.json
@@ -1,0 +1,9 @@
+{
+  "vars": {
+    "props": {
+      "$_": "t",
+      "$init": "m",
+      "$$getbutton": "o"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<button
+  data-count="0"
+>
+  after
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/csr.expected.md
@@ -1,0 +1,15 @@
+# Render
+```html
+<button
+  data-count="0"
+>
+  after
+</button>
+```
+
+# Mutations
+```
+INSERT button
+REMOVE #text in button
+INSERT button/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,4 @@
+// size: 72 (min) 73 (brotli)
+const $getbutton = _._el("a0", 0);
+(_._script("a1", ($scope) => ($getbutton($scope)().textContent = "after")),
+  init());

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/dom.expected/template.js
@@ -1,0 +1,11 @@
+export const $template = "<button>Initial</button>";
+export const $walks = /* get, over(1) */" b";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $getbutton = _._el("__tests__/template.marko_0/#button", "#button/0");
+const $count = /* @__PURE__ */_._let("count/1", $scope => _._attr($scope["#button/0"], "data-count", $scope.count));
+const $setup__script = _._script("__tests__/template.marko_0", $scope => ((0, $getbutton($scope))().textContent = "after"));
+export function $setup($scope) {
+  $count($scope, 0);
+  $setup__script($scope);
+}
+export default /* @__PURE__ */_._template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/html.expected/template.js
@@ -1,0 +1,10 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/template.marko", input => {
+  const $scope0_id = _._scope_id();
+  const btn = _._el($scope0_id, "__tests__/template.marko_0/#button");
+  let count = 0;
+  _._html(`<button${_._attr("data-count", count)}>Initial</button>${_._el_resume($scope0_id, "#button/0")}`);
+  _._script($scope0_id, "__tests__/template.marko_0");
+  _._scope($scope0_id, {}, "__tests__/template.marko", 0);
+  _._resume_branch($scope0_id);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<button
+  data-count="0"
+>
+  after
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/resume.expected.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <button
+      data-count="0"
+    >
+      after
+    </button>
+    <!--M_*1 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.a = [0,
+        {}]),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+REMOVE #text in html/body/button
+INSERT html/body/button/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,8 @@
+# Render End
+```html
+<button
+  data-count="0"
+>
+  Initial
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/__snapshots__/ssr.expected.md
@@ -1,0 +1,39 @@
+# Write
+```html
+  <button data-count=0>Initial</button><!--M_*1 #button/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.a=[0,{}]),"__tests__/template.marko_0 1"];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <button
+      data-count="0"
+    >
+      Initial
+    </button>
+    <!--M_*1 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.a = [0,
+        {}]),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/button
+INSERT html/body/button/#text
+INSERT html/body/#comment
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/template.marko
@@ -1,0 +1,5 @@
+<let/count=0>
+<button/btn data-count=count>
+  Initial
+</button>
+<script>(0, btn)().textContent = "after"</script>

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -260,7 +260,9 @@ export function trackDomVarReferences(
     const refSection = getOrCreateSection(ref);
     setReferencesScope(ref);
     if (isSameOrChildSection(binding.section, refSection)) {
-      (ref.node.extra ??= {}).read = createRead(binding, undefined);
+      const refExtra = (ref.node.extra ??= {});
+      refExtra.read = createRead(binding, undefined);
+      refExtra.section = refSection;
 
       if (!isInvokedFunction(ref)) {
         section.domGetterBindings.set(

--- a/packages/runtime-tags/src/translator/util/scope-read.ts
+++ b/packages/runtime-tags/src/translator/util/scope-read.ts
@@ -76,21 +76,21 @@ export function getScopeExpression(section: Section, targetSection: Section) {
 
 export function createScopeReadExpression(
   reference: Binding,
-  section?: Section | undefined,
+  section = reference.section,
 ) {
   const propName = toPropertyName(getScopeAccessor(reference));
-  const scope =
-    section && reference.type !== BindingType.local
-      ? getScopeExpression(section, reference.section)
-      : scopeIdentifier;
   const expr = t.memberExpression(
-    scope,
+    reference.type === BindingType.local
+      ? scopeIdentifier
+      : getScopeExpression(section, reference.section),
     propName,
     propName.type !== "Identifier",
   );
 
-  if (scope === scopeIdentifier) {
-    (expr.extra ??= {}).read = createRead(reference, undefined);
+  if (section === reference.section && reference.type !== BindingType.dom) {
+    const exprExtra = (expr.extra ??= {});
+    exprExtra.read = createRead(reference, undefined);
+    exprExtra.section = section;
   }
   return expr;
 }


### PR DESCRIPTION
## Description

Fixes a regression caused by #3021 which caused the compiler to error when attempting to write out the reads for some signals.

Also refactor and cleanup the signal construction and `hasSideEffect` logic a bit.