### PR TITLE
fix(runtime-tags): clear spread event handlers removed between renders

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,43 @@
+// template.marko
+const $template = "<div><!>:<!></div>";
+const $walks = " D%c%l";
+const $attrs4__script = _script("__tests__/template.marko_0_attrs", ($scope) => _attrs_script($scope, "#div/0"));
+const $attrs4 = /* @__PURE__ */ _const("attrs", ($scope) => {
+	_attrs($scope, "#div/0", $scope.attrs);
+	$attrs4__script($scope);
+});
+const $phase__OR__log = /* @__PURE__ */ _or(5, ($scope) => $attrs4($scope, $scope.phase === 0 ? {
+	onClick: $attrs($scope),
+	onMouseOver: $attrs2($scope)
+} : { onClick: $attrs3($scope) }));
+const $phase = /* @__PURE__ */ _let("phase/3", ($scope) => {
+	_text($scope["#text/1"], $scope.phase);
+	$phase__OR__log($scope);
+});
+const $log = /* @__PURE__ */ _let("log/4", ($scope) => {
+	_text($scope["#text/2"], $scope.log);
+	$phase__OR__log($scope);
+});
+function $setup($scope) {
+	$phase($scope, 0);
+	$log($scope, "");
+}
+function $attrs3($scope) {
+	return function() {
+		$phase($scope, 0);
+	};
+}
+function $attrs2($scope) {
+	return function() {
+		$log($scope, `${$scope.log}M`);
+	};
+}
+function $attrs($scope) {
+	return function() {
+		$phase($scope, 1);
+	};
+}
+_resume("__tests__/template.marko_0/attrs3", $attrs3);
+_resume("__tests__/template.marko_0/attrs2", $attrs2);
+_resume("__tests__/template.marko_0/attrs", $attrs);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,36 @@
+// template.marko
+const $attrs4__script = _script("a3", ($scope) => _attrs_script($scope, "a"));
+const $attrs4 = /* @__PURE__ */ _const(6, ($scope) => {
+	_attrs($scope, "a", $scope.g);
+	$attrs4__script($scope);
+});
+const $phase__OR__log = /* @__PURE__ */ _or(5, ($scope) => $attrs4($scope, $scope.d === 0 ? {
+	onClick: $attrs($scope),
+	onMouseOver: $attrs2($scope)
+} : { onClick: $attrs3($scope) }));
+const $phase = /* @__PURE__ */ _let(3, ($scope) => {
+	_text($scope.b, $scope.d);
+	$phase__OR__log($scope);
+});
+const $log = /* @__PURE__ */ _let(4, ($scope) => {
+	_text($scope.c, $scope.e);
+	$phase__OR__log($scope);
+});
+function $attrs3($scope) {
+	return function() {
+		$phase($scope, 0);
+	};
+}
+function $attrs2($scope) {
+	return function() {
+		$log($scope, `${$scope.e}M`);
+	};
+}
+function $attrs($scope) {
+	return function() {
+		$phase($scope, 1);
+	};
+}
+_resume("a2", $attrs3);
+_resume("a1", $attrs2);
+_resume("a0", $attrs);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let phase = 0;
+	let log = "";
+	const attrs = phase === 0 ? {
+		onClick: _resume(function() {
+			phase = 1;
+		}, "__tests__/template.marko_0/attrs", $scope0_id),
+		onMouseOver: _resume(function() {
+			log = `${log}M`;
+		}, "__tests__/template.marko_0/attrs2", $scope0_id)
+	} : { onClick: _resume(function() {
+		phase = 0;
+	}, "__tests__/template.marko_0/attrs3", $scope0_id) };
+	_html(`<div${_attrs(attrs, "#div/0", $scope0_id, "div")}>${_escape(phase)}${_el_resume($scope0_id, "#text/1")}:<!>${_escape(log)}${_el_resume($scope0_id, "#text/2")}</div>${_el_resume($scope0_id, "#div/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_attrs");
+	writeScope($scope0_id, {
+		phase,
+		log
+	}, "__tests__/template.marko", 0, {
+		phase: "3:6",
+		log: "4:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let phase = 0;
+	let log = "";
+	_html(`<div${_attrs(phase === 0 ? {
+		onClick: _resume(function() {
+			phase = 1;
+		}, "a0", $scope0_id),
+		onMouseOver: _resume(function() {
+			log = `${log}M`;
+		}, "a1", $scope0_id)
+	} : { onClick: _resume(function() {
+		phase = 0;
+	}, "a2", $scope0_id) }, "a", $scope0_id, "div")}>${_escape(phase)}${_el_resume($scope0_id, "b")}:<!>${_escape(log)}${_el_resume($scope0_id, "c")}</div>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a3");
+	writeScope($scope0_id, {
+		d: phase,
+		e: log
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/render.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  0:
+</div>
+```
+
+# Update
+```js
+container.querySelector("div").click();
+```
+```html
+<div>
+  1:
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "0" => "1"
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+div.dispatchEvent(new container.ownerDocument.defaultView.MouseEvent("mouseover", {
+  bubbles: true
+}));
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/__snapshots__/render.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  0:
+</div>
+```
+
+# Update
+```js
+container.querySelector("div").click();
+```
+```html
+<div>
+  1:
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "0" => "1"
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+div.dispatchEvent(new container.ownerDocument.defaultView.MouseEvent("mouseover", {
+  bubbles: true
+}));
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/sizes.json
@@ -1,0 +1,8 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 9138,
+      "brotli": 3445
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/template.marko
@@ -1,0 +1,9 @@
+export interface Input {}
+
+<let/phase=0/>
+<let/log=""/>
+<const/attrs = phase === 0
+  ? { onClick() { phase = 1 }, onMouseOver() { log = `${log}M` } }
+  : { onClick() { phase = 0 } }
+/>
+<div ...attrs>${phase}:${log}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attrs-remove-event-handler/test.ts
@@ -1,0 +1,22 @@
+import type { TestConfig } from "../../main.test";
+
+// An event handler dropped from a spread between renders must stop firing.
+// Clicking removes `onMouseOver` from the spread; the following mouseover must
+// be a no-op (log stays empty).
+function click(container: Element) {
+  container.querySelector("div")!.click();
+}
+
+function mouseover(container: Element) {
+  const div = container.querySelector("div")!;
+  div.dispatchEvent(
+    new container.ownerDocument!.defaultView!.MouseEvent("mouseover", {
+      bubbles: true,
+    }),
+  );
+}
+
+export const config: TestConfig = {
+  skip_ssr: true,
+  steps: [{}, click, mouseover],
+};

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -216,6 +216,10 @@ function attrsInternal(
   nextAttrs: Record<string, unknown>,
 ) {
   const el = scope[nodeAccessor] as Element;
+  const eventsAccessor = AccessorPrefix.EventAttributes + nodeAccessor;
+  const prevEvents = scope[eventsAccessor] as
+    | undefined
+    | Record<string, unknown>;
   let events: undefined | Record<string, unknown>;
   let skip: RegExp | undefined;
   switch (el.tagName) {
@@ -304,8 +308,7 @@ function attrsInternal(
         }
 
         if (isEventHandler(name)) {
-          (events ||= scope[AccessorPrefix.EventAttributes + nodeAccessor] =
-            {})[getEventHandlerName(name)] = value;
+          (events ||= {})[getEventHandlerName(name)] = value;
         } else if (
           !(skip?.test(name) || (name === "content" && el.tagName !== "META"))
         ) {
@@ -315,6 +318,12 @@ function attrsInternal(
       }
     }
   }
+
+  // Clear handlers attached on a previous render that are no longer present.
+  for (const name in prevEvents) {
+    if (!(events && name in events)) (events ||= {})[name] = undefined;
+  }
+  scope[eventsAccessor] = events;
 }
 
 export function _attr_content(


### PR DESCRIPTION
## Problem

When attributes are applied via a spread (`<div ...attrs>`), `attrsInternal` (`src/dom/dom.ts`) collected the event handlers present in the **current** render into a fresh object and `_attrs_script` re-applied only those. Nothing ever cleared a handler that was present in a previous render but is absent now (only an explicit falsy value cleared one). So:

- a handler dropped from the spread between renders stayed attached and kept firing, and
- a render with no event handlers at all left the previous handler object in place entirely.

(Non-event attributes are already removed via an `el.attributes` scan; events had no equivalent.)

## Fix

Capture the previously stored event set, and after collecting the new handlers, mark any handler that vanished as `undefined` so `_attrs_script` detaches it via `_on`. The stored event object is always updated. Non-spread/static handlers and controlled inputs are unaffected.

## Test

New fixture `spread-attrs-remove-event-handler`: the spread starts with `{ onClick, onMouseOver }`; clicking switches it to `{ onClick }`. It goes red→green — without the fix a subsequent `mouseover` still fires the stale handler (`1:` → `1:M`); with the fix it is a no-op. Verified against the spread/event/controllable/attrs fixtures (440 passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_