### PR TITLE
feat: support bound attr modifiers (tags api)

### DIFF
--- a/.changeset/large-files-say.md
+++ b/.changeset/large-files-say.md
@@ -1,0 +1,7 @@
+---
+"@marko/runtime-tags": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Support bound attribute modifiers as a way to cast change handler values.

--- a/package-lock.json
+++ b/package-lock.json
@@ -199,7 +199,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2245,7 +2244,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -2286,7 +2284,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -4151,7 +4148,6 @@
       "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -4215,7 +4211,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -4455,7 +4450,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4819,7 +4813,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -6041,7 +6034,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -9130,7 +9122,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9601,7 +9592,6 @@
       "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -10554,7 +10544,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10706,7 +10695,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -375,7 +375,14 @@ export function parseMarko(file) {
     },
 
     onAttrName(part) {
-      const [, name, modifier] = /^([^:]*)(?::(.*))?/.exec(parser.read(part));
+      let name = parser.read(part);
+      let modifier = null;
+      const modifierIndex = name.lastIndexOf(":");
+      if (~modifierIndex) {
+        modifier = name.slice(modifierIndex + 1);
+        name = name.slice(0, modifierIndex);
+      }
+
       endAttr();
       currentTag.node.attributes.push(
         (currentAttr = t.markoAttribute(

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/.name-cache.json
@@ -1,0 +1,13 @@
+{
+  "vars": {
+    "props": {
+      "$_": "t",
+      "$init": "r",
+      "$$value": "a",
+      "$$valueChange": "m",
+      "$$input_value__OR__input_valueChange": "e",
+      "$$input_value": "o",
+      "$$valueChange$1": "_"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/csr.expected.md
@@ -1,0 +1,65 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+# Mutations
+```
+INSERT input, span
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+# Mutations
+```
+UPDATE span/#text0 "0" => "1"
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```
+
+# Mutations
+```
+UPDATE span/#text0 "1" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/tags/custom-input.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/tags/custom-input.js
@@ -1,0 +1,19 @@
+export const $template = "<input type=number>";
+export const $walks = /* get, over(1) */" b";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $input_value__OR__input_valueChange = /* @__PURE__ */_._or(5, $scope => _._attr_input_value($scope, "#input/0", $scope.input_value, $scope.input_valueChange && $valueChange($scope)));
+export const $input_value = /* @__PURE__ */_._const("input_value", $input_value__OR__input_valueChange);
+export const $input_valueChange = /* @__PURE__ */_._const("input_valueChange", $input_value__OR__input_valueChange);
+const $setup__script = _._script("__tests__/tags/custom-input.marko_0", $scope => _._attr_input_value_script($scope, "#input/0"));
+export const $setup = $setup__script;
+export const $input = ($scope, input) => {
+  $input_value($scope, input.value);
+  $input_valueChange($scope, input.valueChange);
+};
+function $valueChange($scope) {
+  return $next => {
+    $scope.input_valueChange(parseInt($next));
+  };
+}
+_._resume("__tests__/tags/custom-input.marko_0/valueChange", $valueChange);
+export default /* @__PURE__ */_._template("__tests__/tags/custom-input.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,28 @@
+// size: 318 (min) 179 (brotli)
+const $input_value__OR__input_valueChange = _._or(5, ($scope) =>
+    _._attr_input_value(
+      $scope,
+      "a",
+      $scope.d,
+      $scope.e && $valueChange$1($scope),
+    ),
+  ),
+  $input_value = _._const(3, $input_value__OR__input_valueChange);
+function $valueChange$1($scope) {
+  return ($next) => {
+    $scope.e(parseInt($next));
+  };
+}
+(_._script("a1", ($scope) => _._attr_input_value_script($scope, "a")),
+  _._resume("a0", $valueChange$1));
+const $value = _._let(3, ($scope) => {
+  ($input_value($scope.a, $scope.d),
+    _._text($scope.b, $scope.d),
+    _._text($scope.c, typeof $scope.d));
+});
+(_._resume("b0", function ($scope) {
+  return (_new_value) => {
+    $value($scope, _new_value);
+  };
+}),
+  init());

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/dom.expected/template.js
@@ -1,0 +1,21 @@
+export const $template = `${_customInput_template}<span><!> <!></span>`;
+export const $walks = /* <custom-input>, next(1), replace, over(2), replace, out(1) */`/${_customInput_walks}&D%c%l`;
+import { $setup as _customInput, $input_value as _customInput_input_value, $input_valueChange as _customInput_input_valueChange, $template as _customInput_template, $walks as _customInput_walks } from "./tags/custom-input.marko";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $value = /* @__PURE__ */_._let("value/3", $scope => {
+  _customInput_input_value($scope["#childScope/0"], $scope.value);
+  _._text($scope["#text/1"], $scope.value);
+  _._text($scope["#text/2"], typeof $scope.value);
+});
+export function $setup($scope) {
+  _customInput($scope["#childScope/0"]);
+  _customInput_input_valueChange($scope["#childScope/0"], $valueChange($scope));
+  $value($scope, 0);
+}
+function $valueChange($scope) {
+  return _new_value => {
+    $value($scope, _new_value);
+  };
+}
+_._resume("__tests__/template.marko_0/valueChange", $valueChange);
+export default /* @__PURE__ */_._template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.expected/tags/custom-input.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.expected/tags/custom-input.js
@@ -1,0 +1,16 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/tags/custom-input.marko", input => {
+  const $scope0_reason = _._scope_reason();
+  const $scope0_id = _._scope_id();
+  _._html(`<input${_._attr_input_value($scope0_id, "#input/0", input.value, input.valueChange && _._resume($next => {
+    input.valueChange(parseInt($next));
+  }, "__tests__/tags/custom-input.marko_0/valueChange", $scope0_id))} type=number>${_._el_resume($scope0_id, "#input/0", _._serialize_guard($scope0_reason, /* input.value, input.valueChange */0))}`);
+  _._script($scope0_id, "__tests__/tags/custom-input.marko_0");
+  _._scope($scope0_id, {
+    input_value: _._serialize_if($scope0_reason, /* input.valueChange */1) && input.value,
+    input_valueChange: input.valueChange
+  }, "__tests__/tags/custom-input.marko", 0, {
+    input_value: ["input.value"],
+    input_valueChange: ["input.valueChange"]
+  });
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.expected/template.js
@@ -1,0 +1,22 @@
+import _customInput from "./tags/custom-input.marko";
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/template.marko", input => {
+  _._scope_reason();
+  const $scope0_id = _._scope_id();
+  let value = 0;
+  const $childScope = _._peek_scope_id();
+  _._set_serialize_reason({
+    /* input.value, input.valueChange */0: /* value */1
+  });
+  _customInput({
+    value: value,
+    valueChange: _._resume(_new_value => {
+      value = _new_value;
+    }, "__tests__/template.marko_0/valueChange", $scope0_id)
+  });
+  _._html(`<span>${_._escape(value)}${_._el_resume($scope0_id, "#text/1")} <!>${_._escape(typeof value)}${_._el_resume($scope0_id, "#text/2")}</span>`);
+  _._scope($scope0_id, {
+    "#childScope/0": _._existing_scope($childScope)
+  }, "__tests__/template.marko", 0);
+  _._resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/resume.expected.md
@@ -1,0 +1,139 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <input
+      type="number"
+      value="0"
+    />
+    <!--M_*2 #input/0-->
+    <span>
+      0
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.c = {
+          "#childScope/0": _.a = {
+            "ControlledType:#input/0": 2
+          }
+        }, _.a], _.a.input_valueChange = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.c), _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/tags/custom-input.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/tags/custom-input.marko_0 2"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<html>
+  <head />
+  <body>
+    <input
+      default-value="0"
+      type="number"
+      value="1"
+    />
+    <!--M_*2 #input/0-->
+    <span>
+      1
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.c = {
+          "#childScope/0": _.a = {
+            "ControlledType:#input/0": 2
+          }
+        }, _.a], _.a.input_valueChange = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.c), _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/tags/custom-input.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/tags/custom-input.marko_0 2"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/span/#text0 "0" => "1"
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<html>
+  <head />
+  <body>
+    <input
+      default-value="0"
+      type="number"
+      value="10"
+    />
+    <!--M_*2 #input/0-->
+    <span>
+      10
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.c = {
+          "#childScope/0": _.a = {
+            "ControlledType:#input/0": 2
+          }
+        }, _.a], _.a.input_valueChange = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.c), _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/tags/custom-input.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/tags/custom-input.marko_0 2"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/span/#text0 "1" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,10 @@
+# Render End
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/ssr.expected.md
@@ -1,0 +1,59 @@
+# Write
+```html
+  <input value=0 type=number><!--M_*2 #input/0--><span>0<!--M_*1 #text/1--> <!>number<!--M_*1 #text/2--></span><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,_.c={"#childScope/0":_.a={"ControlledType:#input/0":2}},_.a],_.a.input_valueChange=_._["__tests__/template.marko_0/valueChange"](_.c),_.a["ControlledHandler:#input/0"]=_._["__tests__/tags/custom-input.marko_0/valueChange"](_.a),_.b),"__tests__/tags/custom-input.marko_0 2"];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <input
+      type="number"
+      value="0"
+    />
+    <!--M_*2 #input/0-->
+    <span>
+      0
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.c = {
+          "#childScope/0": _.a = {
+            "ControlledType:#input/0": 2
+          }
+        }, _.a], _.a.input_valueChange = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.c), _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/tags/custom-input.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/tags/custom-input.marko_0 2"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/input
+INSERT html/body/#comment
+INSERT html/body/span
+INSERT html/body/span/#text0
+INSERT html/body/span/#comment0
+INSERT html/body/span/#text1
+INSERT html/body/span/#comment1
+INSERT html/body/span/#text2
+INSERT html/body/span/#comment2
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/tags/custom-input.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/tags/custom-input.marko
@@ -1,0 +1,1 @@
+<input type="number" value:parseInt:=input.value/>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/template.marko
@@ -1,0 +1,3 @@
+<let/value = 0>
+<custom-input value:=value/>
+<span>${value} ${typeof value}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+function type(value: string) {
+  return (container: Element) => {
+    const input = container.querySelector("input")!;
+    const window = input.ownerDocument.defaultView!;
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  };
+}
+
+export const config: TestConfig = {
+  steps: [{}, type("1"), type("10")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/.name-cache.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/.name-cache.json
@@ -1,0 +1,10 @@
+{
+  "vars": {
+    "props": {
+      "$_": "t",
+      "$init": "r",
+      "$$value": "a",
+      "$$valueChange": "m"
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/csr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/csr-sanitized.expected.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/csr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/csr.expected.md
@@ -1,0 +1,65 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+# Mutations
+```
+INSERT input, span
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+# Mutations
+```
+UPDATE span/#text0 "0" => "1"
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```
+
+# Mutations
+```
+UPDATE span/#text0 "1" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/dom.expected/template.hydrate.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/dom.expected/template.hydrate.js
@@ -1,0 +1,14 @@
+// size: 218 (min) 133 (brotli)
+const $value = _._let(3, ($scope) => {
+  (_._attr_input_value($scope, "a", $scope.d, $valueChange($scope)),
+    _._text($scope.b, $scope.d),
+    _._text($scope.c, typeof $scope.d));
+});
+function $valueChange($scope) {
+  return (_new_value) => {
+    $value($scope, parseInt(_new_value));
+  };
+}
+(_._script("a1", ($scope) => _._attr_input_value_script($scope, "a")),
+  _._resume("a0", $valueChange),
+  init());

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/dom.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/dom.expected/template.js
@@ -1,0 +1,20 @@
+export const $template = "<input type=number><span><!> <!></span>";
+export const $walks = /* get, over(1), next(1), replace, over(2), replace, out(1) */" bD%c%l";
+import * as _ from "@marko/runtime-tags/debug/dom";
+const $value = /* @__PURE__ */_._let("value/3", $scope => {
+  _._attr_input_value($scope, "#input/0", $scope.value, $valueChange($scope));
+  _._text($scope["#text/1"], $scope.value);
+  _._text($scope["#text/2"], typeof $scope.value);
+});
+const $setup__script = _._script("__tests__/template.marko_0", $scope => _._attr_input_value_script($scope, "#input/0"));
+export function $setup($scope) {
+  $value($scope, 0);
+  $setup__script($scope);
+}
+function $valueChange($scope) {
+  return _new_value => {
+    $value($scope, parseInt(_new_value));
+  };
+}
+_._resume("__tests__/template.marko_0/valueChange", $valueChange);
+export default /* @__PURE__ */_._template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/html.expected/template.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/html.expected/template.js
@@ -1,0 +1,12 @@
+import * as _ from "@marko/runtime-tags/debug/html";
+export default _._template("__tests__/template.marko", input => {
+  _._scope_reason();
+  const $scope0_id = _._scope_id();
+  let value = 0;
+  _._html(`<input${_._attr_input_value($scope0_id, "#input/0", value, _._resume(_new_value => {
+    value = parseInt(_new_value);
+  }, "__tests__/template.marko_0/valueChange", $scope0_id))} type=number>${_._el_resume($scope0_id, "#input/0")}<span>${_._escape(value)}${_._el_resume($scope0_id, "#text/1")} <!>${_._escape(typeof value)}${_._el_resume($scope0_id, "#text/2")}</span>`);
+  _._script($scope0_id, "__tests__/template.marko_0");
+  _._scope($scope0_id, {}, "__tests__/template.marko", 0);
+  _._resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/resume-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/resume-sanitized.expected.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="1"
+/>
+<span>
+  1 number
+</span>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<input
+  default-value="0"
+  type="number"
+  value="10"
+/>
+<span>
+  10 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/resume.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/resume.expected.md
@@ -1,0 +1,127 @@
+# Render
+```html
+<html>
+  <head />
+  <body>
+    <input
+      type="number"
+      value="0"
+    />
+    <!--M_*1 #input/0-->
+    <span>
+      0
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.a = {
+          "ControlledType:#input/0": 2
+        }], _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<html>
+  <head />
+  <body>
+    <input
+      default-value="0"
+      type="number"
+      value="1"
+    />
+    <!--M_*1 #input/0-->
+    <span>
+      1
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.a = {
+          "ControlledType:#input/0": 2
+        }], _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/span/#text0 "0" => "1"
+```
+
+# Render
+```js
+const input = container.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", {
+  bubbles: true
+}));
+```
+```html
+<html>
+  <head />
+  <body>
+    <input
+      default-value="0"
+      type="number"
+      value="10"
+    />
+    <!--M_*1 #input/0-->
+    <span>
+      10
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.a = {
+          "ControlledType:#input/0": 2
+        }], _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+UPDATE html/body/span/#text0 "1" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/ssr-sanitized.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/ssr-sanitized.expected.md
@@ -1,0 +1,10 @@
+# Render End
+```html
+<input
+  type="number"
+  value="0"
+/>
+<span>
+  0 number
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/ssr.expected.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/ssr.expected.md
@@ -1,0 +1,55 @@
+# Write
+```html
+  <input value=0 type=number><!--M_*1 #input/0--><span>0<!--M_*1 #text/1--> <!>number<!--M_*1 #text/2--></span><script>WALKER_RUNTIME("M")("_");M._.r=[_=>(_.b=[0,_.a={"ControlledType:#input/0":2}],_.a["ControlledHandler:#input/0"]=_._["__tests__/template.marko_0/valueChange"](_.a),_.b),"__tests__/template.marko_0 1"];M._.w()</script>
+```
+
+# Render End
+```html
+<html>
+  <head />
+  <body>
+    <input
+      type="number"
+      value="0"
+    />
+    <!--M_*1 #input/0-->
+    <span>
+      0
+      <!--M_*1 #text/1-->
+       
+      <!---->
+      number
+      <!--M_*1 #text/2-->
+    </span>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ =&gt; (_.b = [0, _.a = {
+          "ControlledType:#input/0": 2
+        }], _.a["ControlledHandler:#input/0"] = _._[
+          "__tests__/template.marko_0/valueChange"
+          ](_.a), _.b),
+        "__tests__/template.marko_0 1"
+      ];
+      M._.w()
+    </script>
+  </body>
+</html>
+```
+
+# Mutations
+```
+INSERT html
+INSERT html/head
+INSERT html/body
+INSERT html/body/input
+INSERT html/body/#comment
+INSERT html/body/span
+INSERT html/body/span/#text0
+INSERT html/body/span/#comment0
+INSERT html/body/span/#text1
+INSERT html/body/span/#comment1
+INSERT html/body/span/#text2
+INSERT html/body/span/#comment2
+INSERT html/body/script
+INSERT html/body/script/#text
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/template.marko
@@ -1,0 +1,3 @@
+<let/value = 0>
+<input type="number" value:parseInt:=value/>
+<span>${value} ${typeof value}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+function type(value: string) {
+  return (container: Element) => {
+    const input = container.querySelector("input")!;
+    const window = input.ownerDocument.defaultView!;
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  };
+}
+
+export const config: TestConfig = {
+  steps: [{}, type("1"), type("10")],
+};

--- a/packages/runtime-tags/src/translator/interop/feature-detection.ts
+++ b/packages/runtime-tags/src/translator/interop/feature-detection.ts
@@ -161,9 +161,6 @@ function scanTag(state: FeatureState, tag: t.NodePath<t.MarkoTag>) {
             (attr.get("arguments") as t.NodePath<t.Expression>[])[0],
           );
           break;
-        } else if (attr.node.modifier) {
-          addFeature(state, FeatureType.Class, "Attribute modifier", attr);
-          break;
         } else if (attr.node.bound) {
           addFeature(state, FeatureType.Tags, "Bound attribute", attr);
           break;

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -79,10 +79,16 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
 
   for (let i = 0; i < attributes.length; i++) {
     const attr = attributes[i];
-    if (t.isMarkoAttribute(attr) && attr.bound) {
-      // Inject change handler functions from the binding shorthand.
-      attr.bound = false;
-      attributes.splice(++i, 0, getChangeHandler(tag, attr));
+    if (t.isMarkoAttribute(attr)) {
+      if (attr.bound) {
+        // Inject change handler functions from the binding shorthand.
+        attributes.splice(++i, 0, getChangeHandler(tag, attr));
+        attr.bound = false;
+      } else if (attr.modifier != null) {
+        attr.name += ":" + attr.modifier;
+      }
+
+      attr.modifier = null;
     }
   }
 }
@@ -93,22 +99,26 @@ function getChangeHandler(
 ): t.MarkoAttribute {
   const attrName = attr.name;
   const changeAttrName = attrName + "Change";
+  const modifier =
+    attr.modifier == null
+      ? undefined
+      : withPreviousLocation(t.identifier(attr.modifier), attr);
 
   if (t.isIdentifier(attr.value)) {
     const binding = tag.scope.getBinding(attr.value.name);
     if (!binding)
       return t.markoAttribute(
         changeAttrName,
-        buildChangeHandlerFunction(attr.value),
+        buildChangeHandlerFunction(attr.value, modifier),
       );
 
     const existingChangedAttr = BINDING_CHANGE_HANDLER.get(binding.identifier);
     if (!existingChangedAttr) {
       const bindingIdentifierPath =
         binding.path.getOuterBindingIdentifierPaths()[binding.identifier.name];
-      const changeAttrExpr = bindingIdentifierPath
+      let changeAttrExpr: undefined | t.Expression = bindingIdentifierPath
         ? bindingIdentifierPath.parentPath === binding.path
-          ? buildChangeHandlerFunction(attr.value)
+          ? buildChangeHandlerFunction(attr.value, modifier)
           : bindingIdentifierPath.parentPath!.isObjectProperty()
             ? getChangeHandlerFromObjectPattern(
                 bindingIdentifierPath.parentPath!,
@@ -118,6 +128,14 @@ function getChangeHandler(
 
       if (!changeAttrExpr) {
         throw tag.hub.buildError(attr.value, "Unable to bind to value.");
+      }
+
+      if (modifier && t.isIdentifier(changeAttrExpr)) {
+        changeAttrExpr = t.logicalExpression(
+          "&&",
+          changeAttrExpr,
+          buildChangeHandlerFunction(attr.value, modifier),
+        );
       }
 
       const changeHandlerAttr = t.markoAttribute(
@@ -185,13 +203,29 @@ function getChangeHandler(
               t.stringLiteral("Change"),
             );
       const computed = memberProp.type !== "Identifier";
+      let changeAttrExpr: t.Expression = attr.value.optional
+        ? t.optionalMemberExpression(memberObj, memberProp, computed, true)
+        : t.memberExpression(memberObj, memberProp, computed);
 
-      return t.markoAttribute(
-        changeAttrName,
-        attr.value.optional
-          ? t.optionalMemberExpression(memberObj, memberProp, computed, true)
-          : t.memberExpression(memberObj, memberProp, computed),
-      );
+      if (modifier) {
+        const newValueId = generateUid("next");
+        changeAttrExpr = t.logicalExpression(
+          "&&",
+          changeAttrExpr,
+          t.arrowFunctionExpression(
+            [t.identifier(newValueId)],
+            t.blockStatement([
+              t.expressionStatement(
+                t.callExpression(
+                  t.memberExpression(memberObj, memberProp, computed),
+                  [t.callExpression(modifier, [t.identifier(newValueId)])],
+                ),
+              ),
+            ]),
+          ),
+        );
+      }
+      return t.markoAttribute(changeAttrName, changeAttrExpr);
     }
   }
 
@@ -201,8 +235,15 @@ function getChangeHandler(
   );
 }
 
-function buildChangeHandlerFunction(id: t.Identifier) {
+function buildChangeHandlerFunction(
+  id: t.Identifier,
+  modifier: undefined | t.Identifier,
+) {
   const newId = "_new_" + id.name;
+  let newValue: t.Expression = withPreviousLocation(t.identifier(newId), id);
+  if (modifier) {
+    newValue = t.callExpression(modifier, [newValue]);
+  }
   return t.arrowFunctionExpression(
     [withPreviousLocation(t.identifier(newId), id)],
     t.blockStatement([
@@ -210,7 +251,7 @@ function buildChangeHandlerFunction(id: t.Identifier) {
         t.assignmentExpression(
           "=",
           withPreviousLocation(t.identifier(id.name), id),
-          withPreviousLocation(t.identifier(newId), id),
+          newValue,
         ),
       ),
     ]),

--- a/packages/runtime-tags/src/translator/visitors/tag/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/index.ts
@@ -1,9 +1,5 @@
 import { types as t } from "@marko/compiler";
-import {
-  getTagDef,
-  isNativeTag,
-  type Plugin,
-} from "@marko/compiler/babel-utils";
+import { getTagDef, type Plugin } from "@marko/compiler/babel-utils";
 
 import * as hooks from "../../util/plugin-hooks";
 import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
@@ -84,16 +80,6 @@ export default {
             throw attr.buildCodeFrameError(
               `Unsupported arguments on the \`${attr.node.name}\` attribute.`,
             );
-          }
-
-          if (attr.node.modifier) {
-            if (isNativeTag(attr.parentPath as t.NodePath<t.MarkoTag>)) {
-              attr.node.name += `:${attr.node.modifier}`;
-            } else {
-              throw attr.buildCodeFrameError(
-                `Unsupported modifier \`${attr.node.modifier}\`.`,
-              );
-            }
           }
         }
       }


### PR DESCRIPTION
Adds support for ":modifiers" on bound attributes.
When a bound attribute has a modifier, that identifier is used to process all values passed into the implicit change handler.

TLDR

```marko
<let/value=0>
<input type="number" value:Number:=value>

// shorthand for
<input type="number" value=value valueChange(next) { value = Number(next); }>
```

This saves a lot of typing especially when binding to member expressions, eg
```marko
<input type="number" value:Number:=input.value>

// shorthand for
<input type="number" value=value valueChange=input.valueChange && ((next) => { input.valueChange(Number(next)); })>
```

Note the modifier must always be a valid identifier, however for more complex normalization is still possible to create eg a static function:

```marko
<let/value="hello">
<input value:trim:=value>

static function trim(str) {
  return str.trim();
}
```