### PR TITLE
chore: update types for <button>

### DIFF
--- a/.changeset/thick-goats-dress.md
+++ b/.changeset/thick-goats-dress.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Add missing `command` and `commandfor` for HTMLButtonElement

--- a/packages/runtime-class/tags-html.d.ts
+++ b/packages/runtime-class/tags-html.d.ts
@@ -529,6 +529,18 @@ declare global {
       }
       interface Button extends HTMLAttributes<HTMLButtonElement> {
         /**
+         * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
+         * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
+         */
+        command?: AttrString;
+
+        /**
+         * Specifies the id of the element being controlled
+         * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-commandfor
+         */
+        commandfor?: AttrString;
+
+        /**
          * Specifies whether the button should be disabled.
          * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
          */

--- a/packages/runtime-class/tags-html.d.ts
+++ b/packages/runtime-class/tags-html.d.ts
@@ -532,7 +532,7 @@ declare global {
          * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
          * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
          */
-        command?: AttrString;
+        command?: AttrMissing | "show-modal" | "close" | "request-close" | "show-popover" | "hide-popover" | "toggle-popover" | (string & {});
 
         /**
          * Specifies the id of the element being controlled

--- a/packages/runtime-class/tags-html.d.ts
+++ b/packages/runtime-class/tags-html.d.ts
@@ -532,7 +532,15 @@ declare global {
          * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
          * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
          */
-        command?: AttrMissing | "show-modal" | "close" | "request-close" | "show-popover" | "hide-popover" | "toggle-popover" | (string & {});
+        command?:
+          | AttrMissing
+          | "show-modal"
+          | "close"
+          | "request-close"
+          | "show-popover"
+          | "hide-popover"
+          | "toggle-popover"
+          | (string & {});
 
         /**
          * Specifies the id of the element being controlled

--- a/packages/runtime-tags/tags-html.d.ts
+++ b/packages/runtime-tags/tags-html.d.ts
@@ -628,6 +628,18 @@ declare global {
       }
       interface Button extends HTMLAttributes<HTMLButtonElement> {
         /**
+         * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
+         * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
+         */
+        command?: AttrString;
+
+        /**
+         * Specifies the id of the element being controlled
+         * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-commandfor
+         */
+        commandfor?: AttrString;
+
+        /**
          * Specifies whether the button should be disabled.
          * @see https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#attr-fe-disabled
          */

--- a/packages/runtime-tags/tags-html.d.ts
+++ b/packages/runtime-tags/tags-html.d.ts
@@ -631,7 +631,7 @@ declare global {
          * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
          * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
          */
-        command?: AttrString;
+        command?: AttrMissing | "show-modal" | "close" | "request-close" | "show-popover" | "hide-popover" | "toggle-popover" | (string & {});
 
         /**
          * Specifies the id of the element being controlled

--- a/packages/runtime-tags/tags-html.d.ts
+++ b/packages/runtime-tags/tags-html.d.ts
@@ -631,7 +631,15 @@ declare global {
          * Specifies the action to be performed on an element being controlled specified via the commandfor attribute.
          * @see https://html.spec.whatwg.org/multipage/form-elements.html#attr-button-command
          */
-        command?: AttrMissing | "show-modal" | "close" | "request-close" | "show-popover" | "hide-popover" | "toggle-popover" | (string & {});
+        command?:
+          | AttrMissing
+          | "show-modal"
+          | "close"
+          | "request-close"
+          | "show-popover"
+          | "hide-popover"
+          | "toggle-popover"
+          | (string & {});
 
         /**
          * Specifies the id of the element being controlled


### PR DESCRIPTION
## Description

`mtc` was complaining about `<button command="show-modal" commandfor="123">`

This adds types for `command` and `commandfor`
