### PR TITLE
fix: incorrect decl hoisting in prod runtime build

### DIFF
--- a/.changeset/red-deserts-type.md
+++ b/.changeset/red-deserts-type.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix incorrect declaration hoisting in production runtime builds.

--- a/packages/runtime-tags/scripts/build-plugins/decl-hoist.mts
+++ b/packages/runtime-tags/scripts/build-plugins/decl-hoist.mts
@@ -18,20 +18,26 @@ export default function moduleScopeVarHoistPlugin(): Plugin {
       })["declarations"] = [];
 
       for (const node of ast.body) {
-        if (node.type !== "VariableDeclaration") continue;
+        if (
+          node.type === "VariableDeclaration" &&
+          (node.kind === "let" || node.kind === "const")
+        ) {
+          // Remove keyword (e.g. "let " or "const ")
+          s.remove(node.start, node.declarations[0].start);
 
-        // Remove keyword (e.g. "let ", "const ", "var ")
-        s.remove(node.start, node.declarations[0].start);
+          for (let i = 0; i < node.declarations.length; i++) {
+            const d = node.declarations[i];
+            // Remove ", " between adjacent declarators
+            if (i) s.remove(node.declarations[i - 1].end, d.start);
+            decls.push(d);
+          }
 
-        for (let i = 0; i < node.declarations.length; i++) {
-          const d = node.declarations[i];
-          // Remove ", " between adjacent declarators
-          if (i) s.remove(node.declarations[i - 1].end, d.start);
-          decls.push(d);
+          // Remove trailing semicolon
+          s.remove(
+            node.declarations[node.declarations.length - 1].end,
+            node.end,
+          );
         }
-
-        // Remove trailing semicolon
-        s.remove(node.declarations[node.declarations.length - 1].end, node.end);
       }
 
       if (!decls.length) return null;


### PR DESCRIPTION
Fixes #3170

This is a regression caused by #3165

TLDR: the new production build hoists module scoped variable declarations, but _should not_ hoist `var` declarations which can self reference synchronously (unlike `let/const`).