### PR TITLE
fix(runtime-tags): treat `&&`/ternary results as nullable when either side is

### DIFF
--- a/.changeset/lazy-walls-march.md
+++ b/.changeset/lazy-walls-march.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `&&`, ternary (`a ? b : c`), and `&&=` expression results being treated as non-nullable unless _both_ sides were nullable. Since `a && b` yields `a` when `a` is falsy and a ternary yields whichever branch is taken, the result is nullable if _either_ side is. Under-approximating dropped the optional-chaining / `|| {}` guards on reads of such bindings, throwing at runtime; the result is now correctly treated as nullable when either side is, matching the `||`/`??` cases.

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,24 @@
+// template.marko
+const $template = "<ul><li> </li><li> </li><li> </li></ul><button>toggle</button>";
+const $walks = "E lD lD m b";
+const $viaAnd = ($scope, viaAnd) => $viaAnd_label($scope, viaAnd?.label);
+const $viaTernary = ($scope, viaTernary) => $viaTernary_label($scope, viaTernary?.label);
+const $box = ($scope, box) => $box_inner($scope, box.inner);
+const $on__script = _script("__tests__/template.marko_0_on", ($scope) => _on($scope["#button/3"], "click", function() {
+	$on($scope, $scope.on ? null : true);
+}));
+const $on = /* @__PURE__ */ _let("on/4", ($scope) => {
+	$viaAnd($scope, $scope.on && { label: "and" });
+	$viaTernary($scope, $scope.on ? { label: "ternary" } : null);
+	$box($scope, { inner: $scope.on ? { label: "assign" } : null });
+	$on__script($scope);
+});
+function $setup($scope) {
+	$on($scope, true);
+}
+const $viaAnd_label = ($scope, viaAnd_label) => _text($scope["#text/0"], viaAnd_label ?? "none");
+const $viaTernary_label = ($scope, viaTernary_label) => _text($scope["#text/1"], viaTernary_label ?? "none");
+const $viaAndAssign = ($scope, viaAndAssign) => $viaAndAssign_label($scope, viaAndAssign?.label);
+const $box_inner = ($scope, box_inner) => $viaAndAssign($scope, box_inner &&= { label: "andassign" });
+const $viaAndAssign_label = ($scope, viaAndAssign_label) => _text($scope["#text/2"], viaAndAssign_label ?? "none");
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/dom.bundle.js
@@ -1,0 +1,18 @@
+// template.marko
+const $viaAnd = ($scope, viaAnd) => $viaAnd_label($scope, viaAnd?.label);
+const $viaTernary = ($scope, viaTernary) => $viaTernary_label($scope, viaTernary?.label);
+const $box = ($scope, box) => $box_inner($scope, box.inner);
+const $on__script = _script("a0", ($scope) => _on($scope.d, "click", function() {
+	$on($scope, $scope.e ? null : true);
+}));
+const $on = /* @__PURE__ */ _let(4, ($scope) => {
+	$viaAnd($scope, $scope.e && { label: "and" });
+	$viaTernary($scope, $scope.e ? { label: "ternary" } : null);
+	$box($scope, { inner: $scope.e ? { label: "assign" } : null });
+	$on__script($scope);
+});
+const $viaAnd_label = ($scope, viaAnd_label) => _text($scope.a, viaAnd_label ?? "none");
+const $viaTernary_label = ($scope, viaTernary_label) => _text($scope.b, viaTernary_label ?? "none");
+const $viaAndAssign = ($scope, viaAndAssign) => $viaAndAssign_label($scope, viaAndAssign?.label);
+const $box_inner = ($scope, box_inner) => $viaAndAssign($scope, box_inner &&= { label: "andassign" });
+const $viaAndAssign_label = ($scope, viaAndAssign_label) => _text($scope.c, viaAndAssign_label ?? "none");

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,14 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let on = true;
+	const viaAnd = on && { label: "and" };
+	const viaTernary = on ? { label: "ternary" } : null;
+	const box = { inner: on ? { label: "assign" } : null };
+	const viaAndAssign = box.inner &&= { label: "andassign" };
+	_html(`<ul><li>${_escape(viaAnd.label ?? "none")}${_el_resume($scope0_id, "#text/0")}</li><li>${_escape(viaTernary.label ?? "none")}${_el_resume($scope0_id, "#text/1")}</li><li>${_escape(viaAndAssign.label ?? "none")}${_el_resume($scope0_id, "#text/2")}</li></ul><button>toggle</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0_on");
+	writeScope($scope0_id, { on }, "__tests__/template.marko", 0, { on: "3:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/html.bundle.js
@@ -1,0 +1,14 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let on = true;
+	const viaAnd = { label: "and" };
+	const viaTernary = { label: "ternary" };
+	const box = { inner: { label: "assign" } };
+	const viaAndAssign = box.inner &&= { label: "andassign" };
+	_html(`<ul><li>${_escape(viaAnd.label ?? "none")}${_el_resume($scope0_id, "a")}</li><li>${_escape(viaTernary.label ?? "none")}${_el_resume($scope0_id, "b")}</li><li>${_escape(viaAndAssign.label ?? "none")}${_el_resume($scope0_id, "c")}</li></ul><button>toggle</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: on });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/render.debug.md
@@ -1,0 +1,44 @@
+# Render
+```html
+<ul>
+  <li>
+    and
+  </li>
+  <li>
+    ternary
+  </li>
+  <li>
+    andassign
+  </li>
+</ul>
+<button>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<ul>
+  <li>
+    none
+  </li>
+  <li>
+    none
+  </li>
+  <li>
+    none
+  </li>
+</ul>
+<button>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text "and" => "none"
+UPDATE: ul > li:nth-of-type(2)::text "ternary" => "none"
+UPDATE: ul > li:nth-of-type(3)::text "andassign" => "none"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/render.md
@@ -1,0 +1,44 @@
+# Render
+```html
+<ul>
+  <li>
+    and
+  </li>
+  <li>
+    ternary
+  </li>
+  <li>
+    andassign
+  </li>
+</ul>
+<button>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<ul>
+  <li>
+    none
+  </li>
+  <li>
+    none
+  </li>
+  <li>
+    none
+  </li>
+</ul>
+<button>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text "and" => "none"
+UPDATE: ul > li:nth-of-type(2)::text "ternary" => "none"
+UPDATE: ul > li:nth-of-type(3)::text "andassign" => "none"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<ul>
+  <li>and<!--M_*1 #text/0--></li>
+  <li>ternary<!--M_*1 #text/1--></li>
+  <li>andassign<!--M_*1 #text/2--></li>
+</ul><button>toggle</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      on: !0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/template.marko_0_on 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<ul>
+  <li>and<!--M_*1 a--></li>
+  <li>ternary<!--M_*1 b--></li>
+  <li>andassign<!--M_*1 c--></li>
+</ul><button>toggle</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: !0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2990,
+      "brotli": 1472
+    }
+  },
+  "html": {
+    "min": 439,
+    "brotli": 282
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/template.marko
@@ -1,0 +1,13 @@
+export interface Input {}
+
+<let/on=true/>
+<const/viaAnd=(on && { label: "and" })/>
+<const/viaTernary=(on ? { label: "ternary" } : null)/>
+<const/box=({ inner: on ? { label: "assign" } : null })/>
+<const/viaAndAssign=(box.inner &&= { label: "andassign" })/>
+<ul>
+  <li>${viaAnd.label ?? "none"}</li>
+  <li>${viaTernary.label ?? "none"}</li>
+  <li>${viaAndAssign.label ?? "none"}</li>
+</ul>
+<button onClick() { on = on ? null : true }>toggle</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+// `on && {…}`, `on ? {…} : null`, and `box.inner &&= {…}` (where `box.inner`
+// is itself `on ? {…} : null`) are all nullable: each yields a nullish value
+// when its left/condition side is falsy, so reading a member off the result
+// must be guarded. Toggling `on` to null must not throw.
+function toggle(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, toggle],
+};

--- a/packages/runtime-tags/src/translator/util/evaluate.ts
+++ b/packages/runtime-tags/src/translator/util/evaluate.ts
@@ -78,7 +78,7 @@ function isNullableExpr(expr: t.Expression): boolean {
           );
         case "&&=":
           return (
-            isNullableExpr(expr.left as t.Expression) &&
+            isNullableExpr(expr.left as t.Expression) ||
             isNullableExpr(expr.right)
           );
         default:
@@ -87,14 +87,14 @@ function isNullableExpr(expr: t.Expression): boolean {
     case "AwaitExpression":
       return isNullableExpr(expr.argument);
     case "ConditionalExpression":
-      return isNullableExpr(expr.consequent) && isNullableExpr(expr.alternate);
+      return isNullableExpr(expr.consequent) || isNullableExpr(expr.alternate);
     case "LogicalExpression":
       switch (expr.operator) {
         case "||":
         case "??":
           return isNullableExpr(expr.right) || isNullableExpr(expr.left);
         case "&&":
-          return isNullableExpr(expr.left) && isNullableExpr(expr.right);
+          return isNullableExpr(expr.left) || isNullableExpr(expr.right);
         default:
           return true;
       }


### PR DESCRIPTION
## Problem

`isNullableExpr` (`src/translator/util/evaluate.ts`) decides whether an expression can be `null`/`undefined`, which drives whether generated reads use optional chaining / a `|| {}` destructure guard. It under-approximated three cases by requiring **both** operands to be nullable:

```ts
a && b   → isNullableExpr(a) && isNullableExpr(b)
a ? b : c → isNullableExpr(b) && isNullableExpr(c)
a &&= b  → isNullableExpr(a) && isNullableExpr(b)
```

But `a && b` evaluates to `a` whenever `a` is falsy, and a ternary yields whichever branch is taken — so each result is nullable if **either** side is. (The sibling `||`/`??` cases already correctly use `||`.)

A binding wrongly marked non-nullable then generated `data.label` instead of `data?.label` (and skipped the `|| {}` guard), throwing at runtime. For example `<const/data=(on && { label: "hi" })/>` followed by `${data.label}` crashed once `on` became nullish.

## Fix

Use `||` (over-approximation, matching `||`/`??`) for all three cases. Over-approximating only adds guards; it never removes them.

## Test

New fixture `const-logical-nullable-member` reads a member off both an `&&` result and a ternary result, then toggles the condition to `null`. It goes red→green: without the fix the generated read omits optional chaining (compiled `dom.bundle.js` diff) and throws on toggle; with it the reads are guarded and render `none`.

Full `runtime-tags` suite (4993) and interop suite (266) pass unchanged — no existing snapshots shift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_