### PR TITLE
Fix typo in custom-tags.md regarding Marko

### DIFF
--- a/packages/runtime-class/docs/custom-tags.md
+++ b/packages/runtime-class/docs/custom-tags.md
@@ -146,7 +146,7 @@ To use [tags from npm](https://www.npmjs.com/search?q=keywords%3Amarko%20compone
 npm install --save @marko-tags/match-media
 ```
 
-Marko discover tags from packages defined in your `package.json`, so you can start using them right away:
+Marko discovers tags from packages defined in your `package.json`, so you can start using them right away:
 
 ```marko
 <div>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Use third-person singular “discovers” for subject “Marko”
## Description

<!--- Describe your changes in detail -->
Since “Marko” is a singular subject, the verb should be in third-person singular form.
Updated the sentence to: “Marko discovers tags from packages defined in your package.json, so you can start using them right away.”

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.
