### PR TITLE
fix(runtime-tags): skip runEffects for already-destroyed branch scopes

### DIFF
--- a/.changeset/cozy-ways-nail.md
+++ b/.changeset/cozy-ways-nail.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix a race condition whereby effects can still fire in stale scopes

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 21171,
-        "brotli": 7956
+        "min": 21193,
+        "brotli": 7940
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 120
       },
       "runtime": {
-        "min": 4082,
-        "brotli": 1825
+        "min": 4104,
+        "brotli": 1835
       },
       "total": {
-        "min": 4245,
-        "brotli": 1945
+        "min": 4267,
+        "brotli": 1955
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 79
       },
       "runtime": {
-        "min": 2376,
-        "brotli": 1236
+        "min": 2398,
+        "brotli": 1245
       },
       "total": {
-        "min": 2465,
-        "brotli": 1315
+        "min": 2487,
+        "brotli": 1324
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 393
       },
       "runtime": {
-        "min": 6448,
-        "brotli": 2831
+        "min": 6470,
+        "brotli": 2841
       },
       "total": {
-        "min": 7130,
-        "brotli": 3224
+        "min": 7152,
+        "brotli": 3234
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 104
       },
       "runtime": {
-        "min": 2548,
-        "brotli": 1287
+        "min": 2570,
+        "brotli": 1299
       },
       "total": {
-        "min": 2670,
-        "brotli": 1391
+        "min": 2692,
+        "brotli": 1403
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6448 (min) 2831 (brotli)
+// size: 6470 (min) 2841 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -73,7 +73,11 @@ let decodeAccessor = (num) =>
   pendingScopes = [],
   rendering,
   runEffects = (effects) => {
-    for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
+    for (let i = 0; i < effects.length; ) {
+      let fn = effects[i++],
+        scope = effects[i++];
+      scope.F?.I || fn(scope);
+    }
   },
   runRender = (render) => render.c(render.b, render.d),
   _template = (id, template, walks, setup, inputSignal) => {

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2548 (min) 1287 (brotli)
+// size: 2570 (min) 1299 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -15,7 +15,11 @@ let decodeAccessor = (num) =>
   pendingScopes = [],
   rendering,
   runEffects = (effects) => {
-    for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
+    for (let i = 0; i < effects.length; ) {
+      let fn = effects[i++],
+        scope = effects[i++];
+      scope.F?.I || fn(scope);
+    }
   },
   runRender = (render) => render.c(render.b, render.d);
 function _on(element, type, handler) {

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 4082 (min) 1825 (brotli)
+// size: 4104 (min) 1835 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -68,7 +68,11 @@ let decodeAccessor = (num) =>
   pendingScopes = [],
   rendering,
   runEffects = (effects) => {
-    for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
+    for (let i = 0; i < effects.length; ) {
+      let fn = effects[i++],
+        scope = effects[i++];
+      scope.F?.I || fn(scope);
+    }
   },
   runRender = (render) => render.c(render.b, render.d),
   _template = (id, template, walks, setup, inputSignal) => {

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2376 (min) 1236 (brotli)
+// size: 2398 (min) 1245 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -15,7 +15,11 @@ let decodeAccessor = (num) =>
   pendingScopes = [],
   rendering,
   runEffects = (effects) => {
-    for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
+    for (let i = 0; i < effects.length; ) {
+      let fn = effects[i++],
+        scope = effects[i++];
+      scope.F?.I || fn(scope);
+    }
   },
   runRender = (render) => render.c(render.b, render.d);
 function _on(element, type, handler) {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 21171 (min) 7956 (brotli)
+// size: 21193 (min) 7940 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -205,7 +205,11 @@ let empty = [],
   pendingScopes = [],
   rendering,
   runEffects = (effects) => {
-    for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
+    for (let i = 0; i < effects.length; ) {
+      let fn = effects[i++],
+        scope = effects[i++];
+      scope.F?.I || fn(scope);
+    }
   },
   runRender = (render) => render.c(render.b, render.d),
   catchEnabled,

--- a/packages/runtime-tags/src/__tests__/queue-destroyed-branch.test.ts
+++ b/packages/runtime-tags/src/__tests__/queue-destroyed-branch.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Regression test for the race condition where runEffects executes effects
+ * for branch scopes that have already been destroyed.
+ *
+ * Scenario:
+ *   1. A branch is created and its setup render runs, queuing script effects.
+ *   2. Within the same runRenders() pass a later render destroys the branch
+ *      (branch[Destroyed] = 1), but the effect is already in pendingEffects.
+ *   3. runEffects() fires — without the guard it calls the script effect on the
+ *      stale scope, where any node ref returns undefined, producing a TypeError.
+ *
+ * The fix adds `!scope[ClosestBranch]?.[Destroyed]` to the base runEffects
+ * loop, mirroring the same guard already in runRenders and the _enable_catch
+ * enhanced path.
+ */
+
+import assert from "assert/strict";
+import { JSDOM } from "jsdom";
+
+import { AccessorProp } from "../common/types";
+
+describe("runEffects — destroyed branch guard", () => {
+  let queue: typeof import("../dom/queue");
+  let prevDocument: unknown;
+
+  before(() => {
+    // Save whatever was in globalThis.document (typically undefined in Node).
+    prevDocument = (globalThis as any).document;
+
+    const { window: jsdomWindow } = new JSDOM("");
+    (globalThis as any).document = jsdomWindow.document;
+
+    // Lazily loaded so the dom/* modules only load after globalThis.document is
+    // set (walker.ts calls document.createTreeWalker(document) at
+    // module-evaluation time).
+    queue = require("../dom/queue");
+  });
+
+  after(() => {
+    // Restore the original value so subsequent suites see a clean state.
+    if (prevDocument === undefined) {
+      delete (globalThis as any).document;
+    } else {
+      (globalThis as any).document = prevDocument;
+    }
+  });
+
+  it("skips an effect whose closest branch is marked Destroyed", () => {
+    let effectRan = false;
+    const fn = () => {
+      effectRan = true;
+    };
+
+    const branch = { [AccessorProp.Destroyed]: 1 as const };
+    const scope = { [AccessorProp.ClosestBranch]: branch };
+
+    queue.runEffects([fn, scope as any]);
+
+    assert.equal(
+      effectRan,
+      false,
+      "effect must not run when branch is already destroyed",
+    );
+  });
+
+  it("runs an effect whose closest branch is not destroyed", () => {
+    let effectRan = false;
+    const fn = () => {
+      effectRan = true;
+    };
+
+    const branch = {} as any;
+    const scope = { [AccessorProp.ClosestBranch]: branch };
+
+    queue.runEffects([fn, scope as any]);
+
+    assert.equal(effectRan, true, "effect must run when branch is active");
+  });
+
+  it("runs an effect on a scope with no branch (top-level scope)", () => {
+    let effectRan = false;
+    const fn = () => {
+      effectRan = true;
+    };
+
+    const scope = {} as any;
+
+    queue.runEffects([fn, scope]);
+
+    assert.equal(effectRan, true, "effect must run when scope has no branch");
+  });
+
+  it("processes multiple effects, skipping only the destroyed-branch ones", () => {
+    const ran: string[] = [];
+
+    const activeBranch = {} as any;
+    const destroyedBranch = { [AccessorProp.Destroyed]: 1 as const };
+
+    const scopeA = { [AccessorProp.ClosestBranch]: activeBranch };
+    const scopeB = { [AccessorProp.ClosestBranch]: destroyedBranch };
+    const scopeC = {} as any;
+
+    queue.runEffects([
+      () => ran.push("A"),
+      scopeA as any,
+      () => ran.push("B"),
+      scopeB as any,
+      () => ran.push("C"),
+      scopeC,
+    ]);
+
+    assert.deepEqual(ran, ["A", "C"], "only non-destroyed-branch effects run");
+  });
+});

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -109,6 +109,8 @@ export function prepareEffects(fn: () => void): unknown[] {
 }
 
 export let runEffects = ((effects) => {
+  // Skip effects for scopes whose closest branch has been destroyed
+  // to prevent runtime errors from stale DOM references.
   for (let i = 0; i < effects.length; ) {
     const fn = effects[i++] as (scope: Scope) => void;
     const scope = effects[i++] as Scope;

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -110,7 +110,11 @@ export function prepareEffects(fn: () => void): unknown[] {
 
 export let runEffects = ((effects) => {
   for (let i = 0; i < effects.length; ) {
-    (effects[i++] as (scope: Scope) => void)(effects[i++] as Scope);
+    const fn = effects[i++] as (scope: Scope) => void;
+    const scope = effects[i++] as Scope;
+    if (!scope[AccessorProp.ClosestBranch]?.[AccessorProp.Destroyed]) {
+      fn(scope);
+    }
   }
 }) as (effects: unknown[], checkPending?: boolean | 1) => void;
 


### PR DESCRIPTION
## Description

Guard the base `runEffects` loop with
`!scope[ClosestBranch]?.[Destroyed]`, mirroring the identical guard already present in `runRenders` and the `_enable_catch`-enhanced path.

Without the guard, if a branch is destroyed during the same `runRenders()` pass that queued its setup effects, those effects still fire in `runEffects()` on a stale scope where DOM node refs are `undefined`, producing a TypeError at runtime.

Adds a regression test suite (`queue-destroyed-branch.test.ts`) that exercises the four key cases: destroyed-branch effect is skipped, active-branch effect runs, top-level (no-branch) effect runs, and a mixed batch skips only the destroyed-branch effects.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
