### PR TITLE
fix: avoid parenthesized expressions

### DIFF
--- a/.changeset/social-mice-clap.md
+++ b/.changeset/social-mice-clap.md
@@ -1,0 +1,8 @@
+---
+"marko": patch
+"@marko/runtime-tags": patch
+"@marko/compiler": patch
+---
+
+Revert a recent change to preserve parenthesized expressions in the compiler.
+This caused a regression through some analysis which did not account for parenthesized expressions.

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -75,7 +75,6 @@ export default (api, markoOpts) => {
         parserOpts.allowSuperOutsideMethod =
         parserOpts.allowUndeclaredExports =
         parserOpts.allowNewTargetOutsideFunction =
-        parserOpts.createParenthesizedExpressions =
         parserOpts.createImportExpressions =
           true;
 

--- a/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/cjs-expected.js
@@ -12,7 +12,7 @@ const _marko_componentType = "__tests__/template.marko",
 var _default = exports.default = _marko_template;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
-  out.w(`<div${(0, _attr.default)("class", (0, _classValue.default)(input.className))}${(0, _attr.default)("foo", ('a' + input.foo + 'b'))} bar="a ${_attr.default.d(input.foo)} b"></div>`);
+  out.w(`<div${(0, _attr.default)("class", (0, _classValue.default)(input.className))}${(0, _attr.default)("foo", 'a' + input.foo + 'b')} bar="a ${_attr.default.d(input.foo)} b"></div>`);
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/html-expected.js
@@ -7,7 +7,7 @@ import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", ('a' + input.foo + 'b'))} bar="a ${_marko_attr.d(input.foo)} b"></div>`);
+  out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", 'a' + input.foo + 'b')} bar="a ${_marko_attr.d(input.foo)} b"></div>`);
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/htmlProduction-expected.js
@@ -7,7 +7,7 @@ import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", ('a' + input.foo + 'b'))} bar="a ${_marko_attr.d(input.foo)} b"></div>`);
+  out.w(`<div${_marko_attr("class", _marko_class_merge(input.className))}${_marko_attr("foo", 'a' + input.foo + 'b')} bar="a ${_marko_attr.d(input.foo)} b"></div>`);
 }, {
   t: _marko_componentType,
   i: true

--- a/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/vdom-expected.js
@@ -10,7 +10,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.e("div", {
     "class": _marko_class_merge(input.className),
-    "foo": ('a' + input.foo + 'b'),
+    "foo": 'a' + input.foo + 'b',
     "bar": `a ${input.foo} b`
   }, "0", _component, 0, 0);
 }, {

--- a/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/attr-escape/snapshots/vdomProduction-expected.js
@@ -10,7 +10,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.e("div", {
     "class": _marko_class_merge(input.className),
-    "foo": ('a' + input.foo + 'b'),
+    "foo": 'a' + input.foo + 'b',
     "bar": `a ${input.foo} b`
   }, "0", _component, 0, 0);
 }, {

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/cjs-expected.js
@@ -13,7 +13,7 @@ var _default = exports.default = _marko_template;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
   (0, _renderTag.default)(_customTagDataTag.default, {
-    "name": ("Frank".toUpperCase()),
+    "name": "Frank".toUpperCase(),
     "age": 32
   }, out, _componentDef, "0");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/generated-expected.marko
@@ -1,1 +1,1 @@
-<custom-tag-data name=("Frank".toUpperCase()) age=32/>
+<custom-tag-data name="Frank".toUpperCase() age=32/>

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/html-expected.js
@@ -8,7 +8,7 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_customTagData, {
-    "name": ("Frank".toUpperCase()),
+    "name": "Frank".toUpperCase(),
     "age": 32
   }, out, _componentDef, "0");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/htmlProduction-expected.js
@@ -8,7 +8,7 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_customTagData, {
-    "name": ("Frank".toUpperCase()),
+    "name": "Frank".toUpperCase(),
     "age": 32
   }, out, _componentDef, "0");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/vdom-expected.js
@@ -10,7 +10,7 @@ _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_customTagData, {
-    "name": ("Frank".toUpperCase()),
+    "name": "Frank".toUpperCase(),
     "age": 32
   }, out, _componentDef, "0");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/custom-tag-data/snapshots/vdomProduction-expected.js
@@ -10,7 +10,7 @@ _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   _marko_tag(_customTagData, {
-    "name": ("Frank".toUpperCase()),
+    "name": "Frank".toUpperCase(),
     "age": 32
   }, out, _componentDef, "0");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/cjs-expected.js
@@ -13,7 +13,7 @@ var _default = exports.default = _marko_template;
 const _marko_component = {};
 _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
   const x = "hello!";
-  out.w(`<div${(0, _attr.default)("class", (0, _classValue.default)((window).x))}>`);
+  out.w(`<div${(0, _attr.default)("class", (0, _classValue.default)(window.x))}>`);
   out.w("Hello");
   out.w("</div>");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/html-expected.js
@@ -8,7 +8,7 @@ import _marko_renderer from "marko/src/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   const x = "hello!";
-  out.w(`<div${_marko_attr("class", _marko_class_merge((window).x))}>`);
+  out.w(`<div${_marko_attr("class", _marko_class_merge(window.x))}>`);
   out.w("Hello");
   out.w("</div>");
 }, {

--- a/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/htmlProduction-expected.js
@@ -8,7 +8,7 @@ import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   const x = "hello!";
-  out.w(`<div${_marko_attr("class", _marko_class_merge((window).x))}>Hello</div>`);
+  out.w(`<div${_marko_attr("class", _marko_class_merge(window.x))}>Hello</div>`);
 }, {
   t: _marko_componentType,
   i: true

--- a/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/vdom-expected.js
@@ -10,7 +10,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   const x = "hello!";
   out.be("div", {
-    "class": _marko_class_merge((window).x)
+    "class": _marko_class_merge(window.x)
   }, "0", _component, null, 1);
   out.t("Hello", _component);
   out.ee();

--- a/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/typescript-basic/snapshots/vdomProduction-expected.js
@@ -10,7 +10,7 @@ const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   const x = "hello!";
   out.be("div", {
-    "class": _marko_class_merge((window).x)
+    "class": _marko_class_merge(window.x)
   }, "0", _component, null, 1);
   out.t("Hello", _component);
   out.ee();

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.expected/tags/child.js
@@ -4,7 +4,7 @@ export const $setup = () => {};
 import * as _ from "@marko/runtime-tags/debug/dom";
 const $input__OR__valueChange__script = _._script("__tests__/tags/child.marko_0_input_$valueChange", $scope => {
   $scope.input;
-  if ((_._call($scope.$valueChange, 2)) !== 2) {
+  if (_._call($scope.$valueChange, 2) !== 2) {
     // Assignments always return their value.
     throw new Error(`Expected value to be 2`);
   }

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/__snapshots__/dom.expected/template.js
@@ -4,7 +4,7 @@ import * as _2 from "@marko/runtime-tags/debug/dom";
 const $liveCount = /* @__PURE__ */_2._let("liveCount/2", $scope => _2._text($scope["#text/1"], $scope.liveCount));
 const $count = /* @__PURE__ */_2._let("count/3");
 const $setup__script = _2._script("__tests__/template.marko_0", $scope => _2._on($scope["#button/0"], "click", function (_, el) {
-  el.textContent = "" + ($count($scope, 1));
+  el.textContent = "" + $count($scope, 1);
 }));
 export function $setup($scope) {
   $liveCount($scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/__snapshots__/dom.expected/template.js
@@ -2,7 +2,7 @@ export const $template = "<button>Before</button>";
 export const $walks = /* get, over(1) */" b";
 import * as _2 from "@marko/runtime-tags/debug/dom";
 const $setup__script = _2._script("__tests__/template.marko_0", $scope => _2._on($scope["#button/0"], "click", function (_, el) {
-  el.textContent = "" + (/* count */0);
+  el.textContent = "" + /* count */0;
 }));
 export function $setup($scope) {
   /* count */0;

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.expected/template.js
@@ -5,7 +5,7 @@ import * as _ from "@marko/runtime-tags/debug/dom";
 const $input_foo__OR__input_bar = /* @__PURE__ */_._or(5, $scope => _._attr($scope["#div/0"], "nested", `a ${$scope.input_foo + ` nested ${$scope.input_bar}`} b`));
 export const $input_foo = /* @__PURE__ */_._const("input_foo", $scope => {
   _._attr_class($scope["#div/0"], $scope.input_foo);
-  _._attr($scope["#div/0"], "foo", ('a' + $scope.input_foo + 'b'));
+  _._attr($scope["#div/0"], "foo", 'a' + $scope.input_foo + 'b');
   $input_foo__OR__input_bar($scope);
 });
 export const $input_bar = /* @__PURE__ */_._const("input_bar", $scope => {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/html.expected/template.js
@@ -2,7 +2,7 @@ import * as _ from "@marko/runtime-tags/debug/html";
 export default _._template("__tests__/template.marko", input => {
   const $scope0_reason = _._scope_reason();
   const $scope0_id = _._scope_id();
-  _._html(`<div${_._attr_class(input.foo)}${_._attr("foo", ('a' + input.foo + 'b'))}${_._attr("bar", `a ${input.bar} b`)}${_._attr("nested", `a ${input.foo + ` nested ${input.bar}`} b`)}></div>${_._el_resume($scope0_id, "#div/0", _._serialize_guard($scope0_reason, /* input.foo, input.bar */0))}`);
+  _._html(`<div${_._attr_class(input.foo)}${_._attr("foo", 'a' + input.foo + 'b')}${_._attr("bar", `a ${input.bar} b`)}${_._attr("nested", `a ${input.foo + ` nested ${input.bar}`} b`)}></div>${_._el_resume($scope0_id, "#div/0", _._serialize_guard($scope0_reason, /* input.foo, input.bar */0))}`);
   _._serialize_if($scope0_reason, /* input.foo, input.bar */0) && _._scope($scope0_id, {
     input_foo: _._serialize_if($scope0_reason, /* input.bar */2) && input.foo,
     input_bar: _._serialize_if($scope0_reason, /* input.foo */1) && input.bar

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/dom.expected/template.js
@@ -11,7 +11,7 @@ const $await_content__value__script = _._script("__tests__/template.marko_3_valu
 }));
 const $await_content__value = /* @__PURE__ */_._let("value/3", $scope => {
   _._text($scope["#text/1"], $scope.value);
-  $await_content__if($scope, ($scope.value > 0) ? 0 : 1);
+  $await_content__if($scope, $scope.value > 0 ? 0 : 1);
   $if_content__value($scope);
   $await_content__value__script($scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/html.expected/template.js
@@ -11,7 +11,7 @@ export default _._template("__tests__/template.marko", input => {
       let value = 1;
       _._html(`<button>${_._escape(value)}${_._el_resume($scope3_id, "#text/1")}</button>${_._el_resume($scope3_id, "#button/0")}`);
       _._if(() => {
-        if ((value > 0)) {
+        if (value > 0) {
           const $scope4_id = _._scope_id();
           _._html(`<span>${_._escape(value)}${_._el_resume($scope4_id, "#text/0")}</span>`);
           _._scope($scope4_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/__snapshots__/html.expected/template.js
@@ -2,6 +2,6 @@ import * as _2 from "@marko/runtime-tags/debug/html";
 export default _2._template("__tests__/template.marko", input => {
   _2._scope_reason();
   const $scope0_id = _2._scope_id();
-  const _ = (_2.$global().__flush__ = ($global, html) => `BEFORE-${$global.runtimeId}-${html}-AFTER`);
+  const _ = _2.$global().__flush__ = ($global, html) => `BEFORE-${$global.runtimeId}-${html}-AFTER`;
   _2._html("<h1>Hello World</h1>");
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/dom.expected/template.js
@@ -2,8 +2,8 @@ export const $template = "<!><!><!>";
 export const $walks = /* over(1), replace, over(2) */"b%c";
 import * as _ from "@marko/runtime-tags/debug/dom";
 const $for_content__selected__OR__num = /* @__PURE__ */_._or(4, $scope => {
-  _._attr($scope["#button/0"], "data-selected", ($scope._.selected === $scope.num));
-  _._attr($scope["#button/0"], "data-multiple", ($scope.num % $scope._.selected === 0));
+  _._attr($scope["#button/0"], "data-selected", $scope._.selected === $scope.num);
+  _._attr($scope["#button/0"], "data-multiple", $scope.num % $scope._.selected === 0);
 });
 const $for_content__selected = /* @__PURE__ */_._for_closure("#text/0", $for_content__selected__OR__num);
 const $for_content__setup = $for_content__selected;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.expected/template.js
@@ -5,7 +5,7 @@ export default _._template("__tests__/template.marko", input => {
   let selected = 0;
   _._for_of([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], num => {
     const $scope1_id = _._scope_id();
-    _._html(`<button${_._attr("data-selected", (selected === num))}${_._attr("data-multiple", (num % selected === 0))}>${_._escape(num)}</button>${_._el_resume($scope1_id, "#button/0")}`);
+    _._html(`<button${_._attr("data-selected", selected === num)}${_._attr("data-multiple", num % selected === 0)}>${_._escape(num)}</button>${_._el_resume($scope1_id, "#button/0")}`);
     _._script($scope1_id, "__tests__/template.marko_1_num");
     _._scope($scope1_id, {
       num,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/__snapshots__/dom.expected/template.js
@@ -1,9 +1,9 @@
 export const $template = "<button> </button>";
 export const $walks = /* get, next(1), get, out(1) */" D l";
 import * as _ from "@marko/runtime-tags/debug/dom";
-const $clickCount__script = _._script("__tests__/template.marko_0_clickCount", $scope => _._on($scope["#button/0"], "click", ($scope.clickCount <= 1 ? (() => {
+const $clickCount__script = _._script("__tests__/template.marko_0_clickCount", $scope => _._on($scope["#button/0"], "click", $scope.clickCount <= 1 ? () => {
   $clickCount($scope, $scope.clickCount + 1);
-}) : false)));
+} : false));
 const $clickCount = /* @__PURE__ */_._let("clickCount/2", $scope => {
   _._text($scope["#text/1"], $scope.clickCount);
   $clickCount__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/html.expected/template.js
@@ -11,7 +11,7 @@ export default _._template("__tests__/template.marko", input => {
     }
   }, $scope0_id, "#text/0", _._serialize_guard($scope0_reason, /* input.a, input.b */0), _._serialize_guard($scope0_reason, /* input.a, input.b */0), _._serialize_guard($scope0_reason, /* input.a, input.b */0));
   _._if(() => {
-    if ((input.a, input.b)) {
+    if (input.a, input.b) {
       const $scope2_id = _._scope_id();
       _._html("World");
       _._serialize_if($scope0_reason, /* input.a, input.b */0) && _._scope($scope2_id, {}, "__tests__/template.marko", "5:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/.name-cache.json
@@ -12,7 +12,9 @@
       "$$otherState": "u",
       "$$input": "l",
       "$$source": "i",
-      "$$valueChange": "m"
+      "$$valueChange": "m",
+      "$$thirdState__script": "s",
+      "$$thirdState": "f"
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/csr-sanitized.expected.md
@@ -6,6 +6,9 @@
 <button>
   1|1
 </button>
+<button>
+  1|1
+</button>
 source=1
 ```
 
@@ -15,6 +18,9 @@ source=1
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  2|2
+</button>
 <button>
   2|2
 </button>
@@ -36,6 +42,9 @@ container.querySelectorAll("button").forEach(item => item.click());
 <button>
   3|3
 </button>
+<button>
+  3|3
+</button>
 source=3
 ```
 
@@ -45,6 +54,9 @@ source=3
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  4|4
+</button>
 <button>
   4|4
 </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/csr.expected.md
@@ -6,12 +6,15 @@
 <button>
   1|1
 </button>
+<button>
+  1|1
+</button>
 source=1
 ```
 
 # Mutations
 ```
-INSERT button0, button1, #text0, #text1
+INSERT button0, button1, button2, #text0, #text1
 ```
 
 # Render
@@ -19,6 +22,9 @@ INSERT button0, button1, #text0, #text1
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  2|2
+</button>
 <button>
   2|2
 </button>
@@ -32,9 +38,11 @@ source=2
 ```
 UPDATE button0/#text0 "1" => "2"
 UPDATE button1/#text0 "1" => "2"
+UPDATE button2/#text0 "1" => "2"
 UPDATE button1/#text2 "1" => "2"
 UPDATE #text1 "1" => "2"
 UPDATE button0/#text2 "1" => "2"
+UPDATE button2/#text2 "1" => "2"
 ```
 
 # Render
@@ -42,6 +50,9 @@ UPDATE button0/#text2 "1" => "2"
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  3|3
+</button>
 <button>
   3|3
 </button>
@@ -55,9 +66,11 @@ source=3
 ```
 UPDATE button0/#text0 "2" => "3"
 UPDATE button1/#text0 "2" => "3"
+UPDATE button2/#text0 "2" => "3"
 UPDATE button1/#text2 "2" => "3"
 UPDATE #text1 "2" => "3"
 UPDATE button0/#text2 "2" => "3"
+UPDATE button2/#text2 "2" => "3"
 ```
 
 # Render
@@ -71,6 +84,9 @@ container.querySelectorAll("button").forEach(item => item.click());
 <button>
   4|4
 </button>
+<button>
+  4|4
+</button>
 source=4
 ```
 
@@ -78,7 +94,9 @@ source=4
 ```
 UPDATE button0/#text0 "3" => "4"
 UPDATE button1/#text0 "3" => "4"
+UPDATE button2/#text0 "3" => "4"
 UPDATE button1/#text2 "3" => "4"
 UPDATE #text1 "3" => "4"
 UPDATE button0/#text2 "3" => "4"
+UPDATE button2/#text2 "3" => "4"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/tags/child.js
@@ -1,25 +1,36 @@
-export const $template = "<button><!>|<!></button><button><!>|<!></button>";
-export const $walks = /* get, next(1), replace, over(2), replace, out(1), get, next(1), replace, over(2), replace, out(1) */" D%c%l D%c%l";
+export const $template = "<button><!>|<!></button><button><!>|<!></button><button><!>|<!></button>";
+export const $walks = /* get, next(1), replace, over(2), replace, out(1), get, next(1), replace, over(2), replace, out(1), get, next(1), replace, over(2), replace, out(1) */" D%c%l D%c%l D%c%l";
 export const $setup = () => {};
 import * as _ from "@marko/runtime-tags/debug/dom";
 const $state__script = _._script("__tests__/tags/child.marko_0_state", $scope => _._on($scope["#button/0"], "click", function () {
   $state($scope, $scope.state + 1);
 }));
-const $state = /* @__PURE__ */_._let("state/11", $scope => {
+const $state = /* @__PURE__ */_._let("state/14", $scope => {
   _._text($scope["#text/2"], $scope.state);
   $state__script($scope);
 });
-const $input_value__OR__input_valueChange = /* @__PURE__ */_._or(10, $scope => $state($scope, $scope.input_value, $scope.input_valueChange));
+const $thirdState__script = _._script("__tests__/tags/child.marko_0_thirdState", $scope => _._on($scope["#button/6"], "click", function () {
+  $thirdState($scope, $scope.thirdState + 1);
+}));
+const $thirdState = /* @__PURE__ */_._let("thirdState/16", $scope => {
+  _._text($scope["#text/8"], $scope.thirdState);
+  $thirdState__script($scope);
+});
+const $input_value__OR__input_valueChange = /* @__PURE__ */_._or(13, $scope => {
+  $state($scope, $scope.input_value, $scope.input_valueChange);
+  $thirdState($scope, $scope.input_value, $scope.input_valueChange);
+});
 const $input_value = /* @__PURE__ */_._const("input_value", $scope => {
   _._text($scope["#text/1"], $scope.input_value);
   _._text($scope["#text/4"], $scope.input_value);
+  _._text($scope["#text/7"], $scope.input_value);
   $input_value__OR__input_valueChange($scope);
 });
 const $input_valueChange = /* @__PURE__ */_._const("input_valueChange", $input_value__OR__input_valueChange);
 const $otherState__script = _._script("__tests__/tags/child.marko_0_otherState", $scope => _._on($scope["#button/3"], "click", function () {
   $otherState($scope, $scope.otherState + 1);
 }));
-const $otherState = /* @__PURE__ */_._let("otherState/12", $scope => {
+const $otherState = /* @__PURE__ */_._let("otherState/15", $scope => {
   _._text($scope["#text/5"], $scope.otherState);
   $otherState__script($scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/dom.expected/template.hydrate.js
@@ -1,28 +1,38 @@
-// size: 507 (min) 236 (brotli)
+// size: 644 (min) 264 (brotli)
 const $state__script = _._script("a0", ($scope) =>
     _._on($scope.a, "click", function () {
-      $state($scope, $scope.l + 1);
+      $state($scope, $scope.o + 1);
     }),
   ),
-  $state = _._let(11, ($scope) => {
-    (_._text($scope.c, $scope.l), $state__script($scope));
+  $state = _._let(14, ($scope) => {
+    (_._text($scope.c, $scope.o), $state__script($scope));
   }),
-  $input_value__OR__input_valueChange = _._or(10, ($scope) =>
-    $state($scope, $scope.i, $scope.j),
+  $thirdState__script = _._script("a1", ($scope) =>
+    _._on($scope.g, "click", function () {
+      $thirdState($scope, $scope.q + 1);
+    }),
   ),
-  $input_value = _._const(8, ($scope) => {
-    (_._text($scope.b, $scope.i),
-      _._text($scope.e, $scope.i),
+  $thirdState = _._let(16, ($scope) => {
+    (_._text($scope.i, $scope.q), $thirdState__script($scope));
+  }),
+  $input_value__OR__input_valueChange = _._or(13, ($scope) => {
+    ($state($scope, $scope.l, $scope.m),
+      $thirdState($scope, $scope.l, $scope.m));
+  }),
+  $input_value = _._const(11, ($scope) => {
+    (_._text($scope.b, $scope.l),
+      _._text($scope.e, $scope.l),
+      _._text($scope.h, $scope.l),
       $input_value__OR__input_valueChange($scope));
   }),
-  $input_valueChange = _._const(9, $input_value__OR__input_valueChange),
-  $otherState__script = _._script("a1", ($scope) =>
+  $input_valueChange = _._const(12, $input_value__OR__input_valueChange),
+  $otherState__script = _._script("a2", ($scope) =>
     _._on($scope.d, "click", function () {
-      $otherState($scope, $scope.m + 1);
+      $otherState($scope, $scope.p + 1);
     }),
   ),
-  $otherState = _._let(12, ($scope) => {
-    (_._text($scope.f, $scope.m), $otherState__script($scope));
+  $otherState = _._let(15, ($scope) => {
+    (_._text($scope.f, $scope.p), $otherState__script($scope));
   }),
   $source = _._let(2, ($scope) => {
     ((($scope, input) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/tags/child.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.expected/tags/child.js
@@ -4,7 +4,9 @@ export default _._template("__tests__/tags/child.marko", input => {
   const $scope0_id = _._scope_id();
   let state = input.value;
   let otherState = input["value"];
-  _._html(`<button>${_._escape(input.value)}${_._el_resume($scope0_id, "#text/1", _._serialize_guard($scope0_reason, /* input.value */0))}|<!>${_._escape(state)}${_._el_resume($scope0_id, "#text/2")}</button>${_._el_resume($scope0_id, "#button/0")}<button>${_._escape(input.value)}${_._el_resume($scope0_id, "#text/4", _._serialize_guard($scope0_reason, /* input.value */0))}|<!>${_._escape(otherState)}${_._el_resume($scope0_id, "#text/5")}</button>${_._el_resume($scope0_id, "#button/3")}`);
+  let thirdState = input.value;
+  _._html(`<button>${_._escape(input.value)}${_._el_resume($scope0_id, "#text/1", _._serialize_guard($scope0_reason, /* input.value */0))}|<!>${_._escape(state)}${_._el_resume($scope0_id, "#text/2")}</button>${_._el_resume($scope0_id, "#button/0")}<button>${_._escape(input.value)}${_._el_resume($scope0_id, "#text/4", _._serialize_guard($scope0_reason, /* input.value */0))}|<!>${_._escape(otherState)}${_._el_resume($scope0_id, "#text/5")}</button>${_._el_resume($scope0_id, "#button/3")}<button>${_._escape(input.value)}${_._el_resume($scope0_id, "#text/7", _._serialize_guard($scope0_reason, /* input.value */0))}|<!>${_._escape(thirdState)}${_._el_resume($scope0_id, "#text/8")}</button>${_._el_resume($scope0_id, "#button/6")}`);
+  _._script($scope0_id, "__tests__/tags/child.marko_0_thirdState");
   _._script($scope0_id, "__tests__/tags/child.marko_0_otherState");
   _._script($scope0_id, "__tests__/tags/child.marko_0_state");
   _._scope($scope0_id, {
@@ -12,13 +14,16 @@ export default _._template("__tests__/tags/child.marko", input => {
     input_valueChange: _._serialize_if($scope0_reason, /* input.value */0) && input.valueChange,
     state,
     otherState,
+    thirdState,
     "TagVariableChange:state": input.valueChange || void 0,
-    "TagVariableChange:otherState": input["value" + "Change"] || void 0
+    "TagVariableChange:otherState": input["value" + "Change"] || void 0,
+    "TagVariableChange:thirdState": input.valueChange || void 0
   }, "__tests__/tags/child.marko", 0, {
     input_value: ["input.value"],
     input_valueChange: ["input.valueChange"],
     state: "1:6",
-    otherState: "6:6"
+    otherState: "6:6",
+    thirdState: "11:6"
   });
   _._resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/resume-sanitized.expected.md
@@ -6,6 +6,9 @@
 <button>
   1|1
 </button>
+<button>
+  1|1
+</button>
 source=1
 ```
 
@@ -15,6 +18,9 @@ source=1
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  2|2
+</button>
 <button>
   2|2
 </button>
@@ -36,6 +42,9 @@ container.querySelectorAll("button").forEach(item => item.click());
 <button>
   3|3
 </button>
+<button>
+  3|3
+</button>
 source=3
 ```
 
@@ -45,6 +54,9 @@ source=3
 container.querySelectorAll("button").forEach(item => item.click());
 ```
 ```html
+<button>
+  4|4
+</button>
 <button>
   4|4
 </button>

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/resume.expected.md
@@ -21,6 +21,15 @@
       <!--M_*2 #text/5-->
     </button>
     <!--M_*2 #button/3-->
+    <button>
+      1
+      <!--M_*2 #text/7-->
+      |
+      <!---->
+      1
+      <!--M_*2 #text/8-->
+    </button>
+    <!--M_*2 #button/6-->
     source=
     <!---->
     1
@@ -31,13 +40,15 @@
             "#childScope/0": _.a = {
               input_value: 1,
               state: 1,
-              otherState: 1
+              otherState: 1,
+              thirdState: 1
             }
           }, _.a], _.a.input_valueChange = _.a["TagVariableChange:state"] = _
-          .a["TagVariableChange:otherState"] = _._[
+          .a["TagVariableChange:otherState"] = _.a[
+            "TagVariableChange:thirdState"] = _._[
             "__tests__/template.marko_0/valueChange"
             ](_.c), _.b),
-        "__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
+        "__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
       ];
       M._.w()
     </script>
@@ -72,6 +83,15 @@ container.querySelectorAll("button").forEach(item => item.click());
       <!--M_*2 #text/5-->
     </button>
     <!--M_*2 #button/3-->
+    <button>
+      2
+      <!--M_*2 #text/7-->
+      |
+      <!---->
+      2
+      <!--M_*2 #text/8-->
+    </button>
+    <!--M_*2 #button/6-->
     source=
     <!---->
     2
@@ -82,13 +102,15 @@ container.querySelectorAll("button").forEach(item => item.click());
             "#childScope/0": _.a = {
               input_value: 1,
               state: 1,
-              otherState: 1
+              otherState: 1,
+              thirdState: 1
             }
           }, _.a], _.a.input_valueChange = _.a["TagVariableChange:state"] = _
-          .a["TagVariableChange:otherState"] = _._[
+          .a["TagVariableChange:otherState"] = _.a[
+            "TagVariableChange:thirdState"] = _._[
             "__tests__/template.marko_0/valueChange"
             ](_.c), _.b),
-        "__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
+        "__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
       ];
       M._.w()
     </script>
@@ -100,9 +122,11 @@ container.querySelectorAll("button").forEach(item => item.click());
 ```
 UPDATE html/body/button0/#text0 "1" => "2"
 UPDATE html/body/button1/#text0 "1" => "2"
+UPDATE html/body/button2/#text0 "1" => "2"
 UPDATE html/body/button1/#text2 "1" => "2"
 UPDATE html/body/#text1 "1" => "2"
 UPDATE html/body/button0/#text2 "1" => "2"
+UPDATE html/body/button2/#text2 "1" => "2"
 ```
 
 # Render
@@ -131,6 +155,15 @@ container.querySelectorAll("button").forEach(item => item.click());
       <!--M_*2 #text/5-->
     </button>
     <!--M_*2 #button/3-->
+    <button>
+      3
+      <!--M_*2 #text/7-->
+      |
+      <!---->
+      3
+      <!--M_*2 #text/8-->
+    </button>
+    <!--M_*2 #button/6-->
     source=
     <!---->
     3
@@ -141,13 +174,15 @@ container.querySelectorAll("button").forEach(item => item.click());
             "#childScope/0": _.a = {
               input_value: 1,
               state: 1,
-              otherState: 1
+              otherState: 1,
+              thirdState: 1
             }
           }, _.a], _.a.input_valueChange = _.a["TagVariableChange:state"] = _
-          .a["TagVariableChange:otherState"] = _._[
+          .a["TagVariableChange:otherState"] = _.a[
+            "TagVariableChange:thirdState"] = _._[
             "__tests__/template.marko_0/valueChange"
             ](_.c), _.b),
-        "__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
+        "__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
       ];
       M._.w()
     </script>
@@ -159,9 +194,11 @@ container.querySelectorAll("button").forEach(item => item.click());
 ```
 UPDATE html/body/button0/#text0 "2" => "3"
 UPDATE html/body/button1/#text0 "2" => "3"
+UPDATE html/body/button2/#text0 "2" => "3"
 UPDATE html/body/button1/#text2 "2" => "3"
 UPDATE html/body/#text1 "2" => "3"
 UPDATE html/body/button0/#text2 "2" => "3"
+UPDATE html/body/button2/#text2 "2" => "3"
 ```
 
 # Render
@@ -190,6 +227,15 @@ container.querySelectorAll("button").forEach(item => item.click());
       <!--M_*2 #text/5-->
     </button>
     <!--M_*2 #button/3-->
+    <button>
+      4
+      <!--M_*2 #text/7-->
+      |
+      <!---->
+      4
+      <!--M_*2 #text/8-->
+    </button>
+    <!--M_*2 #button/6-->
     source=
     <!---->
     4
@@ -200,13 +246,15 @@ container.querySelectorAll("button").forEach(item => item.click());
             "#childScope/0": _.a = {
               input_value: 1,
               state: 1,
-              otherState: 1
+              otherState: 1,
+              thirdState: 1
             }
           }, _.a], _.a.input_valueChange = _.a["TagVariableChange:state"] = _
-          .a["TagVariableChange:otherState"] = _._[
+          .a["TagVariableChange:otherState"] = _.a[
+            "TagVariableChange:thirdState"] = _._[
             "__tests__/template.marko_0/valueChange"
             ](_.c), _.b),
-        "__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
+        "__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
       ];
       M._.w()
     </script>
@@ -218,7 +266,9 @@ container.querySelectorAll("button").forEach(item => item.click());
 ```
 UPDATE html/body/button0/#text0 "3" => "4"
 UPDATE html/body/button1/#text0 "3" => "4"
+UPDATE html/body/button2/#text0 "3" => "4"
 UPDATE html/body/button1/#text2 "3" => "4"
 UPDATE html/body/#text1 "3" => "4"
 UPDATE html/body/button0/#text2 "3" => "4"
+UPDATE html/body/button2/#text2 "3" => "4"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/ssr-sanitized.expected.md
@@ -6,5 +6,8 @@
 <button>
   1|1
 </button>
+<button>
+  1|1
+</button>
 source=1
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/ssr.expected.md
@@ -1,6 +1,6 @@
 # Write
 ```html
-  <button>1<!--M_*2 #text/1-->|<!>1<!--M_*2 #text/2--></button><!--M_*2 #button/0--><button>1<!--M_*2 #text/4-->|<!>1<!--M_*2 #text/5--></button><!--M_*2 #button/3-->source=<!>1<!--M_*1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,_.c={"#childScope/0":_.a={input_value:1,state:1,otherState:1}},_.a],_.a.input_valueChange=_.a["TagVariableChange:state"]=_.a["TagVariableChange:otherState"]=_._["__tests__/template.marko_0/valueChange"](_.c),_.b),"__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"];M._.w()</script>
+  <button>1<!--M_*2 #text/1-->|<!>1<!--M_*2 #text/2--></button><!--M_*2 #button/0--><button>1<!--M_*2 #text/4-->|<!>1<!--M_*2 #text/5--></button><!--M_*2 #button/3--><button>1<!--M_*2 #text/7-->|<!>1<!--M_*2 #text/8--></button><!--M_*2 #button/6-->source=<!>1<!--M_*1 #text/1--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,_.c={"#childScope/0":_.a={input_value:1,state:1,otherState:1,thirdState:1}},_.a],_.a.input_valueChange=_.a["TagVariableChange:state"]=_.a["TagVariableChange:otherState"]=_.a["TagVariableChange:thirdState"]=_._["__tests__/template.marko_0/valueChange"](_.c),_.b),"__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"];M._.w()</script>
 ```
 
 # Render End
@@ -26,6 +26,15 @@
       <!--M_*2 #text/5-->
     </button>
     <!--M_*2 #button/3-->
+    <button>
+      1
+      <!--M_*2 #text/7-->
+      |
+      <!---->
+      1
+      <!--M_*2 #text/8-->
+    </button>
+    <!--M_*2 #button/6-->
     source=
     <!---->
     1
@@ -36,13 +45,15 @@
             "#childScope/0": _.a = {
               input_value: 1,
               state: 1,
-              otherState: 1
+              otherState: 1,
+              thirdState: 1
             }
           }, _.a], _.a.input_valueChange = _.a["TagVariableChange:state"] = _
-          .a["TagVariableChange:otherState"] = _._[
+          .a["TagVariableChange:otherState"] = _.a[
+            "TagVariableChange:thirdState"] = _._[
             "__tests__/template.marko_0/valueChange"
             ](_.c), _.b),
-        "__tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
+        "__tests__/tags/child.marko_0_thirdState 2 __tests__/tags/child.marko_0_otherState 2 __tests__/tags/child.marko_0_state 2"
       ];
       M._.w()
     </script>
@@ -71,10 +82,18 @@ INSERT html/body/button1/#comment1
 INSERT html/body/button1/#text2
 INSERT html/body/button1/#comment2
 INSERT html/body/#comment1
-INSERT html/body/#text0
+INSERT html/body/button2
+INSERT html/body/button2/#text0
+INSERT html/body/button2/#comment0
+INSERT html/body/button2/#text1
+INSERT html/body/button2/#comment1
+INSERT html/body/button2/#text2
+INSERT html/body/button2/#comment2
 INSERT html/body/#comment2
-INSERT html/body/#text1
+INSERT html/body/#text0
 INSERT html/body/#comment3
+INSERT html/body/#text1
+INSERT html/body/#comment4
 INSERT html/body/script
 INSERT html/body/script/#text
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/tags/child.marko
@@ -7,3 +7,8 @@
 <button onClick() { otherState++; }>
   ${input.value}|${otherState}
 </button>
+
+<let/thirdState:=((input.value))>
+<button onClick() { thirdState++; }>
+  ${input.value}|${thirdState}
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/dom.expected/template.js
@@ -2,7 +2,7 @@ export const $template = "<button>Increment</button><!> <!>";
 export const $walks = /* get, over(1), replace, over(2), replace, over(1) */" b%c%b";
 export const $setup = () => {};
 import * as _ from "@marko/runtime-tags/debug/dom";
-const $b__script = _._script("__tests__/template.marko_0_b", $scope => _._on($scope["#button/0"], "click", (() => $b($scope, $scope.b + 1) - 1)));
+const $b__script = _._script("__tests__/template.marko_0_b", $scope => _._on($scope["#button/0"], "click", () => $b($scope, $scope.b + 1) - 1));
 const $b = /* @__PURE__ */_._let("b/6", $scope => {
   _._text($scope["#text/2"], $scope.b);
   $b__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.expected/template.js
@@ -11,7 +11,7 @@ const $z = /* @__PURE__ */_._const("z", $scope => {
   _._text($scope["#text/3"], $scope.z);
   $y__OR__z($scope);
 });
-const $x__script = _._script("__tests__/template.marko_0_x", $scope => _._on($scope["#button/0"], "click", (() => $x($scope, $scope.x + 1) - 1)));
+const $x__script = _._script("__tests__/template.marko_0_x", $scope => _._on($scope["#button/0"], "click", () => $x($scope, $scope.x + 1) - 1));
 const $x = /* @__PURE__ */_._let("x/5", $scope => {
   _._text($scope["#text/1"], $scope.x);
   $y($scope, $scope.x + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.expected/template.js
@@ -1,7 +1,7 @@
 export const $template = "<button> </button><!>";
 export const $walks = /* get, next(1), get, out(1), replace, over(1) */" D l%b";
 import * as _ from "@marko/runtime-tags/debug/dom";
-const $x__OR__y__script = _._script("__tests__/template.marko_0_x_y", $scope => _._on($scope["#button/0"], "click", (() => $x($scope, $y($scope, $scope.x + $scope.y)))));
+const $x__OR__y__script = _._script("__tests__/template.marko_0_x_y", $scope => _._on($scope["#button/0"], "click", () => $x($scope, $y($scope, $scope.x + $scope.y))));
 const $x__OR__y = /* @__PURE__ */_._or(5, $x__OR__y__script);
 const $x = /* @__PURE__ */_._let("x/3", $scope => {
   _._text($scope["#text/1"], $scope.x);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.expected/template.js
@@ -2,7 +2,7 @@ export const $template = "<!><!><button>More</button>";
 export const $walks = /* over(1), replace, over(1), get, over(1) */"b%b b";
 import * as _ from "@marko/runtime-tags/debug/dom";
 const $for_content__if = /* @__PURE__ */_._if("#text/0", "<div>b</div>", /* over(1) */"b");
-const $for_content__items_length = /* @__PURE__ */_._for_closure("#text/0", $scope => $for_content__if($scope, ($scope._.items_length > 1) ? 0 : 1));
+const $for_content__items_length = /* @__PURE__ */_._for_closure("#text/0", $scope => $for_content__if($scope, $scope._.items_length > 1 ? 0 : 1));
 const $for_content__setup = $for_content__items_length;
 const $itemId__OR__items__script = _._script("__tests__/template.marko_0_itemId_items", $scope => _._on($scope["#button/1"], "click", function () {
   $items($scope, [...$scope.items, $itemId($scope, $scope.itemId + 1)]);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/html.expected/template.js
@@ -8,7 +8,7 @@ export default _._template("__tests__/template.marko", input => {
     const $scope1_id = _._scope_id();
     _._html("<div>a</div>");
     _._if(() => {
-      if ((items.length > 1)) {
+      if (items.length > 1) {
         const $scope2_id = _._scope_id();
         _._html("<div>b</div>");
         _._scope($scope2_id, {}, "__tests__/template.marko", "6:4");

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/__snapshots__/dom.expected/template.js
@@ -9,7 +9,7 @@ const $d = /* @__PURE__ */_2._let("d/9", $scope => _2._text($scope["#text/4"], $
 const $e = /* @__PURE__ */_2._let("e/10", $scope => _2._text($scope["#text/5"], JSON.stringify($scope.e)));
 const $setup__script = _2._script("__tests__/template.marko_0", $scope => _2._on($scope["#button/0"], "click", function () {
   let local;
-  ((($result2, $a2, $b2, unused, $c2) => ({
+  (($result2, $a2, $b2, unused, $c2) => ({
     a: $a2,
     _b: {
       _b: $b2
@@ -24,7 +24,7 @@ const $setup__script = _2._script("__tests__/template.marko_0", $scope => _2._on
     },
     local: 3,
     c: 4
-  }));
+  });
   noop((($result, $d2, $e2) => ([{
     arr: [local, $d2,, ...$e2]
   }] = $result, $d($scope, $d2), $e($scope, $e2), $result))([{

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/__snapshots__/dom.expected/template.js
@@ -4,13 +4,13 @@ const identity = fn => fn;
 import * as _2 from "@marko/runtime-tags/debug/dom";
 const $setup__script = _2._script("__tests__/template.marko_0", $scope => _2._on($scope["#button/0"], "click", identity((_, el) => {
   let bar;
-  ((($result, value) => ({
+  (($result, value) => ({
     value,
     bar
   } = $result, $result))({
     value: "updated",
     bar: "bar"
-  }));
+  });
   el.textContent = bar;
 })));
 export function $setup($scope) {


### PR DESCRIPTION
Revert a recent change to preserve parenthesized expressions in the compiler.
This caused a regression through some analysis which did not account for parenthesized expressions.
