### PR TITLE
fix: improve void valid normalization of attributes across ssr/csr

### DIFF
--- a/.changeset/tidy-forks-cheer.md
+++ b/.changeset/tidy-forks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Normalize void and empty-string attribute values consistently across SSR and CSR. A generic dynamic attribute with an empty string now renders as a present (bare) attribute matching the server output, instead of being removed on the client. For controllable form values (`checkedValue`, `<select>`/`<option>` value), `null`/`undefined`/`false`/`""` are all treated as the same empty value, so a void binding matches an empty `value` or `<option value="">` placeholder — the same on the server and the client.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 23647,
-        "brotli": 8745
+        "min": 23654,
+        "brotli": 8738
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 393
       },
       "runtime": {
-        "min": 6486,
-        "brotli": 2830
+        "min": 6520,
+        "brotli": 2837
       },
       "total": {
-        "min": 7168,
-        "brotli": 3223
+        "min": 7202,
+        "brotli": 3230
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 104
       },
       "runtime": {
-        "min": 2735,
-        "brotli": 1333
+        "min": 2768,
+        "brotli": 1352
       },
       "total": {
-        "min": 2857,
-        "brotli": 1437
+        "min": 2890,
+        "brotli": 1456
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6486 (min) 2830 (brotli)
+// size: 6520 (min) 2837 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -91,6 +91,9 @@ function forOf(list, cb) {
     let i = 0;
     for (let item of list) cb(item, i++);
   }
+}
+function isNotVoid(value) {
+  return value != null && value !== !1;
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];
@@ -305,7 +308,7 @@ function _text(node, value) {
   node.data !== normalizedValue && (node.data = normalizedValue);
 }
 function normalizeAttrValue(value) {
-  if (value || value === 0) return value === !0 ? "" : value + "";
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function removeChildNodes(startNode, endNode) {
   let stop = endNode.nextSibling;

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2735 (min) 1333 (brotli)
+// size: 2768 (min) 1352 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -19,6 +19,9 @@ let decodeAccessor = (num) =>
   },
   runRender = (render) => render.c(render.b, render.d),
   catchEnabled;
+function isNotVoid(value) {
+  return value != null && value !== !1;
+}
 function _on(element, type, handler) {
   (element["$" + type] === void 0 &&
     defaultDelegator(element, type, handleDelegated),
@@ -214,7 +217,7 @@ function _text(node, value) {
   node.data !== normalizedValue && (node.data = normalizedValue);
 }
 function normalizeAttrValue(value) {
-  if (value || value === 0) return value === !0 ? "" : value + "";
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 23647 (min) 8745 (brotli)
+// size: 23654 (min) 8738 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -357,6 +357,9 @@ function isEventHandler(name) {
 }
 function getEventHandlerName(name) {
   return name[2] === "-" ? name.slice(3) : name.slice(2).toLowerCase();
+}
+function isNotVoid(value) {
+  return value != null && value !== !1;
 }
 function normalizeDynamicRenderer(value) {
   if (value) {
@@ -1021,7 +1024,7 @@ function _el(id, accessor) {
 }
 function _attr_input_checked_default(scope, nodeAccessor, checked) {
   let el = scope[nodeAccessor],
-    normalizedChecked = normalizeBoolProp(checked);
+    normalizedChecked = isNotVoid(checked);
   if (el.defaultChecked !== normalizedChecked) {
     let restoreValue = scope.H ? normalizedChecked : el.checked;
     ((el.defaultChecked = normalizedChecked),
@@ -1030,7 +1033,7 @@ function _attr_input_checked_default(scope, nodeAccessor, checked) {
 }
 function _attr_input_checked(scope, nodeAccessor, checked, checkedChange) {
   let el = scope[nodeAccessor],
-    normalizedChecked = normalizeBoolProp(checked);
+    normalizedChecked = isNotVoid(checked);
   ((scope["E" + nodeAccessor] = checkedChange),
     (scope["F" + nodeAccessor] = checkedChange ? 0 : 5),
     checkedChange && !scope.H
@@ -1058,7 +1061,7 @@ function _attr_input_checkedValue_default(
     normalizedCheckedValue = multiple
       ? checkedValue.map(normalizeStrProp)
       : normalizeStrProp(checkedValue);
-  (_attr(scope[nodeAccessor], "value", normalizedValue),
+  (_attr(scope[nodeAccessor], "value", value),
     _attr_input_checked_default(
       scope,
       nodeAccessor,
@@ -1076,22 +1079,21 @@ function _attr_input_checkedValue(
 ) {
   let el = scope[nodeAccessor],
     multiple = Array.isArray(checkedValue),
-    normalizedValue = normalizeStrProp(value),
     normalizedCheckedValue = (scope["G" + nodeAccessor] = multiple
       ? checkedValue.map(normalizeStrProp)
       : normalizeStrProp(checkedValue));
-  (_attr(el, "value", normalizedValue),
-    (scope["E" + nodeAccessor] = checkedValueChange),
+  ((scope["E" + nodeAccessor] = checkedValueChange),
     (scope["F" + nodeAccessor] = checkedValueChange ? 1 : 5),
     checkedValueChange && !scope.H
-      ? (el.checked = multiple
-          ? normalizedCheckedValue.includes(normalizedValue)
-          : normalizedValue === normalizedCheckedValue)
+      ? ((el.checked = multiple
+          ? normalizedCheckedValue.includes(normalizeStrProp(value))
+          : normalizeStrProp(value) === normalizedCheckedValue),
+        _attr(el, "value", value))
       : _attr_input_checkedValue_default(
           scope,
           nodeAccessor,
-          normalizedCheckedValue,
-          normalizedValue,
+          checkedValue,
+          value,
         ));
 }
 function _attr_input_checkedValue_script(scope, nodeAccessor) {
@@ -1125,7 +1127,7 @@ function _attr_input_checkedValue_script(scope, nodeAccessor) {
 }
 function _attr_input_value_default(scope, nodeAccessor, value) {
   let el = scope[nodeAccessor],
-    normalizedValue = normalizeStrProp(value);
+    normalizedValue = normalizeAttrValue(value) || "";
   if (el.defaultValue !== normalizedValue) {
     let restoreValue = scope.H ? normalizedValue : el.value;
     ((el.defaultValue = normalizedValue), setInputValue(el, restoreValue));
@@ -1133,7 +1135,7 @@ function _attr_input_value_default(scope, nodeAccessor, value) {
 }
 function _attr_input_value(scope, nodeAccessor, value, valueChange) {
   let el = scope[nodeAccessor],
-    normalizedValue = normalizeStrProp(value);
+    normalizedValue = normalizeAttrValue(value) || "";
   ((scope["E" + nodeAccessor] = valueChange),
     (scope["G" + nodeAccessor] = normalizedValue),
     (scope["F" + nodeAccessor] = valueChange ? 2 : 5),
@@ -1248,10 +1250,10 @@ function getSelectValue(el, multiple) {
     : el.value;
 }
 function _attr_details_or_dialog_open_default(scope, nodeAccessor, open) {
-  scope.H && (scope[nodeAccessor].open = normalizeBoolProp(open));
+  scope.H && (scope[nodeAccessor].open = isNotVoid(open));
 }
 function _attr_details_or_dialog_open(scope, nodeAccessor, open, openChange) {
-  let normalizedOpen = (scope["G" + nodeAccessor] = normalizeBoolProp(open));
+  let normalizedOpen = (scope["G" + nodeAccessor] = isNotVoid(open));
   ((scope["E" + nodeAccessor] = openChange),
     (scope["F" + nodeAccessor] = openChange ? 4 : 5),
     openChange && !scope.H
@@ -1309,9 +1311,6 @@ function hasFormElementChanged(el) {
 }
 function normalizeStrProp(value) {
   return normalizeAttrValue(value) || "";
-}
-function normalizeBoolProp(value) {
-  return value != null && value !== !1;
 }
 function updateList(arr, val, push) {
   let index = arr.indexOf(val);
@@ -1543,7 +1542,7 @@ function normalizeClientRender(value) {
   if (renderer && renderer.a) return renderer;
 }
 function normalizeAttrValue(value) {
-  if (value || value === 0) return value === !0 ? "" : value + "";
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function _lifecycle(scope, thisObj, index = 0) {
   let accessor = "K" + index,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68001,
-        "brotli": 21124
+        "min": 68005,
+        "brotli": 21167
       },
       "files": {
         "components/custom-tag.marko": 1121,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65750,
-        "brotli": 20196
+        "min": 65755,
+        "brotli": 20191
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67209,
-        "brotli": 20851
+        "min": 67210,
+        "brotli": 20817
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66794,
-        "brotli": 20565
+        "min": 66798,
+        "brotli": 20602
       },
       "files": {
         "tags/components/hello-internal.marko": 941,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65750,
-        "brotli": 20196
+        "min": 65755,
+        "brotli": 20191
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67520,
-        "brotli": 20919
+        "min": 67523,
+        "brotli": 20945
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67162,
-        "brotli": 20792
+        "min": 67163,
+        "brotli": 20784
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66073,
-        "brotli": 20394
+        "min": 66082,
+        "brotli": 20340
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65745,
-        "brotli": 20241
+        "min": 65752,
+        "brotli": 20202
       },
       "files": {
         "components/tags-layout.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 67629,
-        "brotli": 20990
+        "brotli": 20976
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66949,
-        "brotli": 20708
+        "min": 66950,
+        "brotli": 20678
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66100,
-        "brotli": 20389
+        "min": 66107,
+        "brotli": 20399
       },
       "files": {
         "components/tags-layout.marko": 922,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67987,
-        "brotli": 21138
+        "min": 67985,
+        "brotli": 21140
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13310,
-        "brotli": 5107
+        "min": 13315,
+        "brotli": 5111
       },
       "files": {
         "tags/hello/index.marko": 196,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2925,
-      "brotli": 1444
+      "min": 2958,
+      "brotli": 1468
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,14 @@
+// template.marko
+const $template = "<div></div><button type=button>toggle</button>";
+const $walks = " b b";
+const $value__script = _script("__tests__/template.marko_0_value", ($scope) => _on($scope["#button/1"], "click", function() {
+	$value($scope, $scope.value ? "" : "set");
+}));
+const $value = /* @__PURE__ */ _let("value/2", ($scope) => {
+	_attr($scope["#div/0"], "title", $scope.value);
+	$value__script($scope);
+});
+function $setup($scope) {
+	$value($scope, "");
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// template.marko
+const $value__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$value($scope, $scope.c ? "" : "set");
+}));
+const $value = /* @__PURE__ */ _let(2, ($scope) => {
+	_attr($scope.a, "title", $scope.c);
+	$value__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = "";
+	_html(`<div${_attr("title", value)}></div>${_el_resume($scope0_id, "#div/0")}<button type=button>toggle</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0_value");
+	writeScope($scope0_id, { value }, "__tests__/template.marko", 0, { value: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = "";
+	_html(`<div${_attr("title", value)}></div>${_el_resume($scope0_id, "a")}<button type=button>toggle</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: value });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/render.debug.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<div
+  title=""
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<div
+  title="set"
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: div[title] "" => "set"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<div
+  title=""
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: div[title] "set" => ""
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/render.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<div
+  title=""
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<div
+  title="set"
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: div[title] "" => "set"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<div
+  title=""
+/>
+<button
+  type="button"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: div[title] "set" => ""
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<div title></div><!--M_*1 #div/0--><button
+  type=button>toggle</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      value: ""
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/template.marko_0_value 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<div title></div><!--M_*1 a--><button type=button>toggle</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: ""
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2845,
+      "brotli": 1427
+    }
+  },
+  "html": {
+    "min": 387,
+    "brotli": 260
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/template.marko
@@ -1,0 +1,4 @@
+<let/value = ""/>
+
+<div title=value/>
+<button type="button" onClick() { value = value ? "" : "set" }>toggle</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+// A reactive attribute whose value is "" must render as a present (bare)
+// attribute, matching SSR, rather than being removed on the client. Toggling
+// moves it between "" and "set" to exercise the update path in both directions.
+function toggle(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, toggle, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2918,
-      "brotli": 1446
+      "min": 2951,
+      "brotli": 1471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13881,
-        "brotli": 5355
+        "min": 13887,
+        "brotli": 5357
       },
       "files": {
         "tags/child.marko": 440,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3165,
-      "brotli": 1561
+      "min": 3198,
+      "brotli": 1573
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7317,
-      "brotli": 3301
+      "min": 7352,
+      "brotli": 3314
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3840,
-        "brotli": 1835
+        "min": 3873,
+        "brotli": 1859
       },
       "files": {
         "tags/counter.marko": 478,

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9268,
-        "brotli": 3553
+        "min": 9273,
+        "brotli": 3551
       },
       "files": {
         "tags/FancyButton.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4461,
-      "brotli": 2050
+      "min": 4472,
+      "brotli": 2058
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4347,
-      "brotli": 2010
+      "min": 4358,
+      "brotli": 2023
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4436,
-      "brotli": 2025
+      "min": 4447,
+      "brotli": 2038
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15458,
-        "brotli": 6053
+        "min": 15463,
+        "brotli": 6032
       },
       "files": {
         "tags/sections.marko": 827,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8445,
-      "brotli": 3735
+      "min": 8444,
+      "brotli": 3741
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8815,
+        "min": 8820,
         "brotli": 3336
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+const $template = "<button>toggle</button><input><output> </output>";
+const $walks = " b bD l";
+const $v__OR__rest__script = _script("__tests__/template.marko_0_v_rest", ($scope) => _attrs_script($scope, "#input/1"));
+const $v__OR__rest = /* @__PURE__ */ _or(5, ($scope) => {
+	_attrs($scope, "#input/1", {
+		type: "checkbox",
+		checkedValue: $scope.v,
+		value: "",
+		...$scope.rest
+	});
+	$v__OR__rest__script($scope);
+});
+const $v__script = _script("__tests__/template.marko_0_v", ($scope) => _on($scope["#button/0"], "click", function() {
+	$v($scope, $scope.v === "" ? "x" : "");
+}));
+const $v = /* @__PURE__ */ _let("v/3", ($scope) => {
+	_text($scope["#text/2"], $scope.v === undefined ? "undefined" : "value=" + $scope.v);
+	$v__OR__rest($scope);
+	$v__script($scope);
+});
+const $rest = /* @__PURE__ */ _const("rest", $v__OR__rest);
+function $setup($scope) {
+	$v($scope, "");
+	$rest($scope, { placeholder: "p" });
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/dom.bundle.js
@@ -1,0 +1,19 @@
+// template.marko
+const $v__OR__rest__script = _script("a0", ($scope) => _attrs_script($scope, "b"));
+const $v__OR__rest = /* @__PURE__ */ _or(5, ($scope) => {
+	_attrs($scope, "b", {
+		type: "checkbox",
+		checkedValue: $scope.d,
+		value: "",
+		...$scope.e
+	});
+	$v__OR__rest__script($scope);
+});
+const $v__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$v($scope, $scope.d === "" ? "x" : "");
+}));
+const $v = /* @__PURE__ */ _let(3, ($scope) => {
+	_text($scope.c, $scope.d === void 0 ? "undefined" : "value=" + $scope.d);
+	$v__OR__rest($scope);
+	$v__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = "";
+	const rest = { placeholder: "p" };
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}<input${_attrs({
+		type: "checkbox",
+		checkedValue: v,
+		value: "",
+		...rest
+	}, "#input/1", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/1")}<output>${_escape(v === undefined ? "undefined" : "value=" + v)}${_el_resume($scope0_id, "#text/2")}</output>`);
+	_script($scope0_id, "__tests__/template.marko_0_v_rest");
+	_script($scope0_id, "__tests__/template.marko_0_v");
+	writeScope($scope0_id, {
+		v,
+		rest
+	}, "__tests__/template.marko", 0, {
+		v: "1:6",
+		rest: "2:8"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.js
@@ -1,0 +1,20 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = "";
+	const rest = { placeholder: "p" };
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}<input${_attrs({
+		type: "checkbox",
+		checkedValue: v,
+		value: "",
+		...rest
+	}, "b", $scope0_id, "input")}>${_el_resume($scope0_id, "b")}<output>${_escape(v === void 0 ? "undefined" : "value=" + v)}${_el_resume($scope0_id, "c")}</output>`);
+	_script($scope0_id, "a0");
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		d: v,
+		e: rest
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/render.debug.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<input
+  checked=""
+  placeholder="p"
+  type="checkbox"
+  value=""
+/>
+<output>
+  value=
+</output>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<input
+  checked=""
+  placeholder="p"
+  type="checkbox"
+  value=""
+/>
+<output>
+  value=x
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=" => "value=x"
+UPDATE: input[checked] "" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/render.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<input
+  checked=""
+  placeholder="p"
+  type="checkbox"
+  value=""
+/>
+<output>
+  value=
+</output>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<input
+  checked=""
+  placeholder="p"
+  type="checkbox"
+  value=""
+/>
+<output>
+  value=x
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=" => "value=x"
+UPDATE: input[checked] "" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<button>toggle</button><!--M_*1 #button/0--><input value checked type=checkbox
+  placeholder=p><!--M_*1 #input/1--><output>value=<!--M_*1 #text/2--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      v: "",
+      rest: {
+        placeholder: "p"
+      }
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/template.marko_0_v_rest 1 packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/template.marko_0_v 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>toggle</button><!--M_*1 a--><input value checked type=checkbox
+  placeholder=p><!--M_*1 b--><output>value=<!--M_*1 c--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: "",
+    e: {
+      placeholder: "p"
+    }
+  }], "a0 1 a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8883,
+      "brotli": 3374
+    }
+  },
+  "html": {
+    "min": 468,
+    "brotli": 289
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/template.marko
@@ -1,0 +1,5 @@
+<let/v = ""/>
+<const/rest = { placeholder: "p" }/>
+<button onClick() { v = v === "" ? "x" : "" }>toggle</button>
+<input type="checkbox" checkedValue=v value="" ...rest/>
+<output>${v === undefined ? "undefined" : "value=" + v}</output>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/test.ts
@@ -1,0 +1,15 @@
+import type { TestConfig } from "../../main.test";
+
+// A one-way `checkedValue=""` provided through a spread must still be routed to
+// the controlled-value logic. It is falsy, so the old truthy `data.checkedValue`
+// guard dropped it — leaking a bogus `checkedValue` attribute and never
+// computing `checked` on the server, while CSR did → hydration mismatch.
+// With `v = ""` the `value=""` checkbox is checked; toggling `v` to "x" unchecks
+// it (the binding no longer matches the empty value).
+function toggle(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<input type=checkbox><output> </output>";
+const $walks = " bD l";
+const $selected = /* @__PURE__ */ _let("selected/2", ($scope) => {
+	_attr_input_checkedValue($scope, "#input/0", $scope.selected, $checkedValueChange($scope), "");
+	_text($scope["#text/1"], $scope.selected === undefined ? "undefined" : $scope.selected === null ? "null" : "value=" + $scope.selected);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_checkedValue_script($scope, "#input/0"));
+function $setup($scope) {
+	$selected($scope, null);
+	$setup__script($scope);
+}
+function $checkedValueChange($scope) {
+	return (_new_selected) => {
+		$selected($scope, _new_selected);
+	};
+}
+_resume("__tests__/template.marko_0/checkedValueChange", $checkedValueChange);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $selected = /* @__PURE__ */ _let(2, ($scope) => {
+	_attr_input_checkedValue($scope, "a", $scope.c, $checkedValueChange($scope), "");
+	_text($scope.b, $scope.c === void 0 ? "undefined" : $scope.c === null ? "null" : "value=" + $scope.c);
+});
+const $setup__script = _script("a1", ($scope) => _attr_input_checkedValue_script($scope, "a"));
+function $checkedValueChange($scope) {
+	return (_new_selected) => {
+		$selected($scope, _new_selected);
+	};
+}
+_resume("a0", $checkedValueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = null;
+	_html(`<input${_attr_input_checkedValue($scope0_id, "#input/0", selected, _resume((_new_selected) => {
+		selected = _new_selected;
+	}, "__tests__/template.marko_0/checkedValueChange", $scope0_id), "")} type=checkbox>${_el_resume($scope0_id, "#input/0")}<output>${_escape(selected === undefined ? "undefined" : selected === null ? "null" : "value=" + selected)}${_el_resume($scope0_id, "#text/1")}</output>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = null;
+	_html(`<input${_attr_input_checkedValue($scope0_id, "a", selected, _resume((_new_selected) => {
+		selected = _new_selected;
+	}, "a0", $scope0_id), "")} type=checkbox>${_el_resume($scope0_id, "a")}<output>${_escape(selected === void 0 ? "undefined" : selected === null ? "null" : "value=" + selected)}${_el_resume($scope0_id, "b")}</output>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/render.debug.md
@@ -1,0 +1,35 @@
+# Render
+```html
+<input
+  checked=""
+  type="checkbox"
+  value=""
+/>
+<output>
+  null
+</output>
+```
+
+# Update
+```js
+container.querySelector("input").click();
+```
+```html
+<input
+  checked=""
+  type="checkbox"
+  value=""
+/>
+<output>
+  undefined
+</output>
+```
+## Change
+```
+UPDATE: output::text "null" => "undefined"
+```
+
+# Update
+```js
+container.querySelector("input").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/render.md
@@ -1,0 +1,35 @@
+# Render
+```html
+<input
+  checked=""
+  type="checkbox"
+  value=""
+/>
+<output>
+  null
+</output>
+```
+
+# Update
+```js
+container.querySelector("input").click();
+```
+```html
+<input
+  checked=""
+  type="checkbox"
+  value=""
+/>
+<output>
+  undefined
+</output>
+```
+## Change
+```
+UPDATE: output::text "null" => "undefined"
+```
+
+# Update
+```js
+container.querySelector("input").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<input value checked
+  type=checkbox><!--M_*1 #input/0--><output>null<!--M_*1 #text/1--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledType:#input/0": 1,
+      "ControlledHandler:#input/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/template.marko_0/checkedValueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<input value checked
+  type=checkbox><!--M_*1 a--><output>null<!--M_*1 b--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Fa: 1,
+    Ea: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 4340,
+      "brotli": 1961
+    }
+  },
+  "html": {
+    "min": 404,
+    "brotli": 272
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/template.marko
@@ -1,0 +1,8 @@
+<let/selected = null/>
+
+<input type="checkbox" checkedValue:=selected value=""/>
+<output>${selected === undefined
+  ? "undefined"
+  : selected === null
+    ? "null"
+    : "value=" + selected}</output>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/test.ts
@@ -1,0 +1,15 @@
+import type { TestConfig } from "../../main.test";
+
+// `null`/`undefined`/`""` are treated as the same empty value, so a `value=""`
+// checkbox bound to a void value renders/hydrates as checked (and stays checked
+// since unchecking sets the binding to `undefined`, which still matches `""`).
+// The `value=""` attribute must be present and consistent between SSR and CSR.
+// This is a degenerate case (`value=""` on a checkbox is an anti-pattern); the
+// point of the fixture is SSR/CSR consistency of the collapsed empty handling.
+function toggle(container: Element) {
+  container.querySelector("input")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, toggle, toggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4730,
-      "brotli": 2084
+      "min": 4727,
+      "brotli": 2090
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4468,
-      "brotli": 1978
+      "min": 4465,
+      "brotli": 1982
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9065,
-        "brotli": 3404
+        "min": 9070,
+        "brotli": 3403
       },
       "files": {
         "tags/radio.marko": 261,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4473,
-      "brotli": 2008
+      "min": 4470,
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9068,
-        "brotli": 3408
+        "min": 9073,
+        "brotli": 3405
       },
       "files": {
         "tags/checkbox.marko": 267,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4473,
-      "brotli": 2008
+      "min": 4470,
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3446,
-      "brotli": 1610
+      "brotli": 1631
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2807,
-      "brotli": 1393
+      "brotli": 1396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2807,
-      "brotli": 1393
+      "brotli": 1396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8240,
+      "min": 8238,
       "brotli": 3547
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4229,
-        "brotli": 1941
+        "min": 4240,
+        "brotli": 1956
       },
       "files": {
         "tags/custom-input.marko": 500,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4247,
-        "brotli": 1952
+        "min": 4258,
+        "brotli": 1960
       },
       "files": {
         "tags/my-input.marko": 511,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3966,
-      "brotli": 1832
+      "min": 3977,
+      "brotli": 1851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8794,
-        "brotli": 3323
+        "min": 8799,
+        "brotli": 3326
       },
       "files": {
         "tags/my-input.marko": 237,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3938,
-      "brotli": 1823
+      "min": 3949,
+      "brotli": 1840
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8859,
-      "brotli": 3371
+      "min": 8863,
+      "brotli": 3374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13515,
-      "brotli": 5157
+      "min": 13521,
+      "brotli": 5159
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,25 @@
+// template.marko
+const $template = "<select><option>-- choose --</option><option value=a>A</option><option value=b>B</option></select><output> </output>";
+const $walks = " D lD l";
+const $value = /* @__PURE__ */ _let("value/3", ($scope) => {
+	_attr_select_value($scope, "#select/0", $scope.value, $valueChange($scope));
+	_text($scope["#text/2"], $scope.value === undefined ? "undefined" : "value=" + $scope.value);
+});
+const $placeholder__script = _script("__tests__/template.marko_0_placeholder", ($scope) => _attrs_script($scope, "#option/1"));
+const $placeholder = /* @__PURE__ */ _const("placeholder", ($scope) => {
+	_attrs($scope, "#option/1", $scope.placeholder);
+	$placeholder__script($scope);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_select_value_script($scope, "#select/0"));
+function $setup($scope) {
+	$value($scope, "");
+	$placeholder($scope, { value: "" });
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const $value = /* @__PURE__ */ _let(3, ($scope) => {
+	_attr_select_value($scope, "a", $scope.d, $valueChange($scope));
+	_text($scope.c, $scope.d === void 0 ? "undefined" : "value=" + $scope.d);
+});
+const $placeholder__script = _script("a1", ($scope) => _attrs_script($scope, "b"));
+const $setup__script = _script("a2", ($scope) => _attr_select_value_script($scope, "a"));
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = "";
+	const placeholder = { value: "" };
+	_attr_select_value($scope0_id, "#select/0", value, _resume(function(v) {
+		value = v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id), () => {
+		_html(`<select><option${_attrs(placeholder, "#option/1", $scope0_id, "option")}>-- choose --</option>${_el_resume($scope0_id, "#option/1")}<option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
+	});
+	_html(`${_el_resume($scope0_id, "#select/0")}<output>${_escape(value === undefined ? "undefined" : "value=" + value)}${_el_resume($scope0_id, "#text/2")}</output>`);
+	_script($scope0_id, "__tests__/template.marko_0_placeholder");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { placeholder }, "__tests__/template.marko", 0, { placeholder: "2:8" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = "";
+	const placeholder = { value: "" };
+	_attr_select_value($scope0_id, "a", value, _resume(function(v) {
+		value = v;
+	}, "a0", $scope0_id), () => {
+		_html(`<select><option${_attrs(placeholder, "b", $scope0_id, "option")}>-- choose --</option>${_el_resume($scope0_id, "b")}<option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
+	});
+	_html(`${_el_resume($scope0_id, "a")}<output>${_escape(value === void 0 ? "undefined" : "value=" + value)}${_el_resume($scope0_id, "c")}</output>`);
+	_script($scope0_id, "a1");
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, { e: placeholder });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/render.debug.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<select>
+  <option
+    selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=
+</output>
+```
+
+# Update
+```js
+select(container, "a");
+```
+```html
+<select>
+  <option
+    default-selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    selected=""
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=a
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=" => "value=a"
+```
+
+# Update
+```js
+select(container, "");
+```
+```html
+<select>
+  <option
+    selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=a" => "value="
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/render.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<select>
+  <option
+    selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=
+</output>
+```
+
+# Update
+```js
+select(container, "a");
+```
+```html
+<select>
+  <option
+    default-selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    selected=""
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=a
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=" => "value=a"
+```
+
+# Update
+```js
+select(container, "");
+```
+```html
+<select>
+  <option
+    selected=""
+    value=""
+  >
+    -- choose --
+  </option>
+  <option
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+</select>
+<output>
+  value=
+</output>
+```
+## Change
+```
+UPDATE: output::text "value=a" => "value="
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/writes.debug.html
@@ -1,0 +1,20 @@
+<select>
+  <option value selected>-- choose --</option><!--M_*1 #option/1-->
+  <option value=a>A</option>
+  <option value=b>B</option>
+</select><!--M_*1 #select/0--><output>value=<!--M_*1 #text/2--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledType:#select/0": 3,
+      "ControlledHandler:#select/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/template.marko_0/valueChange"
+        ),
+      placeholder: {
+        value: ""
+      }
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/template.marko_0_placeholder 1 packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/writes.html
@@ -1,0 +1,16 @@
+<select>
+  <option value selected>-- choose --</option><!--M_*1 b-->
+  <option value=a>A</option>
+  <option value=b>B</option>
+</select><!--M_*1 a--><output>value=<!--M_*1 c--></output>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Fa: 3,
+    Ea: _(1, "a0"),
+    e: {
+      value: ""
+    }
+  }], "a1 1 a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6095,
+      "brotli": 2528
+    }
+  },
+  "html": {
+    "min": 515,
+    "brotli": 310
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/template.marko
@@ -1,0 +1,8 @@
+<let/value = ""/>
+<const/placeholder = { value: "" }/>
+<select value=value valueChange(v) { value = v }>
+  <option ...placeholder>-- choose --</option>
+  <option value="a">A</option>
+  <option value="b">B</option>
+</>
+<output>${value === undefined ? "undefined" : "value=" + value}</output>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/test.ts
@@ -1,0 +1,20 @@
+import type { TestConfig } from "../../main.test";
+
+// A spread `<option ...{ value: "" }>` must be marked selected when the
+// enclosing controlled <select> is bound to "". Previously SSR's `_attrs` used a
+// truthy check (`data.value`) and silently dropped the empty-string value, so
+// the option rendered unselected on the server while CSR selected it — a
+// hydration mismatch.
+function select(container: Element, value: string) {
+  const el = container.querySelector("select")!;
+  const window = el.ownerDocument.defaultView!;
+  el.value = value;
+  el.dispatchEvent(new window.Event("input", { bubbles: true }));
+}
+
+const selectA = (container: Element) => select(container, "a");
+const selectEmpty = (container: Element) => select(container, "");
+
+export const config: TestConfig = {
+  steps: [{}, selectA, selectEmpty],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4464,
-      "brotli": 1979
+      "min": 4497,
+      "brotli": 1993
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9219,
-      "brotli": 3963
+      "min": 9254,
+      "brotli": 3957
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11846,
-        "brotli": 4423
+        "min": 11850,
+        "brotli": 4424
       },
       "files": {
         "tags/my-select.marko": 246,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4445,
-      "brotli": 1974
+      "min": 4478,
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4234,
-      "brotli": 1869
+      "min": 4267,
+      "brotli": 1899
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8782,
-        "brotli": 3314
+        "min": 8787,
+        "brotli": 3318
       },
       "files": {
         "tags/my-textarea.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3938,
-      "brotli": 1823
+      "min": 3949,
+      "brotli": 1840
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13445,
-        "brotli": 5173
+        "min": 13451,
+        "brotli": 5167
       },
       "files": {
         "tags/custom-tag.marko": 686,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13431,
-        "brotli": 5170
+        "min": 13437,
+        "brotli": 5174
       },
       "files": {
         "tags/custom-tag.marko": 524,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13343,
-        "brotli": 5126
+        "min": 13349,
+        "brotli": 5133
       },
       "files": {
         "tags/custom-tag.marko": 469,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13279,
+        "min": 13284,
         "brotli": 5093
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13210,
-      "brotli": 5077
+      "min": 13216,
+      "brotli": 5076
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13083,
-      "brotli": 5016
+      "min": 13089,
+      "brotli": 5018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14037,
-        "brotli": 5371
+        "min": 14043,
+        "brotli": 5379
       },
       "files": {
         "tags/custom-tag.marko": 343,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13854,
-        "brotli": 5304
+        "min": 13860,
+        "brotli": 5310
       },
       "files": {
         "tags/custom-tag.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13879,
-        "brotli": 5324
+        "min": 13885,
+        "brotli": 5335
       },
       "files": {
         "tags/child.marko": 323,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14116,
-        "brotli": 5406
+        "min": 14122,
+        "brotli": 5405
       },
       "files": {
         "tags/child1.marko": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13215,
-        "brotli": 5078
+        "min": 13221,
+        "brotli": 5075
       },
       "files": {
         "tags/my-tag.marko": 515,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13899,
-        "brotli": 5322
+        "min": 13905,
+        "brotli": 5319
       },
       "files": {
         "tags/custom-tag.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13059,
-      "brotli": 4995
+      "min": 13065,
+      "brotli": 4990
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13322,
-        "brotli": 5091
+        "min": 13328,
+        "brotli": 5098
       },
       "files": {
         "tags/counter.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6875,
-      "brotli": 3120
+      "min": 6910,
+      "brotli": 3129
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6869,
-      "brotli": 3139
+      "min": 6904,
+      "brotli": 3128
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13773,
+        "min": 13779,
         "brotli": 5271
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14428,
-        "brotli": 5521
+        "min": 14434,
+        "brotli": 5525
       },
       "files": {
         "tags/child.marko": 351,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13506,
-        "brotli": 5158
+        "min": 13512,
+        "brotli": 5164
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8953,
-      "brotli": 3718
+      "min": 8988,
+      "brotli": 3713
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8942,
-      "brotli": 3706
+      "min": 8977,
+      "brotli": 3703
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3134,
-      "brotli": 1554
+      "min": 3167,
+      "brotli": 1568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3027,
-      "brotli": 1500
+      "min": 3060,
+      "brotli": 1516
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3014,
-      "brotli": 1487
+      "min": 3047,
+      "brotli": 1499
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4216,
-      "brotli": 1968
+      "min": 4227,
+      "brotli": 1978
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13882,
+      "min": 13888,
       "brotli": 5311
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14403,
-      "brotli": 5577
+      "min": 14409,
+      "brotli": 5575
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5598,
-      "brotli": 2352
+      "min": 5633,
+      "brotli": 2375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14597,
-        "brotli": 5709
+        "min": 14601,
+        "brotli": 5723
       },
       "files": {
         "tags/child.marko": 879,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13381,
-        "brotli": 5130
+        "min": 13387,
+        "brotli": 5135
       },
       "files": {
         "tags/consumer.marko": 547,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14283,
-        "brotli": 5465
+        "min": 14289,
+        "brotli": 5459
       },
       "files": {
         "tags/a/index.marko": 376,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13740,
-      "brotli": 5283
+      "min": 13746,
+      "brotli": 5292
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3529,
-      "brotli": 1707
+      "min": 3536,
+      "brotli": 1712
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3230,
+      "min": 3237,
       "brotli": 1597
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3356,
-      "brotli": 1649
+      "min": 3363,
+      "brotli": 1654
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7369,
-      "brotli": 3242
+      "min": 7380,
+      "brotli": 3238
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2810,
-      "brotli": 1412
+      "min": 2843,
+      "brotli": 1422
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3001,
-      "brotli": 1480
+      "brotli": 1494
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3001,
-      "brotli": 1480
+      "brotli": 1494
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4387,
-      "brotli": 1999
+      "min": 4384,
+      "brotli": 2002
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3522,
-      "brotli": 1651
+      "brotli": 1664
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4381,
-      "brotli": 1992
+      "min": 4378,
+      "brotli": 1997
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4023,
-      "brotli": 1881
+      "min": 4034,
+      "brotli": 1886
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4311,
-      "brotli": 1929
+      "min": 4344,
+      "brotli": 1940
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4317,
-      "brotli": 1933
+      "min": 4350,
+      "brotli": 1946
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4065,
-      "brotli": 1894
+      "min": 4076,
+      "brotli": 1897
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13503,
-      "brotli": 5199
+      "min": 13509,
+      "brotli": 5198
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/html-attrs.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-attrs.test.ts
@@ -94,6 +94,30 @@ describe("runtime-tags/html/attrs", () => {
     });
   });
 
+  describe("checkedValue", () => {
+    const checkedValue = (checkedValue: unknown, value: unknown) =>
+      helpers._attr_input_checkedValue(0, "a", checkedValue, undefined, value);
+
+    it("checks the input when the value matches", () => {
+      assert.equal(checkedValue("x", "x"), " value=x checked");
+    });
+
+    it("treats a void or empty-string checkedValue and value as the same", () => {
+      for (const empty of [null, undefined, false, ""]) {
+        assert.equal(checkedValue(empty, ""), " value checked");
+        assert.equal(checkedValue(empty, "x"), " value=x");
+      }
+      assert.equal(checkedValue("", null), " checked");
+    });
+
+    it("matches a member of a checkedValue array", () => {
+      assert.equal(checkedValue(["a", "b"], "b"), " value=b checked");
+      assert.equal(checkedValue(["a", "b"], "c"), " value=c");
+      assert.equal(checkedValue([], ""), " value");
+      assert.equal(checkedValue([null], ""), " value checked");
+    });
+  });
+
   describe("classAttr", () => {
     it("should return empty string for empty values", () => {
       for (const value of emptyValues) {

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -60,6 +60,10 @@ export function isVoid(value: unknown) {
   return value == null || value === false;
 }
 
+export function isNotVoid(value: unknown) {
+  return value != null && value !== false;
+}
+
 export function normalizeDynamicRenderer<Renderer>(
   value: any,
 ): Renderer | string | undefined {

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -1,3 +1,4 @@
+import { isNotVoid } from "../common/helpers";
 import {
   type Accessor,
   AccessorPrefix,
@@ -20,7 +21,7 @@ export function _attr_input_checked_default(
   checked: boolean,
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
-  const normalizedChecked = normalizeBoolProp(checked);
+  const normalizedChecked = isNotVoid(checked);
   if (el.defaultChecked !== normalizedChecked) {
     const restoreValue = scope[AccessorProp.Creating]
       ? normalizedChecked
@@ -38,7 +39,7 @@ export function _attr_input_checked(
   checkedChange: unknown,
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
-  const normalizedChecked = normalizeBoolProp(checked);
+  const normalizedChecked = isNotVoid(checked);
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = checkedChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = checkedChange
     ? ControlledType.InputChecked
@@ -80,7 +81,7 @@ export function _attr_input_checkedValue_default(
     ? checkedValue.map(normalizeStrProp)
     : normalizeStrProp(checkedValue);
 
-  _attr(scope[nodeAccessor] as HTMLInputElement, "value", normalizedValue);
+  _attr(scope[nodeAccessor] as HTMLInputElement, "value", value);
   _attr_input_checked_default(
     scope,
     nodeAccessor,
@@ -98,13 +99,11 @@ export function _attr_input_checkedValue(
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
   const multiple = Array.isArray(checkedValue);
-  const normalizedValue = normalizeStrProp(value);
   const normalizedCheckedValue = (scope[
     AccessorPrefix.ControlledValue + nodeAccessor
   ] = multiple
     ? checkedValue.map(normalizeStrProp)
     : normalizeStrProp(checkedValue));
-  _attr(el, "value", normalizedValue);
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = checkedValueChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = checkedValueChange
     ? ControlledType.InputCheckedValue
@@ -112,15 +111,11 @@ export function _attr_input_checkedValue(
 
   if (checkedValueChange && !scope[AccessorProp.Creating]) {
     el.checked = multiple
-      ? normalizedCheckedValue.includes(normalizedValue)
-      : normalizedValue === normalizedCheckedValue;
+      ? normalizedCheckedValue.includes(normalizeStrProp(value))
+      : normalizeStrProp(value) === normalizedCheckedValue;
+    _attr(el, "value", value);
   } else {
-    _attr_input_checkedValue_default(
-      scope,
-      nodeAccessor,
-      normalizedCheckedValue,
-      normalizedValue,
-    );
+    _attr_input_checkedValue_default(scope, nodeAccessor, checkedValue, value);
   }
 }
 export function _attr_input_checkedValue_script(
@@ -177,7 +172,7 @@ export function _attr_input_value_default(
   value: unknown,
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
-  const normalizedValue = normalizeStrProp(value);
+  const normalizedValue = normalizeAttrValue(value) || "";
   if (el.defaultValue !== normalizedValue) {
     const restoreValue = scope[AccessorProp.Creating]
       ? normalizedValue
@@ -193,7 +188,7 @@ export function _attr_input_value(
   valueChange: unknown,
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
-  const normalizedValue = normalizeStrProp(value);
+  const normalizedValue = normalizeAttrValue(value) || "";
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = valueChange;
   scope[AccessorPrefix.ControlledValue + nodeAccessor] = normalizedValue;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = valueChange
@@ -374,7 +369,7 @@ export function _attr_details_or_dialog_open_default(
   open: unknown,
 ) {
   if (scope[AccessorProp.Creating]) {
-    (scope[nodeAccessor] as HTMLDetailsElement).open = normalizeBoolProp(open);
+    (scope[nodeAccessor] as HTMLDetailsElement).open = isNotVoid(open);
   }
 }
 export function _attr_details_or_dialog_open(
@@ -384,7 +379,7 @@ export function _attr_details_or_dialog_open(
   openChange: unknown,
 ) {
   const normalizedOpen = (scope[AccessorPrefix.ControlledValue + nodeAccessor] =
-    normalizeBoolProp(open));
+    isNotVoid(open));
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = openChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = openChange
     ? ControlledType.DetailsOrDialogOpen
@@ -482,10 +477,6 @@ function hasFormElementChanged(el: Element) {
 
 function normalizeStrProp(value: unknown) {
   return normalizeAttrValue(value) || "";
-}
-
-function normalizeBoolProp(value: unknown) {
-  return value != null && value !== false;
 }
 
 function updateList(arr: unknown[], val: unknown, push: boolean) {

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -3,6 +3,7 @@ import {
   getEventHandlerName,
   htmlAttrNameReg,
   isEventHandler,
+  isNotVoid,
   normalizeDynamicRenderer,
   stringifyClassObject,
   stringifyStyleObject,
@@ -410,7 +411,7 @@ function normalizeClientRender(value: any) {
 }
 
 export function normalizeAttrValue(value: unknown) {
-  if (value || value === 0) {
+  if (isNotVoid(value)) {
     return value === true ? "" : value + "";
   }
 }

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -3,6 +3,7 @@ import {
   getEventHandlerName,
   htmlAttrNameReg,
   isEventHandler,
+  isNotVoid,
   isVoid,
   stringifyClassObject,
   stringifyStyleObject,
@@ -115,7 +116,7 @@ export function _attr_input_checked(
       checkedChange,
     );
   }
-  return normalizeBoolAttrValue(checked) ? " checked" : "";
+  return isNotVoid(checked) ? " checked" : "";
 }
 
 export function _attr_input_checkedValue(
@@ -161,13 +162,13 @@ export function _attr_details_or_dialog_open(
   open: unknown,
   openChange: unknown,
 ) {
-  const normalizedOpen = normalizeBoolAttrValue(open);
+  const normalizedOpen = isNotVoid(open);
   if (openChange) {
     writeControlledScope(
       ControlledType.DetailsOrDialogOpen,
       scopeId,
       nodeAccessor,
-      normalizedOpen,
+      normalizedOpen || undefined,
       openChange,
     );
   }
@@ -205,7 +206,7 @@ export function _attrs(
           data.checked,
           data.checkedChange,
         );
-      } else if (data.checkedValue || data.checkedValueChange) {
+      } else if ("checkedValue" in data || data.checkedValueChange) {
         result += _attr_input_checkedValue(
           scopeId,
           nodeAccessor,
@@ -227,12 +228,12 @@ export function _attrs(
       break;
     case "select":
     case "textarea":
-      if (data.value || data.valueChange) {
+      if ("value" in data || data.valueChange) {
         skip = /^value(?:Change)?$|[\s/>"'=]/;
       }
       break;
     case "option":
-      if (data.value) {
+      if ("value" in data) {
         result += _attr_option_value(data.value);
         skip = /^value$|[\s/>"'=]/;
       }
@@ -429,10 +430,4 @@ function normalizedValueMatches(a: unknown, b: unknown) {
 
 function normalizeStrAttrValue(value: unknown) {
   return (value && value !== true) || value === 0 ? value + "" : "";
-}
-
-function normalizeBoolAttrValue(value: unknown) {
-  if (value != null && value !== false) {
-    return true;
-  }
 }

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -1,6 +1,6 @@
 import { types as t } from "@marko/compiler";
 
-import { isVoid } from "../../common/helpers";
+import { isNotVoid, isVoid } from "../../common/helpers";
 import { WalkCode } from "../../common/types";
 import evaluate from "../util/evaluate";
 import { isNonHTMLText } from "../util/is-non-html-text";
@@ -222,7 +222,7 @@ function isStaticText(node?: t.Node) {
     case "MarkoPlaceholder": {
       if (node.escape) {
         const { confident, computed } = evaluate(node.value);
-        return confident && !isVoid(computed);
+        return confident && isNotVoid(computed);
       } else {
         return false;
       }


### PR DESCRIPTION
Normalize void and empty-string attribute values consistently across SSR and CSR. A generic dynamic attribute with an empty string now renders as a present (bare) attribute matching the server output, instead of being removed on the client. For controllable form values (`checkedValue`, `<select>`/`<option>` value), `null`/`undefined`/`false`/`""` are all treated as the same empty value, so a void binding matches an empty `value` or `<option value="">` placeholder which is the same on the server and the client.