### PR TITLE
fix(runtime-tags): escape backslashes and `${` in text-only tag literals

### DIFF
--- a/.changeset/text-literal-raw-escape.md
+++ b/.changeset/text-literal-raw-escape.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix text-only native tags (`<title>`, `<style>`, `<html-comment>`, etc.) corrupting dynamic text in the client build. When such a tag's body contained a placeholder, the compiler built the template literal's `raw` string escaping only backticks — not backslashes or `${`. Babel emits code from `raw`, so a backslash in the static text became a JS escape sequence at runtime (e.g. `\b` → backspace) and a literal `${` became a stray interpolation; the server (HTML) build used the correct escaper, so SSR and the hydrated client diverged. The compiler now reuses the shared `escapeTemplateRaw` helper for these literals.

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+const $template = "<title></title><button>go</button>";
+const $walks = " b b";
+const $name = /* @__PURE__ */ _let("name/2", ($scope) => _text_content($scope["#title/0"], `back\\slash ${_to_text($scope.name)}`));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$name($scope, "earth");
+}));
+function $setup($scope) {
+	$name($scope, "world");
+	$setup__script($scope);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $name = /* @__PURE__ */ _let(2, ($scope) => _text_content($scope.a, `back\\slash ${_to_text($scope.c)}`));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$name($scope, "earth");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let name = "world";
+	_html(`<title>back\\slash ${_escape(name)}</title>${_el_resume($scope0_id, "#title/0")}<button>go</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/html.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<title>back\\slash ${_escape("world")}</title>${_el_resume($scope0_id, "a")}<button>go</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.debug.md
@@ -1,0 +1,11 @@
+# Render
+```html
+<button>
+  go
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.md
@@ -1,0 +1,11 @@
+# Render
+```html
+<button>
+  go
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/writes.debug.html
@@ -1,0 +1,9 @@
+<title>back\slash world</title>
+<!--M_*1 #title/0--><button>go</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/writes.html
@@ -1,0 +1,6 @@
+<title>back\slash world</title><!--M_*1 a--><button>go</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = ["a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2720,
+      "brotli": 1378
+    }
+  },
+  "html": {
+    "min": 371,
+    "brotli": 254
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/template.marko
@@ -1,0 +1,3 @@
+<let/name = "world"/>
+<title>back\slash ${name}</title>
+<button onClick() { name = "earth" }>go</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
+++ b/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
@@ -1,5 +1,6 @@
 import { types as t } from "@marko/compiler";
 
+import { escapeTemplateRaw } from "./normalize-string-expression";
 import { callRuntime } from "./runtime";
 
 export function bodyToTextLiteral(body: t.MarkoTagBody) {
@@ -29,7 +30,7 @@ export function bodyToTextLiteral(body: t.MarkoTagBody) {
 function templateElement(value: string, tail: boolean) {
   return t.templateElement(
     {
-      raw: value.replace(/`/g, "\\`"),
+      raw: escapeTemplateRaw(value),
       cooked: value,
     },
     tail,

--- a/packages/runtime-tags/src/translator/util/normalize-string-expression.ts
+++ b/packages/runtime-tags/src/translator/util/normalize-string-expression.ts
@@ -76,7 +76,7 @@ export function appendLiteral(arr: unknown[], str: string) {
   arr[arr.length - 1] += str;
 }
 
-function escapeTemplateRaw(raw: string) {
+export function escapeTemplateRaw(raw: string) {
   return raw
     .replace(/\\/g, "\\\\")
     .replace(/`/g, "\\`")


### PR DESCRIPTION
## What

Text-only native tags (`<title>`, `<style>`, `<html-comment>`, …) with a dynamic placeholder in their body **corrupt the text in the client build**: a backslash in the surrounding static text turns into a JS escape sequence at runtime, and a literal `${` turns into a stray interpolation. The server (HTML) build is correct, so SSR and the hydrated client diverge.

## Why

`bodyToTextLiteral` builds a JS template literal for the tag's text. Babel emits code from a template element's **`raw`** field, but the helper escaped only backticks:

```js
raw: value.replace(/`/g, "\\`"),   // misses \  and  ${
```

So for `<title>back\slash ${name}</title>` the compiled client code was:

```js
_text_content($scope["#title/0"], `back\slash ${_to_text($scope.name)}`)
```

`` `back\slash` `` cooks to `"backslash"` (the `\s` escape drops the backslash) — verified — while SSR sends `back\slash`. A literal `${…}` would likewise become a real interpolation (ReferenceError / wrong value). The rest of the string codegen already escapes correctly via `escapeTemplateRaw` (`\\`, `` ` ``, `${`); this helper was a stale partial copy.

## Fix

Export the canonical `escapeTemplateRaw` from `normalize-string-expression.ts` and reuse it, removing the duplicated (incomplete) escaping:

```js
raw: escapeTemplateRaw(value),
```

Server/HTML output is unchanged (already correct); only the client codegen is corrected.

## Test

Adds `text-only-tag-escape` — `<title>back\slash ${name}</title>` with a button that mutates `name` (so the title is client-rendered through `_text_content`). Verified **red→green** via the compiled DOM bundle snapshot: without the fix it emits the unescaped `` `back\slash …` ``; with it, `` `back\\slash …` `` (which cooks back to `back\slash`). The assertion is at the bundle level because the mutation harness doesn't track text-only-tag text content.

Full `runtime-tags` suite green (5121 passing); no other fixture's output changed; `.sizes` unaffected (translator-only); lint/tsc/prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_