### PR TITLE
perf: optimize known define tag input reference

### DIFF
--- a/.changeset/heavy-friends-stick.md
+++ b/.changeset/heavy-friends-stick.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Optimize input references for known define tag usage.

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.expected/template.js
@@ -8,8 +8,8 @@ const $Child_content__input_a = ($scope, input_a) => _._text($scope["#text/0"], 
 const $Child_content__input_b = ($scope, input_b) => _._text($scope["#text/1"], input_b);
 const $Child_content__$params = ($scope, $params2) => $Child_content__input($scope, $params2[0]);
 const $Child_content__input = ($scope, input) => {
-  $Child_content__input_a($scope, input?.a);
-  $Child_content__input_b($scope, input?.b);
+  $Child_content__input_a($scope, input.a);
+  $Child_content__input_b($scope, input.b);
 };
 export function $setup($scope) {
   _child($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/dom.expected/template.js
@@ -7,10 +7,10 @@ export const $walks = /* over(1), <Bar>, over(1) */`b/${$Bar_content__walks}&b`;
 import * as _ from "@marko/runtime-tags/debug/dom";
 const $Bar_content__input_foo = ($scope, input_foo) => $Foo_content__input_foo($scope["#childScope/0"], input_foo);
 const $Bar_content__$params = ($scope, $params3) => $Bar_content__input($scope, $params3[0]);
-const $Bar_content__input = ($scope, input) => $Bar_content__input_foo($scope, input?.foo);
+const $Bar_content__input = ($scope, input) => $Bar_content__input_foo($scope, input.foo);
 const $Foo_content__input_foo = ($scope, input_foo) => _._text($scope["#text/0"], input_foo || "fallback");
 const $Foo_content__$params = ($scope, $params2) => $Foo_content__input($scope, $params2[0]);
-const $Foo_content__input = ($scope, input) => $Foo_content__input_foo($scope, input?.foo);
+const $Foo_content__input = ($scope, input) => $Foo_content__input_foo($scope, input.foo);
 export function $setup($scope) {
   $Bar_content__input_foo($scope["#childScope/0"]);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/dom.expected/template.js
@@ -30,8 +30,8 @@ const $Child_content__for = /* @__PURE__ */_._for_of("#select/0", "<option></opt
 const $Child_content__input_option = ($scope, input_option) => $Child_content__for($scope, [input_option]);
 const $Child_content__$params = ($scope, $params2) => $Child_content__input($scope, $params2[0]);
 const $Child_content__input = ($scope, input) => {
-  $Child_content__input_class($scope, input?.class);
-  $Child_content__input_option($scope, input?.option);
+  $Child_content__input_class($scope, input.class);
+  $Child_content__input_option($scope, input.option);
 };
 export function $setup($scope) {
   $Wrap_content__rest_option($scope["#childScope/0"], (_.attrTags(_.attrTags(_.attrTag({

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.expected/template.js
@@ -9,8 +9,8 @@ const $Foo_content2__input_content = /* @__PURE__ */_._const("input_content", $F
 const $Foo_content2__input_value = /* @__PURE__ */_._const("input_value", $Foo_content2__input_content__OR__input_value);
 const $Foo_content2__$params = ($scope, $params2) => $Foo_content2__input($scope, $params2[0]);
 const $Foo_content2__input = ($scope, input) => {
-  $Foo_content2__input_content($scope, input?.content);
-  $Foo_content2__input_value($scope, input?.value);
+  $Foo_content2__input_content($scope, input.content);
+  $Foo_content2__input_value($scope, input.value);
 };
 const $if_content__a = /* @__PURE__ */_._closure_get("a", $scope => _._text($scope["#text/0"], $scope._._.a), $scope => $scope._._);
 const $if_content__setup = $if_content__a;

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.expected/template.js
@@ -10,8 +10,8 @@ export default _._template("__tests__/template.marko", input => {
       const $scope3_reason = _._scope_reason();
       _._dynamic_tag($scope3_id, "#text/0", input.content, [input.value], 0, 1, _._serialize_guard($scope3_reason, /* input.content, input.value */0));
       _._serialize_if($scope3_reason, /* input.content, input.value */0) && _._scope($scope3_id, {
-        input_content: _._serialize_if($scope3_reason, /* input.value */2) && input?.content,
-        input_value: _._serialize_if($scope3_reason, /* input.content */1) && input?.value
+        input_content: _._serialize_if($scope3_reason, /* input.value */2) && input.content,
+        input_value: _._serialize_if($scope3_reason, /* input.content */1) && input.value
       }, "__tests__/template.marko", "3:2", {
         input_content: ["input.content", "3:13"],
         input_value: ["input.value", "3:13"]


### PR DESCRIPTION
* Optimizes define tag `input` references when all usage sites are known to provide `input`.