### PR TITLE
test(runtime-tags): cover getWrongAttrSuggestion

### DIFF
--- a/packages/runtime-tags/src/__tests__/common-helpers.test.ts
+++ b/packages/runtime-tags/src/__tests__/common-helpers.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "assert/strict";
 
 import {
+  getWrongAttrSuggestion,
   stringifyClassObject,
   stringifyStyleObject,
   toDelimitedString,
@@ -90,6 +91,57 @@ describe("runtime-tags/common/helpers", () => {
           styleValue([{ color: "red", border: value }, { background: "blue" }]),
           "color:red;background:blue",
         );
+      }
+    });
+  });
+
+  describe("getWrongAttrSuggestion", () => {
+    it("suggests the Marko equivalent for known framework idioms", () => {
+      const cases: Record<string, string> = {
+        className: "class",
+        classList: "class",
+        htmlFor: "for",
+        acceptCharset: "accept-charset",
+        httpEquiv: "http-equiv",
+        defaultValue: "value",
+        defaultChecked: "checked",
+        dangerouslySetInnerHTML: "$!{html}",
+        key: "<for by>",
+        ref: "<tag/ref>",
+        "v-if": "<if>",
+        "v-else": "<else>",
+        "v-else-if": "<else if>",
+        "v-for": "<for>",
+        "v-show": "<if>",
+        "v-model": "value:=state",
+        "v-bind": "...attrs",
+        "v-html": "$!{html}",
+        "v-text": "${text}",
+        "class:active": "class={ active: condition }",
+        "style:color": "style={ color: value }",
+        "on:click": "onClick",
+        "v-on:click": "onClick",
+        "bind:value": "value:=state",
+        "v-model:value": "value:=state",
+        "v-bind:class": "class",
+      };
+      for (const name in cases) {
+        assert.equal(getWrongAttrSuggestion(name), cases[name]);
+      }
+    });
+
+    it("returns undefined for valid attribute names", () => {
+      for (const name of [
+        "class",
+        "for",
+        "onClick",
+        "value",
+        "tabIndex",
+        "xlink:href",
+        "xml:lang",
+        "data-foo",
+      ]) {
+        assert.equal(getWrongAttrSuggestion(name), undefined);
       }
     });
   });


### PR DESCRIPTION
Follow-up to #3251 (now merged) — improves test coverage of the new attribute-idiom suggestions.

`getWrongAttrSuggestion` (the helper that maps React/Svelte/Vue attribute idioms to their Marko equivalents) was only partially covered: the error fixtures abort on the first compile error, so each fixture only exercises a single branch. This adds a focused unit test in `common-helpers.test.ts` that calls the helper directly and asserts the suggestion for:

- every exact-name entry (`className`, `htmlFor`, `defaultValue`, `defaultChecked`, `dangerouslySetInnerHTML`, `key`, `ref`, `classList`, `acceptCharset`, `httpEquiv`, and all `v-*` directives), and
- every colon-directive case (`class:`, `style:`, `on:`/`v-on:`, `bind:`/`v-model:`, `v-bind:`), plus
- the returns-`undefined` path for valid names (`class`, `onClick`, `tabIndex`, `xlink:href`, `xml:lang`, `data-foo`).

Test-only; no runtime behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeeQVUg7MU16nuUVTogSHx

---
_Generated by [Claude Code](https://claude.ai/code/session_01TeeQVUg7MU16nuUVTogSHx)_