### PR TITLE
fix(runtime-tags): error on non string/void lowercase event handler attrs

### DIFF
--- a/.changeset/native-lowercase-event-handler.md
+++ b/.changeset/native-lowercase-event-handler.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Error when a non string/void value is passed to a lowercase `on*` attribute on a native tag (e.g. `<button onclick=() => {}>`). Marko event handlers use the `onClick`/`on-click` form, so a lowercase `onclick` is treated as a plain native attribute and the value would have been silently stringified instead of attaching a listener. Lowercase `on*` attribute values must now be a string, `null`, `undefined`, or `false`. Statically known invalid values are reported as a compile error, and a `MARKO_DEBUG`-only runtime check catches dynamically passed invalid values; both suggest the correct camelCase handler name.

--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 23798,
-        "brotli": 8832
+        "brotli": 8818
       }
     },
     {
@@ -49,11 +49,11 @@
       },
       "runtime": {
         "min": 6514,
-        "brotli": 2852
+        "brotli": 2842
       },
       "total": {
         "min": 7196,
-        "brotli": 3245
+        "brotli": 3235
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6514 (min) 2852 (brotli)
+// size: 6514 (min) 2842 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -86,14 +86,14 @@ let decodeAccessor = (num) =>
       _resume(id, renderer)
     );
   };
+function isNotVoid(value) {
+  return value != null && value !== !1;
+}
 function forOf(list, cb) {
   if (list) {
     let i = 0;
     for (let item of list) cb(item, i++);
   }
-}
-function isNotVoid(value) {
-  return value != null && value !== !1;
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 23798 (min) 8832 (brotli)
+// size: 23798 (min) 8818 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -318,28 +318,6 @@ function attrTags(first, attrs) {
 function* attrTagIterator() {
   (yield this, yield* this[rest]);
 }
-function _assert_hoist(value) {}
-function forIn(obj, cb) {
-  for (let key in obj) cb(key, obj[key]);
-}
-function forOf(list, cb) {
-  if (list) {
-    let i = 0;
-    for (let item of list) cb(item, i++);
-  }
-}
-function forTo(to, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
-    cb(start + i * delta);
-}
-function forUntil(until, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
-    cb(start + i * delta);
-}
 function _call(fn, v) {
   return (fn(v), v);
 }
@@ -364,6 +342,28 @@ function normalizeDynamicRenderer(value) {
     let normalized = value.content || value.default || value;
     if ("a" in normalized) return normalized;
   }
+}
+function _assert_hoist(value) {}
+function forIn(obj, cb) {
+  for (let key in obj) cb(key, obj[key]);
+}
+function forOf(list, cb) {
+  if (list) {
+    let i = 0;
+    for (let item of list) cb(item, i++);
+  }
+}
+function forTo(to, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
+    cb(start + i * delta);
+}
+function forUntil(until, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
+    cb(start + i * delta);
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `onclick` attribute must be a string, null, undefined, or false, but received type "function". To attach an event listener, use the `onClick` event handler instead.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<button${_attr("onclick", input.handler)}>Click me</button>${_el_resume($scope0_id, "#button/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `onclick` attribute must be a string, null, undefined, or false, but received type "function". To attach an event listener, use the `onClick` event handler instead.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/template.marko
@@ -1,0 +1,3 @@
+<button onclick=input.handler>
+  Click me
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ handler: () => {} }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
+    > 1 | <button onclick=() => console.log("clicked")>
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
+    > 1 | <button onclick=() => console.log("clicked")>
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
+    > 1 | <button onclick=() => console.log("clicked")>
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
+    > 1 | <button onclick=() => console.log("clicked")>
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko
@@ -1,0 +1,3 @@
+<button onclick=() => console.log("clicked")>
+  Click me
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -1,3 +1,7 @@
+import { isVoid } from "./helpers";
+
+const lowercaseEventHandlerReg = /^on[a-z]/;
+
 export function _el_read_error() {
   if (MARKO_DEBUG) {
     throw new Error(
@@ -54,6 +58,18 @@ export function assertExclusiveAttrs(
         `The attributes ${joinWithAnd(exclusiveAttrs)} are mutually exclusive.`,
       );
     }
+  }
+}
+
+export function assertValidEventHandlerAttr(name: string, value: unknown) {
+  if (
+    !isVoid(value) &&
+    typeof value !== "string" &&
+    lowercaseEventHandlerReg.test(name)
+  ) {
+    throw new Error(
+      `The \`${name}\` attribute must be a string, null, undefined, or false, but received type "${typeof value}". To attach an event listener, use the \`on${name[2].toUpperCase()}${name.slice(3)}\` event handler instead.`,
+    );
   }
 }
 

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -1,4 +1,7 @@
-import { assertExclusiveAttrs } from "../common/errors";
+import {
+  assertExclusiveAttrs,
+  assertValidEventHandlerAttr,
+} from "../common/errors";
 import {
   getEventHandlerName,
   htmlAttrNameReg,
@@ -41,6 +44,9 @@ export function _to_text(value: unknown) {
 }
 
 export function _attr(element: Element, name: string, value: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidEventHandlerAttr(name, value);
+  }
   setAttribute(element, name, normalizeAttrValue(value));
 }
 

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -1,4 +1,7 @@
-import { assertExclusiveAttrs } from "../common/errors";
+import {
+  assertExclusiveAttrs,
+  assertValidEventHandlerAttr,
+} from "../common/errors";
 import {
   getEventHandlerName,
   htmlAttrNameReg,
@@ -181,6 +184,9 @@ export function _attr_nonce() {
 }
 
 export function _attr(name: string, value: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidEventHandlerAttr(name, value);
+  }
   return isVoid(value) ? "" : nonVoidAttr(name, value);
 }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -126,8 +126,11 @@ export default {
           if (isEventHandler(attr.name)) {
             valueExtra.isEffect = true;
             hasEventHandlers = true;
-          } else if (!evaluate(attr.value).confident) {
-            hasDynamicAttributes = true;
+          } else {
+            assertValidNativeEventHandlerAttr(tag, attr);
+            if (!evaluate(attr.value).confident) {
+              hasDynamicAttributes = true;
+            }
           }
         } else if (t.isMarkoSpreadAttribute(attr)) {
           valueExtra.isEffect = true;
@@ -1103,6 +1106,34 @@ function isInjectNonceTag(tagName: string) {
       return true;
     default:
       return false;
+  }
+}
+
+const lowercaseEventHandlerReg = /^on[a-z]/;
+
+function assertValidNativeEventHandlerAttr(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute,
+) {
+  if (!lowercaseEventHandlerReg.test(attr.name)) return;
+
+  const { value } = attr;
+  let invalid = t.isFunction(value);
+  if (!invalid) {
+    const { confident, computed } = evaluate(value);
+    invalid =
+      confident &&
+      !(computed == null || computed === false || typeof computed === "string");
+  }
+
+  if (invalid) {
+    const suggestion = "on" + attr.name[2].toUpperCase() + attr.name.slice(3);
+    throw tag.hub.buildError(
+      value,
+      `The \`${attr.name}\` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, \`null\`, \`undefined\`, or \`false\`. ` +
+        `To attach an event listener, use the \`${suggestion}\` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.`,
+      Error,
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

Marko event handlers use the `onClick` / `on-click` form (see `isEventHandler`, which matches `/^on[A-Z-]/`). A **lowercase** `on*` attribute such as `onclick` is therefore treated as a plain native attribute. Passing a function to it silently stringifies the function into the attribute value instead of attaching a listener — a common, easy-to-miss mistake:

```marko
<button onclick=() => doThing()>Click me</button>
```

previously compiled without complaint and produced a broken `onclick` attribute at runtime.

## Change

On native tags, lowercase `on*` attribute values must now be a **string, `null`, `undefined`, or `false`**:

- **Compile-time error** when the value is statically known to be invalid (a function literal, or a confidently-evaluated number/boolean/object/etc.). The error points at the value and suggests the correct camelCase handler.

  ```
  > 1 | <button onclick=() => console.log("clicked")>
        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a native tag must be
        |                 a string, `null`, `undefined`, or `false`. To attach an event listener, use
        |                 the `onClick` event handler attribute instead.
  ```

- **`MARKO_DEBUG`-only runtime error** for values that can't be determined statically (e.g. `onclick=input.handler`). Added to `_attr` in both the HTML and DOM runtimes; gated by `MARKO_DEBUG` so it's stripped (and tree-shaken) in production.

  ```
  The `onclick` attribute must be a string, null, undefined, or false, but received type "function".
  To attach an event listener, use the `onClick` event handler instead.
  ```

Recognized handlers (`onClick`, `on-click`) are unaffected.

## Tests

- `error-native-tag-lowercase-event-handler` — compile-time error fixture.
- `error-native-tag-lowercase-event-handler-dynamic` — runtime (`error_html`/`error_dom`) fixture for the dynamic case.
- Full `runtime-tags/translator` suite passes (8023 passing, 0 failing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeeQVUg7MU16nuUVTogSHx