### PR TITLE
fix: expose type definition for internal babel file

### DIFF
--- a/.changeset/giant-apes-juggle.md
+++ b/.changeset/giant-apes-juggle.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Expose types for internal babel file through package.json exports.

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -109,6 +109,7 @@
     },
     "./modules": "./modules.js",
     "./internal/babel": {
+      "types": "./internal/babel/index.ts",
       "browser": "./dist/babel.web.js",
       "default": "./dist/babel.js"
     },


### PR DESCRIPTION
* exposes babel internal types to resolve type issues for tools which reference it.