### PR TITLE
fix(runtime-tags): preserve async/generator flags when normalizing methods

### DIFF
--- a/.changeset/quick-otters-cheer.md
+++ b/.changeset/quick-otters-cheer.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `async` method-shorthand event handlers (e.g. `async onClick() { … }`) being normalized with their `async` and `generator` flags swapped. The handler was rewritten as a non-async generator, so any `await` inside it failed to compile (`` `await` is only allowed within async functions ``). The flags are now preserved.

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,18 @@
+// template.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $loaded = /* @__PURE__ */ _let("loaded/2", ($scope) => _text($scope["#text/1"], $scope.loaded));
+const $handlers2 = ($scope, handlers) => $handlers_load($scope, handlers.load);
+function $setup($scope) {
+	$loaded($scope, "no");
+	$handlers2($scope, { load: $handlers($scope) });
+}
+const $handlers_load__script = _script("__tests__/template.marko_0_handlers_load", ($scope) => _on($scope["#button/0"], "click", $scope.handlers_load));
+const $handlers_load = /* @__PURE__ */ _const("handlers_load", $handlers_load__script);
+function $handlers($scope) {
+	return async function() {
+		$loaded($scope, await Promise.resolve("yes"));
+	};
+}
+_resume("__tests__/template.marko_0/handlers", $handlers);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $loaded = /* @__PURE__ */ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $handlers_load = /* @__PURE__ */ _const(4, _script("a1", ($scope) => _on($scope.a, "click", $scope.e)));
+function $handlers($scope) {
+	return async function() {
+		$loaded($scope, await Promise.resolve("yes"));
+	};
+}
+_resume("a0", $handlers);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loaded = "no";
+	const handlers = { load: _resume(async function() {
+		loaded = await Promise.resolve("yes");
+	}, "__tests__/template.marko_0/handlers", $scope0_id) };
+	_html(`<button>${_escape(loaded)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_handlers_load");
+	writeScope($scope0_id, { handlers_load: handlers.load }, "__tests__/template.marko", 0, { handlers_load: ["handlers.load", "4:8"] });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loaded = "no";
+	const handlers = { load: _resume(async function() {
+		loaded = await Promise.resolve("yes");
+	}, "a0", $scope0_id) };
+	_html(`<button>${_escape(loaded)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, { e: handlers.load });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/render.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  no
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  yes
+</button>
+```
+## Change
+```
+UPDATE: button::text "no" => "yes"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/render.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  no
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  yes
+</button>
+```
+## Change
+```
+UPDATE: button::text "no" => "yes"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button>no<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      handlers_load: _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/template.marko_0/handlers"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/template.marko_0_handlers_load 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<button>no<!--M_*1 b--></button><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2748,
+      "brotli": 1387
+    }
+  },
+  "html": {
+    "min": 361,
+    "brotli": 254
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/template.marko
@@ -1,0 +1,7 @@
+export interface Input {}
+
+<let/loaded="no"/>
+<const/handlers={
+  async load() { loaded = await Promise.resolve("yes"); }
+}/>
+<button onClick=handlers.load>${loaded}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+// An `async` method-shorthand handler must keep its `async` flag through
+// function normalization (it would otherwise become a generator and its
+// `await` would fail to compile).
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/util/simplify-fn.ts
+++ b/packages/runtime-tags/src/translator/util/simplify-fn.ts
@@ -16,8 +16,8 @@ export function simplifyFunction(
         null,
         fn.params as t.FunctionDeclaration["params"],
         fn.body,
-        fn.async,
         fn.generator,
+        fn.async,
       );
   }
 }


### PR DESCRIPTION
## Problem

`simplifyFunction` (`src/translator/util/simplify-fn.ts`) normalizes method-shorthand functions (`ObjectMethod`/`ClassMethod`) into a `FunctionExpression`:

```ts
t.functionExpression(null, fn.params, fn.body, fn.async, fn.generator)
```

Babel's signature is `functionExpression(id, params, body, generator, async)`, so `fn.async` and `fn.generator` are passed in each other's slots. A method-shorthand handler authored as `async run() { … }` is rewritten as a non-async **generator**, so its `await` lands in a non-async function and the generated module fails to build:

```
[PARSE_ERROR] `await` is only allowed within async functions ...
```

(The arrow/function-expression forms are unaffected — they hit `simplifyFunction`'s early return and keep their flags.)

## Fix

Pass the flags in the correct order: `(null, fn.params, fn.body, fn.generator, fn.async)`.

## Test

New fixture `const-async-method-handler` uses an `async` method-shorthand event handler. It goes red→green: without the fix the bundle fails to compile; with it the handler awaits and updates state (`no` → `yes`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_