### PR TITLE
fix(runtime-tags): error on non-function native event/change handlers

### DIFF
--- a/.changeset/native-handler-must-be-function.md
+++ b/.changeset/native-handler-must-be-function.md
@@ -1,0 +1,7 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Error when a non-function value is passed to a native tag event handler (`onClick`, `on-click`, …) or change handler (`valueChange`, `checkedChange`, `openChange`, …). Previously a value like `<button onClick=5>` or `<input value=x valueChange="handler">` silently compiled and the handler was wired up with a non-function (or dropped), doing nothing at runtime. Handler values must now be a function or a falsey value — falsey values (`null`, `undefined`, `false`, `0`, …) are still allowed and mean "no handler", matching the runtime, so patterns like `onClick=items.length && (() => …)` continue to work. Statically known invalid values are reported as a compile error; a `MARKO_DEBUG`-only runtime check catches dynamically passed invalid values.
+
+The lowercase `on*` attribute check (e.g. `<button onclick=…>`) is aligned to the same falsey rule: its value must be a string or a falsey value (including `0`, `""`, etc.), not just `null`/`undefined`/`false`.

--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 23815,
-        "brotli": 8839
+        "brotli": 8831
       }
     },
     {
@@ -49,11 +49,11 @@
       },
       "runtime": {
         "min": 6531,
-        "brotli": 2849
+        "brotli": 2851
       },
       "total": {
         "min": 7213,
-        "brotli": 3242
+        "brotli": 3244
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6531 (min) 2849 (brotli)
+// size: 6531 (min) 2851 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -86,14 +86,14 @@ let decodeAccessor = (num) =>
       _resume(id, renderer)
     );
   };
-function isNotVoid(value) {
-  return value != null && value !== !1;
-}
 function forOf(list, cb) {
   if (list) {
     let i = 0;
     for (let item of list) cb(item, i++);
   }
+}
+function isNotVoid(value) {
+  return value != null && value !== !1;
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 23815 (min) 8839 (brotli)
+// size: 23815 (min) 8831 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -318,6 +318,28 @@ function attrTags(first, attrs) {
 function* attrTagIterator() {
   (yield this, yield* this[rest]);
 }
+function _assert_hoist(value) {}
+function forIn(obj, cb) {
+  for (let key in obj) cb(key, obj[key]);
+}
+function forOf(list, cb) {
+  if (list) {
+    let i = 0;
+    for (let item of list) cb(item, i++);
+  }
+}
+function forTo(to, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
+    cb(start + i * delta);
+}
+function forUntil(until, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
+    cb(start + i * delta);
+}
 function _call(fn, v) {
   return (fn(v), v);
 }
@@ -342,28 +364,6 @@ function normalizeDynamicRenderer(value) {
     let normalized = value.content || value.default || value;
     if ("a" in normalized) return normalized;
   }
-}
-function _assert_hoist(value) {}
-function forIn(obj, cb) {
-  for (let key in obj) cb(key, obj[key]);
-}
-function forOf(list, cb) {
-  if (list) {
-    let i = 0;
-    for (let item of list) cb(item, i++);
-  }
-}
-function forTo(to, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
-    cb(start + i * delta);
-}
-function forUntil(until, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
-    cb(start + i * delta);
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+const $template = "<button>Clicked <!> times</button>";
+const $walks = " Db%l";
+const $clicks__script = _script("__tests__/template.marko_0_clicks", ($scope) => _on($scope["#button/0"], "click", $scope.clicks < 3 && (() => $clicks($scope, $scope.clicks + 1) - 1)));
+const $clicks = /* @__PURE__ */ _let("clicks/2", ($scope) => {
+	_text($scope["#text/1"], $scope.clicks);
+	$clicks__script($scope);
+});
+function $setup($scope) {
+	$clicks($scope, 0);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $clicks__script = _script("a0", ($scope) => _on($scope.a, "click", $scope.c < 3 && (() => $clicks($scope, $scope.c + 1) - 1)));
+const $clicks = /* @__PURE__ */ _let(2, ($scope) => {
+	_text($scope.b, $scope.c);
+	$clicks__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicks = 0;
+	_html(`<button>Clicked <!>${_escape(clicks)}${_el_resume($scope0_id, "#text/1")} times</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_clicks");
+	writeScope($scope0_id, { clicks }, "__tests__/template.marko", 0, { clicks: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicks = 0;
+	_html(`<button>Clicked <!>${_escape(clicks)}${_el_resume($scope0_id, "b")} times</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: clicks });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/render.debug.md
@@ -1,0 +1,53 @@
+# Render
+```html
+<button>
+  Clicked 0 times
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 1 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "0" => "1"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 2 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 3 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "2" => "3"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/render.md
@@ -1,0 +1,53 @@
+# Render
+```html
+<button>
+  Clicked 0 times
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 1 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "0" => "1"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 2 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  Clicked 3 times
+</button>
+```
+## Change
+```
+UPDATE: button::text@8 "2" => "3"
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<button>Clicked <!>0<!--M_*1 #text/1--> times</button><!--M_*1 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      clicks: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/template.marko_0_clicks 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<button>Clicked <!>0<!--M_*1 b--> times</button><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2696,
+      "brotli": 1371
+    }
+  },
+  "html": {
+    "min": 369,
+    "brotli": 255
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/template.marko
@@ -1,0 +1,4 @@
+<let/clicks=0/>
+<button onClick=clicks < 3 && (() => clicks++)>
+  Clicked ${clicks} times
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko:1:38
+    > 1 | <input value=input.value valueChange=42>
+        |                                      ^^ The `valueChange` change handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko:1:38
+    > 1 | <input value=input.value valueChange=42>
+        |                                      ^^ The `valueChange` change handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko:1:38
+    > 1 | <input value=input.value valueChange=42>
+        |                                      ^^ The `valueChange` change handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko:1:38
+    > 1 | <input value=input.value valueChange=42>
+        |                                      ^^ The `valueChange` change handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/template.marko
@@ -1,0 +1,1 @@
+<input value=input.value valueChange=42>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-literal/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `valueChange` handler must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "number".

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<input>";
+const $walks = " b";
+const $input_value__OR__input_onChange = /* @__PURE__ */ _or(5, ($scope) => _attr_input_value($scope, "#input/0", $scope.input_value, $scope.input_onChange));
+const $input_value = /* @__PURE__ */ _const("input_value", $input_value__OR__input_onChange);
+const $input_onChange = /* @__PURE__ */ _const("input_onChange", $input_value__OR__input_onChange);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#input/0"));
+const $setup = $setup__script;
+const $input = ($scope, input) => {
+	$input_value($scope, input.value);
+	$input_onChange($scope, input.onChange);
+};
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,14 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", input.value, input.onChange)}>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		input_value: _serialize_if($scope0_reason, 1) && input.value,
+		input_onChange: _serialize_if($scope0_reason, 0) && input.onChange
+	}, "__tests__/template.marko", 0, {
+		input_value: ["input.value"],
+		input_onChange: ["input.onChange"]
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `valueChange` handler must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "number".

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/template.marko
@@ -1,0 +1,1 @@
+<input value=input.value valueChange=input.onChange>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: "x", onChange: 5 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko:1:17
+    > 1 | <button onClick="alert(1)">
+        |                 ^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko:1:17
+    > 1 | <button onClick="alert(1)">
+        |                 ^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko:1:17
+    > 1 | <button onClick="alert(1)">
+        |                 ^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko:1:17
+    > 1 | <button onClick="alert(1)">
+        |                 ^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
+      2 |   Click me
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/template.marko
@@ -1,0 +1,3 @@
+<button onClick="alert(1)">
+  Click me
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-literal/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `onClick` handler must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "number".

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+const $template = "<button>Click me</button>";
+const $walks = " b";
+const $setup = () => {};
+const $input_onClick__script = _script("__tests__/template.marko_0_input_onClick", ($scope) => _on($scope["#button/0"], "click", $scope.input_onClick));
+const $input_onClick = /* @__PURE__ */ _const("input_onClick", $input_onClick__script);
+const $input = ($scope, input) => $input_onClick($scope, input.onClick);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<button>Click me</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_input_onClick");
+	writeScope($scope0_id, { input_onClick: input.onClick }, "__tests__/template.marko", 0, { input_onClick: ["input.onClick"] });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/template.marko
@@ -1,0 +1,3 @@
+<button onClick=input.onClick>
+  Click me
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_dom: true,
+  skip_optimize: true,
+  skip_ssr: true,
+  steps: [{ onClick: 5 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,1 +1,1 @@
-The `onclick` attribute must be a string, null, undefined, or false, but received type "function". To attach an event listener, use the `onClick` event handler instead.
+The `onclick` attribute must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "function". To attach an event listener, use the `onClick` event handler instead.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,1 +1,1 @@
-The `onclick` attribute must be a string, null, undefined, or false, but received type "function". To attach an event listener, use the `onClick` event handler instead.
+The `onclick` attribute must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "function". To attach an event listener, use the `onClick` event handler instead.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
     > 1 | <button onclick=() => console.log("clicked")>
-        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …). To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
       2 |   Click me
       3 | </button>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-dom.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
     > 1 | <button onclick=() => console.log("clicked")>
-        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …). To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
       2 |   Click me
       3 | </button>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
     > 1 | <button onclick=() => console.log("clicked")>
-        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …). To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
       2 |   Click me
       3 | </button>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/__snapshots__/error-compile-html.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler/template.marko:1:17
     > 1 | <button onclick=() => console.log("clicked")>
-        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, `null`, `undefined`, or `false`. To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
+        |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ The `onclick` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string or a falsey value (`null`, `undefined`, `false`, `0`, …). To attach an event listener, use the `onClick` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.
       2 |   Click me
       3 | </button>
       4 |

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -1,5 +1,3 @@
-import { isVoid } from "./helpers";
-
 const lowercaseEventHandlerReg = /^on[a-z]/;
 
 export function _el_read_error() {
@@ -63,12 +61,20 @@ export function assertExclusiveAttrs(
 
 export function assertValidEventHandlerAttr(name: string, value: unknown) {
   if (
-    !isVoid(value) &&
+    value &&
     typeof value !== "string" &&
     lowercaseEventHandlerReg.test(name)
   ) {
     throw new Error(
-      `The \`${name}\` attribute must be a string, null, undefined, or false, but received type "${typeof value}". To attach an event listener, use the \`on${name[2].toUpperCase()}${name.slice(3)}\` event handler instead.`,
+      `The \`${name}\` attribute must be a string or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …), but received type "${typeof value}". To attach an event listener, use the \`on${name[2].toUpperCase()}${name.slice(3)}\` event handler instead.`,
+    );
+  }
+}
+
+export function assertHandlerIsFunction(name: string, value: unknown) {
+  if (value && typeof value !== "function") {
+    throw new Error(
+      `The \`${name}\` handler must be a function or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …), but received type "${typeof value}".`,
     );
   }
 }

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -1,3 +1,4 @@
+import { assertHandlerIsFunction } from "../common/errors";
 import { isNotVoid } from "../common/helpers";
 import {
   type Accessor,
@@ -39,6 +40,9 @@ export function _attr_input_checked(
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
   const normalizedChecked = isNotVoid(checked);
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("checkedChange", checkedChange);
+  }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = checkedChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = checkedChange
     ? ControlledType.InputChecked
@@ -103,6 +107,9 @@ export function _attr_input_checkedValue(
   ] = multiple
     ? checkedValue.map(normalizeStrProp)
     : normalizeStrProp(checkedValue));
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("checkedValueChange", checkedValueChange);
+  }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = checkedValueChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = checkedValueChange
     ? ControlledType.InputCheckedValue
@@ -187,6 +194,9 @@ export function _attr_input_value(
 ) {
   const el = scope[nodeAccessor] as HTMLInputElement;
   const normalizedValue = normalizeAttrValue(value) || "";
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("valueChange", valueChange);
+  }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = valueChange;
   scope[AccessorPrefix.ControlledValue + nodeAccessor] = normalizedValue;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = valueChange
@@ -275,6 +285,9 @@ export function _attr_select_value(
   const normalizedValue = (scope[
     AccessorPrefix.ControlledValue + nodeAccessor
   ] = multiple ? value.map(normalizeStrProp) : normalizeStrProp(value));
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("valueChange", valueChange);
+  }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = valueChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = valueChange
     ? ControlledType.SelectValue
@@ -378,6 +391,9 @@ export function _attr_details_or_dialog_open(
 ) {
   const normalizedOpen = (scope[AccessorPrefix.ControlledValue + nodeAccessor] =
     isNotVoid(open));
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("openChange", openChange);
+  }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = openChange;
   scope[AccessorPrefix.ControlledType + nodeAccessor] = openChange
     ? ControlledType.DetailsOrDialogOpen

--- a/packages/runtime-tags/src/dom/event.ts
+++ b/packages/runtime-tags/src/dom/event.ts
@@ -1,3 +1,4 @@
+import { assertHandlerIsFunction } from "../common/errors";
 import { rendering } from "./queue";
 
 type EventNames = keyof GlobalEventHandlersEventMap;
@@ -11,6 +12,13 @@ export function _on<
     | undefined
     | ((ev: GlobalEventHandlersEventMap[T], target: Element) => void),
 >(element: Element, type: T, handler: H) {
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction(
+      "on" + type[0].toUpperCase() + type.slice(1),
+      handler,
+    );
+  }
+
   if ((element as any)["$" + type] === undefined) {
     defaultDelegator(element, type, handleDelegated);
   }

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -1,5 +1,6 @@
 import {
   assertExclusiveAttrs,
+  assertHandlerIsFunction,
   assertValidEventHandlerAttr,
 } from "../common/errors";
 import {
@@ -350,6 +351,10 @@ function writeControlledScope(
   value: unknown,
   valueChange: unknown,
 ) {
+  if (MARKO_DEBUG) {
+    assertHandlerIsFunction("valueChange", valueChange);
+  }
+
   _scope(scopeId, {
     [AccessorPrefix.ControlledType + nodeAccessor]: type,
     [AccessorPrefix.ControlledValue + nodeAccessor]: value,

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -3,6 +3,7 @@ import {
   assertNoArgs,
   assertNoAttributeTags,
   assertNoParams,
+  computeNode,
   getProgram,
   getTagDef,
 } from "@marko/compiler/babel-utils";
@@ -15,6 +16,7 @@ import evaluate from "../../util/evaluate";
 import { generateUidIdentifier } from "../../util/generate-uid";
 import { getAccessorProp } from "../../util/get-accessor-char";
 import { getTagName } from "../../util/get-tag-name";
+import { isEventOrChangeHandler } from "../../util/is-event-or-change-handler";
 import { isTextOnlyNativeTag } from "../../util/is-non-html-text";
 import { getMarkoOpts, isOutputHTML } from "../../util/marko-config";
 import { includes, type Opt, push } from "../../util/optional";
@@ -121,6 +123,10 @@ export default {
 
           if (injectNonce && attr.name === "nonce") {
             injectNonce = false;
+          }
+
+          if (isEventOrChangeHandler(attr.name)) {
+            assertNativeHandlerAttr(tag, attr);
           }
 
           if (isEventHandler(attr.name)) {
@@ -1109,6 +1115,21 @@ function isInjectNonceTag(tagName: string) {
   }
 }
 
+function assertNativeHandlerAttr(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute,
+) {
+  if (computeNode(attr.value)?.value) {
+    throw tag.hub.buildError(
+      attr.value,
+      `The \`${attr.name}\` ${
+        isEventHandler(attr.name) ? "event handler" : "change handler"
+      } on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …).`,
+      Error,
+    );
+  }
+}
+
 const lowercaseEventHandlerReg = /^on[a-z]/;
 
 function assertValidNativeEventHandlerAttr(
@@ -1121,16 +1142,14 @@ function assertValidNativeEventHandlerAttr(
   let invalid = t.isFunction(value);
   if (!invalid) {
     const { confident, computed } = evaluate(value);
-    invalid =
-      confident &&
-      !(computed == null || computed === false || typeof computed === "string");
+    invalid = confident && !!computed && typeof computed !== "string";
   }
 
   if (invalid) {
     const suggestion = "on" + attr.name[2].toUpperCase() + attr.name.slice(3);
     throw tag.hub.buildError(
       value,
-      `The \`${attr.name}\` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string, \`null\`, \`undefined\`, or \`false\`. ` +
+      `The \`${attr.name}\` attribute on a [native tag](https://markojs.com/docs/reference/native-tag) must be a string or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …). ` +
         `To attach an event listener, use the \`${suggestion}\` [event handler attribute](https://markojs.com/docs/reference/event-handling) instead.`,
       Error,
     );


### PR DESCRIPTION
## Problem

Native tag **event handlers** (`onClick`, `on-click`, …) and **change handlers** (`valueChange`, `checkedChange`, `checkedValueChange`, `openChange`) silently accepted values that are not functions:

```marko
<button onClick=5>
<button onClick="doThing()">                 ← string handler (a habit from inline HTML)
<input value=x valueChange="handler">
```

These compiled without complaint and wired the handler up with a non-function (or dropped it), so it silently did nothing at runtime. There was already precedent for catching this — `<let valueChange=…>` errors on a confident non-function — but native tags didn't.

## Change

Handler values must now be a **function or a falsey value**. Falsey values (`null`, `undefined`, `false`, `0`, `""`, …) are still allowed and mean "no handler", matching the runtime (`element["$"+type] = handler || null`, `if (valueChange) …`). In particular the common conditional-handler pattern keeps working:

```marko
<button onClick=items.length && (() => …)>   ← `0` when empty, the fn otherwise — both valid
```

- **Compile-time error** when the value is statically known to be a non-function truthy value (number, string, object, …), for both event and change handlers, pointing at the value:

  ```
  > 1 | <button onClick="alert(1)">
        |                 ^^^^^^^^^^ The `onClick` event handler on a native tag must be
        |                 a function or a falsey value (`null`, `undefined`, `false`, `0`, …).
  ```

- **`MARKO_DEBUG`-only runtime error** for values that can't be determined statically (e.g. `onClick=input.handler`). Added via a shared `assertHandlerIsFunction` helper at the runtime chokepoints — `_on` (DOM events), `writeControlledScope` (HTML change handlers), and the DOM controllable setup functions. Gated by `MARKO_DEBUG`, so stripped and tree-shaken in production (verified: no trace in `.sizes`).

  ```
  The `onClick` handler must be a function or a falsey value (`null`, `undefined`, `false`, `0`, …), but received type "number".
  ```

### Also: lowercase `on*` consistency

The lowercase `on*` attribute check added in #3248 (e.g. `<button onclick=…>`) is aligned to the same falsey rule — its value must be a **string or a falsey value** (now including `0`, `""`, …), not just `null`/`undefined`/`false`. Its messages are updated to match, and the existing fixtures are regenerated.

## Tests

- Compile-error fixtures: `error-native-event-handler-literal`, `error-native-change-handler-literal`.
- Runtime fixtures: `error-native-event-handler-not-function` (CSR), `error-native-change-handler-not-function` (SSR + CSR).
- Positive fixture: `conditional-event-handler` — `onClick=clicks < 3 && (() => clicks++)` clicks through to the falsey state and back, confirming no spurious error.
- Full `runtime-tags/translator` suite: 8056 passing, 0 failing.