### PR TITLE
chore: export object from test fixtures for improved typescript support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -196,7 +196,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2230,7 +2229,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2271,7 +2269,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4094,7 +4091,6 @@
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -4158,7 +4154,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4398,7 +4393,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4762,7 +4756,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5994,7 +5987,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9072,7 +9064,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9541,7 +9532,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10494,7 +10484,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10646,7 +10635,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/runtime-tags/src/__tests__/fixtures/abort-signal-render-phase-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/abort-signal-render-phase-error/test.ts
@@ -1,2 +1,6 @@
-export const skip_dom = true;
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_dom: true,
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-export const steps = [{}, click];
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/test.ts
@@ -1,3 +1,5 @@
-export const steps = [{}];
+import type { TestConfig } from "../../main.test";
 
-export const error_compiler = true;
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, flush, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, flush, flush, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/test.ts
@@ -1,9 +1,11 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, wait, click, wait];
-
-export const skip_equivalent = true; // in-order streaming
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, wait, click, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-nested-resolve-in-order/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-nested-resolve-in-order/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, flush, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, flush, wait, click];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-isolated-boundaries/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-isolated-boundaries/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-resolve-in-order/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-resolve-in-order/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-resolve-out-of-order/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-resolve-out-of-order/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, wait, click, wait, click, wait];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, wait, click, wait, click, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ x: true }, { x: false }, { x: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ x: true }, { x: false }, { x: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/test.ts
@@ -1,4 +1,8 @@
-export const steps = [
-  { c: true, d: true },
-  { c: false, d: false },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    { c: true, d: true },
+    { c: false, d: false },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-escape/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-escape/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ foo: "c", bar: "d" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ foo: "c", bar: "d" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ color: "red" }, { color: "purple" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ color: "red" }, { color: "purple" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ name: "Marko" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ name: "Marko" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, wait, click];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, wait, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/test.ts
@@ -1,19 +1,21 @@
+import type { TestConfig } from "../../main.test";
 import { after, flush } from "../../utils/resolve";
-
-export const steps = [
-  {},
-  after(1),
-  click,
-  after(2),
-  click,
-  after(3),
-  flush,
-  after(5),
-  click,
-];
-
-export const skip_equivalent = true; // in-order streaming
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    after(1),
+    click,
+    after(2),
+    click,
+    after(3),
+    flush,
+    after(5),
+    click,
+  ],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, wait, click, wait, click];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, wait, click, wait, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/test.ts
@@ -1,17 +1,20 @@
+import type { TestConfig } from "../../main.test";
 import { after, flush } from "../../utils/resolve";
-
-export const steps = [
-  {},
-  after(1),
-  click,
-  after(2),
-  click,
-  after(3),
-  flush,
-  after(5),
-  click,
-];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    after(1),
+    click,
+    after(2),
+    click,
+    after(3),
+    flush,
+    after(5),
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, wait, flush];
-
-export const skip_equivalent = true; // try removed before flush
+export const config: TestConfig = {
+  steps: [{}, wait, flush],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/test.ts
@@ -1,9 +1,11 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, flush, wait, click, click, click];
-
-export const skip_equivalent = true; // in-order streaming
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait, click, click, click],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { after, flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, after(2), flush, wait];
+export const config: TestConfig = {
+  steps: [{}, after(2), flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-chain/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-chain/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/test.ts
@@ -1,8 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
 const increment = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc")!.click();
 };
+
 const toggle = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.toggle")!.click();
 };
 
-export const steps = [{}, increment, toggle, increment, toggle, increment];
+export const config: TestConfig = {
+  steps: [{}, increment, toggle, increment, toggle, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/test.ts
@@ -1,8 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
 const increment = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc")!.click();
 };
+
 const toggle = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.toggle")!.click();
 };
 
-export const steps = [{}, increment, toggle, increment, toggle, increment];
+export const config: TestConfig = {
+  steps: [{}, increment, toggle, increment, toggle, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, count, count, multiplier];
+import type { TestConfig } from "../../main.test";
 
 function count(container: Element) {
   container.querySelector<HTMLButtonElement>("button#count")!.click();
@@ -7,3 +7,7 @@ function count(container: Element) {
 function multiplier(container: Element) {
   container.querySelector<HTMLButtonElement>("button#multiplier")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, count, count, multiplier],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ tagName: "h1" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ tagName: "h1" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-export/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-export/test.ts
@@ -1,5 +1,9 @@
-export const steps = () => [
-  {
-    value: require("./template.marko").v,
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: () => [
+    {
+      value: require("./template.marko").v,
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/test.ts
@@ -1,2 +1,5 @@
-export const steps = [{}];
-export const skip_dom = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_dom: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/test.ts
@@ -1,27 +1,31 @@
-export const steps = [
-  {
-    comments: [
-      {
-        text: "Hello World",
-        comments: [
-          {
-            text: "testing 123",
-          },
-        ],
-      },
-      {
-        text: "Goodbye World",
-      },
-    ],
-  },
-  toggle("0"),
-  toggle("0"),
-  toggle("0-0"),
-  toggle("1"),
-];
+import type { TestConfig } from "../../main.test";
 
 function toggle(id: string) {
   return (container: Element) => {
     (container.querySelector(`#c-${id} > button`) as HTMLButtonElement).click();
   };
 }
+
+export const config: TestConfig = {
+  steps: [
+    {
+      comments: [
+        {
+          text: "Hello World",
+          comments: [
+            {
+              text: "testing 123",
+            },
+          ],
+        },
+        {
+          text: "Goodbye World",
+        },
+      ],
+    },
+    toggle("0"),
+    toggle("0"),
+    toggle("0-0"),
+    toggle("1"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-layout/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-layout/test.ts
@@ -1,3 +1,7 @@
-export const steps = [{ name: "World" }];
-export const skip_csr = true;
-export const skip_resume = false;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ name: "World" }],
+  skip_csr: true,
+  skip_resume: false,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/test.ts
@@ -1,9 +1,4 @@
-export const steps = [
-  {},
-  (c: Element) => click(c, 2),
-  (c: Element) => click(c, 3),
-  (c: Element) => click(c, 5),
-];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element, number: number) {
   const buttons: HTMLButtonElement[] = Array.from(
@@ -12,3 +7,12 @@ function click(container: Element, number: number) {
   const button = buttons.find((b) => b.textContent === "" + number)!;
   button.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    (c: Element) => click(c, 2),
+    (c: Element) => click(c, 3),
+    (c: Element) => click(c, 5),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, add, add, remove, add];
+import type { TestConfig } from "../../main.test";
 
 function add(container: Element) {
   (container.querySelector("#add") as HTMLButtonElement).click();
@@ -7,3 +7,7 @@ function add(container: Element) {
 function remove(container: Element) {
   (container.querySelector("#remove") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, add, add, remove, add],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, toggle, toggle, reverse];
+import type { TestConfig } from "../../main.test";
 
 function toggle(container: Element) {
   (container.querySelector("#toggle") as HTMLButtonElement).click();
@@ -7,3 +7,7 @@ function toggle(container: Element) {
 function reverse(container: Element) {
   (container.querySelector("#reverse") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, toggle, toggle, reverse],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector("button")!.click();
 };
 
-export const steps = [{}, click] as const;
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector("button")!.click();
 };
 
-export const steps = [{}, click] as const;
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/test.ts
@@ -1,3 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 const clickControlled = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#controlled")!.click();
 };
@@ -6,12 +8,14 @@ const clickUncontrolled = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#uncontrolled")!.click();
 };
 
-export const steps = [
-  {},
-  clickControlled,
-  clickUncontrolled,
-  clickControlled,
-  clickUncontrolled,
-  clickControlled,
-  clickUncontrolled,
-] as const;
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickControlled,
+    clickUncontrolled,
+    clickControlled,
+    clickUncontrolled,
+    clickControlled,
+    clickUncontrolled,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector("button")!.click();
 };
 
-export const steps = [{}, click, click, click];
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/cdata/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cdata/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/test.ts
@@ -1,13 +1,4 @@
-export const steps = [
-  {},
-  clickInner,
-  clickMiddle,
-  clickOuter,
-  clickInner,
-  clickMiddle,
-  clickOuter,
-  clickOuter,
-];
+import type { TestConfig } from "../../main.test";
 
 function clickOuter(container: Element) {
   container.querySelector<HTMLButtonElement>("button#outer")!.click();
@@ -20,3 +11,16 @@ function clickMiddle(container: Element) {
 function clickInner(container: Element) {
   container.querySelector<HTMLButtonElement>("button#inner")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickInner,
+    clickMiddle,
+    clickOuter,
+    clickInner,
+    clickMiddle,
+    clickOuter,
+    clickOuter,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/test.ts
@@ -1,13 +1,4 @@
-export const steps = [
-  {},
-  clickInner,
-  clickMiddle,
-  clickOuter,
-  clickInner,
-  clickMiddle,
-  clickOuter,
-  clickOuter,
-];
+import type { TestConfig } from "../../main.test";
 
 function clickOuter(container: Element) {
   container.querySelector<HTMLButtonElement>("button#outer")!.click();
@@ -20,3 +11,16 @@ function clickMiddle(container: Element) {
 function clickInner(container: Element) {
   container.querySelector<HTMLButtonElement>("button#inner")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickInner,
+    clickMiddle,
+    clickOuter,
+    clickInner,
+    clickMiddle,
+    clickOuter,
+    clickOuter,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-export const steps = [{ message: "hello" }, click, click];
+export const config: TestConfig = {
+  steps: [{ message: "hello" }, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/test.ts
@@ -1,8 +1,11 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
 
-export const skip_csr = true;
-export const error_runtime = true;
+export const config: TestConfig = {
+  steps: [{}, click],
+  skip_csr: true,
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelectorAll("button")!.forEach((button) => button.click());
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelectorAll("button")!.forEach((button) => button.click());
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag-hoist-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag-hoist-error/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, click0, click1, click1];
+import type { TestConfig } from "../../main.test";
 
 function click0(container: Element) {
   container.querySelectorAll("input").item(0).click();
@@ -7,3 +7,7 @@ function click0(container: Element) {
 function click1(container: Element) {
   container.querySelectorAll("input").item(1).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click0, click1, click1],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("input")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/test.ts
@@ -1,11 +1,13 @@
-export const steps = [{}, click0, click1, click2, reset];
+import type { TestConfig } from "../../main.test";
 
 function click0(container: Element) {
   container.querySelectorAll(`input`)[0]!.click();
 }
+
 function click1(container: Element) {
   container.querySelectorAll(`input`)[1]!.click();
 }
+
 function click2(container: Element) {
   container.querySelectorAll(`input`)[2]!.click();
 }
@@ -13,3 +15,7 @@ function click2(container: Element) {
 function reset(container: Element) {
   container.querySelector<HTMLButtonElement>("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click0, click1, click2, reset],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/test.ts
@@ -1,11 +1,17 @@
-export const steps = [{}, click1, click2, click0];
+import type { TestConfig } from "../../main.test";
 
 function click0(container: Element) {
   container.querySelectorAll(`input`)[0]!.click();
 }
+
 function click1(container: Element) {
   container.querySelectorAll(`input`)[1]!.click();
 }
+
 function click2(container: Element) {
   container.querySelectorAll(`input`)[2]!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click1, click2, click0],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/test.ts
@@ -1,11 +1,17 @@
-export const steps = [{}, clickB, clickC, clickA];
+import type { TestConfig } from "../../main.test";
 
 function clickA(container: Element) {
   container.querySelectorAll(`input`)[0]!.click();
 }
+
 function clickB(container: Element) {
   container.querySelectorAll(`input`)[1]!.click();
 }
+
 function clickC(container: Element) {
   container.querySelectorAll(`input`)[2]!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickB, clickC, clickA],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/test.ts
@@ -1,11 +1,17 @@
-export const steps = [{}, clickB, clickC, clickA];
+import type { TestConfig } from "../../main.test";
 
 function clickA(container: Element) {
   container.querySelectorAll(`input`)[0]!.click();
 }
+
 function clickB(container: Element) {
   container.querySelectorAll(`input`)[1]!.click();
 }
+
 function clickC(container: Element) {
   container.querySelectorAll(`input`)[2]!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickB, clickC, clickA],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("input")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/test.ts
@@ -1,11 +1,17 @@
-export const steps = [{}, clickB, clickC, clickA];
+import type { TestConfig } from "../../main.test";
 
 function clickA(container: Element) {
   container.querySelectorAll(`input`)[0]!.click();
 }
+
 function clickB(container: Element) {
   container.querySelectorAll(`input`)[1]!.click();
 }
+
 function clickC(container: Element) {
   container.querySelectorAll(`input`)[2]!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickB, clickC, clickA],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("input")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/test.ts
@@ -1,6 +1,10 @@
-export const steps = [{}, toggle, toggle, toggle];
+import type { TestConfig } from "../../main.test";
 
 function toggle(container: Element) {
   const details = container.querySelector<HTMLDetailsElement>("details")!;
   details.open = !details.open;
 }
+
+export const config: TestConfig = {
+  steps: [{}, toggle, toggle, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/test.ts
@@ -1,6 +1,10 @@
-export const steps = [{}, toggle, toggle, toggle];
+import type { TestConfig } from "../../main.test";
 
 function toggle(container: Element) {
   const dialog = container.querySelector<HTMLDialogElement>("dialog")!;
   dialog.open = !dialog.open;
 }
+
+export const config: TestConfig = {
+  steps: [{}, toggle, toggle, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/test.ts
@@ -1,11 +1,17 @@
-export const steps = [{}, clickB, toggleB, toggleB, clickA];
+import type { TestConfig } from "../../main.test";
 
 function clickA(container: Element) {
   container.querySelector<HTMLInputElement>(`input[value=a]`)!.click();
 }
+
 function clickB(container: Element) {
   container.querySelector<HTMLInputElement>(`input[value=b]`)!.click();
 }
+
 function toggleB(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickB, toggleB, toggleB, clickA],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, type("w"), type("wor"), type("world")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -8,3 +8,7 @@ function type(value: string) {
     input.dispatchEvent(new window.Event("input", { bubbles: true }));
   };
 }
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, type("w"), type("wor"), type("world")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -8,3 +8,7 @@ function type(value: string) {
     input.dispatchEvent(new window.Event("input", { bubbles: true }));
   };
 }
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, selectC];
+import type { TestConfig } from "../../main.test";
 
 function selectC(container: Element) {
   const select = container.querySelector(`select`)!;
@@ -6,3 +6,7 @@ function selectC(container: Element) {
   select.value = "c";
   select.dispatchEvent(new window.Event("input", { bubbles: true }));
 }
+
+export const config: TestConfig = {
+  steps: [{}, selectC],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/test.ts
@@ -1,11 +1,13 @@
-export const steps = [{}, select0, select1, select2, reset];
+import type { TestConfig } from "../../main.test";
 
 function select0(container: Element) {
   selectIndex(container, 0);
 }
+
 function select1(container: Element) {
   selectIndex(container, 1);
 }
+
 function select2(container: Element) {
   selectIndex(container, 2);
 }
@@ -21,3 +23,7 @@ function selectIndex(container: Element, index: number) {
     new select.ownerDocument.defaultView!.Event("input", { bubbles: true }),
   );
 }
+
+export const config: TestConfig = {
+  steps: [{}, select0, select1, select2, reset],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/test.ts
@@ -1,12 +1,4 @@
-export const steps = [
-  {},
-  clickRemove,
-  clickRemove,
-  clickRemove,
-  clickAdd,
-  clickAdd,
-  clickAdd,
-];
+import type { TestConfig } from "../../main.test";
 
 function clickAdd(container: Element) {
   container.querySelector<HTMLButtonElement>(".add")!.click();
@@ -15,3 +7,15 @@ function clickAdd(container: Element) {
 function clickRemove(container: Element) {
   container.querySelector<HTMLButtonElement>(".remove")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickRemove,
+    clickRemove,
+    clickRemove,
+    clickAdd,
+    clickAdd,
+    clickAdd,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, selectC];
+import type { TestConfig } from "../../main.test";
 
 function selectC(container: Element) {
   const select = container.querySelector(`select`)!;
@@ -6,3 +6,7 @@ function selectC(container: Element) {
   select.value = "c";
   select.dispatchEvent(new window.Event("input", { bubbles: true }));
 }
+
+export const config: TestConfig = {
+  steps: [{}, selectC],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/test.ts
@@ -1,11 +1,13 @@
-export const steps = [{}, select0, select1, select2, reset];
+import type { TestConfig } from "../../main.test";
 
 function select0(container: Element) {
   selectIndex(container, 0);
 }
+
 function select1(container: Element) {
   selectIndex(container, 1);
 }
+
 function select2(container: Element) {
   selectIndex(container, 2);
 }
@@ -21,3 +23,7 @@ function selectIndex(container: Element, index: number) {
     new select.ownerDocument.defaultView!.Event("input", { bubbles: true }),
   );
 }
+
+export const config: TestConfig = {
+  steps: [{}, select0, select1, select2, reset],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, selectC];
+import type { TestConfig } from "../../main.test";
 
 function selectC(container: Element) {
   const select = container.querySelector(`select`)!;
@@ -6,3 +6,7 @@ function selectC(container: Element) {
   select.value = "c";
   select.dispatchEvent(new window.Event("input", { bubbles: true }));
 }
+
+export const config: TestConfig = {
+  steps: [{}, selectC],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, type("w"), type("wor"), type("world")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -8,3 +8,7 @@ function type(value: string) {
     textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
   };
 }
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, type("w"), type("wor"), type("world")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -8,3 +8,7 @@ function type(value: string) {
     textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
   };
 }
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, clickA, clickB];
+import type { TestConfig } from "../../main.test";
 
 function clickA(container: Element) {
   container.querySelector<HTMLButtonElement>("button.a")!.click();
@@ -7,3 +7,7 @@ function clickA(container: Element) {
 function clickB(container: Element) {
   container.querySelector<HTMLButtonElement>("button.b")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickA, clickB],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/test.ts
@@ -1,24 +1,28 @@
-export const steps = [
-  {
-    to: 3,
-  },
-  {
-    from: 4,
-    to: 6,
-  },
-  {
-    from: 7,
-    to: 16,
-    step: 3,
-  },
-  {
-    from: 0,
-    to: -1,
-    step: -0.3,
-  },
-  {
-    from: 0,
-    to: 3,
-    step: 0.5,
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      to: 3,
+    },
+    {
+      from: 4,
+      to: 6,
+    },
+    {
+      from: 7,
+      to: 16,
+      step: 3,
+    },
+    {
+      from: 0,
+      to: -1,
+      step: -0.3,
+    },
+    {
+      from: 0,
+      to: 3,
+      step: 0.5,
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/test.ts
@@ -1,19 +1,23 @@
-export const steps = [
-  {
-    children: {
-      "1": "a",
-      "2": "b",
-      "3": "c",
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: {
+        "1": "a",
+        "2": "b",
+        "3": "c",
+      },
     },
-  },
-  {
-    children: {},
-  },
-  {
-    children: {
-      "1": "a",
-      "2": "b",
-      "3": "c",
+    {
+      children: {},
     },
-  },
-];
+    {
+      children: {
+        "1": "a",
+        "2": "b",
+        "3": "c",
+      },
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-args-and-attributes-error/test.ts
@@ -1,2 +1,5 @@
-export const steps = [{}];
-export const error_compiler = ["template.marko"];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: ["template.marko"],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-args-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-args-error/test.ts
@@ -1,2 +1,5 @@
-export const steps = [{}];
-export const error_compiler = ["template.marko"];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: ["template.marko"],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/test.ts
@@ -1,2 +1,6 @@
-export const skip_csr = true;
-export const skip_ssr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_csr: true,
+  skip_ssr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/test.ts
@@ -1,3 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 const increment_child = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc-child")!.click();
 };
@@ -10,4 +12,6 @@ const reset = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.reset")!.click();
 };
 
-export const steps = [{}, increment_child, increment_parent, reset];
+export const config: TestConfig = {
+  steps: [{}, increment_child, increment_parent, reset],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const increment = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc")!.click();
 };
 
-export const steps = [{}, increment, increment, increment];
+export const config: TestConfig = {
+  steps: [{}, increment, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const increment = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc")!.click();
 };
 
-export const steps = [{}, increment, increment, increment];
+export const config: TestConfig = {
+  steps: [{}, increment, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/debug-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/debug-tag/test.ts
@@ -1,3 +1,6 @@
-// Skipped because it triggers the debugger and you probably don't want that.
-export const skip_ssr = true;
-export const skip_csr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_ssr: true,
+  skip_csr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/declaration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/declaration/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ a: "foo", b: "bar" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ a: "foo", b: "bar" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/doctype/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/doctype/test.ts
@@ -1,1 +1,5 @@
-export const skip_csr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_csr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/test.ts
@@ -1,10 +1,9 @@
-export const steps = [
-  { $global: { x: 1, serializedGlobals: ["x"] } },
-  click,
-  click,
-  click,
-];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{ $global: { x: 1, serializedGlobals: ["x"] } }, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/test.ts
@@ -1,7 +1,11 @@
-export const steps = [
-  {
-    a: "a",
-    b: "b",
-    c: "c",
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      a: "a",
+      b: "b",
+      c: "c",
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector("button")!.click();
 };
 
-export const steps = [{}, click, click, click] as const;
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector<HTMLElement>(".A")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/test.ts
@@ -1,3 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 const increment = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.inc")!.click();
 };
@@ -6,4 +8,6 @@ const reset = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.reset")!.click();
 };
 
-export const steps = [{}, increment, increment, reset, increment];
+export const config: TestConfig = {
+  steps: [{}, increment, increment, reset, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/test.ts
@@ -1,3 +1,7 @@
-export const steps = [{ show: true, dynamic: "div" }];
-export const skip_csr = true;
-export const skip_ssr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true, dynamic: "div" }],
+  skip_csr: true,
+  skip_ssr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, count, changeTag, count];
+import type { TestConfig } from "../../main.test";
 
 function count(container: Element) {
   container.querySelector<HTMLButtonElement>("#count")!.click();
@@ -7,3 +7,7 @@ function count(container: Element) {
 function changeTag(container: Element) {
   container.querySelector<HTMLButtonElement>("#changeTag")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, count, changeTag, count],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-async/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-async/test.ts
@@ -1,4 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
-export const error_runtime = true;
+export const config: TestConfig = {
+  steps: [{}, wait],
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-basic-scriptlet/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-basic-scriptlet/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-base-var-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-base-var-assignment/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/test.ts
@@ -1,3 +1,6 @@
-// export const error_compiler = true;
-export const skip_ssr = true;
-export const skip_csr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_ssr: true,
+  skip_csr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-default-value/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-local-case/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-not-found/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-own-body-read-before-return/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-own-body-read-before-return/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-debug-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-debug-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-define-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-define-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-define-no-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-define-tag-hoist/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-define-tag-hoist/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-name/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-name/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-no-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-no-default-value/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-html-comment-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-destructure/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-no-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-id-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-id-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-else-else-if/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-else-else-if/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-else-wrong-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-else-wrong-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-no-default-value/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-invalid-binding/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-invalid-binding/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-spread-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-no-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-spread-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-lifecycle-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-no-default-value/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-log-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-log-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-partial-spread-native-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-partial-spread-native-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-spread-native-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-spread-native-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-static-native-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-static-native-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-args/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-body-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-body-content/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-extra-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-extra-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-multiple/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-no-default-value/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-params/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-spread-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-spread-attr/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-var/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-write/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-write/test.ts
@@ -1,3 +1,7 @@
-export const error_runtime = true;
-export const skip_ssr = true;
-export const skip_resume = false;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+  skip_ssr: true,
+  skip_resume: false,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-placeholder/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-attrs/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-placeholder/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-sync/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-sync/test.ts
@@ -1,2 +1,5 @@
-export const steps = [{}];
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/test.ts
@@ -1,13 +1,4 @@
-export const steps = [
-  {},
-  clickChange,
-  clickUp,
-  clickChange,
-  clickChange,
-  clickDown,
-  clickChange,
-  clickChange,
-];
+import type { TestConfig } from "../../main.test";
 
 function clickUp(container: Element) {
   container.querySelector<HTMLButtonElement>(".up")!.click();
@@ -20,3 +11,16 @@ function clickDown(container: Element) {
 function clickChange(container: Element) {
   container.querySelector<HTMLButtonElement>(".change")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickChange,
+    clickUp,
+    clickChange,
+    clickChange,
+    clickDown,
+    clickChange,
+    clickChange,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   (container.querySelector("button") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   (container.querySelector("button") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, add, remove, remove, add];
+import type { TestConfig } from "../../main.test";
 
 function add(container: Element) {
   (container.querySelector("#add") as HTMLButtonElement).click();
@@ -7,3 +7,7 @@ function add(container: Element) {
 function remove(container: Element) {
   (container.querySelector("#remove") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, add, remove, remove, add],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/test.ts
@@ -1,35 +1,37 @@
-// Tests edge cases around growing and shrinking the list,
-// including empty <-> non-empty transitions and single-item lists.
-export const steps = [
-  // Start empty
-  { children: [] as { id: number; text: string }[] },
-  // Grow to single item
-  { children: [{ id: 1, text: "a" }] },
-  // Grow to multiple
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Shrink to single (keep middle)
-  { children: [{ id: 2, text: "b" }] },
-  // Grow again with mix of old and new
-  {
-    children: [
-      { id: 4, text: "d" },
-      { id: 2, text: "b" },
-      { id: 5, text: "e" },
-    ],
-  },
-  // Shrink to empty
-  { children: [] as { id: number; text: string }[] },
-  // Grow from empty to multiple
-  {
-    children: [
-      { id: 6, text: "f" },
-      { id: 7, text: "g" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    // Start empty
+    { children: [] as { id: number; text: string }[] },
+    // Grow to single item
+    { children: [{ id: 1, text: "a" }] },
+    // Grow to multiple
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Shrink to single (keep middle)
+    { children: [{ id: 2, text: "b" }] },
+    // Grow again with mix of old and new
+    {
+      children: [
+        { id: 4, text: "d" },
+        { id: 2, text: "b" },
+        { id: 5, text: "e" },
+      ],
+    },
+    // Shrink to empty
+    { children: [] as { id: number; text: string }[] },
+    // Grow from empty to multiple
+    {
+      children: [
+        { id: 6, text: "f" },
+        { id: 7, text: "g" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/test.ts
@@ -1,31 +1,35 @@
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Insert in middle: no moves needed, only insert
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 4, text: "x" },
-      { id: 2, text: "b" },
-      { id: 5, text: "y" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Insert at start and end
-  {
-    children: [
-      { id: 6, text: "!" },
-      { id: 1, text: "a" },
-      { id: 4, text: "x" },
-      { id: 2, text: "b" },
-      { id: 5, text: "y" },
-      { id: 3, text: "c" },
-      { id: 7, text: "?" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Insert in middle: no moves needed, only insert
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 4, text: "x" },
+        { id: 2, text: "b" },
+        { id: 5, text: "y" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Insert at start and end
+    {
+      children: [
+        { id: 6, text: "!" },
+        { id: 1, text: "a" },
+        { id: 4, text: "x" },
+        { id: 2, text: "b" },
+        { id: 5, text: "y" },
+        { id: 3, text: "c" },
+        { id: 7, text: "?" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/test.ts
@@ -1,31 +1,35 @@
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-    ],
-  },
-  // Move + insert + remove: remove b,d; move e before a; insert x
-  {
-    children: [
-      { id: 5, text: "e" },
-      { id: 6, text: "x" },
-      { id: 1, text: "a" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Interleave old and new items
-  {
-    children: [
-      { id: 7, text: "p" },
-      { id: 5, text: "e" },
-      { id: 8, text: "q" },
-      { id: 3, text: "c" },
-      { id: 9, text: "r" },
-      { id: 1, text: "a" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+      ],
+    },
+    // Move + insert + remove: remove b,d; move e before a; insert x
+    {
+      children: [
+        { id: 5, text: "e" },
+        { id: 6, text: "x" },
+        { id: 1, text: "a" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Interleave old and new items
+    {
+      children: [
+        { id: 7, text: "p" },
+        { id: 5, text: "e" },
+        { id: 8, text: "q" },
+        { id: 3, text: "c" },
+        { id: 9, text: "r" },
+        { id: 1, text: "a" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/test.ts
@@ -1,41 +1,43 @@
-// Tests complete replacement — all old items removed, all new items inserted.
-// No branch reuse between steps.
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Replace all: entirely new keys
-  {
-    children: [
-      { id: 10, text: "x" },
-      { id: 11, text: "y" },
-      { id: 12, text: "z" },
-    ],
-  },
-  // Back to original
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-    ],
-  },
-  // Replace with fewer items
-  {
-    children: [{ id: 20, text: "only" }],
-  },
-  // Replace with more items
-  {
-    children: [
-      { id: 30, text: "p" },
-      { id: 31, text: "q" },
-      { id: 32, text: "r" },
-      { id: 33, text: "s" },
-      { id: 34, text: "t" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Replace all: entirely new keys
+    {
+      children: [
+        { id: 10, text: "x" },
+        { id: 11, text: "y" },
+        { id: 12, text: "z" },
+      ],
+    },
+    // Back to original
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    },
+    // Replace with fewer items
+    {
+      children: [{ id: 20, text: "only" }],
+    },
+    // Replace with more items
+    {
+      children: [
+        { id: 30, text: "p" },
+        { id: 31, text: "q" },
+        { id: 32, text: "r" },
+        { id: 33, text: "s" },
+        { id: 34, text: "t" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/test.ts
@@ -1,31 +1,35 @@
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-    ],
-  },
-  // Full reverse: optimal is to keep the longest subsequence in place
-  {
-    children: [
-      { id: 5, text: "e" },
-      { id: 4, text: "d" },
-      { id: 3, text: "c" },
-      { id: 2, text: "b" },
-      { id: 1, text: "a" },
-    ],
-  },
-  // Back to original
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+      ],
+    },
+    // Full reverse: optimal is to keep the longest subsequence in place
+    {
+      children: [
+        { id: 5, text: "e" },
+        { id: 4, text: "d" },
+        { id: 3, text: "c" },
+        { id: 2, text: "b" },
+        { id: 1, text: "a" },
+      ],
+    },
+    // Back to original
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/test.ts
@@ -1,43 +1,45 @@
-// Tests rotation — a classic reconciler case.
-// Only 1 item should need to move per rotation step.
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-    ],
-  },
-  // Rotate right by 1: move last to first
-  {
-    children: [
-      { id: 5, text: "e" },
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-    ],
-  },
-  // Rotate left by 1: move first to last
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-    ],
-  },
-  // Rotate right by 2
-  {
-    children: [
-      { id: 4, text: "d" },
-      { id: 5, text: "e" },
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+      ],
+    },
+    // Rotate right by 1: move last to first
+    {
+      children: [
+        { id: 5, text: "e" },
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+      ],
+    },
+    // Rotate left by 1: move first to last
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+      ],
+    },
+    // Rotate right by 2
+    {
+      children: [
+        { id: 4, text: "d" },
+        { id: 5, text: "e" },
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/test.ts
@@ -1,28 +1,32 @@
-export const steps = [
-  {
-    children: [
-      { id: 1, text: "a" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 4, text: "d" },
-    ],
-  },
-  // Swap first and last: middle items stay, endpoints move
-  {
-    children: [
-      { id: 4, text: "d" },
-      { id: 2, text: "b" },
-      { id: 3, text: "c" },
-      { id: 1, text: "a" },
-    ],
-  },
-  // Swap adjacent: b <-> c
-  {
-    children: [
-      { id: 4, text: "d" },
-      { id: 3, text: "c" },
-      { id: 2, text: "b" },
-      { id: 1, text: "a" },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        { id: 1, text: "a" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 4, text: "d" },
+      ],
+    },
+    // Swap first and last: middle items stay, endpoints move
+    {
+      children: [
+        { id: 4, text: "d" },
+        { id: 2, text: "b" },
+        { id: 3, text: "c" },
+        { id: 1, text: "a" },
+      ],
+    },
+    // Swap adjacent: b <-> c
+    {
+      children: [
+        { id: 4, text: "d" },
+        { id: 3, text: "c" },
+        { id: 2, text: "b" },
+        { id: 1, text: "a" },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   (container.querySelector("button") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-registration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-registration/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/test.ts
@@ -1,5 +1,10 @@
-export const steps = [{}, click];
-export const skip_ssr = true;
+import type { TestConfig } from "../../main.test";
+
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+  skip_ssr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ name: "Marko" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ name: "Marko" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/test.ts
@@ -1,3 +1,6 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
 
-export const skip_equivalent = true;
+export const config: TestConfig = {
+  steps: [{ show: true }],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/test.ts
@@ -1,3 +1,6 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
 
-export const skip_equivalent = true;
+export const config: TestConfig = {
+  steps: [{ show: true }],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/test.ts
@@ -1,1 +1,0 @@
-export const steps = [];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/test.ts
@@ -1,3 +1,6 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
 
-export const skip_equivalent = true;
+export const config: TestConfig = {
+  steps: [{ show: true }],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/test.ts
@@ -1,2 +1,5 @@
-export const steps = [{}];
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-script-read/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-script-read/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/test.ts
@@ -1,3 +1,6 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
 
-export const skip_equivalent = true;
+export const config: TestConfig = {
+  steps: [{ show: true }],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-minimum-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-minimum-scope/test.ts
@@ -1,1 +1,0 @@
-export const steps = [];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-only/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-throws-in-render/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-throws-in-render/test.ts
@@ -1,3 +1,6 @@
-export const steps = [{}];
-export const error_runtime = true;
-export const skip_resume = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+  skip_resume: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/test.ts
@@ -1,11 +1,14 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [
-  {
-    $global: {
-      cspNonce: "default-nonce",
-      serializedGlobals: { cspNonce: true },
+export const config: TestConfig = {
+  steps: [
+    {
+      $global: {
+        cspNonce: "default-nonce",
+        serializedGlobals: { cspNonce: true },
+      },
     },
-  },
-  wait,
-];
+    wait,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("script")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/test.ts
@@ -1,11 +1,14 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [
-  {
-    $global: {
-      cspNonce: "default-nonce",
-      serializedGlobals: { cspNonce: true },
+export const config: TestConfig = {
+  steps: [
+    {
+      $global: {
+        cspNonce: "default-nonce",
+        serializedGlobals: { cspNonce: true },
+      },
     },
-  },
-  wait,
-];
+    wait,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("style")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-hoist-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-hoist-error/test.ts
@@ -1,1 +1,5 @@
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/if-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-tag/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ a: 1, b: 2, x: false, y: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ a: 1, b: 2, x: false, y: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/test.ts
@@ -1,1 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 export {};
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/test.ts
@@ -1,1 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 export {};
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag/test.ts
@@ -1,1 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 export {};
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector<HTMLDivElement>("#target")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, selectLast];
+import type { TestConfig } from "../../main.test";
 
 function selectLast(container: Element) {
   const select = container.querySelector<HTMLSelectElement>("select")!;
@@ -7,3 +7,7 @@ function selectLast(container: Element) {
     new select.ownerDocument.defaultView!.Event("change", { bubbles: true }),
   );
 }
+
+export const config: TestConfig = {
+  steps: [{}, selectLast],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{ show: true }, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{ show: true }, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{ show: false }, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{ show: false }, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/input-destructure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-destructure/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ a: "a", b: "b" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ a: "a", b: "b" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ value: [1, 2] }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ value: [1, 2] }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ text: "foo" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ text: "foo" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ a: "a", b: "b" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ a: "a", b: "b" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ a: "a", b: "b" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ a: "a", b: "b" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelectorAll("button")!.forEach((item) => item.click());
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-compile-error/test.ts
@@ -1,8 +1,11 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
 
-export const skip_resume = true;
-export const error_compiler = true;
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+  skip_resume: true,
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, increment, increment, toggle, increment, increment];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("#inc")!.click();
@@ -7,3 +7,7 @@ function increment(container: Element) {
 function toggle(container: Element) {
   container.querySelector<HTMLButtonElement>("#toggle")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment, toggle, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{ a: 2 }, click, { a: 3 }, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{ a: 2 }, click, { a: 3 }, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/let-without-assignments/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-without-assignments/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
-
-export const steps = [{}, increment, increment, wait];
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("#increment")?.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/test.ts
@@ -1,10 +1,14 @@
-export const skip_ssr = true;
-
-export const steps = [{}, increment, toggle, increment, toggle];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("#increment")?.click();
 }
+
 function toggle(container: Element) {
   container.querySelector<HTMLButtonElement>("#toggle")?.click();
 }
+
+export const config: TestConfig = {
+  skip_ssr: true,
+  steps: [{}, increment, toggle, increment, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, increment, increment];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("#increment")?.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, increment, increment];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("#increment")?.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/log-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/log-tag/test.ts
@@ -1,1 +1,5 @@
-export const skip_equivalent = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-input/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ x: 1 }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ x: 1 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-out-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-out-global/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ $global: { x: 1 } }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ $global: { x: 1 } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/test.ts
@@ -1,37 +1,41 @@
-export const steps = [
-  {
-    children: [
-      {
-        id: 1,
-        text: "a",
-      },
-      {
-        id: 2,
-        text: "b",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-  {
-    children: [
-      {
-        id: 2,
-        text: "b",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-      {
-        id: 1,
-        text: "a",
-      },
-    ],
-  },
-  {
-    children: [],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        {
+          id: 1,
+          text: "a",
+        },
+        {
+          id: 2,
+          text: "b",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+    {
+      children: [
+        {
+          id: 2,
+          text: "b",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+        {
+          id: 1,
+          text: "a",
+        },
+      ],
+    },
+    {
+      children: [],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/test.ts
@@ -1,37 +1,41 @@
-export const steps = [
-  {
-    children: [
-      {
-        id: 1,
-        text: "a",
-      },
-      {
-        id: 2,
-        text: "b",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-  {
-    children: [],
-  },
-  {
-    children: [
-      {
-        id: 1,
-        text: "a",
-      },
-      {
-        id: 2,
-        text: "b",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        {
+          id: 1,
+          text: "a",
+        },
+        {
+          id: 2,
+          text: "b",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+    {
+      children: [],
+    },
+    {
+      children: [
+        {
+          id: 1,
+          text: "a",
+        },
+        {
+          id: 2,
+          text: "b",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, increment, increment];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, clickAllButtons, clickAllButtons, clickAllButtons];
+import type { TestConfig } from "../../main.test";
 
 function clickAllButtons(container: Element) {
   container.querySelectorAll("button")!.forEach((item) => item.click());
 }
+
+export const config: TestConfig = {
+  steps: [{}, clickAllButtons, clickAllButtons, clickAllButtons],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/test.ts
@@ -1,14 +1,4 @@
-export const steps = [
-  {
-    value: "<a href=#></a>",
-  },
-  clickParent,
-  clickParent,
-  clickParent,
-  clickChild,
-  clickChild,
-  clickChild,
-];
+import type { TestConfig } from "../../main.test";
 
 function clickParent(container: Element) {
   (container.querySelector(".toggle-parent") as HTMLButtonElement).click();
@@ -17,3 +7,17 @@ function clickParent(container: Element) {
 function clickChild(container: Element) {
   (container.querySelector(".toggle-child") as HTMLButtonElement).click();
 }
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: "<a href=#></a>",
+    },
+    clickParent,
+    clickParent,
+    clickParent,
+    clickChild,
+    clickChild,
+    clickChild,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-duplicate-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-duplicate-attrs/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-throws-in-render/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-throws-in-render/test.ts
@@ -1,3 +1,5 @@
-export const steps = [{}];
+import type { TestConfig } from "../../main.test";
 
-export const error_runtime = true;
+export const config: TestConfig = {
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-var-in-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-var-in-body/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/test.ts
@@ -1,15 +1,4 @@
-export const steps = [
-  {},
-  click,
-  click,
-  click,
-  click,
-  click,
-  click,
-  click,
-  click,
-  click,
-];
+import type { TestConfig } from "../../main.test";
 
 let buttonIndex = 0;
 
@@ -17,3 +6,7 @@ function click(container: Element) {
   container.querySelectorAll("button")[buttonIndex].click();
   buttonIndex = (buttonIndex + 1) % 3;
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click, click, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ foo: "bar" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ foo: "bar" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ show: true }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ show: true }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, increment, increment];
+import type { TestConfig } from "../../main.test";
 
 function increment(container: Element) {
   container.querySelector<HTMLButtonElement>("button")?.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/test.ts
@@ -1,5 +1,7 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
-export const steps = [{}, flush, flush, flush, wait];
-
-export const skip_equivalent = true; // in-order streaming
+export const config: TestConfig = {
+  steps: [{}, flush, flush, flush, wait],
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ x: "replaced" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ x: "replaced" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, addTwo, triple, cube];
+import type { TestConfig } from "../../main.test";
 
 function addTwo(container: Element) {
   container.querySelector<HTMLButtonElement>("#addTwo")!.click();
@@ -11,3 +11,7 @@ function triple(container: Element) {
 function cube(container: Element) {
   container.querySelector<HTMLButtonElement>("#cube")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, addTwo, triple, cube],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/test.ts
@@ -1,42 +1,46 @@
-export const steps = [
-  {
-    children: [
-      {
-        id: 1,
-        text: "a",
-      },
-      {
-        id: 2,
-        text: "b",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-  {
-    children: [
-      {
-        id: 1,
-        text: "a",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-  {
-    children: [
-      {
-        id: 4,
-        text: "d",
-      },
-      {
-        id: 3,
-        text: "c",
-      },
-    ],
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      children: [
+        {
+          id: 1,
+          text: "a",
+        },
+        {
+          id: 2,
+          text: "b",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+    {
+      children: [
+        {
+          id: 1,
+          text: "a",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+    {
+      children: [
+        {
+          id: 4,
+          text: "d",
+        },
+        {
+          id: 3,
+          text: "c",
+        },
+      ],
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/render-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/render-effect/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ value: { foo: "bar", class: "test" } }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ value: { foo: "bar", class: "test" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-export const steps = [{}, click, click];
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/test.ts
@@ -1,15 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
 const clickOnce = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.once")!.click();
 };
+
 const clickTwice = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button.twice")!.click();
 };
 
-export const steps = [
-  {},
-  clickOnce,
-  clickOnce,
-  clickTwice,
-  clickTwice,
-  clickTwice,
-];
+export const config: TestConfig = {
+  steps: [{}, clickOnce, clickOnce, clickTwice, clickTwice, clickTwice],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/test.ts
@@ -1,7 +1,11 @@
-export const steps = [
-  {
-    a: {
-      b: 1,
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      a: {
+        b: 1,
+      },
     },
-  },
-];
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/script-no-references/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-no-references/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/test.ts
@@ -1,1 +1,5 @@
-export const error_compiler = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{}, wait];
+export const config: TestConfig = {
+  steps: [{}, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/server-client/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/server-client/test.ts
@@ -1,1 +1,5 @@
-export const skip_equivalent = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_equivalent: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, click, click, click, click, reset];
+import type { TestConfig } from "../../main.test";
 
 let buttonNum = 0;
 
@@ -9,3 +9,7 @@ function click(container: Element) {
 function reset() {
   buttonNum = 0;
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click, reset],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ class: "success", ["data-rest"]: 1 }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ class: "success", ["data-rest"]: 1 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ class: "success", ["data-rest"]: 1 }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ class: "success", ["data-rest"]: 1 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ class: "success", ["data-rest"]: 1 }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ class: "success", ["data-rest"]: 1 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/static-function-invoked-render-reference/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-function-invoked-render-reference/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-default/test.ts
@@ -1,2 +1,6 @@
-export const skip_csr = true;
-export const skip_ssr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_csr: true,
+  skip_ssr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-destructured/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-destructured/test.ts
@@ -1,2 +1,6 @@
-export const skip_csr = true;
-export const skip_ssr = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_csr: true,
+  skip_ssr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container?.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/test.ts
@@ -1,1 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
 export {};
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure-rest-chain/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure-rest-chain/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container?.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/test.ts
@@ -1,1 +1,5 @@
-export const steps = [{ value: "foo" }];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ value: "foo" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/test.ts
@@ -1,14 +1,18 @@
-export const steps = [
-  {
-    value: "Hello",
-  },
-  {
-    value: false,
-  },
-  {
-    value: "World",
-  },
-  {
-    value: "!",
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: "Hello",
+    },
+    {
+      value: false,
+    },
+    {
+      value: "World",
+    },
+    {
+      value: "!",
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/test.ts
@@ -1,21 +1,27 @@
+import type { TestConfig } from "../../main.test";
+
 const clickOuter = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#outer")!.click();
 };
+
 const clickInner = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#inner")!.click();
 };
+
 const clickCount = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#count")!.click();
 };
 
-export const steps = [
-  {},
-  clickCount,
-  clickCount,
-  clickInner,
-  clickInner,
-  clickCount,
-  clickOuter,
-  clickOuter,
-  clickCount,
-];
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickCount,
+    clickCount,
+    clickInner,
+    clickInner,
+    clickCount,
+    clickOuter,
+    clickOuter,
+    clickCount,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/test.ts
@@ -1,21 +1,27 @@
+import type { TestConfig } from "../../main.test";
+
 const clickOuter = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#outer")!.click();
 };
+
 const clickInner = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#inner")!.click();
 };
+
 const clickCount = (container: Element) => {
   container.querySelector<HTMLButtonElement>("#count")!.click();
 };
 
-export const steps = [
-  {},
-  clickCount,
-  clickCount,
-  clickInner,
-  clickInner,
-  clickCount,
-  clickOuter,
-  clickOuter,
-  clickCount,
-];
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickCount,
+    clickCount,
+    clickInner,
+    clickInner,
+    clickCount,
+    clickOuter,
+    clickOuter,
+    clickCount,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/test.ts
@@ -1,27 +1,31 @@
-export const steps = [
-  {
-    show: false,
-    value1: "Hello",
-    value2: "World",
-  },
-  {
-    show: true,
-    value1: "Hello",
-    value2: "World",
-  },
-  {
-    show: true,
-    value1: false,
-    value2: "World",
-  },
-  {
-    show: true,
-    value1: "Goodbye",
-    value2: "World",
-  },
-  {
-    show: false,
-    value1: "Goodbye",
-    value2: "World",
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      show: false,
+      value1: "Hello",
+      value2: "World",
+    },
+    {
+      show: true,
+      value1: "Hello",
+      value2: "World",
+    },
+    {
+      show: true,
+      value1: false,
+      value2: "World",
+    },
+    {
+      show: true,
+      value1: "Goodbye",
+      value2: "World",
+    },
+    {
+      show: false,
+      value1: "Goodbye",
+      value2: "World",
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/test.ts
@@ -1,5 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
 const click = (container: Element) => {
   container.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-export const steps = [{ show: true }, click, click];
+export const config: TestConfig = {
+  steps: [{ show: true }, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{ value: "Hello" }, type(""), type("World"), type("!")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -9,3 +9,7 @@ function type(value: string) {
     );
   };
 }
+
+export const config: TestConfig = {
+  steps: [{ value: "Hello" }, type(""), type("World"), type("!")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/test.ts
@@ -1,8 +1,11 @@
-export const skip_csr = true;
-export const skip_resume = false;
+import type { TestConfig } from "../../main.test";
 
-export const steps = [{}, click, click];
-
-function click(container: HTMLElement) {
+function click(container: Element) {
   container.querySelector("button")?.click();
 }
+
+export const config: TestConfig = {
+  skip_csr: true,
+  skip_resume: false,
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/test.ts
@@ -1,7 +1,10 @@
+import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
-
-export const steps = [{}, flush, wait, click, wait, click, wait];
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, flush, wait, click, wait, click, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/test.ts
@@ -1,0 +1,3 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/test.ts
@@ -1,0 +1,3 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/try-tag-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-tag-closure/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, selectLast];
+import type { TestConfig } from "../../main.test";
 
 function selectLast(container: Element) {
   const select = container.querySelector<HTMLSelectElement>("select")!;
@@ -7,3 +7,7 @@ function selectLast(container: Element) {
     new select.ownerDocument.defaultView!.Event("change", { bubbles: true }),
   );
 }
+
+export const config: TestConfig = {
+  steps: [{}, selectLast],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value/test.ts
@@ -1,4 +1,4 @@
-export const steps = [{}, type("w"), type("wor"), type("world")];
+import type { TestConfig } from "../../main.test";
 
 function type(value: string) {
   return (container: Element) => {
@@ -8,3 +8,7 @@ function type(value: string) {
     textarea.dispatchEvent(new window.Event("input", { bubbles: true }));
   };
 }
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/unserializable-warning/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/unserializable-warning/test.ts
@@ -1,2 +1,6 @@
-export const skip_dom = true;
-export const error_runtime = true;
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_dom: true,
+  error_runtime: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/update-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-attr/test.ts
@@ -1,20 +1,24 @@
-export const steps = [
-  {
-    value: 1,
-  },
-  {
-    value: "1",
-  },
-  {
-    value: "2",
-  },
-  {
-    value: null,
-  },
-  {
-    value: "1",
-  },
-  {
-    value: false,
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: 1,
+    },
+    {
+      value: "1",
+    },
+    {
+      value: "2",
+    },
+    {
+      value: null,
+    },
+    {
+      value: "1",
+    },
+    {
+      value: false,
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/test.ts
@@ -1,17 +1,21 @@
-export const steps = [
-  {
-    value: { a: 1, b: 2 },
-  },
-  {
-    value: { b: 2, c: 3 },
-  },
-  {
-    value: {},
-  },
-  {
-    value: null,
-  },
-  {
-    value: { a: 1 },
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: { a: 1, b: 2 },
+    },
+    {
+      value: { b: 2, c: 3 },
+    },
+    {
+      value: {},
+    },
+    {
+      value: null,
+    },
+    {
+      value: { a: 1 },
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/update-html/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-html/test.ts
@@ -1,11 +1,15 @@
-export const steps = [
-  {
-    value: "Hello <strong>World</strong>",
-  },
-  {
-    value: "Some content",
-  },
-  {
-    value: "<div/>",
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: "Hello <strong>World</strong>",
+    },
+    {
+      value: "Some content",
+    },
+    {
+      value: "<div/>",
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/update-text/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-text/test.ts
@@ -1,11 +1,15 @@
-export const steps = [
-  {
-    value: "Dynamic 1",
-  },
-  {
-    value: "Dynamic 2",
-  },
-  {
-    value: "Dynamic 3",
-  },
-];
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {
+      value: "Dynamic 1",
+    },
+    {
+      value: "Dynamic 2",
+    },
+    {
+      value: "Dynamic 3",
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/test.ts
@@ -1,5 +1,9 @@
-export const steps = [{}, click];
+import type { TestConfig } from "../../main.test";
 
 function click(container: Element) {
   container.querySelector("button")!.click();
 }
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/test.ts
@@ -1,3 +1,6 @@
+import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-export const steps = [{ value: 0 }, wait, { value: 1 }, wait];
+export const config: TestConfig = {
+  steps: [{ value: 0 }, wait, { value: 1 }, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/test.ts
@@ -1,1 +1,0 @@
-export const steps = [{}];

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -13,17 +13,22 @@ import { bundle } from "./utils/bundle";
 import { captureConsole, type ConsoleRecord } from "./utils/capture-console";
 import createBrowser from "./utils/create-browser";
 import {
+  type Flush,
   isFlush,
   isThrows,
   isWait,
   resetResolveState,
   resolveAfter,
+  type Throws,
+  type Wait,
 } from "./utils/resolve";
 import { stripInlineRuntime } from "./utils/strip-inline-runtime";
 import createMutationTracker from "./utils/track-mutations";
 
-type TestConfig = {
-  steps?: unknown[] | (() => Promise<unknown[]>);
+type Step = Input | Wait | Flush | Throws | ((container: Element) => unknown);
+type Steps = [Input, ...Step[]];
+export type TestConfig = {
+  steps?: Steps | (() => Steps | Promise<Steps>);
   skip_dom?: boolean;
   skip_html?: boolean;
   skip_csr?: boolean;
@@ -93,7 +98,7 @@ describe("runtime-tags/translator", () => {
       const initialNameCache = structuredClone(nameCache);
       const config: TestConfig = (() => {
         try {
-          return require(resolve("test.ts"));
+          return require(resolve("test.ts")).config ?? {};
         } catch {
           return {};
         }
@@ -202,11 +207,10 @@ describe("runtime-tags/translator", () => {
           const serverTemplate = require(manualSSR ? serverFile : templateFile)
             .default as Template;
 
-          const [input = {}, ...steps] = (
+          const [input = {}, ...steps] =
             typeof config.steps === "function"
               ? await config.steps()
-              : config.steps || []
-          ) as [Input, ...unknown[]];
+              : config.steps || [];
 
           const chunks: string[] = [];
           const logs: ConsoleRecord[][] = [];
@@ -305,11 +309,10 @@ describe("runtime-tags/translator", () => {
 
           const { window } = browser;
           const { document } = window;
-          const [input, ...steps] = (
+          const [input = {}, ...steps] =
             typeof config.steps === "function"
               ? await config.steps()
-              : config.steps || []
-          ) as [Input, ...unknown[]];
+              : config.steps || [];
           const { run } = browser.require<
             typeof import("@marko/runtime-tags/dom")
           >("@marko/runtime-tags/dom");

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -15,6 +15,7 @@ export function resetResolveState() {
   state.promises = new Map();
 }
 
+export type Wait = typeof wait;
 export const wait = Object.assign(
   async () => {
     let id: number;
@@ -30,7 +31,7 @@ export const wait = Object.assign(
   },
 );
 
-export function after(id: number) {
+export function after(id: number): Wait {
   return Object.assign(
     async () => {
       await getSharedPromise(id);
@@ -42,23 +43,25 @@ export function after(id: number) {
   );
 }
 
+export type Flush = typeof flush;
 export const flush = Object.assign(() => {}, {
   flush: true,
 });
 
+export type Throws = ReturnType<typeof throws>;
 export function throws(fn: (...args: any[]) => void) {
   return Object.assign(fn, { throws: true });
 }
 
-export function isWait(value: any): value is typeof wait {
+export function isWait(value: any): value is Wait {
   return typeof value === "function" && value.wait;
 }
 
-export function isFlush(value: any): value is typeof flush {
+export function isFlush(value: any): value is Flush {
   return typeof value === "function" && value.flush;
 }
 
-export function isThrows(value: any): value is ReturnType<typeof throws> {
+export function isThrows(value: any): value is Throws {
   return typeof value === "function" && value.throws;
 }
 


### PR DESCRIPTION
* Refactors the tags api test suite to have better types in the config files (`test.ts` files).
* Remove `test.ts` files which have an empty config.