### PR TITLE
fix(runtime-tags): error on non-Marko attribute idioms with a suggestion

### DIFF
--- a/.changeset/known-wrong-attr-names.md
+++ b/.changeset/known-wrong-attr-names.md
@@ -1,0 +1,11 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Error on native tags when an attribute name is a recognizable idiom from another framework (React, Svelte, Vue) that is not valid in Marko, with a suggestion for the correct syntax. These previously compiled but silently produced a junk attribute (HTML attribute names are case-insensitive, so e.g. `className` becomes the `classname` attribute, not `class`). Examples:
+
+- React: `className` → `class`, `htmlFor` → `for`, `defaultValue` → `value`, `defaultChecked` → `checked`, `acceptCharset` → `accept-charset`, `httpEquiv` → `http-equiv`
+- Svelte: `class:active` → `class={ active: condition }`, `style:color` → `style={ color: value }`, `on:click` → `onClick`, `bind:value` → `value:=state`
+- Vue: `v-if` → `<if>`, `v-for` → `<for>`, `v-model` → `value:=state`, `v-on:click` → `onClick`, `v-bind:class` → `class`
+
+The check runs for both static attributes (compile error) and dynamic/spread attributes (`MARKO_DEBUG`-only runtime error in the server and client attribute runtimes). Only native tags are checked — custom components may still accept input props with these names. (Vue's `:`/`@` and Angular's `[`/`(`/`*` shorthands already error as invalid attribute names.)

--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 23837,
-        "brotli": 8812
+        "brotli": 8807
       }
     },
     {
@@ -49,11 +49,11 @@
       },
       "runtime": {
         "min": 6531,
-        "brotli": 2851
+        "brotli": 2849
       },
       "total": {
         "min": 7213,
-        "brotli": 3244
+        "brotli": 3242
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6531 (min) 2851 (brotli)
+// size: 6531 (min) 2849 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -86,14 +86,14 @@ let decodeAccessor = (num) =>
       _resume(id, renderer)
     );
   };
+function isNotVoid(value) {
+  return value != null && value !== !1;
+}
 function forOf(list, cb) {
   if (list) {
     let i = 0;
     for (let item of list) cb(item, i++);
   }
-}
-function isNotVoid(value) {
-  return value != null && value !== !1;
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 23837 (min) 8812 (brotli)
+// size: 23837 (min) 8807 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -318,28 +318,6 @@ function attrTags(first, attrs) {
 function* attrTagIterator() {
   (yield this, yield* this[rest]);
 }
-function _assert_hoist(value) {}
-function forIn(obj, cb) {
-  for (let key in obj) cb(key, obj[key]);
-}
-function forOf(list, cb) {
-  if (list) {
-    let i = 0;
-    for (let item of list) cb(item, i++);
-  }
-}
-function forTo(to, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
-    cb(start + i * delta);
-}
-function forUntil(until, from, step, cb) {
-  let start = from || 0,
-    delta = step || 1;
-  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
-    cb(start + i * delta);
-}
 function _call(fn, v) {
   return (fn(v), v);
 }
@@ -364,6 +342,28 @@ function normalizeDynamicRenderer(value) {
     let normalized = value.content || value.default || value;
     if ("a" in normalized) return normalized;
   }
+}
+function _assert_hoist(value) {}
+function forIn(obj, cb) {
+  for (let key in obj) cb(key, obj[key]);
+}
+function forOf(list, cb) {
+  if (list) {
+    let i = 0;
+    for (let item of list) cb(item, i++);
+  }
+}
+function forTo(to, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (to - start) / delta, i = 0; i <= steps; i++)
+    cb(start + i * delta);
+}
+function forUntil(until, from, step, cb) {
+  let start = from || 0,
+    delta = step || 1;
+  for (let steps = (until - start) / delta, i = 0; i < steps; i++)
+    cb(start + i * delta);
 }
 function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+`className` is not a valid attribute, did you mean `class`?

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+const $template = "<div>Hello</div>";
+const $walks = " b";
+const $setup = () => {};
+const $input_attrs__script = _script("__tests__/template.marko_0_input_attrs", ($scope) => _attrs_script($scope, "#div/0"));
+const $input_attrs = /* @__PURE__ */ _const("input_attrs", ($scope) => {
+	_attrs($scope, "#div/0", $scope.input_attrs);
+	$input_attrs__script($scope);
+});
+const $input = ($scope, input) => $input_attrs($scope, input.attrs);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_attrs(input.attrs, "#div/0", $scope0_id, "div")}>Hello</div>${_el_resume($scope0_id, "#div/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_input_attrs");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+`className` is not a valid attribute, did you mean `class`?

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/template.marko
@@ -1,0 +1,3 @@
+<div ...input.attrs>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ attrs: { className: "x" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko:1:6
+    > 1 | <div className="container">
+        |      ^^^^^^^^^ `className` is not a valid attribute, did you mean `class`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko:1:6
+    > 1 | <div className="container">
+        |      ^^^^^^^^^ `className` is not a valid attribute, did you mean `class`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko:1:6
+    > 1 | <div className="container">
+        |      ^^^^^^^^^ `className` is not a valid attribute, did you mean `class`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko:1:6
+    > 1 | <div className="container">
+        |      ^^^^^^^^^ `className` is not a valid attribute, did you mean `class`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/template.marko
@@ -1,0 +1,3 @@
+<div className="container">
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-react-attribute/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko:1:6
+    > 1 | <div class:active=input.isActive>
+        |      ^^^^^^^^^^^^ `class:active` is not a valid attribute, did you mean `class={ active: condition }`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko:1:6
+    > 1 | <div class:active=input.isActive>
+        |      ^^^^^^^^^^^^ `class:active` is not a valid attribute, did you mean `class={ active: condition }`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko:1:6
+    > 1 | <div class:active=input.isActive>
+        |      ^^^^^^^^^^^^ `class:active` is not a valid attribute, did you mean `class={ active: condition }`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko:1:6
+    > 1 | <div class:active=input.isActive>
+        |      ^^^^^^^^^^^^ `class:active` is not a valid attribute, did you mean `class={ active: condition }`?
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/template.marko
@@ -1,0 +1,3 @@
+<div class:active=input.isActive>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-svelte-directive/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko:1:9
+    > 1 | <button v-on:click=input.onClick>
+        |         ^^^^^^^^^^ `v-on:click` is not a valid attribute, did you mean `onClick`?
+      2 |   Click
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko:1:9
+    > 1 | <button v-on:click=input.onClick>
+        |         ^^^^^^^^^^ `v-on:click` is not a valid attribute, did you mean `onClick`?
+      2 |   Click
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko:1:9
+    > 1 | <button v-on:click=input.onClick>
+        |         ^^^^^^^^^^ `v-on:click` is not a valid attribute, did you mean `onClick`?
+      2 |   Click
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko:1:9
+    > 1 | <button v-on:click=input.onClick>
+        |         ^^^^^^^^^^ `v-on:click` is not a valid attribute, did you mean `onClick`?
+      2 |   Click
+      3 | </button>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/template.marko
@@ -1,0 +1,3 @@
+<button v-on:click=input.onClick>
+  Click
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-vue-directive/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -1,4 +1,18 @@
+import { getWrongAttrSuggestion, htmlAttrNameReg } from "./helpers";
+
 const lowercaseEventHandlerReg = /^on[a-z]/;
+
+export function assertValidAttrName(name: string) {
+  if (htmlAttrNameReg.test(name)) {
+    throw new Error(`Invalid attribute name: ${JSON.stringify(name)}`);
+  }
+  const suggestion = getWrongAttrSuggestion(name);
+  if (suggestion) {
+    throw new Error(
+      `\`${name}\` is not a valid attribute, did you mean \`${suggestion}\`?`,
+    );
+  }
+}
 
 export function _el_read_error() {
   if (MARKO_DEBUG) {

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -2,6 +2,51 @@ import { RendererProp } from "./accessor.debug";
 
 export const htmlAttrNameReg = /^[^a-z_]|[^a-z0-9._:-]/i;
 export const userAttrNameReg = /^[^a-z_$]|[^a-z0-9._:-]/i;
+const knownWrongAttrs: Record<string, string> = {
+  className: "class",
+  classList: "class",
+  htmlFor: "for",
+  acceptCharset: "accept-charset",
+  httpEquiv: "http-equiv",
+  defaultValue: "value",
+  defaultChecked: "checked",
+  dangerouslySetInnerHTML: "$!{html}",
+  key: "<for by>",
+  ref: "<tag/ref>",
+  "v-if": "<if>",
+  "v-else": "<else>",
+  "v-else-if": "<else if>",
+  "v-for": "<for>",
+  "v-show": "<if>",
+  "v-model": "value:=state",
+  "v-bind": "...attrs",
+  "v-html": "$!{html}",
+  "v-text": "${text}",
+};
+
+export function getWrongAttrSuggestion(name: string): string | undefined {
+  const exact = knownWrongAttrs[name];
+  if (exact) return exact;
+
+  const colon = name.indexOf(":");
+  if (colon > 0) {
+    const rest = name.slice(colon + 1);
+    switch (name.slice(0, colon)) {
+      case "class":
+        return `class={ ${rest}: condition }`;
+      case "style":
+        return `style={ ${rest}: value }`;
+      case "on":
+      case "v-on":
+        return `on${rest.charAt(0).toUpperCase()}${rest.slice(1)}`;
+      case "bind":
+      case "v-model":
+        return `${rest}:=state`;
+      case "v-bind":
+        return rest;
+    }
+  }
+}
 
 export function _call<T>(fn: (v: T) => unknown, v: T): T {
   fn(v);

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -1,10 +1,10 @@
 import {
   assertExclusiveAttrs,
+  assertValidAttrName,
   assertValidEventHandlerAttr,
 } from "../common/errors";
 import {
   getEventHandlerName,
-  htmlAttrNameReg,
   isEventHandler,
   isNotVoid,
   normalizeDynamicRenderer,
@@ -309,9 +309,7 @@ function attrsInternal(
         break;
       default: {
         if (MARKO_DEBUG) {
-          if (htmlAttrNameReg.test(name)) {
-            throw new Error(`Invalid attribute name: ${JSON.stringify(name)}`);
-          }
+          assertValidAttrName(name);
         }
 
         if (isEventHandler(name)) {

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -1,11 +1,11 @@
 import {
   assertExclusiveAttrs,
   assertHandlerIsFunction,
+  assertValidAttrName,
   assertValidEventHandlerAttr,
 } from "../common/errors";
 import {
   getEventHandlerName,
-  htmlAttrNameReg,
   isEventHandler,
   isNotVoid,
   isVoid,
@@ -279,11 +279,7 @@ export function _attrs(
           )
         ) {
           if (MARKO_DEBUG) {
-            if (htmlAttrNameReg.test(name)) {
-              throw new Error(
-                `Invalid attribute name: ${JSON.stringify(name)}`,
-              );
-            }
+            assertValidAttrName(name);
           }
 
           if (isEventHandler(name)) {

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -9,7 +9,11 @@ import {
 } from "@marko/compiler/babel-utils";
 
 import { assertExclusiveAttrs } from "../../../common/errors";
-import { getEventHandlerName, isEventHandler } from "../../../common/helpers";
+import {
+  getEventHandlerName,
+  getWrongAttrSuggestion,
+  isEventHandler,
+} from "../../../common/helpers";
 import { WalkCode } from "../../../common/types";
 import { bodyToTextLiteral } from "../../util/body-to-text-literal";
 import evaluate from "../../util/evaluate";
@@ -120,6 +124,7 @@ export default {
           }
 
           seen[attr.name] = attr;
+          assertValidNativeAttrName(tag, attr);
 
           if (injectNonce && attr.name === "nonce") {
             injectNonce = false;
@@ -1112,6 +1117,29 @@ function isInjectNonceTag(tagName: string) {
       return true;
     default:
       return false;
+  }
+}
+
+function assertValidNativeAttrName(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute,
+) {
+  const suggestion = getWrongAttrSuggestion(attr.name);
+  if (suggestion) {
+    throw tag.hub.buildError(
+      attr.loc?.end &&
+        ({
+          loc: {
+            start: attr.loc.start,
+            end: {
+              line: attr.loc.start.line,
+              column: attr.loc.start.column + attr.name.length,
+            },
+          },
+        } as any),
+      `\`${attr.name}\` is not a valid attribute, did you mean \`${suggestion}\`?`,
+      Error,
+    );
   }
 }
 


### PR DESCRIPTION
## Problem

Attribute names that are recognizable idioms from another framework but aren't valid in Marko used to compile cleanly and silently render a junk attribute. HTML parses attribute names case-insensitively, so e.g. `className` becomes the `classname` attribute (not `class`), and Svelte's `class:active` / Vue's `v-if` just become literal attributes that do nothing.

```marko
<div className="x">          → classname="x"  (no class applied)
<div class:active=cond>      → class:active="..."  (junk)
<button v-on:click=fn>       → v-on:click="..."  (junk)
```

## Change

On **native tags**, these now error with a suggestion for the correct Marko syntax:

| Framework | Idiom | Suggestion |
|---|---|---|
| React | `className` | `class` |
| React | `htmlFor` | `for` |
| React | `defaultValue` / `defaultChecked` | `value` / `checked` |
| React | `acceptCharset` / `httpEquiv` | `accept-charset` / `http-equiv` |
| React | `dangerouslySetInnerHTML` | `$!{html}` |
| React | `key` / `ref` | `<for by>` / tag variable `<tag/ref>` |
| Solid | `classList` | `class` |
| Svelte | `class:active` | `class={ active: condition }` |
| Svelte | `style:color` | `style={ color: value }` |
| Svelte | `on:click` | `onClick` |
| Svelte | `bind:value` | `value:=state` |
| Vue | `v-if` / `v-else` / `v-else-if` / `v-for` | `<if>` / `<else>` / `<else if>` / `<for>` |
| Vue | `v-show` | `<if>` |
| Vue | `v-model` / `v-model:x` | `value:=state` |
| Vue | `v-on:click` | `onClick` |
| Vue | `v-bind:class` / `v-bind` | `class` / `...attrs` |
| Vue | `v-html` / `v-text` | `$!{html}` / `${text}` |

```
> 1 | <div class:active=isActive>
      |      ^^^^^^^^^^^^ `class:active` is not a valid attribute, did you mean `class={ active: condition }`?
```

Implementation:
- A shared `getWrongAttrSuggestion(name)` helper (exact-name map + colon-directive prefix switch).
- **Compile-time** error lives in the native-tag logic (`native-tag.ts` analyze), for static attributes.
- **`MARKO_DEBUG`-only runtime** error in the server (`html` `_attrs`) and client (`dom` `attrsInternal`) spread/dynamic attribute runtimes, consolidated with the existing structural attribute-name check. Stripped & tree-shaken in production (verified: no trace in `.sizes`).
- **Native tags only** — custom components may still accept input props with these names (verified `<MyComponent className="x"/>` compiles, and `<el/ref>` tag variables are unaffected).

No false positives: camelCase attrs that work via case-insensitivity (`tabIndex`, `readOnly`, `spellCheck`), SVG attrs (`viewBox`), XML namespaces (`xlink:href`, `xml:lang`), and Marko's own `value:=` / `onClick` all stay valid. Vue's `:`/`@` and Angular's `[`/`(`/`*`/`#` shorthands already error as invalid attribute names.

Deliberately excluded: Svelte actions/animations (`use:`, `transition:`, …) and `v-slot`/`v-cloak` (no clean Marko equivalent), and Angular app-specific directives.

## Tests

- Fixtures: `error-native-tag-react-attribute`, `error-native-tag-svelte-directive`, `error-native-tag-vue-directive`, `error-native-spread-react-attribute` (runtime, SSR + CSR).
- Full `runtime-tags/translator` suite: 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeeQVUg7MU16nuUVTogSHx