### PR TITLE
fix: avoid namespace imports

### DIFF
--- a/.changeset/sparkly-plants-wear.md
+++ b/.changeset/sparkly-plants-wear.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid namespace imports which leads to better inlining in rolldown.

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 2848 (min) 1466 (brotli)
-// template.marko: 283 (min) 188 (brotli)
+// template.marko: 279 (min) 181 (brotli)
 const $pattern2 = ($scope, $pattern) => {
 	$foo2($scope, $pattern.foo);
 	$fooChange2($scope, $pattern.fooChange);
@@ -11,10 +11,9 @@ const $bar = /* @__PURE__ */ _let(3, ($scope) => {
 		fooChange: $foo($scope)
 	});
 });
-const $foo__OR__$fooChange__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+const $foo__OR__$fooChange = /* @__PURE__ */ _or(7, _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$scope.g($scope.f + 1);
-}));
-const $foo__OR__$fooChange = /* @__PURE__ */ _or(7, $foo__OR__$fooChange__script);
+})));
 const $foo2 = /* @__PURE__ */ _const(5, ($scope) => {
 	_text($scope.b, $scope.f);
 	$foo__OR__$fooChange($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 2669 (min) 1383 (brotli)
-// template.marko: 168 (min) 128 (brotli)
-const $bar__OR__$fooChange__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+// template.marko: 164 (min) 125 (brotli)
+const $bar__OR__$fooChange = /* @__PURE__ */ _or(7, _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$scope.g($scope.d + 1);
-}));
-const $bar__OR__$fooChange = /* @__PURE__ */ _or(7, $bar__OR__$fooChange__script);
+})));
 const $bar = /* @__PURE__ */ _let(3, ($scope) => {
 	_text($scope.c, $scope.d);
 	$bar__OR__$fooChange($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 2709 (min) 1390 (brotli)
-// template.marko: 244 (min) 150 (brotli)
-const $resetCount2__script = _script("a1", ($scope) => _on($scope.c, "click", $scope.e));
-const $resetCount2 = /* @__PURE__ */ _const(4, $resetCount2__script);
+// template.marko: 240 (min) 152 (brotli)
+const $resetCount2 = /* @__PURE__ */ _const(4, _script("a1", ($scope) => _on($scope.c, "click", $scope.e)));
 const $count__script = _script("a2", ($scope) => {
 	_on($scope.a, "click", function() {
 		$count($scope, $scope.d + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 5605 (min) 2606 (brotli)
-// template.marko: 125 (min) 99 (brotli)
-const $if_content__setup = _script("a0", ($scope) => _on($scope.a, "click", function() {
+// template.marko: 121 (min) 97 (brotli)
+const $if = /* @__PURE__ */ _if(0, "<button></button>", " b", _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$hide($scope._, true);
-}));
-const $if = /* @__PURE__ */ _if(0, "<button></button>", " b", $if_content__setup);
+})));
 const $hide = /* @__PURE__ */ _let(1, ($scope) => $if($scope, !$scope.b ? 0 : 1));

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 6867 (min) 3118 (brotli)
-// template.marko: 198 (min) 144 (brotli)
+// template.marko: 194 (min) 139 (brotli)
 _enable_catch();
 const $placeholder_content = _content_resume("a2", "loading...", "b");
 const $await_content__value__script = _script("a1", ($scope) => !$scope._._.b && $value($scope._._, $scope._._.b + 1) - 1);
@@ -7,5 +7,4 @@ const $await_content__value = /* @__PURE__ */ _closure_get(1, ($scope) => {
 	_text($scope.a, $scope._._.b);
 	$await_content__value__script($scope);
 }, ($scope) => $scope._._, "a0");
-const $value__closure = /* @__PURE__ */ _closure($await_content__value);
-const $value = /* @__PURE__ */ _let(1, $value__closure);
+const $value = /* @__PURE__ */ _let(1, /* @__PURE__ */ _closure($await_content__value));

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 6337 (min) 2898 (brotli)
-// template.marko: 193 (min) 142 (brotli)
+// template.marko: 189 (min) 145 (brotli)
 const $if_content__value = /* @__PURE__ */ _if_closure(3, 0, ($scope) => _text($scope.a, $scope._.e));
-const $if_content__setup = $if_content__value;
-const $if = /* @__PURE__ */ _if(3, "<span> </span>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(3, "<span> </span>", "D l", $if_content__value);
 const $value__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$value($scope, $scope.e + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 7034 (min) 3200 (brotli)
-// template.marko: 252 (min) 173 (brotli)
+// template.marko: 248 (min) 171 (brotli)
 _enable_catch();
 const $if_content__value = /* @__PURE__ */ _if_closure(2, 0, ($scope) => _text($scope.a, $scope._.d));
-const $if_content__setup = $if_content__value;
-const $await_content__if = /* @__PURE__ */ _if(2, "<span> </span>", "D l", $if_content__setup);
+const $await_content__if = /* @__PURE__ */ _if(2, "<span> </span>", "D l", $if_content__value);
 const $await_content__value__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$await_content__value($scope, $scope.d + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/__snapshots__/html.bundle.js
@@ -10,8 +10,7 @@ var template_default = _template("a", (input) => {
 				const $scope2_id = _scope_id();
 				_scope_reason();
 				_await($scope2_id, "a", resolveAfter(0, 1), () => {
-					const $scope4_id = _scope_id();
-					_script($scope4_id, "a0");
+					_script(_scope_id(), "a0");
 				}, 0);
 			}, $scope1_id), { placeholder: attrTag({ content: _content_resume("a1", () => {
 				_scope_reason();

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
@@ -1,6 +1,6 @@
 // tags/my-button.marko
 var my_button_default = _template("b", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_value_text = _serialize_guard($scope0_reason, 0);
+	const $sg__input_value_text = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const { onClick, value: { text } } = input;
 	const { value: { text: textAlias } } = input;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
@@ -1,6 +1,6 @@
 // tags/my-button.marko
 var my_button_default = _template("b", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_text = _serialize_guard($scope0_reason, 0);
+	const $sg__input_text = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const { onClick, text } = input;
 	const { text: textAlias } = input;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5927 (min) 2735 (brotli)
-// template.marko: 258 (min) 165 (brotli)
+// template.marko: 254 (min) 161 (brotli)
 const $if_content__count = /* @__PURE__ */ _if_closure(2, 0, ($scope) => _text($scope.a, $scope._.e));
-const $if_content__setup = $if_content__count;
-const $if = /* @__PURE__ */ _if(2, "The count is <!>", "b%b", $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, "The count is <!>", "b%b", $if_content__count);
 const $show__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$show($scope, !$scope.d);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5925 (min) 2728 (brotli)
-// template.marko: 256 (min) 162 (brotli)
+// template.marko: 252 (min) 159 (brotli)
 const $if_content__count = /* @__PURE__ */ _if_closure(2, 0, ($scope) => _text($scope.a, $scope._.e));
-const $if_content__setup = $if_content__count;
-const $if = /* @__PURE__ */ _if(2, "<span> </span>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, "<span> </span>", "D l", $if_content__count);
 const $show__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$show($scope, !$scope.d);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 2633 (min) 1363 (brotli)
-// template.marko: 160 (min) 120 (brotli)
-const $increment2__script = _script("a1", ($scope) => _on($scope.a, "click", $scope.d));
-const $increment2 = /* @__PURE__ */ _const(3, $increment2__script);
+// template.marko: 156 (min) 126 (brotli)
+const $increment2 = /* @__PURE__ */ _const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d)));
 const $clickCount = /* @__PURE__ */ _let(2, ($scope) => {
 	_text($scope.b, $scope.c);
 	$increment2($scope, $increment($scope));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-effect-no-deps/__snapshots__/html.bundle.js
@@ -1,6 +1,5 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
-	_script($scope0_id, "a0");
+	_script(_scope_id(), "a0");
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 2637 (min) 1376 (brotli)
-// template.marko: 130 (min) 111 (brotli)
-const $a__OR__b__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+// template.marko: 126 (min) 110 (brotli)
+const $a__OR__b = /* @__PURE__ */ _or(4, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$a($scope, $scope.c.map((a) => $scope.d));
-}));
-const $a__OR__b = /* @__PURE__ */ _or(4, $a__OR__b__script);
+})));
 const $a = /* @__PURE__ */ _let(2, ($scope) => {
 	_text($scope.b, $scope.c.join(""));
 	$a__OR__b($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/__snapshots__/dom.bundle.js
@@ -1,19 +1,18 @@
 // total: 2739 (min) 1428 (brotli)
-// template.marko: 272 (min) 201 (brotli)
+// template.marko: 268 (min) 197 (brotli)
 const names = [
 	"Dylan",
 	"Michael",
 	"Ryan",
 	"Luke"
 ];
-const $index__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+const $index = /* @__PURE__ */ _let(3, _script("a0", ($scope) => _on($scope.c, "click", function() {
 	$index($scope, $scope.d === names.length - 1 ? -1 : $scope.d + 1);
 	$user($scope, $scope.d !== -1 && {
 		id: $scope.d,
 		name: names[$scope.d]
 	});
-}));
-const $index = /* @__PURE__ */ _let(3, $index__script);
+})));
 const $user = /* @__PURE__ */ _let(4, ($scope) => {
 	$user_id($scope, $scope.e?.id);
 	$user_name($scope, $scope.e?.name);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.js
@@ -7,7 +7,7 @@ const $input_content__OR__input_value = /* @__PURE__ */ _or(5, ($scope) => $dyna
 const $content = /* @__PURE__ */ _const(3, $input_content__OR__input_value);
 const $value = /* @__PURE__ */ _const(4, $input_content__OR__input_value);
 
-// template.marko: 421 (min) 238 (brotli)
+// template.marko: 417 (min) 234 (brotli)
 const $child_content2__outer = /* @__PURE__ */ _closure_get(2, ($scope) => _text($scope.a, $scope._.c));
 const $child_content2__setup = $child_content2__outer;
 const $child_content2__inner = ($scope, inner) => _text($scope.b, inner);
@@ -20,8 +20,7 @@ const $child_content__setup = ($scope) => {
 	$content($scope.a, $child_content2($scope));
 };
 const $child_content__$params = ($scope, $params2) => $child_content__outer($scope, $params2[0]);
-const $child_content__outer__closure = /* @__PURE__ */ _closure($child_content2__outer);
-const $child_content__outer = /* @__PURE__ */ _const(2, $child_content__outer__closure);
+const $child_content__outer = /* @__PURE__ */ _const(2, /* @__PURE__ */ _closure($child_content2__outer));
 const $child_content = _content_resume("a1", $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D%l"), $child_content__setup, $child_content__$params);
 const $x__script = _script("a2", ($scope) => _on($scope.a, "click", function() {
 	$x($scope, $scope.c + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
@@ -33,7 +33,7 @@ var template_default = _template("a", (input) => {
 			child_default({
 				value: y,
 				content: _content_resume("a0", (inner) => {
-					const $scope2_reason = _scope_reason(), $sg__inner = _serialize_guard($scope2_reason, 0);
+					const $sg__inner = _serialize_guard(_scope_reason(), 0);
 					const $scope2_id = _scope_id();
 					_html(`<div>${_escape(outer)}${_el_resume($scope2_id, "a", _serialize_guard($scope1_reason, 0))}.${_sep($sg__inner)}${_escape(inner)}${_el_resume($scope2_id, "b", $sg__inner)}</div>`);
 					_subscribe($child_content__outer__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 2983 (min) 1528 (brotli)
-// template.marko: 140 (min) 113 (brotli)
+// template.marko: 136 (min) 111 (brotli)
 const $child_content__count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$count($scope._, $scope._.b + 1);
 }));
@@ -7,5 +7,4 @@ const $child_content__count = /* @__PURE__ */ _closure_get(1, ($scope) => {
 	_text($scope.b, $scope._.b);
 	$child_content__count__script($scope);
 });
-const $count__closure = /* @__PURE__ */ _closure($child_content__count);
-const $count = /* @__PURE__ */ _let(1, $count__closure);
+const $count = /* @__PURE__ */ _let(1, /* @__PURE__ */ _closure($child_content__count));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 4553 (min) 2133 (brotli)
-// template.marko: 202 (min) 146 (brotli)
+// template.marko: 194 (min) 147 (brotli)
 const $falseChild_content__count__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$count($scope._, $scope._.b + 1);
 }));
@@ -7,7 +7,5 @@ const $falseChild_content__count = /* @__PURE__ */ _closure_get(1, ($scope) => {
 	_text($scope.b, $scope._.b);
 	$falseChild_content__count__script($scope);
 });
-const $falseChild_content__setup = $falseChild_content__count;
-const $falseChild_content = _content_resume("a0", "<button> </button>", " D l", $falseChild_content__setup);
-const $count__closure = /* @__PURE__ */ _closure($falseChild_content__count);
-const $count = /* @__PURE__ */ _let(1, $count__closure);
+const $falseChild_content = _content_resume("a0", "<button> </button>", " D l", $falseChild_content__count);
+const $count = /* @__PURE__ */ _let(1, /* @__PURE__ */ _closure($falseChild_content__count));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 5965 (min) 2764 (brotli)
-// template.marko: 299 (min) 200 (brotli)
+// template.marko: 295 (min) 197 (brotli)
 const $else_content__clickCount = /* @__PURE__ */ _if_closure(0, 1, ($scope) => _text($scope.a, $scope._.b));
 const $else_content__setup = $else_content__clickCount;
 const $if_content__clickCount__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
@@ -9,8 +9,7 @@ const $if_content__clickCount = /* @__PURE__ */ _if_closure(0, 0, ($scope) => {
 	_text($scope.b, $scope._.b);
 	$if_content__clickCount__script($scope);
 });
-const $if_content__setup = $if_content__clickCount;
-const $if = /* @__PURE__ */ _if(0, "<button> </button>", " D l", $if_content__setup, "<span>The button was clicked <!> times.</span>", "Db%l", $else_content__setup);
+const $if = /* @__PURE__ */ _if(0, "<button> </button>", " D l", $if_content__clickCount, "<span>The button was clicked <!> times.</span>", "Db%l", $else_content__setup);
 const $clickCount = /* @__PURE__ */ _let(1, ($scope) => {
 	$if($scope, $scope.b < 3 ? 0 : 1);
 	$if_content__clickCount($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.js
@@ -1,13 +1,12 @@
 // total: 6943 (min) 3208 (brotli)
-// template.marko: 284 (min) 187 (brotli)
+// template.marko: 280 (min) 185 (brotli)
 const $for_content__item = ($scope, item) => _text($scope.a, item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
-const $id__OR__items__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
+const $id__OR__items = /* @__PURE__ */ _or(5, _script("a1", ($scope) => _on($scope.b, "click", function() {
 	const nextId = $scope.d + 1;
 	$id($scope, nextId);
 	$items($scope, [...$scope.e, nextId]);
-}));
-const $id__OR__items = /* @__PURE__ */ _or(5, $id__OR__items__script);
+})));
 const $id = /* @__PURE__ */ _let(3, $id__OR__items);
 const $for = /* @__PURE__ */ _for_of(0, " ", " b", 0, $for_content__$params);
 const $items__script = _script("a0", ($scope) => _on($scope.c, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5870 (min) 2714 (brotli)
-// template.marko: 195 (min) 143 (brotli)
+// template.marko: 191 (min) 145 (brotli)
 const $if_content__message = /* @__PURE__ */ _if_closure(1, 0, ($scope) => _text($scope.a, $scope._.d));
-const $if_content__setup = $if_content__message;
-const $if = /* @__PURE__ */ _if(1, "<span> </span>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(1, "<span> </span>", "D l", $if_content__message);
 const $show__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$message($scope, "bye");
 	$show($scope, !$scope.c);

--- a/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/__snapshots__/dom.bundle.js
@@ -1,8 +1,8 @@
 // total: 1839 (min) 971 (brotli)
 // template.marko: 127 (min) 90 (brotli)
-const $fooChange2__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+const $fooChange2 = /* @__PURE__ */ _const(2, _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$scope.c("After");
-}));
+})));
 function $fooBar($scope) {
 	return function(v) {
 		$scope.a.textContent = v;

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
@@ -1,6 +1,6 @@
 // tags/child.marko
 var child_default = _template("b", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 0);
+	const $sg__input_name = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const { name, write } = input;
 	_html(`<div>${_escape(name)}${_el_resume($scope0_id, "a", $sg__input_name)}</div><span>${_escape(name)}${_el_resume($scope0_id, "b", $sg__input_name)}</span><p>${_escape(name)}${_el_resume($scope0_id, "c", $sg__input_name)}</p>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/html.bundle.js
@@ -1,6 +1,6 @@
 // tags/child.marko
 var child_default = _template("b", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 0);
+	const $sg__input_name = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const { name, write } = input;
 	_html(`<div>${_escape(name)}${_el_resume($scope0_id, "a", $sg__input_name)} a</div><span>${_escape(name)}${_el_resume($scope0_id, "b", $sg__input_name)} a</span><p>${_escape(name)}${_el_resume($scope0_id, "c", $sg__input_name)} a</p>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 1534 (min) 839 (brotli)
 // template.marko: 134 (min) 94 (brotli)
-const $if_content__run__script = _script("a2", ($scope) => $scope.b());
+const $if_content__run = /* @__PURE__ */ _const(1, _script("a2", ($scope) => $scope.b()));
 function $run($scope) {
 	return function() {
 		$scope.a.innerHTML = $scope._.b();

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5896 (min) 2729 (brotli)
 // template.marko: 230 (min) 163 (brotli)
 const $if_content__getMessage = /* @__PURE__ */ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.h()));
-const $if_content__setup = $if_content__getMessage;
-const $if = /* @__PURE__ */ _if(0, "<span> </span>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(0, "<span> </span>", "D l", $if_content__getMessage);
 const $x__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$x($scope, $scope.g + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 13249 (min) 5094 (brotli)
-// template.marko: 470 (min) 221 (brotli)
+// template.marko: 466 (min) 219 (brotli)
 _resume_dynamic_tag();
 const $tagselect_content__setup__script = _script("a2", ($scope) => {
 	_attrs_script($scope, "a");
@@ -12,8 +12,7 @@ const $tagselect_content__setup = ($scope) => {
 	_attrs($scope, "c", { value: "c" });
 	$tagselect_content__setup__script($scope);
 };
-const $tagselect_content = _content_resume("a1", "<option>A</option><option>B</option><option>C</option>", " b b b", $tagselect_content__setup);
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, $tagselect_content);
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a1", "<option>A</option><option>B</option><option>C</option>", " b b b", $tagselect_content__setup));
 const $value__OR__tag = /* @__PURE__ */ _or(4, ($scope) => $dynamicTag($scope, $scope.d ? "select" : {}, () => ({
 	value: $scope.c,
 	valueChange: $valueChange($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.bundle.js
@@ -8,7 +8,7 @@ function $valueChange($scope) {
 }
 _resume("b0", $valueChange);
 
-// template.marko: 170 (min) 133 (brotli)
+// template.marko: 166 (min) 130 (brotli)
 const $mytag_content__count__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	_var_change($scope._.a, $scope._.d + 1);
 }));
@@ -16,5 +16,4 @@ const $mytag_content__count = /* @__PURE__ */ _closure_get(3, ($scope) => {
 	_text($scope.b, $scope._.d);
 	$mytag_content__count__script($scope);
 });
-const $count__closure = /* @__PURE__ */ _closure($mytag_content__count);
-const $count = _var_resume("a0", /* @__PURE__ */ _const(3, $count__closure));
+const $count = _var_resume("a0", /* @__PURE__ */ _const(3, /* @__PURE__ */ _closure($mytag_content__count)));

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // total: 13179 (min) 5091 (brotli)
-// tags/custom-tag.marko: 229 (min) 157 (brotli)
-const $x__OR__y__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+// tags/custom-tag.marko: 225 (min) 153 (brotli)
+const $x__OR__y = /* @__PURE__ */ _or(9, _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$x($scope, $scope.h + 1);
 	$y($scope, $scope.i + 1);
-}));
-const $x__OR__y = /* @__PURE__ */ _or(9, $x__OR__y__script);
+})));
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag(3, 0, 0, 1);
 const $input_content__OR__x__OR__y = /* @__PURE__ */ _or(10, ($scope) => $dynamicTag($scope, $scope.g, () => [$scope.h, $scope.i]), 2);
 const $x = /* @__PURE__ */ _let(7, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/__snapshots__/html.bundle.js
@@ -18,11 +18,10 @@ var custom_tag_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	custom_tag_default({ content: _content_resume("a0", (count, count2) => {
 		const $scope1_reason = _scope_reason(), $sg__count = _serialize_guard($scope1_reason, 1), $sg__count2 = _serialize_guard($scope1_reason, 2);
 		const $scope1_id = _scope_id();
 		_html(`<div>Counts: ${_sep($sg__count)}${_escape(count)}${_el_resume($scope1_id, "a", $sg__count)},${_sep($sg__count2)}${_escape(count2)}${_el_resume($scope1_id, "b", $sg__count2)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
-	}, $scope0_id) });
+	}, _scope_id()) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/__snapshots__/html.bundle.js
@@ -20,7 +20,6 @@ var custom_tag_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	custom_tag_default({
 		name: "hello",
 		content: _content_resume("a0", ({ count, name }) => {
@@ -28,6 +27,6 @@ var template_default = _template("a", (input) => {
 			const $scope1_id = _scope_id();
 			_html(`<div>Count (${_sep($sg__name)}${_escape(name)}${_el_resume($scope1_id, "a", $sg__name)}): ${_sep($sg__count)}${_escape(count)}${_el_resume($scope1_id, "b", $sg__count)}</div>`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
-		}, $scope0_id)
+		}, _scope_id())
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/__snapshots__/html.bundle.js
@@ -16,11 +16,10 @@ var custom_tag_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	custom_tag_default({ content: _content_resume("a0", (count) => {
 		const $scope1_reason = _scope_reason(), $sg__count = _serialize_guard($scope1_reason, 0);
 		const $scope1_id = _scope_id();
 		_html(`<div>Count: ${_sep($sg__count)}${_escape(count)}${_el_resume($scope1_id, "a", $sg__count)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
-	}, $scope0_id) });
+	}, _scope_id()) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/__snapshots__/html.bundle.js
@@ -1,6 +1,5 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
-	_script($scope0_id, "a0");
+	_script(_scope_id(), "a0");
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.js
@@ -13,6 +13,5 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	_scope_id();
-	let data = child_default({});
-	_html(`<div>${_escape(data)}</div>`);
+	_html(`<div>${_escape(child_default({}))}</div>`);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.js
@@ -6,5 +6,5 @@ function $_return($scope) {
 _resume("b0", $_return);
 
 // template.marko: 82 (min) 74 (brotli)
-const $child_content__setHtml__script = _script("a0", ($scope) => _assert_init($scope._, "c")("Hello world"));
+const $child_content = /* @__PURE__ */ _content("a1", 0, 0, /* @__PURE__ */ _closure_get(2, _script("a0", ($scope) => _assert_init($scope._, "c")("Hello world"))));
 const $setHtml = _var_resume("a2", /* @__PURE__ */ _const(2));

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/html.bundle.js
@@ -13,12 +13,11 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
-	let setHtml = child_default({ content: _content("a1", () => {
+	writeScope($scope0_id, { c: child_default({ content: _content("a1", () => {
 		_scope_reason();
 		const $scope1_id = _scope_id();
 		_script($scope1_id, "a0");
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 		_resume_branch($scope1_id);
-	}) });
-	writeScope($scope0_id, { c: setHtml });
+	}) }) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/__snapshots__/html.bundle.js
@@ -22,8 +22,7 @@ var template_default = _template("a", (input) => {
 	const $childScope = _peek_scope_id();
 	let data = child_default({ extra: 1 });
 	_var($scope0_id, "b", $childScope, "a0");
-	const message = `${name} ${data}`;
-	_html(`<div>${_escape(message)}${_el_resume($scope0_id, "c")}</div>`);
+	_html(`<div>${_escape(`${name} ${data}`)}${_el_resume($scope0_id, "c")}</div>`);
 	writeScope($scope0_id, {
 		d: name,
 		a: _existing_scope($childScope)

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.js
@@ -14,6 +14,5 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	_scope_id();
-	let data = child_default({});
-	_html(`<div>${_escape(data)}</div>`);
+	_html(`<div>${_escape(child_default({}))}</div>`);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/debug-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/debug-tag/__snapshots__/dom.bundle.js
@@ -1,3 +1,3 @@
 // total: 1450 (min) 803 (brotli)
 // template.marko: 38 (min) 42 (brotli)
-const $x__OR__y__script = _script("a0", ($scope) => console.log($scope.a, $scope.b));
+const $x__OR__y = /* @__PURE__ */ _or(2, _script("a0", ($scope) => console.log($scope.a, $scope.b)));

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 9021 (min) 3739 (brotli)
-// template.marko: 276 (min) 175 (brotli)
+// template.marko: 272 (min) 173 (brotli)
 const $Child_content2__input__script = _script("a1", ($scope) => _attrs_script($scope, "a"));
 const $if_content__value_class = /* @__PURE__ */ _closure_get(2, ($scope) => _attr_class($scope.a, $scope._._.c), ($scope) => $scope._._);
 const $if_content__setup = ($scope) => {
@@ -8,5 +8,4 @@ const $if_content__setup = ($scope) => {
 };
 const $if_content__text = /* @__PURE__ */ _closure_get(3, ($scope) => _text($scope.b, $scope._._.d), ($scope) => $scope._._);
 const $Child_content__if = /* @__PURE__ */ _if(0, "<span> </span>", " D l", $if_content__setup);
-const $Child_content__setup = /* @__PURE__ */ _closure_get(1, ($scope) => $Child_content__if($scope, $scope._.b ? 0 : 1));
-const $Child_content = _content_resume("a2", "<!><!><!>", "b%c", $Child_content__setup);
+const $Child_content = _content_resume("a2", "<!><!><!>", "b%c", /* @__PURE__ */ _closure_get(1, ($scope) => $Child_content__if($scope, $scope._.b ? 0 : 1)));

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // total: 5948 (min) 2771 (brotli)
-// template.marko: 275 (min) 192 (brotli)
+// template.marko: 271 (min) 193 (brotli)
 const $MyTag_content__walks = "Db%l", $MyTag_content__template = "<div>Hello <!></div>";
 const $MyTag_content__value = ($scope, value) => _text($scope.a, value);
 const $if_content__x = /* @__PURE__ */ _if_closure(0, 0, ($scope) => $MyTag_content__value($scope.a, $scope._.e));
-const $if_content__setup = $if_content__x;
-const $if = /* @__PURE__ */ _if(0, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($MyTag_content__template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)($MyTag_content__walks), $if_content__setup);
+const $if = /* @__PURE__ */ _if(0, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($MyTag_content__template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)($MyTag_content__walks), $if_content__x);
 const $show = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $x__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$x($scope, $scope.e + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template("a", (input) => {
 	_scope_id();
 	({ content: _content("a0", ({ name }) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason(), $sg__name = _serialize_guard($scope1_reason, 0);
+		const $sg__name = _serialize_guard(_scope_reason(), 0);
 		let y = 1;
 		_html(`<div>Hello ${_sep($sg__name)}${_escape(name)}${_el_resume($scope1_id, "a", $sg__name)} <!>${_escape(y)}${_el_resume($scope1_id, "b")}</div><button>${_escape(y)}${_el_resume($scope1_id, "d")}</button>${_el_resume($scope1_id, "c")}`);
 		_script($scope1_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.js
@@ -3,12 +3,10 @@
 const $valueChange2__script = _script("b1", ($scope) => $scope.d(2));
 const $rest__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
 
-// template.marko: 162 (min) 111 (brotli)
+// template.marko: 154 (min) 106 (brotli)
 const $child_content__value = /* @__PURE__ */ _closure_get(1, ($scope) => _text($scope.a, $scope._.b));
-const $child_content__setup = $child_content__value;
-const $child_content = _content_resume("a1", " ", " b", $child_content__setup);
-const $value__closure = /* @__PURE__ */ _closure($child_content__value);
-const $value = /* @__PURE__ */ _let(1, $value__closure);
+const $child_content = _content_resume("a1", " ", " b", $child_content__value);
+const $value = /* @__PURE__ */ _let(1, /* @__PURE__ */ _closure($child_content__value));
 function $valueChange($scope) {
 	return (_new_value) => {
 		$value($scope, _new_value);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.js
@@ -18,7 +18,7 @@ function $_return($scope) {
 _resume("b1", $_return2);
 _resume("b0", $_return);
 
-// template.marko: 213 (min) 160 (brotli)
+// template.marko: 209 (min) 157 (brotli)
 const $for_content__item = ($scope, item) => _text($scope.a, item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $store = _var_resume("a0", ($scope, store) => {
@@ -27,5 +27,4 @@ const $store = _var_resume("a0", ($scope, store) => {
 });
 const $for = /* @__PURE__ */ _for_of(3, "<li> </li>", "D l", 0, $for_content__$params);
 const $list = ($scope, list) => $for($scope, [list]);
-const $clear__script = _script("a1", ($scope) => _on($scope.c, "click", $scope.g));
-const $clear = /* @__PURE__ */ _const(6, $clear__script);
+const $clear = /* @__PURE__ */ _const(6, _script("a1", ($scope) => _on($scope.c, "click", $scope.g)));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/__snapshots__/dom.bundle.js
@@ -1,13 +1,12 @@
 // total: 5604 (min) 2657 (brotli)
-// template.marko: 279 (min) 154 (brotli)
+// template.marko: 275 (min) 150 (brotli)
 _enable_catch();
 const $if_content__a = /* @__PURE__ */ _closure_get(2, ($scope) => _text($scope.a, $scope._._.c), ($scope) => $scope._._);
 const $if_content__b = /* @__PURE__ */ _closure_get(3, ($scope) => _text($scope.b, $scope._._.d), ($scope) => $scope._._);
-const $a__OR__b__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+const $a__OR__b = /* @__PURE__ */ _or(4, _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$a($scope, $scope.c + 1);
 	$b($scope, $scope.d + 1);
-}));
-const $a__OR__b = /* @__PURE__ */ _or(4, $a__OR__b__script);
+})));
 const $a__closure = /* @__PURE__ */ _closure($if_content__a);
 const $a = /* @__PURE__ */ _let(2, ($scope) => {
 	$a__OR__b($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 2998 (min) 1533 (brotli)
-// template.marko: 174 (min) 107 (brotli)
+// template.marko: 170 (min) 105 (brotli)
 const $if_content2__c = /* @__PURE__ */ _closure_get(4, ($scope) => _text($scope.c, $scope._._.e), ($scope) => $scope._._);
 const $customtag_content__c = /* @__PURE__ */ _closure_get(4, ($scope) => _text($scope.c, $scope._.e));
-const $c__closure = /* @__PURE__ */ _closure($customtag_content__c, $if_content2__c);
-const $c = /* @__PURE__ */ _let(4, $c__closure);
+const $c = /* @__PURE__ */ _let(4, /* @__PURE__ */ _closure($customtag_content__c, $if_content2__c));
 const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$c($scope, 4);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 12944 (min) 5014 (brotli)
-// template.marko: 212 (min) 150 (brotli)
-const $tagName_content = _content_resume("a0", "body content", "b");
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, $tagName_content);
+// template.marko: 208 (min) 153 (brotli)
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a0", "body content", "b"));
 const $tagName__OR__className = /* @__PURE__ */ _or(4, ($scope) => $dynamicTag($scope, $scope.c, () => ({ class: $scope.d })));
 const $tagName__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$tagName($scope, $scope.c === "span" ? "div" : "span");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 12817 (min) 4953 (brotli)
-// template.marko: 224 (min) 143 (brotli)
+// template.marko: 220 (min) 139 (brotli)
 _resume_dynamic_tag();
-const $tagName_content = _content_resume("a1", "body content", "b");
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, $tagName_content);
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a1", "body content", "b"));
 const $tagName = /* @__PURE__ */ _let(1, ($scope) => $dynamicTag($scope, $scope.b, () => ({
 	class: "A",
 	onClick: $onClick($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.js
@@ -1,4 +1,4 @@
 // total: 6076 (min) 2511 (brotli)
 // tags/wrapper.marko: 53 (min) 52 (brotli)
 _resume_dynamic_tag();
-const $inputAsdiv_content = _content_resume("b0", "hi", "b");
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("b0", "hi", "b"));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 12793 (min) 4932 (brotli)
-// template.marko: 166 (min) 126 (brotli)
-const $x_content = _content_resume("a0", "Body Content", "b");
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, $x_content);
+// template.marko: 162 (min) 129 (brotli)
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a0", "Body Content", "b"));
 const $x__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$x($scope, $scope.c ? null : "div");
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.js
@@ -1,4 +1,4 @@
 // total: 6076 (min) 2511 (brotli)
 // tags/wrapper.marko: 53 (min) 52 (brotli)
 _resume_dynamic_tag();
-const $inputAsdiv_content = _content_resume("b0", "hi", "b");
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("b0", "hi", "b"));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/__snapshots__/dom.bundle.js
@@ -5,10 +5,7 @@ function $_return($scope) {
 }
 _resume("b0", $_return);
 
-// template.marko: 164 (min) 117 (brotli)
-const $Child_content__setHtml__script = _script("a1", ($scope) => _assert_init($scope._, "c")("Hello World"));
-const $Child_content__setHtml = /* @__PURE__ */ _closure_get(2, $Child_content__setHtml__script);
-const $Child_content__setup = $Child_content__setHtml;
-const $Child_content = _content_resume("a0", 0, 0, $Child_content__setup);
-const $setHtml__closure = /* @__PURE__ */ _closure($Child_content__setHtml);
-const $setHtml = _var_resume("a2", /* @__PURE__ */ _const(2, $setHtml__closure));
+// template.marko: 146 (min) 107 (brotli)
+const $Child_content__setHtml = /* @__PURE__ */ _closure_get(2, _script("a1", ($scope) => _assert_init($scope._, "c")("Hello World")));
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a0", 0, 0, $Child_content__setHtml), () => $setHtml);
+const $setHtml = _var_resume("a2", /* @__PURE__ */ _const(2, /* @__PURE__ */ _closure($Child_content__setHtml)));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/__snapshots__/dom.bundle.js
@@ -13,12 +13,11 @@ function $setup($scope) {
 	$count($scope, 0);
 }
 
-// template.marko: 207 (min) 150 (brotli)
+// template.marko: 203 (min) 148 (brotli)
 const $tagName_content__setup = ($scope) => {
 	$setup($scope.a);
 };
-const $tagName_content = _content_resume("a0", $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $tagName_content__setup);
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, $tagName_content);
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("a0", $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $tagName_content__setup));
 const $tagName__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$tagName($scope, $scope.c === "span" ? "div" : "span");
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/__snapshots__/html.bundle.js
@@ -7,6 +7,5 @@ var template_default = _template("a", (input) => {
 		middleName: "R.R.",
 		lastName: "Martin"
 	};
-	const fullName = user.fullName = `${user.firstName} ${user.middleName} ${user.lastName}`;
-	_html(`<p>${_escape(fullName)}</p>`);
+	_html(`<p>${_escape(user.fullName = `${user.firstName} ${user.middleName} ${user.lastName}`)}</p>`);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // total: 2752 (min) 1413 (brotli)
-// template.marko: 258 (min) 163 (brotli)
-const $x__OR__direction__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+// template.marko: 254 (min) 148 (brotli)
+const $x__OR__direction = /* @__PURE__ */ _or(6, _script("a0", ($scope) => _on($scope.c, "click", function() {
 	if ($scope.f === "up") $x($scope, $scope.e + 1);
 	else if ($scope.f === "down") $x($scope, $scope.e - 1);
-}));
-const $x__OR__direction = /* @__PURE__ */ _or(6, $x__OR__direction__script);
+})));
 const $x = /* @__PURE__ */ _let(4, ($scope) => {
 	_text($scope.d, $scope.e);
 	$x__OR__direction($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/__snapshots__/dom.bundle.js
@@ -1,12 +1,11 @@
 // total: 7914 (min) 3598 (brotli)
-// template.marko: 392 (min) 261 (brotli)
+// template.marko: 388 (min) 257 (brotli)
 const $if_content__last = /* @__PURE__ */ _if_closure(1, 0, ($scope) => _text($scope.a, $scope._.d));
 const $if_content__setup = $if_content__last;
-const $for_content__messages__OR__index__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+const $for_content__messages__OR__index = /* @__PURE__ */ _or(5, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$messages($scope._, $scope._.c.toSpliced($scope.e, 1));
 	$last($scope._, $scope.e);
-}));
-const $for_content__messages__OR__index = /* @__PURE__ */ _or(5, $for_content__messages__OR__index__script);
+})));
 const $for_content__messages = /* @__PURE__ */ _for_closure(0, $for_content__messages__OR__index);
 const $for_content__setup = $for_content__messages;
 const $for_content__index = /* @__PURE__ */ _const(4, $for_content__messages__OR__index);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 6852 (min) 3185 (brotli)
-// template.marko: 192 (min) 141 (brotli)
-const $for_content__num__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+// template.marko: 188 (min) 151 (brotli)
+const $for_content__num = /* @__PURE__ */ _for_closure(0, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$num($scope._, $scope._.b + 1);
-}));
-const $for_content__num = /* @__PURE__ */ _for_closure(0, $for_content__num__script);
+})));
 const $for_content__setup = ($scope) => {
 	$for_content__num._($scope);
 	_text($scope.b, $scope.M);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/__snapshots__/dom.bundle.js
@@ -1,12 +1,10 @@
 // total: 6792 (min) 3154 (brotli)
-// template.marko: 198 (min) 150 (brotli)
-const $for_content__items__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+// template.marko: 190 (min) 143 (brotli)
+const $for_content__items = /* @__PURE__ */ _for_closure(0, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$scope._.b.textContent = $scope._.c.join(", ");
 	$items($scope._, []);
-}));
-const $for_content__items = /* @__PURE__ */ _for_closure(0, $for_content__items__script);
-const $for_content__setup = $for_content__items;
-const $for = /* @__PURE__ */ _for_of(0, "<button>Test</button>", " b", $for_content__setup);
+})));
+const $for = /* @__PURE__ */ _for_of(0, "<button>Test</button>", " b", $for_content__items);
 const $items = /* @__PURE__ */ _let(2, ($scope) => {
 	$for($scope, [$scope.c]);
 	$for_content__items($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 1837 (min) 973 (brotli)
 // template.marko: 119 (min) 80 (brotli)
-const $for_content__setup = _script("a0", ($scope) => _on($scope.a, "click", function() {
+const $for = /* @__PURE__ */ _for_of(0, "<button>Click</button>", " b", _script("a0", ($scope) => _on($scope.a, "click", function() {
 	document.getElementById("el").innerHTML = $scope.M === void 0 ? "index missing" : $scope.M;
-}));
+})));

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 1498 (min) 825 (brotli)
 // template.marko: 92 (min) 80 (brotli)
-const $baz2__script = _script("a1", ($scope) => $scope.a.textContent = $scope.c.bar());
+const $baz2 = /* @__PURE__ */ _const(2, _script("a1", ($scope) => $scope.a.textContent = $scope.c.bar()));
 function $baz($scope) {
 	return () => $scope.b?.bar;
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/__snapshots__/dom.bundle.js
@@ -1,8 +1,8 @@
 // total: 1701 (min) 878 (brotli)
 // template.marko: 319 (min) 123 (brotli)
-const $a2__script = _script("a5", ($scope) => $scope.a.textContent = $scope.f.bar() || "missing a");
-const $b2__script = _script("a4", ($scope) => $scope.b.textContent = $scope.g.baz() || "missing b");
-const $c2__script = _script("a3", ($scope) => $scope.c.textContent = $scope.h.baz() || "missing c");
+const $a2 = /* @__PURE__ */ _const(5, _script("a5", ($scope) => $scope.a.textContent = $scope.f.bar() || "missing a"));
+const $b2 = /* @__PURE__ */ _const(6, _script("a4", ($scope) => $scope.b.textContent = $scope.g.baz() || "missing b"));
+const $c2 = /* @__PURE__ */ _const(7, _script("a3", ($scope) => $scope.c.textContent = $scope.h.baz() || "missing c"));
 function $a($scope) {
 	return () => $scope.d?.bar;
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 1809 (min) 959 (brotli)
 // template.marko: 97 (min) 80 (brotli)
-const $onClick3__script = _script("a1", ($scope) => _on($scope.a, "click", $scope.d));
+const $onClick3 = /* @__PURE__ */ _const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d)));
 function $updateText(ev) {
 	ev.target.textContent = "after";
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 1809 (min) 958 (brotli)
 // template.marko: 97 (min) 78 (brotli)
-const $onClick__script = _script("a1", ($scope) => _on($scope.b, "click", $scope.d));
+const $onClick = /* @__PURE__ */ _const(3, _script("a1", ($scope) => _on($scope.b, "click", $scope.d)));
 function $updateText(ev) {
 	ev.target.textContent = "after";
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/html.bundle.js
@@ -24,9 +24,7 @@ var template_default = _template("a", (input) => {
 	const $what_content__subscribers = /* @__PURE__ */ new Set();
 	thing_default({ what: attrTag({ content: _content("a1", () => {
 		_scope_reason();
-		const $scope1_id = _scope_id();
-		let setHtml = child_default({});
-		_subscribe($what_content__subscribers, writeScope($scope1_id, { c: setHtml }));
+		_subscribe($what_content__subscribers, writeScope(_scope_id(), { c: child_default({}) }));
 	}) }) });
 	_script($scope0_id, "a2");
 	writeScope($scope0_id, { B1: $what_content__subscribers });

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var child_default = _template("b", (input) => {
 
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $sg__input_show = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	_hoist($scope0_id, "a0");
 	const $thing_content__subscribers = /* @__PURE__ */ new Set();
@@ -27,9 +27,7 @@ var template_default = _template("a", (input) => {
 	const $inputshowsectionnull_content__subscribers = /* @__PURE__ */ new Set();
 	thing_default({ content: _content("a1", () => {
 		_scope_reason();
-		const $scope1_id = _scope_id();
-		let setHtml = child_default({});
-		_subscribe($thing_content__subscribers, writeScope($scope1_id, { c: setHtml }));
+		_subscribe($thing_content__subscribers, writeScope(_scope_id(), { c: child_default({}) }));
 	}) });
 	_dynamic_tag($scope0_id, "b", input.show ? thing_default : null, {}, _content_resume("a3", () => {
 		const $scope2_id = _scope_id();
@@ -37,17 +35,14 @@ var template_default = _template("a", (input) => {
 		_scope_reason();
 		thing_default({ content: _content("a2", () => {
 			_scope_reason();
-			const $scope3_id = _scope_id();
-			let setHtml2 = child_default({});
-			_subscribe($thing_content2__subscribers, writeScope($scope3_id, { c: setHtml2 }));
+			_subscribe($thing_content2__subscribers, writeScope(_scope_id(), { c: child_default({}) }));
 		}) });
 		_subscribe($inputshowThingnull_content__subscribers, writeScope($scope2_id, { B3: $thing_content2__subscribers }));
 	}, $scope0_id), 0, $sg__input_show);
 	_dynamic_tag($scope0_id, "c", input.show ? "section" : null, {}, _content_resume("a4", () => {
 		const $scope4_id = _scope_id();
 		_scope_reason();
-		let setHtml3 = child_default({});
-		_subscribe($inputshowsectionnull_content__subscribers, writeScope($scope4_id, { c: setHtml3 }));
+		_subscribe($inputshowsectionnull_content__subscribers, writeScope($scope4_id, { c: child_default({}) }));
 	}, $scope0_id), 0, $sg__input_show);
 	_script($scope0_id, "a5");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.js
@@ -14,25 +14,19 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	_hoist($scope0_id, "a0");
 	_for_to(5, 0, 1, () => {
-		const $scope1_id = _scope_id();
-		let setHtml = child_default({});
-		writeScope($scope1_id, { c: setHtml });
+		writeScope(_scope_id(), { c: child_default({}) });
 	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
 	let to = 3;
 	_html("<hr>");
 	_for_to(to, 0, 1, () => {
-		const $scope2_id = _scope_id();
-		let setHtml2 = child_default({});
-		writeScope($scope2_id, { c: setHtml2 });
+		writeScope(_scope_id(), { c: child_default({}) });
 	}, 0, $scope0_id, "b", 1, 0, 0, 0, 1);
 	_html("<hr>");
 	_for_to(3, 0, 1, (i) => {
 		const $scope3_id = _scope_id();
 		_html("<ul>");
 		_for_to(3, 0, 1, (j) => {
-			const $scope4_id = _scope_id();
-			let setHtml3 = child_default({});
-			writeScope($scope4_id, { c: setHtml3 });
+			writeScope(_scope_id(), { c: child_default({}) });
 		}, 0, $scope3_id, "a", 1, 0, 0, 0, 1);
 		_html("</ul>");
 		writeScope($scope3_id, {});

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/html.bundle.js
@@ -21,6 +21,5 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	thing_default({ value: _hoist($scope0_id, "a0") });
-	let setHtml = child_default({});
-	writeScope($scope0_id, { d: setHtml });
+	writeScope($scope0_id, { d: child_default({}) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/html.bundle.js
@@ -26,9 +26,7 @@ var template_default = _template("a", (input) => {
 			const $scope1_id = _scope_id();
 			_if(() => {
 				if (input.show) {
-					const $scope2_id = _scope_id();
-					let setHtml = child_default({});
-					writeScope($scope2_id, { c: setHtml });
+					writeScope(_scope_id(), { c: child_default({}) });
 					return 0;
 				}
 			}, $scope1_id, "a", 1, $sg__input_show, $sg__input_show, 0, 1);
@@ -38,20 +36,12 @@ var template_default = _template("a", (input) => {
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show);
 	thing_default({ value: $setHtml_getter });
 	_if(() => {
-		{
-			const $scope3_id = _scope_id();
-			let setHtml2 = child_default({});
-			writeScope($scope3_id, { c: setHtml2 });
-			return 0;
-		}
+		writeScope(_scope_id(), { c: child_default({}) });
+		return 0;
 	}, $scope0_id, "c", 1, 0, $sg__input_show, 0, 1);
 	_if(() => {
-		{
-			const $scope4_id = _scope_id();
-			let setHtml3 = child_default({});
-			writeScope($scope4_id, { c: setHtml3 });
-			return 0;
-		}
+		writeScope(_scope_id(), { c: child_default({}) });
+		return 0;
 	}, $scope0_id, "d", 1, 0, $sg__input_show, 0, 1);
 	{
 		const $scope5_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var thing_default = _template("c", (input) => {
 
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $sg__input_show = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	_hoist($scope0_id, "a0");
 	const $thing_content__subscribers = /* @__PURE__ */ new Set();

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var child_default = _template("b", (input) => {
 
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $sg__input_show = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	_hoist($scope0_id, "a0");
 	const $child_content__subscribers = /* @__PURE__ */ new Set();

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-only/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-only/__snapshots__/html.bundle.js
@@ -12,9 +12,8 @@ var template_default = _template("a", (input) => {
 				{
 					const $scope2_id = _scope_id();
 					_hoist($scope2_id, "a3");
-					const hoist3 = _resume(() => input.value, "a1", $scope2_id);
 					_subscribe($input_value__closures, writeScope($scope2_id, {
-						a: hoist3,
+						a: _resume(() => input.value, "a1", $scope2_id),
 						_: _scope_with_id($scope1_id)
 					}));
 					return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/html.bundle.js
@@ -19,6 +19,5 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	child_default({ y: _hoist($scope0_id, "a0") });
-	let x = source_default({});
-	writeScope($scope0_id, { d: x });
+	writeScope($scope0_id, { d: source_default({}) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/__snapshots__/dom.bundle.js
@@ -1,11 +1,10 @@
 // total: 2931 (min) 1491 (brotli)
-// template.marko: 233 (min) 155 (brotli)
+// template.marko: 229 (min) 156 (brotli)
 const $sometimesBar = ($scope, sometimesBar) => _attr($scope.c, "id", sometimesBar);
-const $bar__OR__baz__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+const $bar__OR__baz = /* @__PURE__ */ _or(6, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$bar($scope, $scope.e ? null : "bar");
 	$baz($scope, $scope.f ? null : "baz");
-}));
-const $bar__OR__baz = /* @__PURE__ */ _or(6, $bar__OR__baz__script);
+})));
 const $bar = /* @__PURE__ */ _let(4, ($scope) => {
 	$sometimesBar($scope, $scope.e || _id($scope));
 	$bar__OR__baz($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5768 (min) 2668 (brotli)
-// tags/child.marko: 217 (min) 170 (brotli)
+// tags/child.marko: 213 (min) 172 (brotli)
 const $if_content__text = /* @__PURE__ */ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.c));
-const $if_content__setup = $if_content__text;
-const $if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", $if_content__text);
 const $hide__OR__text_length = /* @__PURE__ */ _or(4, ($scope) => $if($scope, !$scope.b && $scope.d ? 0 : 1));
 const $hide = /* @__PURE__ */ _let(1, $hide__OR__text_length);
 const $text = /* @__PURE__ */ _let(2, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 5734 (min) 2661 (brotli)
-// template.marko: 170 (min) 143 (brotli)
-const $if_content__setup = _script("a0", ($scope) => $scope._.a.textContent = "Hit");
-const $if = /* @__PURE__ */ _if(3, 0, 0, $if_content__setup);
+// template.marko: 166 (min) 129 (brotli)
+const $if = /* @__PURE__ */ _if(3, 0, 0, _script("a0", ($scope) => $scope._.a.textContent = "Hit"));
 const $count__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
 	$count($scope, $scope.e + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.js
@@ -12,7 +12,6 @@ var child_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	child_default({
 		value: "Hi",
 		content: _content_resume("a0", (x) => {
@@ -20,6 +19,6 @@ var template_default = _template("a", (input) => {
 			const $scope1_id = _scope_id();
 			_html(`${_escape(x)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
-		}, $scope0_id)
+		}, _scope_id())
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 6148 (min) 2839 (brotli)
 // template.marko: 259 (min) 181 (brotli)
 const $if_content2__input_name = /* @__PURE__ */ _closure_get(4, ($scope) => _text($scope.a, $scope._._.e || "Fallback"), ($scope) => $scope._._);
-const $if_content2__setup = $if_content2__input_name;
-const $if_content__if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", $if_content2__setup);
+const $if_content__if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", $if_content2__input_name);
 const $if_content__setup = ($scope) => $if_content__if($scope, 0);
 const $Child_content__if = /* @__PURE__ */ _if(0, "<!><!><!>", "b%c", $if_content__setup);
 const $Child_content__input_count = ($scope, input_count) => $Child_content__if($scope, input_count ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.js
@@ -3,8 +3,7 @@
 const $Tag_content__walks = "b%c", $Tag_content__template = "<!><!><!>";
 const $template = /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($Tag_content__template);
 const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)($Tag_content__walks);
-const $if_content__setup$1 = /* @__PURE__ */ _closure_get(1, ($scope) => _text($scope.a, $scope._._.b), ($scope) => $scope._._);
-const $Tag_content__if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", $if_content__setup$1);
+const $Tag_content__if = /* @__PURE__ */ _if(0, "<div> </div>", "D l", /* @__PURE__ */ _closure_get(1, ($scope) => _text($scope.a, $scope._._.b), ($scope) => $scope._._));
 const $Tag_content__input_x = ($scope, input_x) => $Tag_content__if($scope, input_x ? 0 : 1);
 const $count = /* @__PURE__ */ _const(1);
 function $setup($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 1803 (min) 964 (brotli)
 // template.marko: 85 (min) 72 (brotli)
-const $MyButton_content__input_message__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+const $MyButton_content__input_message = /* @__PURE__ */ _const(3, _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$scope._.a.textContent += `[onClick(${$scope.d})]`;
-}));
+})));

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/__snapshots__/html.bundle.js
@@ -3,8 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let index = -1;
-	let user = index !== -1 && { id: index };
-	_html(`<div>${_escape(user?.id)}</div><button>Update</button>${_el_resume($scope0_id, "b")}`);
+	_html(`<div>${_escape((index !== -1 && { id: index })?.id)}</div><button>Update</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { c: index });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.js
@@ -18,7 +18,7 @@ function $_return($scope) {
 _resume("b1", $_return2);
 _resume("b0", $_return);
 
-// template.marko: 297 (min) 208 (brotli)
+// template.marko: 293 (min) 199 (brotli)
 const $for_content__item = ($scope, item) => _text($scope.a, item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $store = _var_resume("a0", ($scope, store) => {
@@ -31,5 +31,4 @@ const $list = /* @__PURE__ */ _let(9, ($scope) => $for($scope, [$scope.j]));
 const $store_list__OR__store_listChange = /* @__PURE__ */ _or(7, ($scope) => $list($scope, $scope.f, $scope.g), 1, 1);
 const $store_list = /* @__PURE__ */ _const(5, $store_list__OR__store_listChange);
 const $store_listChange = /* @__PURE__ */ _const(6, $store_list__OR__store_listChange);
-const $store_clear__script = _script("a1", ($scope) => _on($scope.c, "click", $scope.i));
-const $store_clear = /* @__PURE__ */ _const(8, $store_clear__script);
+const $store_clear = /* @__PURE__ */ _const(8, _script("a1", ($scope) => _on($scope.c, "click", $scope.i)));

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 2645 (min) 1377 (brotli)
-// template.marko: 145 (min) 107 (brotli)
-const $x__OR__y__script = _script("a0", ($scope) => _on($scope.a, "click", () => $x($scope, $y($scope, $scope.d + $scope.e))));
-const $x__OR__y = /* @__PURE__ */ _or(5, $x__OR__y__script);
+// template.marko: 141 (min) 109 (brotli)
+const $x__OR__y = /* @__PURE__ */ _or(5, _script("a0", ($scope) => _on($scope.a, "click", () => $x($scope, $y($scope, $scope.d + $scope.e)))));
 const $x = /* @__PURE__ */ _let(3, ($scope) => {
 	_text($scope.b, $scope.d);
 	$x__OR__y($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 6292 (min) 2830 (brotli)
-// template.marko: 487 (min) 196 (brotli)
-const $if_content__x__script = _script("a0", ($scope) => _lifecycle($scope, {
+// template.marko: 483 (min) 204 (brotli)
+const $if_content__x = /* @__PURE__ */ _if_closure(0, 0, _script("a0", ($scope) => _lifecycle($scope, {
 	onMount: function() {
 		document.getElementById("ref").textContent = "Mount " + $scope._.d;
 	},
@@ -10,8 +10,7 @@ const $if_content__x__script = _script("a0", ($scope) => _lifecycle($scope, {
 	onDestroy: function() {
 		document.getElementById("ref").textContent = "Destroy";
 	}
-}));
-const $if_content__x = /* @__PURE__ */ _if_closure(0, 0, $if_content__x__script);
+})));
 const $if_content__setup = $if_content__x;
 const $x__script = _script("a2", ($scope) => _on($scope.b, "click", function() {
 	$x($scope, $scope.d + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 2782 (min) 1423 (brotli)
-// template.marko: 236 (min) 162 (brotli)
-const $x__script = _script("a0", ($scope) => {
+// template.marko: 232 (min) 142 (brotli)
+const $x = /* @__PURE__ */ _let(1, _script("a0", ($scope) => {
 	_lifecycle($scope, {
 		onMount: function() {
 			this.onUpdate();
@@ -13,5 +13,4 @@ const $x__script = _script("a0", ($scope) => {
 	_on($scope.a, "click", function() {
 		$x($scope, $scope.b + 1);
 	});
-});
-const $x = /* @__PURE__ */ _let(1, $x__script);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 2795 (min) 1406 (brotli)
-// template.marko: 249 (min) 126 (brotli)
-const $x__script = _script("a0", ($scope) => {
+// template.marko: 245 (min) 121 (brotli)
+const $x = /* @__PURE__ */ _let(1, _script("a0", ($scope) => {
 	_lifecycle($scope, {
 		onMount: function() {
 			document.getElementById("ref").textContent = "Mount " + $scope.b;
@@ -12,5 +12,4 @@ const $x__script = _script("a0", ($scope) => {
 	_on($scope.a, "click", function() {
 		$x($scope, $scope.b + 1);
 	});
-});
-const $x = /* @__PURE__ */ _let(1, $x__script);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
@@ -16,7 +16,6 @@ var my_for_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	my_for_default({
 		to: 5,
 		content: _content_resume("a0", (i) => {
@@ -24,6 +23,6 @@ var template_default = _template("a", (input) => {
 			const $scope1_id = _scope_id();
 			_html(`${_escape(i)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
-		}, $scope0_id)
+		}, _scope_id())
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/dom.bundle.js
@@ -1,17 +1,14 @@
 // total: 13616 (min) 5234 (brotli)
-// template.marko: 631 (min) 310 (brotli)
+// template.marko: 623 (min) 305 (brotli)
 const $Child_content2 = _content_resume("a1", "Hi", "b");
 const $Child_content = _content_resume("a0", "Hi", "b");
 const $Parent_content__input_value = /* @__PURE__ */ _closure_get(10, ($scope) => _html($scope, $scope._.k, "a"));
-const $Parent_content__setup = $Parent_content__input_value;
-const $Parent_content = _content_resume("a2", " ", " b", $Parent_content__setup);
-const $dynamicTag3 = /* @__PURE__ */ _dynamic_tag(5, $Parent_content);
-const $Parent__OR__Child__script = _script("a3", ($scope) => {
+const $dynamicTag3 = /* @__PURE__ */ _dynamic_tag(5, _content_resume("a2", " ", " b", $Parent_content__input_value));
+const $Parent__OR__Child = /* @__PURE__ */ _or(13, _script("a3", ($scope) => {
 	$scope.l;
 	$scope.m;
 	for (const node of $scope.a.querySelectorAll("a")) if (node.getAttribute("ns") !== node.namespaceURI) node.setAttribute("ns", node.namespaceURI);
-});
-const $Parent__OR__Child = /* @__PURE__ */ _or(13, $Parent__OR__Child__script);
+}));
 const $Parent__script = _script("a5", ($scope) => _on($scope.g, "click", function() {
 	$Parent($scope, $scope.l === "div" ? "svg" : "div");
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/__snapshots__/dom.bundle.js
@@ -1,3 +1,3 @@
 // total: 1455 (min) 803 (brotli)
 // template.marko: 43 (min) 47 (brotli)
-const $if_content__setup = _script("a0", ($scope) => $scope._.a.textContent = "hello");
+const $if = /* @__PURE__ */ _if(1, 0, 0, _script("a0", ($scope) => $scope._.a.textContent = "hello"));

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/html.bundle.js
@@ -38,10 +38,9 @@ var my_div_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	my_div_default({ content: _content_resume("a0", () => {
 		_scope_reason();
 		_scope_id();
 		_html("Hello");
-	}, $scope0_id) });
+	}, _scope_id()) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 8287 (min) 3782 (brotli)
-// template.marko: 614 (min) 348 (brotli)
+// template.marko: 610 (min) 339 (brotli)
 const $else_content__count = /* @__PURE__ */ _if_closure(0, 1, ($scope) => _text($scope.b, $scope._.c));
 const $else_content__setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$for_content__editing($scope._, true);
@@ -8,15 +8,14 @@ const $else_content__setup = ($scope) => {
 	$else_content__count._($scope);
 	$else_content__setup__script($scope);
 };
-const $if_content__counts__OR__count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+const $if_content__counts__OR__count = /* @__PURE__ */ _or(2, _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$counts($scope._._, [
 		...$scope._._.b.slice(0, $scope._.M),
 		$scope._.c + 1,
 		...$scope._._.b.slice($scope._.M + 1)
 	]);
 	$for_content__editing($scope._, false);
-}));
-const $if_content__counts__OR__count = /* @__PURE__ */ _or(2, $if_content__counts__OR__count__script);
+})));
 const $if_content__counts = /* @__PURE__ */ _closure_get(1, $if_content__counts__OR__count, ($scope) => $scope._._);
 const $if_content__setup = ($scope) => {
 	$if_content__counts($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 2043 (min) 1078 (brotli)
-// tags/child.marko: 93 (min) 85 (brotli)
-const $input__OR__x__script = _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f);
-const $input__OR__x = /* @__PURE__ */ _or(6, $input__OR__x__script);
+// tags/child.marko: 89 (min) 93 (brotli)
+const $input__OR__x = /* @__PURE__ */ _or(6, _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f));
 const $x = _var_resume("b0", /* @__PURE__ */ _const(5, $input__OR__x));
 
 // template.marko: 12 (min) 16 (brotli)

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // total: 2043 (min) 1078 (brotli)
-// tags/child.marko: 93 (min) 85 (brotli)
-const $input__OR__x__script = _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f);
-const $input__OR__x = /* @__PURE__ */ _or(6, $input__OR__x__script);
+// tags/child.marko: 89 (min) 93 (brotli)
+const $input__OR__x = /* @__PURE__ */ _or(6, _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f));
 const $x = _var_resume("b0", /* @__PURE__ */ _const(5, $input__OR__x));
 
 // template.marko: 12 (min) 16 (brotli)

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var child_default = _template("b", (input) => {
 
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $sg__input_show = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const output = _el($scope0_id, "a0");
 	_html(`<div></div>${_el_resume($scope0_id, "a")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/__snapshots__/html.bundle.js
@@ -4,10 +4,7 @@ var template_default = _template("a", (input) => {
 	_scope_id();
 	forOf(["foo"], (foo) => {
 		_scope_id();
-		{
-			_scope_id();
-			const baz = foo;
-			_html(_escape(baz));
-		}
+		_scope_id();
+		_html(_escape(foo));
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/__snapshots__/html.bundle.js
@@ -4,10 +4,7 @@ var template_default = _template("a", (input) => {
 	_scope_id();
 	forOf(["foo"], (foo) => {
 		_scope_id();
-		{
-			_scope_id();
-			let baz = foo;
-			_html(_escape(baz));
-		}
+		_scope_id();
+		_html(_escape(foo));
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/__snapshots__/html.bundle.js
@@ -6,8 +6,7 @@ var template_default = _template("a", (input) => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason(), $sg__foo = _serialize_guard($scope1_reason, 0);
 		const { bar: $bar } = void 0 !== $foo ? $foo : { bar: 2 };
-		const bar = void 0 !== $bar ? $bar : 1;
-		_html(`<div class=a>${_escape(bar)}${_el_resume($scope1_id, "a", $sg__foo)} ${_sep($sg__foo)}${_escape(typeof foo)}${_el_resume($scope1_id, "b", $sg__foo)}</div>`);
+		_html(`<div class=a>${_escape(void 0 !== $bar ? $bar : 1)}${_el_resume($scope1_id, "a", $sg__foo)} ${_sep($sg__foo)}${_escape(typeof foo)}${_el_resume($scope1_id, "b", $sg__foo)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
 	ChildA.content({ foo: { bar: 0 } });
@@ -18,8 +17,7 @@ var template_default = _template("a", (input) => {
 		const $scope2_reason = _scope_reason(), $sg__foo2 = _serialize_guard($scope2_reason, 0);
 		const { foo, foo: $foo2 } = input;
 		const { bar: $bar2 } = void 0 !== $foo2 ? $foo2 : { bar: 2 };
-		const bar = void 0 !== $bar2 ? $bar2 : 1;
-		_html(`<div class=b>${_escape(bar)}${_el_resume($scope2_id, "a", $sg__foo2)} ${_sep($sg__foo2)}${_escape(typeof foo)}${_el_resume($scope2_id, "b", $sg__foo2)}</div>`);
+		_html(`<div class=b>${_escape(void 0 !== $bar2 ? $bar2 : 1)}${_el_resume($scope2_id, "a", $sg__foo2)} ${_sep($sg__foo2)}${_escape(typeof foo)}${_el_resume($scope2_id, "b", $sg__foo2)}</div>`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}) };
 	ChildB.content({ foo: { bar: 0 } });

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 5506 (min) 2574 (brotli)
-// template.marko: 136 (min) 125 (brotli)
+// template.marko: 132 (min) 119 (brotli)
 const $if_content__mounted = /* @__PURE__ */ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.b && "C"));
-const $if_content__setup = $if_content__mounted;
-const $if = /* @__PURE__ */ _if(0, "AB<!>D", "b%c", $if_content__setup);
+const $if = /* @__PURE__ */ _if(0, "AB<!>D", "b%c", $if_content__mounted);
 const $mounted = /* @__PURE__ */ _let(1, ($scope) => {
 	$if($scope, $scope.b ? 0 : 1);
 	$if_content__mounted($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/__snapshots__/html.bundle.js
@@ -3,8 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	const double = count * 2;
-	_html(`<button>${_escape(double)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_html(`<button>${_escape(count * 2)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { c: count });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.js
@@ -1,4 +1,4 @@
 // total: 1669 (min) 910 (brotli)
 // template.marko: 80 (min) 84 (brotli)
-const $Tag_content2__name__script = _script("a1", ($scope) => console.log(_assert_init($scope._, "c")));
+const $Tag_content2 = /* @__PURE__ */ _content("a2", 0, 0, /* @__PURE__ */ _closure_get(2, _script("a1", ($scope) => console.log(_assert_init($scope._, "c")))));
 const $name = _var_resume("a3", /* @__PURE__ */ _const(2));

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
-	let name = { content: _content("a0", (input) => {
+	writeScope($scope0_id, { c: { content: _content("a0", (input) => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
 		_dynamic_tag($scope1_id, "a", input.content, {}, 0, 0, _serialize_guard($scope1_reason, 0));
@@ -15,6 +15,5 @@ var template_default = _template("a", (input) => {
 		_script($scope2_id, "a1");
 		writeScope($scope2_id, { _: _scope_with_id($scope0_id) });
 		_resume_branch($scope2_id);
-	}) });
-	writeScope($scope0_id, { c: name });
+	}) }) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/__snapshots__/dom.bundle.js
@@ -1,12 +1,11 @@
 // total: 7437 (min) 3418 (brotli)
-// template.marko: 276 (min) 201 (brotli)
+// template.marko: 272 (min) 195 (brotli)
 const $for_content__if = /* @__PURE__ */ _if(0, "<div>b</div>", "b");
 const $for_content__items_length = /* @__PURE__ */ _for_closure(0, ($scope) => $for_content__if($scope, $scope._.f > 1 ? 0 : 1));
 const $for_content__setup = $for_content__items_length;
-const $itemId__OR__items__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $itemId__OR__items = /* @__PURE__ */ _or(4, _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$items($scope, [...$scope.d, $itemId($scope, $scope.c + 1)]);
-}));
-const $itemId__OR__items = /* @__PURE__ */ _or(4, $itemId__OR__items__script);
+})));
 const $itemId = /* @__PURE__ */ _let(2, $itemId__OR__items);
 const $for = /* @__PURE__ */ _for_of(0, "<div>a</div><!><!>", "b%c", $for_content__setup);
 const $items = /* @__PURE__ */ _let(3, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.js
@@ -9,13 +9,12 @@ function $setter($scope) {
 }
 _resume("b0", $setter);
 
-// template.marko: 162 (min) 120 (brotli)
+// template.marko: 158 (min) 123 (brotli)
 const $count = /* @__PURE__ */ _let(3, ($scope) => {
 	$input_value($scope.a, $scope.d);
 	_text($scope.c, $scope.d);
 });
-const $setCount__script = _script("a2", ($scope) => $scope.e());
-const $setCount = _var_resume("a1", /* @__PURE__ */ _const(4, $setCount__script));
+const $setCount = _var_resume("a1", /* @__PURE__ */ _const(4, _script("a2", ($scope) => $scope.e())));
 function $valueChange($scope) {
 	return (_new_count) => {
 		$count($scope, _new_count);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.bundle.js
@@ -8,7 +8,7 @@ function $valueChange($scope) {
 }
 _resume("b0", $valueChange);
 
-// template.marko: 170 (min) 133 (brotli)
+// template.marko: 166 (min) 130 (brotli)
 const $mytag_content__count__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	_var_change($scope._.a, $scope._.d + 1);
 }));
@@ -16,5 +16,4 @@ const $mytag_content__count = /* @__PURE__ */ _closure_get(3, ($scope) => {
 	_text($scope.b, $scope._.d);
 	$mytag_content__count__script($scope);
 });
-const $count__closure = /* @__PURE__ */ _closure($mytag_content__count);
-const $count = _var_resume("a0", /* @__PURE__ */ _const(3, $count__closure));
+const $count = _var_resume("a0", /* @__PURE__ */ _const(3, /* @__PURE__ */ _closure($mytag_content__count)));

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-state/__snapshots__/html.bundle.js
@@ -11,6 +11,5 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	_scope_id();
-	let value = child_default({});
-	_html(`<div>parent ${_escape(value)}</div>`);
+	_html(`<div>parent ${_escape(child_default({}))}</div>`);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/__snapshots__/dom.bundle.js
@@ -5,6 +5,5 @@ function $getter() {
 }
 _resume("b0", $getter);
 
-// template.marko: 77 (min) 76 (brotli)
-const $get__script = _script("a0", ($scope) => $scope.c.textContent = $scope.d());
-const $get = _var_resume("a1", /* @__PURE__ */ _const(3, $get__script));
+// template.marko: 67 (min) 66 (brotli)
+const $get = _var_resume("a1", /* @__PURE__ */ _const(3, _script("a0", ($scope) => $scope.c.textContent = $scope.d())));

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 3155 (min) 1550 (brotli)
-// template.marko: 612 (min) 247 (brotli)
+// template.marko: 598 (min) 241 (brotli)
 const $Twice_content__value__OR__call = /* @__PURE__ */ _or(4, ($scope) => _return($scope, $_return2($scope)));
 const $Twice_content__call = /* @__PURE__ */ _let(3, $Twice_content__value__OR__call);
 const $Twice_content__value = /* @__PURE__ */ _const(2, $Twice_content__value__OR__call);
@@ -14,10 +14,8 @@ const $clickTwiceCount = /* @__PURE__ */ _let(10, ($scope) => {
 	$Twice_content__value($scope.e, $onClickTwice($scope));
 	_text($scope.h, $scope.k);
 });
-const $onClickOnce2__script = _script("a9", ($scope) => _on($scope.c, "click", $scope.j));
-const $onClickOnce2 = _var_resume("a5", /* @__PURE__ */ _const(9, $onClickOnce2__script));
-const $onClickTwice2__script = _script("a8", ($scope) => _on($scope.g, "click", $scope.l));
-const $onClickTwice2 = _var_resume("a7", /* @__PURE__ */ _const(11, $onClickTwice2__script));
+const $onClickOnce2 = _var_resume("a5", /* @__PURE__ */ _const(9, _script("a9", ($scope) => _on($scope.c, "click", $scope.j))));
+const $onClickTwice2 = _var_resume("a7", /* @__PURE__ */ _const(11, _script("a8", ($scope) => _on($scope.g, "click", $scope.l))));
 function $_return2($scope) {
 	return function() {
 		if ($scope.d) {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag-value-no-scope/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag-value-no-scope/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // total: 1587 (min) 863 (brotli)
 // template.marko: 181 (min) 117 (brotli)
-const $setText2__script = _script("a1", ($scope) => $scope.b());
+const $setText2 = /* @__PURE__ */ _const(1, _script("a1", ($scope) => $scope.b()));
 function $setText($scope) {
 	return function(arg) {
 		if (arg) throw new Error(`Expected no argument to be passed, but received "${typeof arg}".`);

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag/__snapshots__/dom.bundle.js
@@ -1,3 +1,3 @@
 // total: 1476 (min) 815 (brotli)
 // template.marko: 64 (min) 58 (brotli)
-const $x__script = _script("a0", ($scope) => document.getElementById("ref").textContent = $scope.a);
+const $x = /* @__PURE__ */ _let(0, _script("a0", ($scope) => document.getElementById("ref").textContent = $scope.a));

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 1497 (min) 818 (brotli)
 // template.marko: 85 (min) 63 (brotli)
-const $promise__script = _script("a0", ($scope) => (async () => {
+const $promise = /* @__PURE__ */ _const(0, _script("a0", ($scope) => (async () => {
 	document.getElementById("ref").textContent = await $scope.a;
-})());
+})()));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/html.bundle.js
@@ -19,10 +19,9 @@ var wrap_default = _template("c", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
 	wrap_default({ option: attrTag({ content: _content_resume("a0", () => {
 		_scope_reason();
 		_scope_id();
 		_html("1");
-	}, $scope0_id) }) });
+	}, _scope_id()) }) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/__snapshots__/dom.bundle.js
@@ -1,10 +1,10 @@
 // total: 6381 (min) 2618 (brotli)
 // template.marko: 349 (min) 164 (brotli)
 const $MyButton_content2 = _content_resume("a5", "Click Me", "b");
-const $MyButton_content__input_onClick__script = _script("a4", ($scope) => _on($scope.a, "click", function() {
+const $MyButton_content__input_onClick = /* @__PURE__ */ _const(3, _script("a4", ($scope) => _on($scope.a, "click", function() {
 	document.getElementById("el").textContent += "[onClick(child)]";
 	$scope.d();
-}));
+})));
 const $MyButton_content__input__script = _script("a3", ($scope) => _attrs_script($scope, "a"));
 function $onClick() {
 	document.getElementById("el").textContent += "[onClick(parent)]";

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.js
@@ -24,7 +24,7 @@ const $_classspandiv_content__setup = ($scope) => {
 	$_classspandiv_content__input_foo($scope);
 	/* @__PURE__ */ $setup($scope.a);
 };
-const $_classspandiv_content = _content_resume("c0", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $_classspandiv_content__setup);
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("c0", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $_classspandiv_content__setup));
 
 // template.marko: 64 (min) 59 (brotli)
 const $desc_content2 = _content_resume("a1", "Two", "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // total: 13472 (min) 5226 (brotli)
-// template.marko: 317 (min) 220 (brotli)
+// template.marko: 313 (min) 215 (brotli)
 const $Foo_content2__dynamicTag = /* @__PURE__ */ _dynamic_tag(0, 0, 0, 1);
 const $Foo_content2__input_content__OR__input_value = /* @__PURE__ */ _or(5, ($scope) => $Foo_content2__dynamicTag($scope, $scope.d, () => [$scope.e]));
 const $Foo_content2__input_value = /* @__PURE__ */ _const(4, $Foo_content2__input_content__OR__input_value);
-const $if_content__setup = /* @__PURE__ */ _closure_get(3, ($scope) => _text($scope.a, $scope._._.d), ($scope) => $scope._._);
-const $Foo_content__if = /* @__PURE__ */ _if(0, " ", " b", $if_content__setup);
+const $Foo_content__if = /* @__PURE__ */ _if(0, " ", " b", /* @__PURE__ */ _closure_get(3, ($scope) => _text($scope.a, $scope._._.d), ($scope) => $scope._._));
 const $Foo_content__v = ($scope, v) => $Foo_content__if($scope, v ? 0 : 1);
 const $Foo_content__$params = ($scope, $params3) => $Foo_content__v($scope, $params3[0]);
 const $Foo_content = _content_resume("a1", "<!><!><!>", "b%c", 0, $Foo_content__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 	Foo.content({
 		value: count,
 		content: _content_resume("a1", (v) => {
-			const $scope1_reason = _scope_reason(), $sg__v = _serialize_guard($scope1_reason, 0);
+			const $sg__v = _serialize_guard(_scope_reason(), 0);
 			const $scope1_id = _scope_id();
 			_if(() => {
 				if (v) {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // total: 2451 (min) 1280 (brotli)
-// template.marko: 129 (min) 91 (brotli)
-const $clickCount__script = _script("a0", ($scope) => {
+// template.marko: 125 (min) 87 (brotli)
+const $clickCount = /* @__PURE__ */ _let(1, _script("a0", ($scope) => {
 	document.getElementById("button").textContent = $scope.b;
 	_on($scope.a, "click", function() {
 		$clickCount($scope, $scope.b + 1);
 	});
-});
-const $clickCount = /* @__PURE__ */ _let(1, $clickCount__script);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 6574 (min) 2982 (brotli)
-// template.marko: 469 (min) 234 (brotli)
+// template.marko: 457 (min) 225 (brotli)
 const $if_content2__count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$count($scope._._, $scope._._.e + 1);
 }));
@@ -7,8 +7,7 @@ const $if_content2__count = /* @__PURE__ */ _closure_get(4, ($scope) => {
 	_text($scope.b, $scope._._.e);
 	$if_content2__count__script($scope);
 }, ($scope) => $scope._._);
-const $if_content2__setup = $if_content2__count;
-const $if_content__if = /* @__PURE__ */ _if(1, "<button id=count> </button>", " D l", $if_content2__setup);
+const $if_content__if = /* @__PURE__ */ _if(1, "<button id=count> </button>", " D l", $if_content2__count);
 const $if_content__inner__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$inner($scope._, !$scope._.d);
 }));
@@ -16,8 +15,7 @@ const $if_content__inner = /* @__PURE__ */ _if_closure(1, 0, ($scope) => {
 	$if_content__if($scope, $scope._.d ? 0 : 1);
 	$if_content__inner__script($scope);
 });
-const $if_content__setup = $if_content__inner;
-const $if = /* @__PURE__ */ _if(1, "<button id=inner></button><!><!>", " b%c", $if_content__setup);
+const $if = /* @__PURE__ */ _if(1, "<button id=inner></button><!><!>", " b%c", $if_content__inner);
 const $outer__script = _script("a2", ($scope) => _on($scope.a, "click", function() {
 	$outer($scope, !$scope.c);
 }));
@@ -26,5 +24,4 @@ const $outer = /* @__PURE__ */ _let(2, ($scope) => {
 	$outer__script($scope);
 });
 const $inner = /* @__PURE__ */ _let(3, $if_content__inner);
-const $count__closure = /* @__PURE__ */ _closure($if_content2__count);
-const $count = /* @__PURE__ */ _let(4, $count__closure);
+const $count = /* @__PURE__ */ _let(4, /* @__PURE__ */ _closure($if_content2__count));

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 6574 (min) 2982 (brotli)
-// template.marko: 469 (min) 234 (brotli)
+// template.marko: 457 (min) 225 (brotli)
 const $if_content2__count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$count($scope._._, $scope._._.e + 1);
 }));
@@ -7,8 +7,7 @@ const $if_content2__count = /* @__PURE__ */ _closure_get(4, ($scope) => {
 	_text($scope.b, $scope._._.e);
 	$if_content2__count__script($scope);
 }, ($scope) => $scope._._);
-const $if_content2__setup = $if_content2__count;
-const $if_content__if = /* @__PURE__ */ _if(1, "<button id=count> </button>", " D l", $if_content2__setup);
+const $if_content__if = /* @__PURE__ */ _if(1, "<button id=count> </button>", " D l", $if_content2__count);
 const $if_content__inner__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
 	$inner($scope._, !$scope._.d);
 }));
@@ -16,8 +15,7 @@ const $if_content__inner = /* @__PURE__ */ _if_closure(1, 0, ($scope) => {
 	$if_content__if($scope, $scope._.d ? 0 : 1);
 	$if_content__inner__script($scope);
 });
-const $if_content__setup = $if_content__inner;
-const $if = /* @__PURE__ */ _if(1, "<button id=inner></button><!><!>", " b%c", $if_content__setup);
+const $if = /* @__PURE__ */ _if(1, "<button id=inner></button><!><!>", " b%c", $if_content__inner);
 const $outer__script = _script("a2", ($scope) => _on($scope.a, "click", function() {
 	$outer($scope, !$scope.c);
 }));
@@ -26,5 +24,4 @@ const $outer = /* @__PURE__ */ _let(2, ($scope) => {
 	$outer__script($scope);
 });
 const $inner = /* @__PURE__ */ _let(3, $if_content__inner);
-const $count__closure = /* @__PURE__ */ _closure($if_content2__count);
-const $count = /* @__PURE__ */ _let(4, $count__closure);
+const $count = /* @__PURE__ */ _let(4, /* @__PURE__ */ _closure($if_content2__count));

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // total: 7103 (min) 3176 (brotli)
-// template.marko: 246 (min) 164 (brotli)
+// template.marko: 242 (min) 167 (brotli)
 const $if_content__value = /* @__PURE__ */ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.f));
-const $if_content__setup = $if_content__value;
-const $if = /* @__PURE__ */ _if(0, "<span> </span>", "D l", $if_content__setup);
+const $if = /* @__PURE__ */ _if(0, "<span> </span>", "D l", $if_content__value);
 const $value = /* @__PURE__ */ _let(5, ($scope) => {
 	_attr_input_value($scope, "b", $scope.f, $valueChange($scope));
 	$if($scope, $scope.f ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/__snapshots__/dom.bundle.js
@@ -1,11 +1,10 @@
 // total: 6364 (min) 2923 (brotli)
-// tags/counter.marko: 255 (min) 175 (brotli)
+// tags/counter.marko: 251 (min) 156 (brotli)
 const $template = "<button> </button>";
 const $walks = " D l";
-const $input_onCount__OR__clickCount__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+const $input_onCount__OR__clickCount = /* @__PURE__ */ _or(6, _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$scope.e($clickCount($scope, $scope.f + 1));
-}));
-const $input_onCount__OR__clickCount = /* @__PURE__ */ _or(6, $input_onCount__OR__clickCount__script);
+})));
 const $clickCount = /* @__PURE__ */ _let(5, ($scope) => {
 	_text($scope.b, ((() => {
 		if ($scope.f > 0) throw new Error("This should not have executed since the parent removes this component when the count is greater than 0");

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // total: 6796 (min) 3105 (brotli)
-// template.marko: 297 (min) 189 (brotli)
+// template.marko: 293 (min) 187 (brotli)
 _enable_catch();
 const $catch_content__err = ($scope, err) => _text($scope.a, err);
 const $catch_content__$params = ($scope, $params2) => $catch_content__err($scope, $params2[0]);
@@ -16,5 +16,4 @@ const $try_content__clickCount = /* @__PURE__ */ _closure_get(2, ($scope) => {
 	})());
 	$try_content__clickCount__script($scope);
 });
-const $clickCount__closure = /* @__PURE__ */ _closure($try_content__clickCount);
-const $clickCount = /* @__PURE__ */ _let(2, $clickCount__closure);
+const $clickCount = /* @__PURE__ */ _let(2, /* @__PURE__ */ _closure($try_content__clickCount));

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/__snapshots__/html.bundle.js
@@ -1,8 +1,7 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
-	_attr_select_value($scope0_id, "a", "b", void 0, () => {
+	_attr_select_value(_scope_id(), "a", "b", void 0, () => {
 		_html(`<select><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option><option${_attr_option_value("c")}>C</option></select>`);
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/utils/snap.ts
+++ b/packages/runtime-tags/src/__tests__/utils/snap.ts
@@ -66,10 +66,14 @@ export async function snap(
         `Snapshot conflict: "${file}" was written with different content by two tests.`,
       );
     }
+
+    if (actual) {
+      writtenFiles.set(expectedFile, actual);
+      writtenDirs.add(snapdir);
+    }
+
     if (expected !== actual) {
       if (actual) {
-        writtenDirs.add(snapdir);
-        writtenFiles.set(expectedFile, actual);
         fs.mkdirSync(path.dirname(expectedFile), { recursive: true });
         fs.writeFileSync(expectedFile, actual);
       } else {

--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { getFile, importStar } from "@marko/compiler/babel-utils";
+import { getFile, importNamed } from "@marko/compiler/babel-utils";
 
 import type { Falsy } from "../../common/types";
 import {
@@ -14,7 +14,6 @@ import {
 } from "../../html";
 import { getMarkoOpts, isOutputDOM, isOutputHTML } from "./marko-config";
 import runtimeInfo from "./runtime-info";
-import { toMemberExpression } from "./to-property-name";
 
 export type DOMRuntimeHelpers = keyof typeof import("../../dom");
 export type HTMLRuntimeHelpers = keyof typeof import("../../html");
@@ -44,10 +43,7 @@ const pureDOMFunctions = new Set<string>([
 
 export function importRuntime(name: DOMRuntimeHelpers | HTMLRuntimeHelpers) {
   const { output } = getMarkoOpts();
-  return toMemberExpression(
-    importStar(getFile(), getRuntimePath(output), "_"),
-    name,
-  );
+  return importNamed(getFile(), getRuntimePath(output), name);
 }
 
 export function callRuntime(


### PR DESCRIPTION
* switches tags api runtime imports to use named imports instead of namespace (rolldown does better inlining with named imports).