### PR TITLE
fix: issue with typed attr bindings

### DIFF
--- a/.changeset/floppy-houses-design.md
+++ b/.changeset/floppy-houses-design.md
@@ -1,0 +1,7 @@
+---
+"marko": patch
+"@marko/runtime-tags": patch
+"@marko/compiler": patch
+---
+
+Ensure types stripped before transform phase in compiler.

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -278,10 +278,11 @@ function getMarkoFile(code, fileOpts, markoOpts) {
       }
     }
 
+    if (markoOpts.stripTypes) {
+      stripTypes(file);
+    }
+
     if (isMigrate) {
-      if (markoOpts.stripTypes) {
-        stripTypes(file);
-      }
       return file;
     }
 
@@ -299,11 +300,6 @@ function getMarkoFile(code, fileOpts, markoOpts) {
       rootTransformers.push(translator.transform);
     }
     traverseAll(file, rootTransformers);
-
-    if (markoOpts.stripTypes) {
-      stripTypes(file);
-    }
-
     file.path.scope.crawl();
 
     for (const taglibId in taglibLookup.taglibsById) {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/.name-cache.json
@@ -1,0 +1,12 @@
+{
+  "vars": {
+    "props": {
+      "$_": "r",
+      "$init": "t",
+      "$$value": "_",
+      "$$mytag_content__count__script": "o",
+      "$$mytag_content__count": "e",
+      "$$count__closure": "c"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  2
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  3
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/csr.expected.md
@@ -1,0 +1,72 @@
+# Render
+```html
+<!---->
+<!---->
+<button>
+  0
+</button>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+INSERT #comment0, #comment1, button, #comment2, #comment3
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<!---->
+<!---->
+<button>
+  1
+</button>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+UPDATE button/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<!---->
+<!---->
+<button>
+  2
+</button>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+UPDATE button/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<!---->
+<!---->
+<button>
+  3
+</button>
+<!---->
+<!---->
+```
+
+# Mutations
+```
+UPDATE button/#text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/tags/my-let.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/tags/my-let.js
@@ -1,0 +1,16 @@
+export const $template = "";
+export const $walks = "";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $value = /* @__PURE__ */_._let("value/3", $scope => _._return($scope, $scope.value));
+export const $input_value = ($scope, input_value) => $value($scope, input_value);
+export function $setup($scope) {
+  _._return_change($scope, $valueChange($scope));
+}
+export const $input = ($scope, input) => $input_value($scope, input.value);
+function $valueChange($scope) {
+  return _new_value => {
+    $value($scope, _new_value);
+  };
+}
+_._resume("__tests__/tags/my-let.marko_0/valueChange", $valueChange);
+export default /* @__PURE__ */_._template("__tests__/tags/my-let.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/tags/my-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/tags/my-tag.js
@@ -1,0 +1,8 @@
+export const $template = "<!><!><!>";
+export const $walks = /* over(1), replace, over(2) */"b%c";
+export const $setup = () => {};
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $dynamicTag = /* @__PURE__ */_._dynamic_tag("#text/0");
+export const $input_content = ($scope, input_content) => $dynamicTag($scope, input_content);
+export const $input = ($scope, input) => $input_content($scope, input.content);
+export default /* @__PURE__ */_._template("__tests__/tags/my-tag.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,17 @@
+// size: 276 (min) 177 (brotli)
+const $value = _._let(3, ($scope) => _._return($scope, $scope.d));
+_._resume("a0", function ($scope) {
+  return (_new_value) => {
+    $value($scope, _new_value);
+  };
+});
+const $mytag_content__count__script = _._script("c0", ($scope) =>
+    _._on($scope.a, "click", function () {
+      _._var_change($scope._.a, $scope._.d + 1);
+    }),
+  ),
+  $mytag_content__count = _._closure_get(3, ($scope) => {
+    (_._text($scope.b, $scope._.d), $mytag_content__count__script($scope));
+  }),
+  $count__closure = _._closure($mytag_content__count);
+(_._var_resume("c2", _._const(3, $count__closure)), init());

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.expected/template.js
@@ -1,0 +1,24 @@
+export const $template = `<!>${_myLet_template}${_myTag_template}<!>`;
+export const $walks = /* over(1), <my-let/var>, <my-tag>, over(1) */`b0${_myLet_walks}&/${_myTag_walks}&b`;
+import * as _ from "@marko/runtime-tags/debug/dom";
+import { $setup as _myLet, $input_value as _myLet_input_value, $template as _myLet_template, $walks as _myLet_walks } from "./tags/my-let.marko";
+import { $setup as _myTag, $input_content as _myTag_input_content, $template as _myTag_template, $walks as _myTag_walks } from "./tags/my-tag.marko";
+const $mytag_content__count__script = _._script("__tests__/template.marko_1_count", $scope => _._on($scope["#button/0"], "click", function () {
+  _._var_change($scope._["#childScope/0"], $scope._.count + 1, "count");
+}));
+const $mytag_content__count = /* @__PURE__ */_._closure_get("count", $scope => {
+  _._text($scope["#text/1"], $scope._.count);
+  $mytag_content__count__script($scope);
+});
+const $mytag_content__setup = $mytag_content__count;
+const $mytag_content = /* @__PURE__ */_._content("__tests__/template.marko_1_content", "<button> </button>", /* get, next(1), get, out(1) */" D l", $mytag_content__setup);
+const $count__closure = /* @__PURE__ */_._closure($mytag_content__count);
+const $count = _._var_resume("__tests__/template.marko_0_count/var", /* @__PURE__ */_._const("count", $count__closure));
+export function $setup($scope) {
+  _._var($scope, "#childScope/0", $count);
+  _myLet($scope["#childScope/0"]);
+  _myLet_input_value($scope["#childScope/0"], 0);
+  _myTag($scope["#childScope/2"]);
+  _myTag_input_content($scope["#childScope/2"], $mytag_content($scope));
+}
+export default /* @__PURE__ */_._template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/tags/my-let.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/tags/my-let.js
@@ -1,0 +1,14 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/tags/my-let.marko", input => {
+  _._scope_reason();
+  const $scope0_id = _._scope_id();
+  let value = input.value;
+  const $return = value;
+  _._scope($scope0_id, {
+    "#TagVariableChange": _._resume(_new_value => {
+      value = _new_value;
+    }, "__tests__/tags/my-let.marko_0/valueChange", $scope0_id) || void 0
+  }, "__tests__/tags/my-let.marko", 0);
+  _._resume_branch($scope0_id);
+  return $return;
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/tags/my-tag.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/tags/my-tag.js
@@ -1,0 +1,7 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/tags/my-tag.marko", input => {
+  const $scope0_reason = _._scope_reason();
+  const $scope0_id = _._scope_id();
+  _._dynamic_tag($scope0_id, "#text/0", input.content, {}, 0, 0, _._serialize_guard($scope0_reason, /* input.content */0));
+  _._serialize_if($scope0_reason, /* input.content */0) && _._scope($scope0_id, {}, "__tests__/tags/my-tag.marko", 0);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/html.expected/template.js
@@ -1,0 +1,33 @@
+import _myLet from "./tags/my-let.marko";
+import * as _ from "@marko/runtime-tags/debug/html";
+import _myTag from "./tags/my-tag.marko";
+export default _._template("__tests__/template.marko", input => {
+  _._scope_reason();
+  const $scope0_id = _._scope_id();
+  const $count__closures = new Set();
+  const $childScope = _._peek_scope_id();
+  let count = _myLet({
+    value: 0
+  });
+  _._var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_count/var");
+  _myTag({
+    content: _._content("__tests__/template.marko_1_content", () => {
+      _._scope_reason();
+      const $scope1_id = _._scope_id();
+      _._html(`<button>${_._escape(count)}${_._el_resume($scope1_id, "#text/1")}</button>${_._el_resume($scope1_id, "#button/0")}`);
+      _._script($scope1_id, "__tests__/template.marko_1_count");
+      _._subscribe($count__closures, _._scope($scope1_id, {
+        _: _._scope_with_id($scope0_id),
+        "ClosureSignalIndex:count": 0
+      }, "__tests__/template.marko", "2:1"));
+      _._resume_branch($scope1_id);
+    })
+  });
+  _._scope($scope0_id, {
+    count,
+    "#childScope/0": _._existing_scope($childScope),
+    "ClosureScopes:count": $count__closures
+  }, "__tests__/template.marko", 0, {
+    count: "1:8"
+  });
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  2
+</button>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  3
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/resume.expected.md
@@ -1,0 +1,156 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      0
+      <!--M_*5 #text/1-->
+    </button>
+    <!--M_*5 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.c = [0, _.b = {
+          "#scopeOffset/1": 3,
+          count: 0,
+          "#childScope/0": _.a = {},
+          "ClosureScopes:count": _.d = new Set
+        }, _.a, 2, _.e = {
+          _: _.b,
+          "ClosureSignalIndex:count": 0
+        }], _.a["#TagVariableChange"] = _._[
+          "__tests__/tags/my-let.marko_0/valueChange"
+          ](_.a), _.a["#TagVariable"] = _._[
+          "__tests__/template.marko_0_count/var"
+          ](_.b), (_.d).add(_.e), _.c),
+        "__tests__/template.marko_1_count 5"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      1
+      <!--M_*5 #text/1-->
+    </button>
+    <!--M_*5 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.c = [0, _.b = {
+          "#scopeOffset/1": 3,
+          count: 0,
+          "#childScope/0": _.a = {},
+          "ClosureScopes:count": _.d = new Set
+        }, _.a, 2, _.e = {
+          _: _.b,
+          "ClosureSignalIndex:count": 0
+        }], _.a["#TagVariableChange"] = _._[
+          "__tests__/tags/my-let.marko_0/valueChange"
+          ](_.a), _.a["#TagVariable"] = _._[
+          "__tests__/template.marko_0_count/var"
+          ](_.b), (_.d).add(_.e), _.c),
+        "__tests__/template.marko_1_count 5"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/button/#text "0" => "1"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      2
+      <!--M_*5 #text/1-->
+    </button>
+    <!--M_*5 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.c = [0, _.b = {
+          "#scopeOffset/1": 3,
+          count: 0,
+          "#childScope/0": _.a = {},
+          "ClosureScopes:count": _.d = new Set
+        }, _.a, 2, _.e = {
+          _: _.b,
+          "ClosureSignalIndex:count": 0
+        }], _.a["#TagVariableChange"] = _._[
+          "__tests__/tags/my-let.marko_0/valueChange"
+          ](_.a), _.a["#TagVariable"] = _._[
+          "__tests__/template.marko_0_count/var"
+          ](_.b), (_.d).add(_.e), _.c),
+        "__tests__/template.marko_1_count 5"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/button/#text "1" => "2"
+```
+
+# Render
+```js
+container.querySelector("button").click();
+```
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      3
+      <!--M_*5 #text/1-->
+    </button>
+    <!--M_*5 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.c = [0, _.b = {
+          "#scopeOffset/1": 3,
+          count: 0,
+          "#childScope/0": _.a = {},
+          "ClosureScopes:count": _.d = new Set
+        }, _.a, 2, _.e = {
+          _: _.b,
+          "ClosureSignalIndex:count": 0
+        }], _.a["#TagVariableChange"] = _._[
+          "__tests__/tags/my-let.marko_0/valueChange"
+          ](_.a), _.a["#TagVariable"] = _._[
+          "__tests__/template.marko_0_count/var"
+          ](_.b), (_.d).add(_.e), _.c),
+        "__tests__/template.marko_1_count 5"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/button/#text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,6 @@
+# Render End
+```html
+<button>
+  0
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/ssr.expected.md
@@ -1,0 +1,50 @@
+# Write
+```html
+  <button>0<!--M_*5 #text/1--></button><!--M_*5 #button/0--><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.c=[0,_.b={"#scopeOffset/1":3,count:0,"#childScope/0":_.a={},"ClosureScopes:count":_.d=new Set},_.a,2,_.e={_:_.b,"ClosureSignalIndex:count":0}],_.a["#TagVariableChange"]=_._["__tests__/tags/my-let.marko_0/valueChange"](_.a),_.a["#TagVariable"]=_._["__tests__/template.marko_0_count/var"](_.b),(_.d).add(_.e),_.c),"__tests__/template.marko_1_count 5"];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <button>
+      0
+      <!--M_*5 #text/1-->
+    </button>
+    <!--M_*5 #button/0-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.c = [0, _.b = {
+          "#scopeOffset/1": 3,
+          count: 0,
+          "#childScope/0": _.a = {},
+          "ClosureScopes:count": _.d = new Set
+        }, _.a, 2, _.e = {
+          _: _.b,
+          "ClosureSignalIndex:count": 0
+        }], _.a["#TagVariableChange"] = _._[
+          "__tests__/tags/my-let.marko_0/valueChange"
+          ](_.a), _.a["#TagVariable"] = _._[
+          "__tests__/template.marko_0_count/var"
+          ](_.b), (_.d).add(_.e), _.c),
+        "__tests__/template.marko_1_count 5"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/button
+INSERT html/body/button/#text
+INSERT html/body/button/#comment
+INSERT html/body/#comment
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/tags/my-let.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/tags/my-let.marko
@@ -1,0 +1,3 @@
+let/value=input.value
+
+return:=value as number

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/tags/my-tag.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/tags/my-tag.marko
@@ -1,0 +1,1 @@
+${input.content}

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/template.marko
@@ -1,0 +1,3 @@
+my-let/count=0
+my-tag
+  button onClick() { count++ } -- ${count}

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/test.ts
@@ -1,0 +1,5 @@
+export const steps = [{}, click, click, click];
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}


### PR DESCRIPTION
Ensures types are stripped before transform phase.

This fixes an issue with the "preAnalyze" phase seeing type information (and erroring).
Specifically bound attributes with an `as` cast were incorrectly erroring.