### PR TITLE
fix(runtime-tags): keep scope identity for nullish `<for by>` keys

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+const $template = "<ul></ul><button>same</button>";
+const $walks = " b b";
+const $for_content__item_id = ($scope, item_id) => _text($scope["#text/0"], item_id ?? "?");
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for_content__item = ($scope, item) => $for_content__item_id($scope, item?.id);
+const $for = /* @__PURE__ */ _for_of("#ul/0", "<li> </li>", "D l", 0, $for_content__$params);
+const $items__script = _script("__tests__/template.marko_0_items", ($scope) => _on($scope["#button/1"], "click", function() {
+	$items($scope, [...$scope.items]);
+}));
+const $items = /* @__PURE__ */ _let("items/2", ($scope) => {
+	$for($scope, [$scope.items, (item) => item.id]);
+	$items__script($scope);
+});
+function $setup($scope) {
+	$items($scope, [
+		{ id: "a" },
+		{ id: undefined },
+		{ id: "b" }
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $for_content__item_id = ($scope, item_id) => _text($scope.a, item_id ?? "?");
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for_content__item = ($scope, item) => $for_content__item_id($scope, item?.id);
+const $for = /* @__PURE__ */ _for_of(0, "<li> </li>", "D l", 0, $for_content__$params);
+const $items__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$items($scope, [...$scope.c]);
+}));
+const $items = /* @__PURE__ */ _let(2, ($scope) => {
+	$for($scope, [$scope.c, (item) => item.id]);
+	$items__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,20 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{ id: "a" },
+		{ id: undefined },
+		{ id: "b" }
+	];
+	_html("<ul>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(item.id ?? "?")}${_el_resume($scope1_id, "#text/0")}</li>`);
+		writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
+	}, (item) => item.id, $scope0_id, "#ul/0", 1, 1, 1, "</ul>", 1);
+	_html(`<button>same</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0_items");
+	writeScope($scope0_id, { items }, "__tests__/template.marko", 0, { items: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/html.bundle.js
@@ -1,0 +1,20 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{ id: "a" },
+		{ id: void 0 },
+		{ id: "b" }
+	];
+	_html("<ul>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(item.id ?? "?")}${_el_resume($scope1_id, "a")}</li>`);
+		writeScope($scope1_id, {});
+	}, (item) => item.id, $scope0_id, "a", 1, 1, 1, "</ul>", 1);
+	_html(`<button>same</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: items });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/render.debug.md
@@ -1,0 +1,22 @@
+# Render
+```html
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    ?
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+<button>
+  same
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/render.md
@@ -1,0 +1,22 @@
+# Render
+```html
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    ?
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+<button>
+  same
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<ul>
+  <li>a<!--M_*2 #text/0--></li>
+  <li>?<!--M_*3 #text/0--></li>
+  <li>b<!--M_*4 #text/0--></li><!--M_}1 #ul/0 4 3 2-->
+</ul><button>same</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      items: [{
+        id: "a"
+      }, {}, {
+        id: "b"
+      }]
+    }, {
+      "#LoopKey": "a"
+    }, 1, {
+      "#LoopKey": "b"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/template.marko_0_items 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/__snapshots__/writes.html
@@ -1,0 +1,20 @@
+<ul>
+  <li>a<!--M_*2 a--></li>
+  <li>?<!--M_*3 a--></li>
+  <li>b<!--M_*4 a--></li><!--M_}1 a 4 3 2-->
+</ul><button>same</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: [{
+      id: "a"
+    }, {}, {
+      id: "b"
+    }]
+  }, {
+    M: "a"
+  }, 1, {
+    M: "b"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7048,
+      "brotli": 3233
+    }
+  },
+  "html": {
+    "min": 478,
+    "brotli": 303
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/template.marko
@@ -1,0 +1,7 @@
+<let/items=[{ id: "a" }, { id: undefined }, { id: "b" }]/>
+<ul>
+  <for|item| of=items by=(item => item.id)>
+    <li>${item.id ?? "?"}</li>
+  </for>
+</ul>
+<button onClick() { items = [...items] }>same</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-by-nullish-key/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+// Re-rendering an identical list must reuse every branch (no DOM churn), even
+// for an item whose `by` key is nullish. The Change log after clicking should
+// be empty.
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -632,6 +632,7 @@ function loop<T extends unknown[] = unknown[]>(
         var seenKeys = new Set<unknown>();
       }
 
+      let index = 0;
       forEach(value, (key, args) => {
         if (MARKO_DEBUG) {
           if (seenKeys.has(key)) {
@@ -644,14 +645,17 @@ function loop<T extends unknown[] = unknown[]>(
           }
         }
 
+        // A nullish key falls back to its position, matching how the lookup
+        // map is built below, so such items keep their scope across renders.
+        const lookupKey = key ?? index;
         let branch =
           oldLen &&
           (oldScopesByKey ||= oldScopes.reduce(
             (map, scope, i) => map.set(scope[AccessorProp.LoopKey] ?? i, scope),
             new Map<unknown, BranchScope>(),
-          )).get(key);
+          )).get(lookupKey);
         if (branch) {
-          hasPotentialMoves = oldScopesByKey!.delete(key);
+          hasPotentialMoves = oldScopesByKey!.delete(lookupKey);
         } else {
           branch = createAndSetupBranch(
             scope[AccessorProp.Global],
@@ -663,6 +667,7 @@ function loop<T extends unknown[] = unknown[]>(
         branch[AccessorProp.LoopKey] = key;
         newScopes.push(branch);
         params?.(branch, args);
+        index++;
       });
 
       const newLen = newScopes.length;


### PR DESCRIPTION
## Problem

The keyed `<for>` DOM reconciler (`src/dom/control-flow.ts`) builds its old-scope lookup map with a positional fallback for nullish keys:

```js
oldScopes.reduce((map, scope, i) => map.set(scope[LoopKey] ?? i, scope), new Map())
```

…but then looks branches up by the **raw** `by()` result (`.get(key)`). So an item whose `by` returns `null`/`undefined` is stored under its index yet looked up under `undefined`, never matches, and its branch is destroyed and recreated on every update — losing DOM node identity and local component state, with needless churn.

## Fix

Apply the same positional fallback on the lookup side (`key ?? index`, where `index` tracks the item position to mirror the map's `?? i`). This only changes behavior for nullish keys — for any non-nullish key `key ?? index === key`, so normal keyed lists are unaffected.

## Test

New fixture `for-tag-by-nullish-key` has a 3-item list whose middle item's `by` key is `undefined`. Re-rendering an identical list goes red→green: without the fix the middle `<li>` is removed and re-inserted (churn in the Change log); with the fix the update produces no DOM mutations. Verified against the existing reorder/keyed-`for` fixtures (88 passing) for regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_