### PR TITLE
perf: optimize csr render queue

### DIFF
--- a/.changeset/sixty-geese-post.md
+++ b/.changeset/sixty-geese-post.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Improve client side render queue performance.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 23618,
-        "brotli": 8718
+        "min": 23647,
+        "brotli": 8745
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 120
       },
       "runtime": {
-        "min": 4013,
-        "brotli": 1784
+        "min": 4031,
+        "brotli": 1774
       },
       "total": {
-        "min": 4176,
-        "brotli": 1904
+        "min": 4194,
+        "brotli": 1894
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 79
       },
       "runtime": {
-        "min": 2528,
-        "brotli": 1270
+        "min": 2563,
+        "brotli": 1279
       },
       "total": {
-        "min": 2617,
-        "brotli": 1349
+        "min": 2652,
+        "brotli": 1358
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 393
       },
       "runtime": {
-        "min": 6468,
-        "brotli": 2824
+        "min": 6486,
+        "brotli": 2830
       },
       "total": {
-        "min": 7150,
-        "brotli": 3217
+        "min": 7168,
+        "brotli": 3223
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 104
       },
       "runtime": {
-        "min": 2700,
-        "brotli": 1323
+        "min": 2735,
+        "brotli": 1333
       },
       "total": {
-        "min": 2822,
-        "brotli": 1427
+        "min": 2857,
+        "brotli": 1437
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6468 (min) 2824 (brotli)
+// size: 6486 (min) 2830 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -67,16 +67,17 @@ let decodeAccessor = (num) =>
       ? forOf(all, (item, i) => cb(item[by], [item, i]))
       : forOf(all, (item, i) => cb(by(item, i), [item, i]));
   }),
+  runId = 1,
   pendingRenders = [],
-  pendingRendersLookup = {},
-  asyncRendersLookup,
   pendingEffects = [],
   pendingScopes = [],
   rendering,
+  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
   },
   runRender = (render) => render.c(render.b, render.d),
+  catchEnabled,
   _template = (id, template, walks, setup, inputSignal) => {
     let renderer = _content(id, template, walks, setup, inputSignal)();
     return (
@@ -508,19 +509,20 @@ function bySecondArg(_item, index) {
   return index;
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
-  let key = scopeKey * 1e3 + signalKey,
-    render = signalKey >= 0 && pendingRendersLookup[key];
-  render
-    ? (render.d = value)
-    : (queuePendingRender(
-        (render = {
-          a: key,
-          b: scope,
-          c: signal,
-          d: value,
-        }),
-      ),
-      signalKey >= 0 && (pendingRendersLookup[key] = render));
+  let render;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+    if (((render.d = value), render.e === runId || catchEnabled)) return;
+    render.e = runId;
+  } else
+    ((render = {
+      a: scopeKey * scopeKeyOffset + signalKey,
+      b: scope,
+      c: signal,
+      d: value,
+      e: runId,
+    }),
+      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+  queuePendingRender(render);
 }
 function queuePendingRender(render) {
   let i = pendingRenders.push(render) - 1;
@@ -537,31 +539,23 @@ function queueEffect(scope, fn) {
 }
 function run() {
   let effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     ((rendering = 1), runRenders());
   } finally {
-    ((pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = rendering = 0),
-      (pendingRenders = []),
-      (pendingEffects = []));
+    (runId++, (rendering = 0), (pendingRenders = []), (pendingEffects = []));
   }
   runEffects(effects);
 }
 function prepareEffects(fn) {
   let prevRenders = pendingRenders,
     prevEffects = pendingEffects,
-    prevLookup = asyncRendersLookup,
     preparedEffects = (pendingEffects = []);
-  ((pendingRenders = []),
-    (asyncRendersLookup = pendingRendersLookup),
-    (pendingRendersLookup = {}));
+  pendingRenders = [];
   try {
     ((rendering = 1), fn(), runRenders());
   } finally {
-    ((rendering = 0),
-      (pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = prevLookup),
+    (runId++,
+      (rendering = 0),
       (pendingRenders = prevRenders),
       (pendingEffects = prevEffects));
   }

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2700 (min) 1323 (brotli)
+// size: 2735 (min) 1333 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -8,16 +8,17 @@ let decodeAccessor = (num) =>
   registeredValues = {},
   curRenders,
   readyIds,
+  runId = 1,
   pendingRenders = [],
-  pendingRendersLookup = {},
-  asyncRendersLookup,
   pendingEffects = [],
   pendingScopes = [],
   rendering,
+  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
   },
-  runRender = (render) => render.c(render.b, render.d);
+  runRender = (render) => render.c(render.b, render.d),
+  catchEnabled;
 function _on(element, type, handler) {
   (element["$" + type] === void 0 &&
     defaultDelegator(element, type, handleDelegated),
@@ -216,19 +217,20 @@ function normalizeAttrValue(value) {
   if (value || value === 0) return value === !0 ? "" : value + "";
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
-  let key = scopeKey * 1e3 + signalKey,
-    render = signalKey >= 0 && pendingRendersLookup[key];
-  render
-    ? (render.d = value)
-    : (queuePendingRender(
-        (render = {
-          a: key,
-          b: scope,
-          c: signal,
-          d: value,
-        }),
-      ),
-      signalKey >= 0 && (pendingRendersLookup[key] = render));
+  let render;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+    if (((render.d = value), render.e === runId || catchEnabled)) return;
+    render.e = runId;
+  } else
+    ((render = {
+      a: scopeKey * scopeKeyOffset + signalKey,
+      b: scope,
+      c: signal,
+      d: value,
+      e: runId,
+    }),
+      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+  queuePendingRender(render);
 }
 function queuePendingRender(render) {
   let i = pendingRenders.push(render) - 1;
@@ -245,14 +247,10 @@ function queueEffect(scope, fn) {
 }
 function run() {
   let effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     ((rendering = 1), runRenders());
   } finally {
-    ((pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = rendering = 0),
-      (pendingRenders = []),
-      (pendingEffects = []));
+    (runId++, (rendering = 0), (pendingRenders = []), (pendingEffects = []));
   }
   runEffects(effects);
 }

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 4013 (min) 1784 (brotli)
+// size: 4031 (min) 1774 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -61,16 +61,17 @@ let decodeAccessor = (num) =>
   },
   cloneCache = {},
   registeredValues = {},
+  runId = 1,
   pendingRenders = [],
-  pendingRendersLookup = {},
-  asyncRendersLookup,
   pendingEffects = [],
   pendingScopes = [],
   rendering,
+  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
   },
   runRender = (render) => render.c(render.b, render.d),
+  catchEnabled,
   _template = (id, template, walks, setup, inputSignal) => {
     let renderer = _content(id, template, walks, setup, inputSignal)();
     return (
@@ -245,19 +246,20 @@ function toInsertNode(startNode, endNode) {
   return parent;
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
-  let key = scopeKey * 1e3 + signalKey,
-    render = signalKey >= 0 && pendingRendersLookup[key];
-  render
-    ? (render.d = value)
-    : (queuePendingRender(
-        (render = {
-          a: key,
-          b: scope,
-          c: signal,
-          d: value,
-        }),
-      ),
-      signalKey >= 0 && (pendingRendersLookup[key] = render));
+  let render;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+    if (((render.d = value), render.e === runId || catchEnabled)) return;
+    render.e = runId;
+  } else
+    ((render = {
+      a: scopeKey * scopeKeyOffset + signalKey,
+      b: scope,
+      c: signal,
+      d: value,
+      e: runId,
+    }),
+      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+  queuePendingRender(render);
 }
 function queuePendingRender(render) {
   let i = pendingRenders.push(render) - 1;
@@ -274,31 +276,23 @@ function queueEffect(scope, fn) {
 }
 function run() {
   let effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     ((rendering = 1), runRenders());
   } finally {
-    ((pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = rendering = 0),
-      (pendingRenders = []),
-      (pendingEffects = []));
+    (runId++, (rendering = 0), (pendingRenders = []), (pendingEffects = []));
   }
   runEffects(effects);
 }
 function prepareEffects(fn) {
   let prevRenders = pendingRenders,
     prevEffects = pendingEffects,
-    prevLookup = asyncRendersLookup,
     preparedEffects = (pendingEffects = []);
-  ((pendingRenders = []),
-    (asyncRendersLookup = pendingRendersLookup),
-    (pendingRendersLookup = {}));
+  pendingRenders = [];
   try {
     ((rendering = 1), fn(), runRenders());
   } finally {
-    ((rendering = 0),
-      (pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = prevLookup),
+    (runId++,
+      (rendering = 0),
       (pendingRenders = prevRenders),
       (pendingEffects = prevEffects));
   }

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2528 (min) 1270 (brotli)
+// size: 2563 (min) 1279 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -8,16 +8,17 @@ let decodeAccessor = (num) =>
   registeredValues = {},
   curRenders,
   readyIds,
+  runId = 1,
   pendingRenders = [],
-  pendingRendersLookup = {},
-  asyncRendersLookup,
   pendingEffects = [],
   pendingScopes = [],
   rendering,
+  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
   },
-  runRender = (render) => render.c(render.b, render.d);
+  runRender = (render) => render.c(render.b, render.d),
+  catchEnabled;
 function _on(element, type, handler) {
   (element["$" + type] === void 0 &&
     defaultDelegator(element, type, handleDelegated),
@@ -204,19 +205,20 @@ function _text(node, value) {
   node.data !== normalizedValue && (node.data = normalizedValue);
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
-  let key = scopeKey * 1e3 + signalKey,
-    render = signalKey >= 0 && pendingRendersLookup[key];
-  render
-    ? (render.d = value)
-    : (queuePendingRender(
-        (render = {
-          a: key,
-          b: scope,
-          c: signal,
-          d: value,
-        }),
-      ),
-      signalKey >= 0 && (pendingRendersLookup[key] = render));
+  let render;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+    if (((render.d = value), render.e === runId || catchEnabled)) return;
+    render.e = runId;
+  } else
+    ((render = {
+      a: scopeKey * scopeKeyOffset + signalKey,
+      b: scope,
+      c: signal,
+      d: value,
+      e: runId,
+    }),
+      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+  queuePendingRender(render);
 }
 function queuePendingRender(render) {
   let i = pendingRenders.push(render) - 1;
@@ -233,14 +235,10 @@ function queueEffect(scope, fn) {
 }
 function run() {
   let effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     ((rendering = 1), runRenders());
   } finally {
-    ((pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = rendering = 0),
-      (pendingRenders = []),
-      (pendingEffects = []));
+    (runId++, (rendering = 0), (pendingRenders = []), (pendingEffects = []));
   }
   runEffects(effects);
 }

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 23618 (min) 8718 (brotli)
+// size: 23647 (min) 8745 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -192,14 +192,14 @@ let empty = [],
     ([until, from, step, by = byFirstArg], cb) =>
       forUntil(until, from, step, (v) => cb(by(v), [v])),
   ),
+  runId = 1,
   pendingRenders = [],
-  pendingRendersLookup = {},
-  asyncRendersLookup,
   caughtError = /* @__PURE__ */ new WeakSet(),
   placeholderShown = /* @__PURE__ */ new WeakSet(),
   pendingEffects = [],
   pendingScopes = [],
   rendering,
+  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length; ) effects[i++](effects[i++]);
   },
@@ -2013,19 +2013,21 @@ function byFirstArg(name) {
   return name;
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
-  let key = scopeKey * 1e3 + signalKey,
-    render = signalKey >= 0 && pendingRendersLookup[key];
-  render
-    ? (render.d = value)
-    : (queuePendingRender(
-        (render = {
-          a: key,
-          b: scope,
-          c: signal,
-          d: value,
-        }),
-      ),
-      signalKey >= 0 && (pendingRendersLookup[key] = render));
+  let render;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+    if (((render.d = value), render.e === runId || (catchEnabled && render.f)))
+      return;
+    render.e = runId;
+  } else
+    ((render = {
+      a: scopeKey * scopeKeyOffset + signalKey,
+      b: scope,
+      c: signal,
+      d: value,
+      e: runId,
+    }),
+      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+  queuePendingRender(render);
 }
 function queuePendingRender(render) {
   let i = pendingRenders.push(render) - 1;
@@ -2042,14 +2044,10 @@ function queueEffect(scope, fn) {
 }
 function run() {
   let effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     ((rendering = 1), runRenders());
   } finally {
-    ((pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = rendering = 0),
-      (pendingRenders = []),
-      (pendingEffects = []));
+    (runId++, (rendering = 0), (pendingRenders = []), (pendingEffects = []));
   }
   runEffects(effects);
 }
@@ -2059,17 +2057,13 @@ function queueAsyncRender(scope, signal, value) {
 function prepareEffects(fn) {
   let prevRenders = pendingRenders,
     prevEffects = pendingEffects,
-    prevLookup = asyncRendersLookup,
     preparedEffects = (pendingEffects = []);
-  ((pendingRenders = []),
-    (asyncRendersLookup = pendingRendersLookup),
-    (pendingRendersLookup = {}));
+  pendingRenders = [];
   try {
     ((rendering = 1), fn(), runRenders());
   } finally {
-    ((rendering = 0),
-      (pendingRendersLookup = asyncRendersLookup),
-      (asyncRendersLookup = prevLookup),
+    (runId++,
+      (rendering = 0),
       (pendingRenders = prevRenders),
       (pendingEffects = prevEffects));
   }
@@ -2138,14 +2132,10 @@ function _enable_catch() {
         try {
           let branch = render.b.F;
           for (; branch; ) {
-            if (branch.W)
-              return (
-                (asyncRendersLookup[render.a] = render),
-                branch.W.push(render)
-              );
+            if (branch.W) return ((render.f = 1), branch.W.push(render));
             branch = branch.N;
           }
-          runRender(render);
+          ((render.f = 0), runRender(render));
         } catch (error) {
           renderCatch(render.b, error);
         }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 943,
-        "brotli": 464
+        "min": 951,
+        "brotli": 471
       },
       "files": {
         "v:template.marko.hydrate-6.js": 104,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 49586,
-      "brotli": 14684
+      "min": 49596,
+      "brotli": 14716
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67967,
-        "brotli": 21153
+        "min": 68001,
+        "brotli": 21124
       },
       "files": {
         "components/custom-tag.marko": 1121,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65715,
-        "brotli": 20179
+        "min": 65750,
+        "brotli": 20196
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67174,
-        "brotli": 20788
+        "min": 67209,
+        "brotli": 20851
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66760,
-        "brotli": 20561
+        "min": 66794,
+        "brotli": 20565
       },
       "files": {
         "tags/components/hello-internal.marko": 941,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65715,
-        "brotli": 20179
+        "min": 65750,
+        "brotli": 20196
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67486,
-        "brotli": 20945
+        "min": 67520,
+        "brotli": 20919
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67128,
-        "brotli": 20794
+        "min": 67162,
+        "brotli": 20792
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66038,
-        "brotli": 20345
+        "min": 66073,
+        "brotli": 20394
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65710,
-        "brotli": 20172
+        "min": 65745,
+        "brotli": 20241
       },
       "files": {
         "components/tags-layout.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67592,
-        "brotli": 20945
+        "min": 67629,
+        "brotli": 20990
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66914,
-        "brotli": 20658
+        "min": 66949,
+        "brotli": 20708
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66065,
-        "brotli": 20328
+        "min": 66100,
+        "brotli": 20389
       },
       "files": {
         "components/tags-layout.marko": 922,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67952,
-        "brotli": 21142
+        "min": 67987,
+        "brotli": 21138
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-attrs-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1756,
-      "brotli": 874
+      "min": 1764,
+      "brotli": 871
     },
     "child.mjs": {
       "min": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-event/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2005,
+      "min": 2013,
       "brotli": 956
     },
     "child.mjs": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-idle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-idle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1959,
-      "brotli": 942
+      "min": 1967,
+      "brotli": 952
     },
     "child.mjs": {
       "min": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-load-error/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 50631,
-      "brotli": 15006
+      "min": 50642,
+      "brotli": 15018
     },
     "child.mjs": {
       "min": 369,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-media/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-media/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2004,
-      "brotli": 971
+      "min": 2012,
+      "brotli": 968
     },
     "child.mjs": {
       "min": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-multi-trigger/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-multi-trigger/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 51267,
-      "brotli": 15148
+      "min": 51277,
+      "brotli": 15150
     },
     "child.mjs": {
       "min": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-ssr-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-ssr-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 50491,
-      "brotli": 14954
+      "min": 50502,
+      "brotli": 14948
     },
     "child.mjs": {
       "min": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-ssr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-ssr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 50474,
-      "brotli": 14938
+      "min": 50485,
+      "brotli": 14948
     },
     "child.mjs": {
       "min": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-unmount-before-load/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 50491,
-      "brotli": 14954
+      "min": 50502,
+      "brotli": 14976
     },
     "child.mjs": {
       "min": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-visible/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-visible/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 50820,
-      "brotli": 15052
+      "min": 50829,
+      "brotli": 15109
     },
     "child.mjs": {
       "min": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1773,
-      "brotli": 865
+      "min": 1781,
+      "brotli": 873
     },
     "child.mjs": {
       "min": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3208,
-      "brotli": 1560
+      "min": 3259,
+      "brotli": 1581
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2788,
-      "brotli": 1393
+      "min": 2839,
+      "brotli": 1414
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3002,
-      "brotli": 1491
+      "min": 3053,
+      "brotli": 1524
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2527,
-        "brotli": 1281
+        "min": 2578,
+        "brotli": 1302
       },
       "files": {
         "tags/child.marko": 325,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2821,
-      "brotli": 1420
+      "min": 2872,
+      "brotli": 1442
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2682,
-      "brotli": 1355
+      "min": 2733,
+      "brotli": 1379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2685,
-      "brotli": 1376
+      "min": 2736,
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2863,
-      "brotli": 1415
+      "min": 2914,
+      "brotli": 1443
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3016,
-      "brotli": 1498
+      "min": 3067,
+      "brotli": 1526
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5814,
-      "brotli": 2654
+      "min": 5871,
+      "brotli": 2671
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2867,
-      "brotli": 1418
+      "min": 2918,
+      "brotli": 1446
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1983,
-      "brotli": 1024
+      "min": 1991,
+      "brotli": 1021
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7693,
-      "brotli": 3285
+      "min": 7728,
+      "brotli": 3297
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6720,
-      "brotli": 2954
+      "min": 6772,
+      "brotli": 2979
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9166,
-      "brotli": 3892
+      "min": 9201,
+      "brotli": 3901
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13253,
-        "brotli": 5082
+        "min": 13310,
+        "brotli": 5107
       },
       "files": {
         "tags/hello/index.marko": 196,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6407,
-        "brotli": 2598
+        "min": 6417,
+        "brotli": 2614
       },
       "files": {
         "tags/hello/index.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3264,
-      "brotli": 1628
+      "min": 3315,
+      "brotli": 1656
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1678,
-      "brotli": 897
+      "min": 1686,
+      "brotli": 902
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2874,
-      "brotli": 1426
+      "min": 2925,
+      "brotli": 1444
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3278,
-      "brotli": 1608
+      "min": 3329,
+      "brotli": 1631
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10198,
-      "brotli": 4256
+      "min": 10233,
+      "brotli": 4281
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7253,
-      "brotli": 3208
+      "min": 7305,
+      "brotli": 3224
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6723,
-      "brotli": 2977
+      "min": 6780,
+      "brotli": 3000
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7420,
-      "brotli": 3268
+      "min": 7472,
+      "brotli": 3293
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7589,
-      "brotli": 3338
+      "min": 7641,
+      "brotli": 3360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9048,
-      "brotli": 3810
+      "min": 9083,
+      "brotli": 3824
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3826,
-      "brotli": 1795
+      "min": 3877,
+      "brotli": 1823
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9057,
-      "brotli": 3816
+      "min": 9092,
+      "brotli": 3832
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9059,
-      "brotli": 3820
+      "min": 9094,
+      "brotli": 3833
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2807,
-        "brotli": 1397
+        "min": 2858,
+        "brotli": 1424
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2807,
-        "brotli": 1397
+        "min": 2858,
+        "brotli": 1425
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2939,
-        "brotli": 1443
+        "min": 2990,
+        "brotli": 1466
       },
       "files": {
         "tags/my-button.marko": 420,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2834,
-        "brotli": 1409
+        "min": 2885,
+        "brotli": 1434
       },
       "files": {
         "tags/my-button.marko": 344,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2807,
-        "brotli": 1397
+        "min": 2858,
+        "brotli": 1424
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3268,
-        "brotli": 1617
+        "min": 3319,
+        "brotli": 1642
       },
       "files": {
         "tags/my-button.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6136,
-      "brotli": 2772
+      "min": 6193,
+      "brotli": 2800
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6134,
-      "brotli": 2768
+      "min": 6191,
+      "brotli": 2788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2787,
-      "brotli": 1391
+      "min": 2838,
+      "brotli": 1412
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2884,
-      "brotli": 1444
+      "min": 2935,
+      "brotli": 1466
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-effect-no-deps/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-effect-no-deps/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1661,
-      "brotli": 882
+      "min": 1669,
+      "brotli": 886
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6166,
-      "brotli": 2788
+      "min": 6223,
+      "brotli": 2817
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2789,
-      "brotli": 1414
+      "min": 2840,
+      "brotli": 1433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2649,
-      "brotli": 1339
+      "min": 2700,
+      "brotli": 1366
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2867,
-      "brotli": 1427
+      "min": 2918,
+      "brotli": 1446
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2948,
-      "brotli": 1470
+      "min": 2999,
+      "brotli": 1494
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2893,
-      "brotli": 1460
+      "min": 2944,
+      "brotli": 1487
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2975,
-      "brotli": 1459
+      "min": 3026,
+      "brotli": 1483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7478,
-        "brotli": 3422
+        "min": 7535,
+        "brotli": 3429
       },
       "files": {
         "tags/child.marko": 154,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13824,
-        "brotli": 5321
+        "min": 13881,
+        "brotli": 5355
       },
       "files": {
         "tags/child.marko": 440,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3135,
-      "brotli": 1572
+      "min": 3186,
+      "brotli": 1592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4701,
-      "brotli": 2164
+      "min": 4752,
+      "brotli": 2184
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3114,
-      "brotli": 1539
+      "min": 3165,
+      "brotli": 1561
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6174,
-      "brotli": 2806
+      "min": 6231,
+      "brotli": 2830
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7152,
-      "brotli": 3251
+      "min": 7209,
+      "brotli": 3274
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7260,
-      "brotli": 3277
+      "min": 7317,
+      "brotli": 3301
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5812,
-      "brotli": 2650
+      "min": 5869,
+      "brotli": 2675
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6079,
-      "brotli": 2754
+      "min": 6136,
+      "brotli": 2781
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2798,
-      "brotli": 1418
+      "min": 2849,
+      "brotli": 1439
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3789,
-        "brotli": 1815
+        "min": 3840,
+        "brotli": 1835
       },
       "files": {
         "tags/counter.marko": 478,

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9215,
-        "brotli": 3528
+        "min": 9268,
+        "brotli": 3553
       },
       "files": {
         "tags/FancyButton.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2847,
-      "brotli": 1356
+      "min": 2855,
+      "brotli": 1364
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3775,
-      "brotli": 1798
+      "min": 3826,
+      "brotli": 1826
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4408,
-      "brotli": 2030
+      "min": 4461,
+      "brotli": 2050
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4294,
-      "brotli": 1987
+      "min": 4347,
+      "brotli": 2010
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4383,
-      "brotli": 2003
+      "min": 4436,
+      "brotli": 2025
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2843,
-      "brotli": 1422
+      "min": 2894,
+      "brotli": 1444
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7404,
-      "brotli": 3251
+      "min": 7456,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2037,
+      "min": 2045,
       "brotli": 1044
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1729,
-        "brotli": 901
+        "min": 1737,
+        "brotli": 903
       },
       "files": {
         "tags/child.marko": 115,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7728,
-        "brotli": 3505
+        "min": 7785,
+        "brotli": 3529
       },
       "files": {
         "tags/child.marko": 745,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7549,
-        "brotli": 3316
+        "min": 7606,
+        "brotli": 3340
       },
       "files": {
         "tags/child.marko": 757,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6053,
-      "brotli": 2755
+      "min": 6110,
+      "brotli": 2776
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6238,
-        "brotli": 2820
+        "min": 6295,
+        "brotli": 2845
       },
       "files": {
         "tags/child.marko": 387,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8178,
-        "brotli": 3692
+        "min": 8235,
+        "brotli": 3693
       },
       "files": {
         "tags/child.marko": 597,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7678,
-        "brotli": 3486
+        "min": 7735,
+        "brotli": 3509
       },
       "files": {
         "tags/child.marko": 639,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7482,
-        "brotli": 3292
+        "min": 7539,
+        "brotli": 3318
       },
       "files": {
         "tags/child.marko": 635,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6035,
-      "brotli": 2743
+      "min": 6092,
+      "brotli": 2766
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6220,
-        "brotli": 2812
+        "min": 6277,
+        "brotli": 2844
       },
       "files": {
         "tags/child.marko": 369,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-owner-scope-serialize-in-serialized-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1732,
-      "brotli": 911
+      "min": 1740,
+      "brotli": 917
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6105,
-      "brotli": 2765
+      "min": 6162,
+      "brotli": 2787
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2792,
-      "brotli": 1404
+      "min": 2843,
+      "brotli": 1431
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2877,
-        "brotli": 1437
+        "min": 2928,
+        "brotli": 1459
       },
       "files": {
         "tags/display-intersection.marko": 229,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2886,
-        "brotli": 1438
+        "min": 2937,
+        "brotli": 1463
       },
       "files": {
         "tags/counter.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15401,
-        "brotli": 6002
+        "min": 15458,
+        "brotli": 6053
       },
       "files": {
         "tags/sections.marko": 827,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5826,
-      "brotli": 2657
+      "min": 5883,
+      "brotli": 2678
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2663,
-      "brotli": 1351
+      "min": 2714,
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1986,
-      "brotli": 1021
+      "min": 1994,
+      "brotli": 1027
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2783,
-      "brotli": 1404
+      "min": 2834,
+      "brotli": 1423
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3194,
-        "brotli": 1600
+        "min": 3245,
+        "brotli": 1619
       },
       "files": {
         "tags/outer.marko": 162,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8388,
-      "brotli": 3712
+      "min": 8445,
+      "brotli": 3735
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8762,
-        "brotli": 3319
+        "min": 8815,
+        "brotli": 3336
       },
       "files": {
         "tags/checkbox.marko": 267,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4677,
-      "brotli": 2064
+      "min": 4730,
+      "brotli": 2084
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4417,
-      "brotli": 1964
+      "min": 4468,
+      "brotli": 1978
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9012,
-        "brotli": 3392
+        "min": 9065,
+        "brotli": 3404
       },
       "files": {
         "tags/radio.marko": 261,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4422,
-      "brotli": 1984
+      "min": 4473,
+      "brotli": 2008
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9015,
-        "brotli": 3394
+        "min": 9068,
+        "brotli": 3408
       },
       "files": {
         "tags/checkbox.marko": 267,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4422,
-      "brotli": 1984
+      "min": 4473,
+      "brotli": 2008
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3395,
-      "brotli": 1580
+      "min": 3446,
+      "brotli": 1610
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2756,
-      "brotli": 1371
+      "min": 2807,
+      "brotli": 1393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2756,
-      "brotli": 1371
+      "min": 2807,
+      "brotli": 1393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8183,
-      "brotli": 3531
+      "min": 8240,
+      "brotli": 3547
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4178,
-        "brotli": 1915
+        "min": 4229,
+        "brotli": 1941
       },
       "files": {
         "tags/custom-input.marko": 500,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4194,
-        "brotli": 1927
+        "min": 4247,
+        "brotli": 1952
       },
       "files": {
         "tags/my-input.marko": 511,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3915,
-      "brotli": 1816
+      "min": 3966,
+      "brotli": 1832
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8741,
-        "brotli": 3304
+        "min": 8794,
+        "brotli": 3323
       },
       "files": {
         "tags/my-input.marko": 237,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3887,
-      "brotli": 1814
+      "min": 3938,
+      "brotli": 1823
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8806,
-      "brotli": 3354
+      "min": 8859,
+      "brotli": 3371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13458,
-      "brotli": 5135
+      "min": 13515,
+      "brotli": 5157
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4413,
-      "brotli": 1958
+      "min": 4464,
+      "brotli": 1979
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9162,
-      "brotli": 3928
+      "min": 9219,
+      "brotli": 3963
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11793,
-        "brotli": 4403
+        "min": 11846,
+        "brotli": 4423
       },
       "files": {
         "tags/my-select.marko": 246,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4394,
-      "brotli": 1951
+      "min": 4445,
+      "brotli": 1974
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4183,
-      "brotli": 1846
+      "min": 4234,
+      "brotli": 1869
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8729,
-        "brotli": 3296
+        "min": 8782,
+        "brotli": 3314
       },
       "files": {
         "tags/my-textarea.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3887,
-      "brotli": 1814
+      "min": 3938,
+      "brotli": 1823
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2849,
-      "brotli": 1425
+      "min": 2900,
+      "brotli": 1447
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3376,
-        "brotli": 1656
+        "min": 3427,
+        "brotli": 1678
       },
       "files": {
         "tags/my-let.marko": 243,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2670,
-      "brotli": 1357
+      "min": 2721,
+      "brotli": 1403
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13388,
-        "brotli": 5146
+        "min": 13445,
+        "brotli": 5173
       },
       "files": {
         "tags/custom-tag.marko": 686,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13374,
-        "brotli": 5137
+        "min": 13431,
+        "brotli": 5170
       },
       "files": {
         "tags/custom-tag.marko": 524,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13286,
-        "brotli": 5103
+        "min": 13343,
+        "brotli": 5126
       },
       "files": {
         "tags/custom-tag.marko": 469,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-separate-assets/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1645,
-      "brotli": 876
+      "min": 1653,
+      "brotli": 879
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3019,
-        "brotli": 1471
+        "min": 3070,
+        "brotli": 1494
       },
       "files": {
         "tags/counter.marko": 396,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1924,
-        "brotli": 991
+        "min": 1932,
+        "brotli": 996
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3004,
-        "brotli": 1501
+        "min": 3055,
+        "brotli": 1523
       },
       "files": {
         "tags/child.marko": 387,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2762,
-        "brotli": 1392
+        "min": 2813,
+        "brotli": 1410
       },
       "files": {
         "tags/child.marko": 283,

--- a/packages/runtime-tags/src/__tests__/fixtures/debug-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/debug-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1648,
-      "brotli": 877
+      "min": 1656,
+      "brotli": 880
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9260,
-      "brotli": 3811
+      "min": 9317,
+      "brotli": 3836
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13222,
-        "brotli": 5068
+        "min": 13279,
+        "brotli": 5093
       },
       "files": {
         "tags/child.marko": 475,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2719,
-      "brotli": 1376
+      "min": 2770,
+      "brotli": 1399
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2691,
-      "brotli": 1360
+      "min": 2742,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2691,
-      "brotli": 1359
+      "min": 2742,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6555,
-      "brotli": 2975
+      "min": 6612,
+      "brotli": 2998
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6157,
-      "brotli": 2811
+      "min": 6214,
+      "brotli": 2831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2691,
-      "brotli": 1357
+      "min": 2742,
+      "brotli": 1388
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2673,
-      "brotli": 1357
+      "min": 2724,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1976
+      "min": 4730,
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1976
+      "min": 4730,
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7521,
-        "brotli": 3103
+        "min": 7574,
+        "brotli": 3125
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1976
+      "min": 4730,
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2896,
-      "brotli": 1442
+      "min": 2947,
+      "brotli": 1467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7293,
-        "brotli": 3328
+        "min": 7350,
+        "brotli": 3335
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6009,
-      "brotli": 2717
+      "min": 6066,
+      "brotli": 2742
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5813,
-      "brotli": 2706
+      "min": 5865,
+      "brotli": 2737
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1603,
-      "brotli": 854
+      "min": 1611,
+      "brotli": 860
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3150,
-      "brotli": 1570
+      "min": 3201,
+      "brotli": 1593
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5999,
-      "brotli": 2678
+      "min": 6052,
+      "brotli": 2694
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2666,
-      "brotli": 1351
+      "min": 2717,
+      "brotli": 1379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13153,
-      "brotli": 5052
+      "min": 13210,
+      "brotli": 5077
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13026,
-      "brotli": 4991
+      "min": 13083,
+      "brotli": 5016
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13997,
-        "brotli": 5362
+        "min": 14037,
+        "brotli": 5371
       },
       "files": {
         "tags/custom-tag.marko": 343,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13814,
-        "brotli": 5297
+        "min": 13854,
+        "brotli": 5304
       },
       "files": {
         "tags/custom-tag.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2951,
-      "brotli": 1461
+      "min": 3002,
+      "brotli": 1480
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13839,
-        "brotli": 5308
+        "min": 13879,
+        "brotli": 5324
       },
       "files": {
         "tags/child.marko": 323,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14076,
-        "brotli": 5389
+        "min": 14116,
+        "brotli": 5406
       },
       "files": {
         "tags/child1.marko": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13158,
-        "brotli": 5054
+        "min": 13215,
+        "brotli": 5078
       },
       "files": {
         "tags/my-tag.marko": 515,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6268,
-      "brotli": 2566
+      "min": 6278,
+      "brotli": 2573
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13859,
-        "brotli": 5308
+        "min": 13899,
+        "brotli": 5322
       },
       "files": {
         "tags/custom-tag.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13002,
-      "brotli": 4973
+      "min": 13059,
+      "brotli": 4995
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6268,
-      "brotli": 2566
+      "min": 6278,
+      "brotli": 2573
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2865,
-        "brotli": 1423
+        "min": 2916,
+        "brotli": 1441
       },
       "files": {
         "tags/counter.marko": 396,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4145,
-        "brotli": 1905
+        "min": 4194,
+        "brotli": 1931
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1661,
-      "brotli": 875
+      "min": 1669,
+      "brotli": 878
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13265,
-        "brotli": 5070
+        "min": 13322,
+        "brotli": 5091
       },
       "files": {
         "tags/counter.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6581,
-      "brotli": 2971
+      "min": 6638,
+      "brotli": 2995
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3376,
-      "brotli": 1667
+      "min": 3427,
+      "brotli": 1691
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2850,
-      "brotli": 1386
+      "min": 2858,
+      "brotli": 1393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2798,
-      "brotli": 1409
+      "min": 2849,
+      "brotli": 1427
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2904,
-      "brotli": 1451
+      "min": 2955,
+      "brotli": 1470
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8125,
-      "brotli": 3637
+      "min": 8182,
+      "brotli": 3660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7465,
-      "brotli": 3291
+      "min": 7522,
+      "brotli": 3315
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7133,
-      "brotli": 3239
+      "min": 7190,
+      "brotli": 3255
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7061,
-      "brotli": 3231
+      "min": 7118,
+      "brotli": 3277
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7001,
-      "brotli": 3218
+      "min": 7058,
+      "brotli": 3215
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2035,
-      "brotli": 1037
+      "min": 2043,
+      "brotli": 1036
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6818,
-      "brotli": 3098
+      "min": 6875,
+      "brotli": 3120
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6812,
-      "brotli": 3096
+      "min": 6869,
+      "brotli": 3139
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2881,
-      "brotli": 1439
+      "min": 2932,
+      "brotli": 1457
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6628,
-      "brotli": 3041
+      "min": 6685,
+      "brotli": 3062
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-normalize/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1696,
-      "brotli": 900
+      "min": 1704,
+      "brotli": 906
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-references-optional-member-normalize/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1899,
+      "min": 1907,
       "brotli": 953
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1995,
-      "brotli": 1026
+      "min": 2003,
+      "brotli": 1022
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2007,
-      "brotli": 1032
+      "min": 2015,
+      "brotli": 1034
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2007,
-      "brotli": 1029
+      "min": 2015,
+      "brotli": 1030
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7073,
-      "brotli": 3234
+      "min": 7130,
+      "brotli": 3273
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2284,
-        "brotli": 1153
+        "min": 2292,
+        "brotli": 1158
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13716,
-        "brotli": 5240
+        "min": 13773,
+        "brotli": 5271
       },
       "files": {
         "tags/thing.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2394,
-        "brotli": 1193
+        "min": 2402,
+        "brotli": 1195
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2440,
-        "brotli": 1196
+        "min": 2448,
+        "brotli": 1197
       },
       "files": {
         "tags/child.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2351,
-        "brotli": 1193
+        "min": 2359,
+        "brotli": 1196
       },
       "files": {
         "tags/child.marko": 109,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2228,
-        "brotli": 1118
+        "min": 2236,
+        "brotli": 1123
       },
       "files": {
         "tags/thing.marko": 106,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2400,
-        "brotli": 1181
+        "min": 2408,
+        "brotli": 1187
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14388,
-        "brotli": 5505
+        "min": 14428,
+        "brotli": 5521
       },
       "files": {
         "tags/child.marko": 351,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2394,
-        "brotli": 1193
+        "min": 2402,
+        "brotli": 1195
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2400,
-        "brotli": 1181
+        "min": 2408,
+        "brotli": 1187
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-script-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-script-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1655,
-      "brotli": 879
+      "min": 1663,
+      "brotli": 884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13449,
-        "brotli": 5138
+        "min": 13506,
+        "brotli": 5158
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2222,
-      "brotli": 1110
+      "min": 2230,
+      "brotli": 1114
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-minimum-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-minimum-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2293,
-      "brotli": 1116
+      "min": 2301,
+      "brotli": 1120
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1815,
-        "brotli": 933
+        "min": 1823,
+        "brotli": 934
       },
       "files": {
         "tags/child.marko": 109,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2067,
-        "brotli": 1055
+        "min": 2075,
+        "brotli": 1061
       },
       "files": {
         "tags/child.marko": 130,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2272,
-        "brotli": 1137
+        "min": 2280,
+        "brotli": 1144
       },
       "files": {
         "tags/child.marko": 151,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-only/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2044,
+      "min": 2052,
       "brotli": 1049
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2225,
-        "brotli": 1119
+        "min": 2233,
+        "brotli": 1124
       },
       "files": {
         "tags/child.marko": 125,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2709,
-      "brotli": 1365
+      "min": 2760,
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2467,
-        "brotli": 1247
+        "min": 2518,
+        "brotli": 1270
       },
       "files": {
         "tags/parent-el.marko": 225,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8896,
-      "brotli": 3695
+      "min": 8953,
+      "brotli": 3718
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2810,
-      "brotli": 1416
+      "min": 2861,
+      "brotli": 1438
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8885,
-      "brotli": 3683
+      "min": 8942,
+      "brotli": 3706
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2713,
-      "brotli": 1385
+      "min": 2764,
+      "brotli": 1403
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3083,
-      "brotli": 1529
+      "min": 3134,
+      "brotli": 1554
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5808,
-      "brotli": 2651
+      "min": 5865,
+      "brotli": 2673
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5979,
-      "brotli": 2713
+      "min": 6036,
+      "brotli": 2741
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5943,
-      "brotli": 2698
+      "min": 6000,
+      "brotli": 2724
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2976,
-      "brotli": 1476
+      "min": 3027,
+      "brotli": 1500
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2963,
-      "brotli": 1463
+      "min": 3014,
+      "brotli": 1487
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2770,
-      "brotli": 1396
+      "min": 2821,
+      "brotli": 1418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2770,
-      "brotli": 1396
+      "min": 2821,
+      "brotli": 1418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6357,
-      "brotli": 2892
+      "min": 6414,
+      "brotli": 2911
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6211,
-        "brotli": 2803
+        "min": 6268,
+        "brotli": 2829
       },
       "files": {
         "tags/test.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2001,
-      "brotli": 1031
+      "min": 2009,
+      "brotli": 1034
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4746,
-        "brotli": 1985
+        "min": 4754,
+        "brotli": 1987
       },
       "files": {
         "tags/child.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3156,
-      "brotli": 1580
+      "min": 3207,
+      "brotli": 1607
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2691,
-        "brotli": 1358
+        "min": 2742,
+        "brotli": 1387
       },
       "files": {
         "tags/child/index.marko": 104,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7410,
-        "brotli": 3357
+        "min": 7467,
+        "brotli": 3383
       },
       "files": {
         "tags/inner/index.marko": 1078,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2691,
-        "brotli": 1358
+        "min": 2742,
+        "brotli": 1387
       },
       "files": {
         "tags/child/index.marko": 110,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2815,
-        "brotli": 1426
+        "min": 2866,
+        "brotli": 1444
       },
       "files": {
         "tags/leaf.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1744,
-      "brotli": 905
+      "min": 1752,
+      "brotli": 909
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2691,
-        "brotli": 1358
+        "min": 2742,
+        "brotli": 1387
       },
       "files": {
         "tags/child-b/index.marko": 112,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2902,
-        "brotli": 1454
+        "min": 2953,
+        "brotli": 1473
       },
       "files": {
         "tags/child-a/index.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2799,
-      "brotli": 1405
+      "min": 2850,
+      "brotli": 1430
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7616,
-        "brotli": 3439
+        "min": 7673,
+        "brotli": 3489
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3086,
-        "brotli": 1519
+        "min": 3137,
+        "brotli": 1541
       },
       "files": {
         "tags/child.marko": 355,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3320,
-        "brotli": 1637
+        "min": 3371,
+        "brotli": 1657
       },
       "files": {
         "tags/let-global.marko": 574,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3047,
-      "brotli": 1509
+      "min": 3098,
+      "brotli": 1543
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3418,
-        "brotli": 1622
+        "min": 3469,
+        "brotli": 1642
       },
       "files": {
         "tags/child.marko": 1433,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3066,
-      "brotli": 1504
+      "min": 3117,
+      "brotli": 1535
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3009,
-      "brotli": 1489
+      "min": 3060,
+      "brotli": 1508
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2892,
-      "brotli": 1428
+      "min": 2943,
+      "brotli": 1451
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2656,
-      "brotli": 1353
+      "min": 2707,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2371,
-      "brotli": 1214
+      "min": 2422,
+      "brotli": 1241
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2958,
-      "brotli": 1467
+      "min": 3009,
+      "brotli": 1492
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2937,
-      "brotli": 1454
+      "min": 2988,
+      "brotli": 1484
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2342,
-      "brotli": 1202
+      "min": 2393,
+      "brotli": 1222
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-without-assignments/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-without-assignments/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1656,
-      "brotli": 882
+      "min": 1664,
+      "brotli": 888
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3006,
-      "brotli": 1491
+      "min": 3057,
+      "brotli": 1515
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6501,
-      "brotli": 2869
+      "min": 6558,
+      "brotli": 2887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2630,
-      "brotli": 1341
+      "min": 2681,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2934,
-      "brotli": 1460
+      "min": 2985,
+      "brotli": 1486
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2947,
-      "brotli": 1442
+      "min": 2998,
+      "brotli": 1466
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1645,
-      "brotli": 873
+      "min": 1653,
+      "brotli": 879
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2396,
-      "brotli": 1228
+      "min": 2447,
+      "brotli": 1245
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2330,
-      "brotli": 1198
+      "min": 2381,
+      "brotli": 1216
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3061,
-      "brotli": 1511
+      "min": 3112,
+      "brotli": 1531
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4165,
-      "brotli": 1947
+      "min": 4216,
+      "brotli": 1968
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3277,
-        "brotli": 1573
+        "min": 3328,
+        "brotli": 1597
       },
       "files": {
         "tags/2counters.marko": 951,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13825,
-      "brotli": 5278
+      "min": 13882,
+      "brotli": 5311
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14346,
-      "brotli": 5537
+      "min": 14403,
+      "brotli": 5577
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1773,
-      "brotli": 941
+      "min": 1781,
+      "brotli": 948
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1653,
-      "brotli": 882
+      "min": 1661,
+      "brotli": 887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1764,
-        "brotli": 942
+        "min": 1772,
+        "brotli": 943
       },
       "files": {
         "tags/hello-setter.marko": 128,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1651,
-      "brotli": 880
+      "min": 1659,
+      "brotli": 884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6399,
-        "brotli": 2602
+        "min": 6409,
+        "brotli": 2609
       },
       "files": {
         "tags/my-div.marko": 423,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-var-in-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1656,
-      "brotli": 880
+      "min": 1664,
+      "brotli": 884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2716,
-      "brotli": 1371
+      "min": 2767,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8498,
-      "brotli": 3824
+      "min": 8555,
+      "brotli": 3825
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2227,
-        "brotli": 1140
+        "min": 2276,
+        "brotli": 1164
       },
       "files": {
         "tags/child.marko": 225,

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2227,
-        "brotli": 1140
+        "min": 2276,
+        "brotli": 1164
       },
       "files": {
         "tags/child.marko": 225,

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3621,
-      "brotli": 1745
+      "min": 3672,
+      "brotli": 1771
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5715,
-      "brotli": 2611
+      "min": 5772,
+      "brotli": 2632
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6374,
-        "brotli": 2599
+        "min": 6384,
+        "brotli": 2607
       },
       "files": {
         "tags/my-button.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2680,
-      "brotli": 1359
+      "min": 2731,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2696,
-      "brotli": 1360
+      "min": 2747,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2763,
-      "brotli": 1364
+      "min": 2814,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1869,
-      "brotli": 966
+      "min": 1877,
+      "brotli": 972
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1976
+      "min": 4730,
+      "brotli": 1978
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7648,
-      "brotli": 3466
+      "min": 7705,
+      "brotli": 3490
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2734,
-        "brotli": 1356
+        "min": 2785,
+        "brotli": 1383
       },
       "files": {
         "tags/setter.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3376,
-        "brotli": 1656
+        "min": 3427,
+        "brotli": 1678
       },
       "files": {
         "tags/my-let.marko": 243,

--- a/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-value-registered/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1876,
-        "brotli": 990
+        "min": 1884,
+        "brotli": 996
       },
       "files": {
         "tags/getter.marko": 105,

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3309,
-      "brotli": 1584
+      "min": 3360,
+      "brotli": 1619
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2752,
-      "brotli": 1382
+      "min": 2803,
+      "brotli": 1407
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-no-references/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-no-references/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1818,
-      "brotli": 945
+      "min": 1826,
+      "brotli": 949
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag-value-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag-value-no-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1785,
-      "brotli": 937
+      "min": 1793,
+      "brotli": 939
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1674,
-      "brotli": 883
+      "min": 1682,
+      "brotli": 890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2681,
-      "brotli": 1353
+      "min": 2732,
+      "brotli": 1379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5545,
-      "brotli": 2346
+      "min": 5598,
+      "brotli": 2352
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2746,
-      "brotli": 1382
+      "min": 2797,
+      "brotli": 1408
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1986,
-      "brotli": 1021
+      "min": 1994,
+      "brotli": 1020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2921,
-      "brotli": 1449
+      "min": 2972,
+      "brotli": 1471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1695,
-      "brotli": 892
+      "min": 1703,
+      "brotli": 898
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2901,
-      "brotli": 1410
+      "min": 2952,
+      "brotli": 1430
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3250,
-        "brotli": 1500
+        "min": 3258,
+        "brotli": 1506
       },
       "files": {
         "tags/child.marko": 151,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6573,
-      "brotli": 2667
+      "min": 6583,
+      "brotli": 2681
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6348,
-        "brotli": 2584
+        "min": 6358,
+        "brotli": 2598
       },
       "files": {
         "tags/child.marko": 132,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6348,
-      "brotli": 2584
+      "min": 6358,
+      "brotli": 2596
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6344,
-        "brotli": 2577
+        "min": 6354,
+        "brotli": 2588
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1976
+      "min": 4730,
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14540,
-        "brotli": 5692
+        "min": 14597,
+        "brotli": 5709
       },
       "files": {
         "tags/child.marko": 879,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4771,
-        "brotli": 1998
+        "min": 4779,
+        "brotli": 2004
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4772,
-      "brotli": 1999
+      "min": 4780,
+      "brotli": 2004
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13324,
-        "brotli": 5103
+        "min": 13381,
+        "brotli": 5130
       },
       "files": {
         "tags/consumer.marko": 547,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1977,
-      "brotli": 1022
+      "min": 1985,
+      "brotli": 1020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1350
+      "min": 2713,
+      "brotli": 1374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2681,
-      "brotli": 1363
+      "min": 2732,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2662,
-      "brotli": 1351
+      "min": 2713,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14243,
-        "brotli": 5446
+        "min": 14283,
+        "brotli": 5465
       },
       "files": {
         "tags/a/index.marko": 376,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13683,
-      "brotli": 5257
+      "min": 13740,
+      "brotli": 5283
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2944,
-      "brotli": 1473
+      "min": 2995,
+      "brotli": 1497
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2962,
-      "brotli": 1472
+      "min": 3013,
+      "brotli": 1493
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6006,
-        "brotli": 2721
+        "min": 6063,
+        "brotli": 2742
       },
       "files": {
         "tags/child.marko": 178,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6230,
-        "brotli": 2816
+        "min": 6287,
+        "brotli": 2841
       },
       "files": {
         "tags/tree/index.marko": 645,

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3478,
-      "brotli": 1686
+      "min": 3529,
+      "brotli": 1707
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2603,
-      "brotli": 1317
+      "min": 2654,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3179,
-      "brotli": 1566
+      "min": 3230,
+      "brotli": 1597
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4722,
-      "brotli": 1974
+      "min": 4730,
+      "brotli": 1975
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3305,
-      "brotli": 1624
+      "min": 3356,
+      "brotli": 1649
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2730,
-      "brotli": 1372
+      "min": 2781,
+      "brotli": 1396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2875,
-      "brotli": 1441
+      "min": 2926,
+      "brotli": 1462
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6783,
-      "brotli": 3034
+      "min": 6840,
+      "brotli": 3052
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6783,
-      "brotli": 3034
+      "min": 6840,
+      "brotli": 3052
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2009,
-      "brotli": 1029
+      "min": 2017,
+      "brotli": 1026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7312,
-      "brotli": 3217
+      "min": 7369,
+      "brotli": 3242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6575,
-        "brotli": 2967
+        "min": 6632,
+        "brotli": 2986
       },
       "files": {
         "tags/counter.marko": 708,

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2759,
-      "brotli": 1379
+      "min": 2810,
+      "brotli": 1412
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9308,
-      "brotli": 3941
+      "min": 9343,
+      "brotli": 3946
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7005,
-      "brotli": 3143
+      "min": 7057,
+      "brotli": 3170
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5871,
-      "brotli": 2650
+      "min": 5921,
+      "brotli": 2671
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2950,
-      "brotli": 1460
+      "min": 3001,
+      "brotli": 1480
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2950,
-      "brotli": 1460
+      "min": 3001,
+      "brotli": 1480
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4336,
-      "brotli": 1967
+      "min": 4387,
+      "brotli": 1999
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3471,
-      "brotli": 1632
+      "min": 3522,
+      "brotli": 1651
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4330,
-      "brotli": 1967
+      "min": 4381,
+      "brotli": 1992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3972,
-      "brotli": 1863
+      "min": 4023,
+      "brotli": 1881
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4260,
-      "brotli": 1906
+      "min": 4311,
+      "brotli": 1929
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4266,
-      "brotli": 1914
+      "min": 4317,
+      "brotli": 1933
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4014,
-      "brotli": 1869
+      "min": 4065,
+      "brotli": 1894
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13446,
-      "brotli": 5174
+      "min": 13503,
+      "brotli": 5199
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2057,
-      "brotli": 1049
+      "min": 2065,
+      "brotli": 1054
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1983,
-      "brotli": 1020
+      "min": 1991,
+      "brotli": 1026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4753,
-      "brotli": 1988
+      "min": 4761,
+      "brotli": 1993
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2661,
-      "brotli": 1350
+      "min": 2712,
+      "brotli": 1375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2489,
-      "brotli": 1272
+      "min": 2540,
+      "brotli": 1297
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2686,
-      "brotli": 1355
+      "min": 2737,
+      "brotli": 1382
     }
   },
   "html": {

--- a/packages/runtime-tags/src/common/accessor.debug.ts
+++ b/packages/runtime-tags/src/common/accessor.debug.ts
@@ -60,6 +60,8 @@ export enum PendingRenderProp {
   Scope = "scope",
   Signal = "signal",
   Value = "value",
+  Gen = "gen",
+  Pending = "pending",
 }
 
 export enum ClosureSignalProp {

--- a/packages/runtime-tags/src/common/accessor.ts
+++ b/packages/runtime-tags/src/common/accessor.ts
@@ -60,6 +60,8 @@ export enum PendingRenderProp {
   Scope = "b",
   Signal = "c",
   Value = "d",
+  Gen = "e",
+  Pending = "f",
 }
 
 export enum ClosureSignalProp {

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -14,11 +14,12 @@ export type PendingRender = {
   [PendingRenderProp.Scope]: Scope;
   [PendingRenderProp.Signal]: Signal<any, any>;
   [PendingRenderProp.Value]: unknown;
+  [PendingRenderProp.Gen]: number;
+  [PendingRenderProp.Pending]?: 0 | 1;
 };
 
+let runId = 1;
 let pendingRenders: PendingRender[] = [];
-let pendingRendersLookup: Record<number, PendingRender> = {};
-let asyncRendersLookup: typeof pendingRendersLookup | undefined | 0;
 export const caughtError = new WeakSet<unknown[]>();
 export const placeholderShown = new WeakSet<unknown[]>();
 export let pendingEffects: unknown[] = [];
@@ -33,21 +34,27 @@ export function queueRender<T, U extends Scope = Scope>(
   value?: T,
   scopeKey = scope[AccessorProp.Id],
 ) {
-  const key = scopeKey * scopeKeyOffset + signalKey;
-  let render = signalKey >= 0 && pendingRendersLookup[key];
-  if (render) {
+  let render: PendingRender | undefined;
+  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
     render[PendingRenderProp.Value] = value;
+    if (
+      render[PendingRenderProp.Gen] === runId ||
+      (catchEnabled && render[PendingRenderProp.Pending])
+    ) {
+      return;
+    }
+    render[PendingRenderProp.Gen] = runId;
   } else {
-    queuePendingRender(
-      (render = {
-        [PendingRenderProp.Key]: key,
-        [PendingRenderProp.Scope]: scope,
-        [PendingRenderProp.Signal]: signal,
-        [PendingRenderProp.Value]: value,
-      }),
-    );
-    signalKey >= 0 && (pendingRendersLookup[key] = render);
+    render = {
+      [PendingRenderProp.Key]: scopeKey * scopeKeyOffset + signalKey,
+      [PendingRenderProp.Scope]: scope,
+      [PendingRenderProp.Signal]: signal,
+      [PendingRenderProp.Value]: value,
+      [PendingRenderProp.Gen]: runId,
+    };
+    if (signalKey >= 0) scope[signalKey + scopeKeyOffset] = render;
   }
+  queuePendingRender(render);
 }
 
 export function queuePendingRender(render: PendingRender) {
@@ -72,13 +79,12 @@ export function queueEffect<S extends Scope, T extends ExecFn<S>>(
 
 export function run() {
   const effects = pendingEffects;
-  asyncRendersLookup = {};
   try {
     rendering = 1;
     runRenders();
   } finally {
-    pendingRendersLookup = asyncRendersLookup;
-    asyncRendersLookup = rendering = 0;
+    runId++;
+    rendering = 0;
     pendingRenders = [];
     pendingEffects = [];
   }
@@ -97,20 +103,16 @@ export function queueAsyncRender<T, U extends Scope = Scope>(
 export function prepareEffects(fn: () => void): unknown[] {
   const prevRenders = pendingRenders;
   const prevEffects = pendingEffects;
-  const prevLookup = asyncRendersLookup;
   const preparedEffects = (pendingEffects = []);
   pendingRenders = [];
-  asyncRendersLookup = pendingRendersLookup;
-  pendingRendersLookup = {};
 
   try {
     rendering = 1;
     fn();
     runRenders();
   } finally {
+    runId++;
     rendering = 0;
-    pendingRendersLookup = asyncRendersLookup;
-    asyncRendersLookup = prevLookup;
     pendingRenders = prevRenders;
     pendingEffects = prevEffects;
   }
@@ -237,13 +239,12 @@ export function _enable_catch() {
           render[PendingRenderProp.Scope][AccessorProp.ClosestBranch];
         while (branch) {
           if (branch[AccessorProp.PendingRenders]) {
-            (asyncRendersLookup as typeof pendingRendersLookup)[
-              render[PendingRenderProp.Key]
-            ] = render;
+            render[PendingRenderProp.Pending] = 1;
             return branch[AccessorProp.PendingRenders].push(render);
           }
           branch = branch![AccessorProp.ParentBranch];
         }
+        render[PendingRenderProp.Pending] = 0;
         runRender(render);
       } catch (error) {
         renderCatch(render[PendingRenderProp.Scope], error);


### PR DESCRIPTION
Optimizes the CSR render queue by storing queue data on the scope itself instead of a shared pending object.