### PR TITLE
fix: improve warnings for invalid attribute names (tags api)

### DIFF
--- a/.changeset/plain-mirrors-smell.md
+++ b/.changeset/plain-mirrors-smell.md
@@ -1,0 +1,7 @@
+---
+"@marko/runtime-tags": patch
+"@marko/compiler": patch
+"marko": patch
+---
+
+Add validations around tags api attribute names.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/__snapshots__/dom.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/template.marko:1:6
+    > 1 | <div @invalid@attr="value"/>
+        |      ^^^^^^^^^^^^^ Invalid attribute name.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/__snapshots__/html.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/template.marko:1:6
+    > 1 | <div @invalid@attr="value"/>
+        |      ^^^^^^^^^^^^^ Invalid attribute name.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/template.marko
@@ -1,0 +1,1 @@
+<div @invalid@attr="value"/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-html-attr-name/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/__snapshots__/dom.expected/template.error.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/template.marko:2:22
+      1 | <let/value=0/>
+    > 2 | <custom-input myAttr:123:=value/>
+        |                      ^^^ Bound attribute refinement shorthand must be a valid JavaScript identifier.
+      3 |
+      4 |
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/__snapshots__/html.expected/template.error.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/template.marko:2:22
+      1 | <let/value=0/>
+    > 2 | <custom-input myAttr:123:=value/>
+        |                      ^^^ Bound attribute refinement shorthand must be a valid JavaScript identifier.
+      3 |
+      4 |
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/template.marko
@@ -1,0 +1,4 @@
+<let/value=0/>
+<custom-input myAttr:123:=value/>
+
+

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-modifier-name/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/__snapshots__/dom.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/__snapshots__/dom.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/template.marko:1:14
+    > 1 | <MyComponent @invalid@attr="value"/>
+        |              ^^^^^^^^^^^^^ Invalid attribute name.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/__snapshots__/html.expected/template.error.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/__snapshots__/html.expected/template.error.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/template.marko:1:14
+    > 1 | <MyComponent @invalid@attr="value"/>
+        |              ^^^^^^^^^^^^^ Invalid attribute name.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/template.marko
@@ -1,0 +1,1 @@
+<MyComponent @invalid@attr="value"/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-invalid-user-attr-name/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -1,3 +1,6 @@
+export const htmlAttrNameReg = /^[^a-z_]|[^a-z0-9._:-]/i;
+export const userAttrNameReg = /^[^a-z_$]|[^a-z0-9._:-]/i;
+
 export function _call<T>(fn: (v: T) => unknown, v: T): T {
   fn(v);
   return v;

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -2,6 +2,7 @@ import { assertExclusiveAttrs } from "../common/errors";
 import {
   classValue,
   getEventHandlerName,
+  htmlAttrNameReg,
   isEventHandler,
   normalizeDynamicRenderer,
   styleValue,
@@ -285,6 +286,12 @@ function attrsInternal(
         _attr_style(el, value);
         break;
       default: {
+        if (MARKO_DEBUG) {
+          if (htmlAttrNameReg.test(name)) {
+            throw new Error(`Invalid attribute name: ${JSON.stringify(name)}`);
+          }
+        }
+
         if (isEventHandler(name)) {
           (events ||= scope[AccessorPrefix.EventAttributes + nodeAccessor] =
             {})[getEventHandlerName(name)] = value;

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -2,6 +2,7 @@ import { assertExclusiveAttrs } from "../common/errors";
 import {
   classValue,
   getEventHandlerName,
+  htmlAttrNameReg,
   isEventHandler,
   isVoid,
   styleValue,
@@ -262,6 +263,14 @@ export function _attrs(
             (name === "content" && tagName !== "meta")
           )
         ) {
+          if (MARKO_DEBUG) {
+            if (htmlAttrNameReg.test(name)) {
+              throw new Error(
+                `Invalid attribute name: ${JSON.stringify(name)}`,
+              );
+            }
+          }
+
           if (isEventHandler(name)) {
             if (!events) {
               events = {};

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -1,5 +1,7 @@
 import { types as t } from "@marko/compiler";
+import { isNativeTag } from "@marko/compiler/babel-utils";
 
+import { htmlAttrNameReg, userAttrNameReg } from "../../../common/helpers";
 import { preAnalyze as preAnalyzeTextarea } from "../../core/textarea";
 import { generateUid, generateUidIdentifier } from "../../util/generate-uid";
 import { getMarkoRoot, isMarko } from "../../util/get-root";
@@ -38,6 +40,7 @@ function normalizeBody(
 function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
   const { node } = tag;
   const { name, attributes } = node;
+  let attrNameReg = userAttrNameReg;
   normalizeBody(tag.get("body").get("body"));
   normalizeBody(tag.get("attributeTags"));
 
@@ -68,7 +71,8 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
       // Convert tags which have an associated binding to an identifier.
       // <MyTag> --> <${MyTag}>
       node.name = withPreviousLocation(t.identifier(tagName), name);
-    } else {
+    } else if (isNativeTag(tag)) {
+      attrNameReg = htmlAttrNameReg;
       switch (tagName) {
         case "textarea":
           preAnalyzeTextarea(tag);
@@ -88,6 +92,22 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
         attr.name += ":" + attr.modifier;
       }
 
+      if (attrNameReg.test(attr.name)) {
+        throw tag.hub.buildError(
+          attr.loc?.end &&
+            ({
+              loc: {
+                start: attr.loc.start,
+                end: {
+                  line: attr.loc.start.line,
+                  column: attr.loc.start.column + attr.name.length,
+                },
+              },
+            } as any),
+          "Invalid attribute name.",
+        );
+      }
+
       attr.modifier = null;
     }
   }
@@ -99,10 +119,28 @@ function getChangeHandler(
 ): t.MarkoAttribute {
   const attrName = attr.name;
   const changeAttrName = attrName + "Change";
-  const modifier =
-    attr.modifier == null
-      ? undefined
-      : withPreviousLocation(t.identifier(attr.modifier), attr);
+  let modifier: undefined | t.Identifier;
+  if (attr.modifier != null) {
+    if (!t.isValidIdentifier(attr.modifier)) {
+      throw tag.hub.buildError(
+        attr.value.loc?.end &&
+          ({
+            loc: {
+              start: {
+                line: attr.value.loc.start.line,
+                column: attr.value.loc.start.column - attr.modifier.length - 2,
+              },
+              end: {
+                line: attr.value.loc.start.line,
+                column: attr.value.loc.start.column - 2,
+              },
+            },
+          } as any),
+        "Bound attribute refinement shorthand must be a valid JavaScript identifier.",
+      );
+    }
+    modifier = withPreviousLocation(t.identifier(attr.modifier), attr);
+  }
 
   if (t.isIdentifier(attr.value)) {
     const binding = tag.scope.getBinding(attr.value.name);


### PR DESCRIPTION
* Provides error messages for invalid attribute names
* Provides error messages for invalid bind refinement shorthand