### PR TITLE
fix(runtime-tags): error on object/function literal native attr values

### DIFF
--- a/.changeset/native-attr-value-type.md
+++ b/.changeset/native-attr-value-type.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Error in development when a native tag attribute or text interpolation receives a value that can't meaningfully render (a plain object, a promise, a symbol, or a function). For example `<div title={ ... }>` or `${somePromise}` previously rendered useless output like `[object Object]`. Object and function attribute literals are also caught at compile time. `class`/`style`, `content`, event handlers, and change handlers, as well as arrays and values with a meaningful `toString`, are unaffected.

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
@@ -2,33 +2,42 @@
 const $template$1 = "<!><!><!><!>";
 const $walks$1 = "b%b%c";
 const $setup$1 = () => {};
-const $for_content3__row__script = _script("__tests__/tags/hello/index.marko_3_row", ($scope) => _attrs_script($scope, "#div/0"));
-const $for_content3__row = /* @__PURE__ */ _const("row", ($scope) => {
-	_attrs_partial($scope, "#div/0", $scope.row, { class: 1 });
-	$for_content3__row_content($scope, $scope.row?.content);
-	$for_content3__row__script($scope);
+const $for_content3__attrs__script = _script("__tests__/tags/hello/index.marko_3_attrs", ($scope) => _attrs_script($scope, "#div/0"));
+const $for_content3__attrs = /* @__PURE__ */ _const("attrs", ($scope) => {
+	_attrs_partial($scope, "#div/0", $scope.attrs, { class: 1 });
+	$for_content3__attrs__script($scope);
 });
 const $for_content3__dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
-const $for_content3__row_content = ($scope, row_content) => $for_content3__dynamicTag($scope, row_content);
-const $for_content3__$params = ($scope, $params4) => $for_content3__row($scope, $params4[0]);
-const $for_content2__col__script = _script("__tests__/tags/hello/index.marko_2_col", ($scope) => _attrs_script($scope, "#div/0"));
-const $for_content2__col = /* @__PURE__ */ _const("col", ($scope) => {
-	_attrs_partial_content($scope, "#div/0", $scope.col, { class: 1 });
-	$for_content2__col_row($scope, $scope.col?.row);
-	$for_content2__col__script($scope);
+const $for_content3__content = ($scope, content) => $for_content3__dynamicTag($scope, content);
+const $for_content3__$params = ($scope, $params4) => $for_content3__$temp($scope, $params4?.[0]);
+const $for_content3__$temp = ($scope, $temp3) => {
+	(({ content, ...attrs }) => $for_content3__attrs($scope, attrs))($temp3);
+	$for_content3__content($scope, $temp3.content);
+};
+const $for_content2__attrs__script = _script("__tests__/tags/hello/index.marko_2_attrs", ($scope) => _attrs_script($scope, "#div/0"));
+const $for_content2__attrs = /* @__PURE__ */ _const("attrs", ($scope) => {
+	_attrs_partial_content($scope, "#div/0", $scope.attrs, { class: 1 });
+	$for_content2__attrs__script($scope);
 });
 const $for_content2__for = /* @__PURE__ */ _for_of("#text/1", "<div class=row><!></div>", " D%l", 0, $for_content3__$params);
-const $for_content2__col_row = ($scope, col_row) => $for_content2__for($scope, [col_row]);
-const $for_content2__$params = ($scope, $params3) => $for_content2__col($scope, $params3[0]);
-const $for_content__item__script = _script("__tests__/tags/hello/index.marko_1_item", ($scope) => _attrs_script($scope, "#div/0"));
-const $for_content__item = /* @__PURE__ */ _const("item", ($scope) => {
-	_attrs_partial($scope, "#div/0", $scope.item, { class: 1 });
-	$for_content__item_content($scope, $scope.item?.content);
-	$for_content__item__script($scope);
+const $for_content2__row = ($scope, row) => $for_content2__for($scope, [row]);
+const $for_content2__$params = ($scope, $params3) => $for_content2__$temp($scope, $params3?.[0]);
+const $for_content2__$temp = ($scope, $temp2) => {
+	(({ content, row, ...attrs }) => $for_content2__attrs($scope, attrs))($temp2);
+	$for_content2__row($scope, $temp2.row);
+};
+const $for_content__attrs__script = _script("__tests__/tags/hello/index.marko_1_attrs", ($scope) => _attrs_script($scope, "#div/0"));
+const $for_content__attrs = /* @__PURE__ */ _const("attrs", ($scope) => {
+	_attrs_partial($scope, "#div/0", $scope.attrs, { class: 1 });
+	$for_content__attrs__script($scope);
 });
 const $for_content__dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
-const $for_content__item_content = ($scope, item_content) => $for_content__dynamicTag($scope, item_content);
-const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for_content__content = ($scope, content) => $for_content__dynamicTag($scope, content);
+const $for_content__$params = ($scope, $params2) => $for_content__$temp($scope, $params2?.[0]);
+const $for_content__$temp = ($scope, $temp) => {
+	(({ content, ...attrs }) => $for_content__attrs($scope, attrs))($temp);
+	$for_content__content($scope, $temp.content);
+};
 const $for = /* @__PURE__ */ _for_of("#text/0", "<div class=item><!></div>", " D%l", 0, $for_content__$params);
 const $input_list_item = ($scope, input_list_item) => $for($scope, [input_list_item]);
 const $for2 = /* @__PURE__ */ _for_of("#text/1", "<div class=col></div><!><!>", " b%c", 0, $for_content2__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.js
@@ -1,7 +1,7 @@
 // tags/hello/index.marko
-const $for_content3__row__script = _script("b1", ($scope) => _attrs_script($scope, "a"));
-const $for_content2__col__script = _script("b2", ($scope) => _attrs_script($scope, "a"));
-const $for_content__item__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
+const $for_content3__attrs__script = _script("b1", ($scope) => _attrs_script($scope, "a"));
+const $for_content2__attrs__script = _script("b2", ($scope) => _attrs_script($scope, "a"));
+const $for_content__attrs__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
 
 // template.marko
 const $row_content2 = _content_resume("a3", "Outside", "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
@@ -2,32 +2,29 @@
 var hello_default = _template("__tests__/tags/hello/index.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_list_item = _serialize_guard($scope0_reason, 1), $sg__input_col = _serialize_guard($scope0_reason, 2), $sg__input_list_item__OR__input_col = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_for_of(input.list.item, (item) => {
+	_for_of(input.list.item, ({ content, ...attrs }) => {
 		const $scope1_id = _scope_id();
-		_html(`<div class=item${_attrs_partial(item, { class: 1 }, "#div/0", $scope1_id, "div")}>`);
-		_dynamic_tag($scope1_id, "#text/1", item.content, {}, 0, 0, $sg__input_list_item);
+		_html(`<div class=item${_attrs_partial(attrs, { class: 1 }, "#div/0", $scope1_id, "div")}>`);
+		_dynamic_tag($scope1_id, "#text/1", content, {}, 0, 0, $sg__input_list_item);
 		_html(`</div>${_el_resume($scope1_id, "#div/0")}`);
-		_script($scope1_id, "__tests__/tags/hello/index.marko_1_item");
-		writeScope($scope1_id, { item }, "__tests__/tags/hello/index.marko", "1:1", { item: "1:5" });
+		_script($scope1_id, "__tests__/tags/hello/index.marko_1_attrs");
+		writeScope($scope1_id, {}, "__tests__/tags/hello/index.marko", "1:1");
 	}, 0, $scope0_id, "#text/0", $sg__input_list_item, $sg__input_list_item, $sg__input_list_item__OR__input_col, 0, 1);
-	_for_of(input.col, (col) => {
+	_for_of(input.col, ({ content, row, ...attrs }) => {
 		const $scope2_id = _scope_id();
 		_html("<div class=col");
-		_attrs_partial_content(col, { class: 1 }, "#div/0", $scope2_id, "div");
+		_attrs_partial_content(attrs, { class: 1 }, "#div/0", $scope2_id, "div");
 		_html(`</div>${_el_resume($scope2_id, "#div/0")}`);
-		_for_of(col.row, (row) => {
+		_for_of(row, ({ content, ...attrs }) => {
 			const $scope3_id = _scope_id();
-			_html(`<div class=row${_attrs_partial(row, { class: 1 }, "#div/0", $scope3_id, "div")}>`);
-			_dynamic_tag($scope3_id, "#text/1", row.content, {}, 0, 0, $sg__input_col);
+			_html(`<div class=row${_attrs_partial(attrs, { class: 1 }, "#div/0", $scope3_id, "div")}>`);
+			_dynamic_tag($scope3_id, "#text/1", content, {}, 0, 0, $sg__input_col);
 			_html(`</div>${_el_resume($scope3_id, "#div/0")}`);
-			_script($scope3_id, "__tests__/tags/hello/index.marko_3_row");
-			writeScope($scope3_id, { row }, "__tests__/tags/hello/index.marko", "7:3", { row: "7:7" });
+			_script($scope3_id, "__tests__/tags/hello/index.marko_3_attrs");
+			writeScope($scope3_id, {}, "__tests__/tags/hello/index.marko", "7:3");
 		}, 0, $scope2_id, "#text/1", $sg__input_col, $sg__input_col, $sg__input_col, 0, 1);
-		_script($scope2_id, "__tests__/tags/hello/index.marko_2_col");
-		writeScope($scope2_id, { col: {
-			...col,
-			content: undefined
-		} }, "__tests__/tags/hello/index.marko", "5:1", { col: "5:5" });
+		_script($scope2_id, "__tests__/tags/hello/index.marko_2_attrs");
+		writeScope($scope2_id, {}, "__tests__/tags/hello/index.marko", "5:1");
 	}, 0, $scope0_id, "#text/1", $sg__input_col, $sg__input_col, $sg__input_list_item__OR__input_col);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/hello/index.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.js
@@ -2,32 +2,29 @@
 var hello_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_list_item = _serialize_guard($scope0_reason, 1), $sg__input_col = _serialize_guard($scope0_reason, 2), $sg__input_list_item__OR__input_col = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_for_of(input.list.item, (item) => {
+	_for_of(input.list.item, ({ content, ...attrs }) => {
 		const $scope1_id = _scope_id();
-		_html(`<div class=item${_attrs_partial(item, { class: 1 }, "a", $scope1_id, "div")}>`);
-		_dynamic_tag($scope1_id, "b", item.content, {}, 0, 0, $sg__input_list_item);
+		_html(`<div class=item${_attrs_partial(attrs, { class: 1 }, "a", $scope1_id, "div")}>`);
+		_dynamic_tag($scope1_id, "b", content, {}, 0, 0, $sg__input_list_item);
 		_html(`</div>${_el_resume($scope1_id, "a")}`);
 		_script($scope1_id, "b0");
-		writeScope($scope1_id, { d: item });
+		writeScope($scope1_id, {});
 	}, 0, $scope0_id, "a", $sg__input_list_item, $sg__input_list_item, $sg__input_list_item__OR__input_col, 0, 1);
-	_for_of(input.col, (col) => {
+	_for_of(input.col, ({ content, row, ...attrs }) => {
 		const $scope2_id = _scope_id();
 		_html("<div class=col");
-		_attrs_partial_content(col, { class: 1 }, "a", $scope2_id, "div");
+		_attrs_partial_content(attrs, { class: 1 }, "a", $scope2_id, "div");
 		_html(`</div>${_el_resume($scope2_id, "a")}`);
-		_for_of(col.row, (row) => {
+		_for_of(row, ({ content, ...attrs }) => {
 			const $scope3_id = _scope_id();
-			_html(`<div class=row${_attrs_partial(row, { class: 1 }, "a", $scope3_id, "div")}>`);
-			_dynamic_tag($scope3_id, "b", row.content, {}, 0, 0, $sg__input_col);
+			_html(`<div class=row${_attrs_partial(attrs, { class: 1 }, "a", $scope3_id, "div")}>`);
+			_dynamic_tag($scope3_id, "b", content, {}, 0, 0, $sg__input_col);
 			_html(`</div>${_el_resume($scope3_id, "a")}`);
 			_script($scope3_id, "b1");
-			writeScope($scope3_id, { d: row });
+			writeScope($scope3_id, {});
 		}, 0, $scope2_id, "b", $sg__input_col, $sg__input_col, $sg__input_col, 0, 1);
 		_script($scope2_id, "b2");
-		writeScope($scope2_id, { d: {
-			...col,
-			content: void 0
-		} });
+		writeScope($scope2_id, {});
 	}, 0, $scope0_id, "b", $sg__input_col, $sg__input_col, $sg__input_list_item__OR__input_col);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/render.debug.md
@@ -20,7 +20,6 @@
 </div>
 <div
   class="col"
-  row="[object Object]"
   x="0"
 />
 <div
@@ -37,7 +36,6 @@
 </div>
 <div
   class="col"
-  row="[object Object]"
   x="1"
 />
 <div
@@ -55,7 +53,6 @@
 <div
   class="col"
   outside=""
-  row="[object Object]"
 />
 <div
   class="row"

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/render.md
@@ -20,7 +20,6 @@
 </div>
 <div
   class="col"
-  row="[object Object]"
   x="0"
 />
 <div
@@ -37,7 +36,6 @@
 </div>
 <div
   class="col"
-  row="[object Object]"
   x="1"
 />
 <div
@@ -55,7 +53,6 @@
 <div
   class="col"
   outside=""
-  row="[object Object]"
 />
 <div
   class="row"

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/writes.debug.html
@@ -1,120 +1,18 @@
 <div class=item style=color:red>foo</div><!--M_*3 #div/0-->
 <div class=item style=color:blue>bar</div><!--M_*5 #div/0-->
 <div class=item style=color:green>bar</div><!--M_*7 #div/0-->
-<div class=col x=0 row="[object Object]"></div><!--M_*9 #div/0-->
+<div class=col x=0></div><!--M_*9 #div/0-->
 <div class=row row=a>a<!--M_*12 #text/0--></div><!--M_*11 #div/0-->
 <div class=row row=b>b<!--M_*14 #text/0--></div><!--M_*13 #div/0-->
-<div class=col x=1 row="[object Object]"></div><!--M_*15 #div/0-->
+<div class=col x=1></div><!--M_*15 #div/0-->
 <div class=row row=c>c<!--M_*18 #text/0--></div><!--M_*17 #div/0-->
 <div class=row row=d>d<!--M_*20 #text/0--></div><!--M_*19 #div/0-->
-<div class=col outside row="[object Object]"></div><!--M_*21 #div/0-->
+<div class=col outside></div><!--M_*21 #div/0-->
 <div class=row row=-1>Outside</div><!--M_*23 #div/0-->
 <script>
   WALKER_RUNTIME("M")("_");
-  M._.r = [_ => [3, {
-      item: {
-        style: {
-          color: "red"
-        },
-        content: _(1,
-          "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_1_content"
-          ),
-        *[(_.a = [_.b = {
-          style: {
-            color: "blue"
-          },
-          content: _(1,
-            "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_2_content"
-            )
-        }, _.c = {
-          style: {
-            color: "green"
-          },
-          content: _(1,
-            "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_2_content"
-            )
-        }], Symbol.iterator)]() {
-          yield this;
-          yield* _.a
-        }
-      }
-    }, 1, {
-      item: _.b
-    }, 1, {
-      item: _.c
-    }, 1, {
-      col: {
-        x: 0,
-        row: _.g = {
-          row: "a",
-          content: _(1,
-            "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_3_content"
-            ),
-          *[(_.d = [_.h = {
-            row: "b",
-            content: _(1,
-              "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_3_content"
-              )
-          }], Symbol.iterator)]() {
-            yield this;
-            yield* _.d
-          }
-        },
-        *[(_.e = [{
-          x: 1,
-          row: _.i = {
-            row: "c",
-            content: _(1,
-              "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_3_content"
-              ),
-            *[(_.f = [_.j = {
-              row: "d",
-              content: _(1,
-                "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_3_content"
-                )
-            }], Symbol.iterator)]() {
-              yield this;
-              yield* _.f
-            }
-          }
-        }, {
-          outside: !0,
-          row: _.k = {
-            row: -1,
-            content: _(1,
-              "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/template.marko_4_content"
-              ),
-            *[Symbol.iterator]() {
-              yield this
-            }
-          }
-        }], Symbol.iterator)]() {
-          yield this;
-          yield* _.e
-        }
-      }
-    }, 1, {
-      row: _.g
-    }, 1, {
-      row: _.h
-    }, 1, {
-      col: {
-        x: 1,
-        row: _.i
-      }
-    }, 1, {
-      row: _.i
-    }, 1, {
-      row: _.j
-    }, 1, {
-      col: {
-        outside: !0,
-        row: _.k
-      }
-    }, 1, {
-      row: _.k
-    }],
-    "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_1_item 3 5 7 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_row 11 13 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_col 9 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_row 17 19 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_col 15 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_row 23 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_col 21"
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_1_attrs 3 5 7 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_attrs 11 13 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_attrs 9 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_attrs 17 19 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_attrs 15 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_3_attrs 23 packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko_2_attrs 21"
   ];
   M._.w()
 </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/writes.html
@@ -1,102 +1,16 @@
 <div class=item style=color:red>foo</div><!--M_*3 a-->
 <div class=item style=color:blue>bar</div><!--M_*5 a-->
 <div class=item style=color:green>bar</div><!--M_*7 a-->
-<div class=col x=0 row="[object Object]"></div><!--M_*9 a-->
+<div class=col x=0></div><!--M_*9 a-->
 <div class=row row=a>a<!--M_*12 a--></div><!--M_*11 a-->
 <div class=row row=b>b<!--M_*14 a--></div><!--M_*13 a-->
-<div class=col x=1 row="[object Object]"></div><!--M_*15 a-->
+<div class=col x=1></div><!--M_*15 a-->
 <div class=row row=c>c<!--M_*18 a--></div><!--M_*17 a-->
 <div class=row row=d>d<!--M_*20 a--></div><!--M_*19 a-->
-<div class=col outside row="[object Object]"></div><!--M_*21 a-->
+<div class=col outside></div><!--M_*21 a-->
 <div class=row row=-1>Outside</div><!--M_*23 a-->
 <script>
   WALKER_RUNTIME("M")("_");
-  M._.r = [_ => [3, {
-    d: {
-      style: {
-        color: "red"
-      },
-      content: _(1, "a0"),
-      *[(_.a = [_.b = {
-        style: {
-          color: "blue"
-        },
-        content: _(1, "a1")
-      }, _.c = {
-        style: {
-          color: "green"
-        },
-        content: _(1, "a1")
-      }], Symbol.iterator)]() {
-        yield this;
-        yield* _.a
-      }
-    }
-  }, 1, {
-    d: _.b
-  }, 1, {
-    d: _.c
-  }, 1, {
-    d: {
-      x: 0,
-      row: _.g = {
-        row: "a",
-        content: _(1, "a2"),
-        *[(_.d = [_.h = {
-          row: "b",
-          content: _(1, "a2")
-        }], Symbol.iterator)]() {
-          yield this;
-          yield* _.d
-        }
-      },
-      *[(_.e = [{
-        x: 1,
-        row: _.i = {
-          row: "c",
-          content: _(1, "a2"),
-          *[(_.f = [_.j = {
-            row: "d",
-            content: _(1, "a2")
-          }], Symbol.iterator)]() {
-            yield this;
-            yield* _.f
-          }
-        }
-      }, {
-        outside: !0,
-        row: _.k = {
-          row: -1,
-          content: _(1, "a3"),
-          *[Symbol.iterator]() {
-            yield this
-          }
-        }
-      }], Symbol.iterator)]() {
-        yield this;
-        yield* _.e
-      }
-    }
-  }, 1, {
-    d: _.g
-  }, 1, {
-    d: _.h
-  }, 1, {
-    d: {
-      x: 1,
-      row: _.i
-    }
-  }, 1, {
-    d: _.i
-  }, 1, {
-    d: _.j
-  }, 1, {
-    d: {
-      outside: !0,
-      row: _.k
-    }
-  }, 1, {
-    d: _.k
-  }], "b0 3 5 7 b1 11 13 b2 9 b1 17 19 b2 15 b1 23 b2 21"];
+  M._.r = ["b0 3 5 7 b1 11 13 b2 9 b1 17 19 b2 15 b1 23 b2 21"];
   M._.w()
 </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/tags/hello/index.marko
@@ -1,9 +1,9 @@
-for|item| of=input.list.item
-  div.item ...item
-    ${item.content}
+for|{ content, ...attrs }| of=input.list.item
+  div.item ...attrs
+    ${content}
 
-for|col| of=input.col
-  div.col ...col
-  for|row| of=col.row
-    div.row ...row
-      ${row.content}
+for|{ content, row, ...attrs }| of=input.col
+  div.col ...attrs
+  for|{ content, ...attrs }| of=row
+    div.row ...attrs
+      ${content}

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<!--${_escape_comment(input.value)}-->${_el_resume($scope0_id, "#comment/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/template.marko
@@ -1,0 +1,1 @@
+<html-comment>${input.value}</html-comment>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: { key: "value" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a function.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_attr("title", input.handler)}>Hello</div>${_el_resume($scope0_id, "#div/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a function.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/template.marko
@@ -1,0 +1,3 @@
+<div title=input.handler>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ handler: () => {} }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko:1:6
+    > 1 | <div title=() => doThing()>
+        |      ^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a function.
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko:1:6
+    > 1 | <div title=() => doThing()>
+        |      ^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a function.
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko:1:6
+    > 1 | <div title=() => doThing()>
+        |      ^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a function.
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko:1:6
+    > 1 | <div title=() => doThing()>
+        |      ^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a function.
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/template.marko
@@ -1,0 +1,3 @@
+<div title=() => doThing()>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_attr("title", input.value)}>Hello</div>${_el_resume($scope0_id, "#div/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/template.marko
@@ -1,0 +1,3 @@
+<div title=input.value>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: { key: "value" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko:1:6
+    > 1 | <div title={ key: "value" }>
+        |      ^^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a plain object (it would render as `[object Object]`).
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko:1:6
+    > 1 | <div title={ key: "value" }>
+        |      ^^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a plain object (it would render as `[object Object]`).
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko:1:6
+    > 1 | <div title={ key: "value" }>
+        |      ^^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a plain object (it would render as `[object Object]`).
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko:1:6
+    > 1 | <div title={ key: "value" }>
+        |      ^^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a plain object (it would render as `[object Object]`).
+      2 |   Hello
+      3 | </div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/template.marko
@@ -1,0 +1,3 @@
+<div title={ key: "value" }>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a promise (use the `<await>` tag to render its resolved value).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_attr("title", input.value)}>Hello</div>${_el_resume($scope0_id, "#div/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a promise (use the `<await>` tag to render its resolved value).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/template.marko
@@ -1,0 +1,3 @@
+<div title=input.value>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: Promise.resolve("hello") }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a symbol.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_attr("title", input.value)}>Hello</div>${_el_resume($scope0_id, "#div/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The `title` attribute cannot be a symbol.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/template.marko
@@ -1,0 +1,3 @@
+<div title=input.value>
+  Hello
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: Symbol("hello") }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<script${_attr_nonce()}>${_escape_script(input.value)}<\/script>${_el_resume($scope0_id, "#script/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/template.marko
@@ -1,0 +1,1 @@
+<html-script>${input.value}</html-script>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-script-object-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: { key: "value" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<style${_attr_nonce()}>${_escape_style(input.value)}</style>${_el_resume($scope0_id, "#style/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/template.marko
@@ -1,0 +1,1 @@
+<html-style>${input.value}</html-style>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-style-object-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: { key: "value" } }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.value)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Text content cannot be a plain object (it would render as `[object Object]`).

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/template.marko
@@ -1,0 +1,3 @@
+<div>
+  ${input.value}
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: { key: "value" } }],
+};

--- a/packages/runtime-tags/src/__tests__/html-content.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-content.test.ts
@@ -24,7 +24,7 @@ describe("runtime-tags/html/content", () => {
       assert.equal(helpers._escape(42), "42");
       assert.equal(helpers._escape(true), "true");
       assert.equal(helpers._escape("foo"), "foo");
-      assert.equal(helpers._escape({}), "[object Object]");
+      assert.equal(helpers._escape({ toString: () => "custom" }), "custom");
     });
   });
 
@@ -54,7 +54,10 @@ describe("runtime-tags/html/content", () => {
       assert.equal(helpers._escape_script(42), "42");
       assert.equal(helpers._escape_script(true), "true");
       assert.equal(helpers._escape_script("foo"), "foo");
-      assert.equal(helpers._escape_script({}), "[object Object]");
+      assert.equal(
+        helpers._escape_script({ toString: () => "custom" }),
+        "custom",
+      );
     });
   });
 
@@ -88,7 +91,10 @@ describe("runtime-tags/html/content", () => {
       assert.equal(helpers._escape_style(42), "42");
       assert.equal(helpers._escape_style(true), "true");
       assert.equal(helpers._escape_style("foo"), "foo");
-      assert.equal(helpers._escape_style({}), "[object Object]");
+      assert.equal(
+        helpers._escape_style({ toString: () => "custom" }),
+        "custom",
+      );
     });
   });
 
@@ -126,7 +132,10 @@ describe("runtime-tags/html/content", () => {
       assert.equal(helpers._escape_comment(42), "42");
       assert.equal(helpers._escape_comment(true), "true");
       assert.equal(helpers._escape_comment("foo"), "foo");
-      assert.equal(helpers._escape_comment({}), "[object Object]");
+      assert.equal(
+        helpers._escape_comment({ toString: () => "custom" }),
+        "custom",
+      );
     });
   });
 });

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -2,6 +2,59 @@ import { getWrongAttrSuggestion, htmlAttrNameReg } from "./helpers";
 
 const lowercaseEventHandlerReg = /^on[a-z]/;
 
+export function assertValidAttrValue(name: string, value: unknown) {
+  if (
+    value &&
+    typeof value !== "string" &&
+    lowercaseEventHandlerReg.test(name)
+  ) {
+    throw new Error(
+      `The \`${name}\` attribute must be a string or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …), but received type "${typeof value}". To attach an event listener, use the \`on${name[2].toUpperCase()}${name.slice(3)}\` event handler instead.`,
+    );
+  }
+
+  if (typeof value === "function") {
+    if (name === "content" || /^on/i.test(name) || /Change$/.test(name)) {
+      return;
+    }
+    throw new Error(`The \`${name}\` attribute cannot be a function.`);
+  }
+
+  const unrenderable = describeUnrenderable(value);
+  if (unrenderable) {
+    throw new Error(`The \`${name}\` attribute cannot be ${unrenderable}.`);
+  }
+}
+
+export function assertValidTextValue(value: unknown) {
+  const unrenderable = describeUnrenderable(value);
+  if (unrenderable) {
+    throw new Error(`Text content cannot be ${unrenderable}.`);
+  }
+}
+
+function describeUnrenderable(value: unknown) {
+  if (typeof value === "symbol") {
+    return "a symbol";
+  }
+
+  if (typeof value === "object" && value !== null) {
+    let stringified;
+    try {
+      stringified = `${value}`;
+    } catch {
+      stringified = "[object Object]";
+    }
+    if (/^\[object \w+\]$/.test(stringified)) {
+      return stringified === "[object Promise]"
+        ? "a promise (use the `<await>` tag to render its resolved value)"
+        : stringified === "[object Object]"
+          ? "a plain object (it would render as `[object Object]`)"
+          : `a value that renders as \`${stringified}\``;
+    }
+  }
+}
+
 export function assertValidAttrName(name: string) {
   if (htmlAttrNameReg.test(name)) {
     throw new Error(`Invalid attribute name: ${JSON.stringify(name)}`);
@@ -70,18 +123,6 @@ export function assertExclusiveAttrs(
         `The attributes ${joinWithAnd(exclusiveAttrs)} are mutually exclusive.`,
       );
     }
-  }
-}
-
-export function assertValidEventHandlerAttr(name: string, value: unknown) {
-  if (
-    value &&
-    typeof value !== "string" &&
-    lowercaseEventHandlerReg.test(name)
-  ) {
-    throw new Error(
-      `The \`${name}\` attribute must be a string or a falsey value (\`null\`, \`undefined\`, \`false\`, \`0\`, …), but received type "${typeof value}". To attach an event listener, use the \`on${name[2].toUpperCase()}${name.slice(3)}\` event handler instead.`,
-    );
   }
 }
 

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -1,7 +1,8 @@
 import {
   assertExclusiveAttrs,
   assertValidAttrName,
-  assertValidEventHandlerAttr,
+  assertValidAttrValue,
+  assertValidTextValue,
 } from "../common/errors";
 import {
   getEventHandlerName,
@@ -40,12 +41,15 @@ import { createAndSetupBranch, type Renderer } from "./renderer";
 import { subscribeToScopeSet } from "./signals";
 
 export function _to_text(value: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(value);
+  }
   return value || value === 0 ? value + "" : "";
 }
 
 export function _attr(element: Element, name: string, value: unknown) {
   if (MARKO_DEBUG) {
-    assertValidEventHandlerAttr(name, value);
+    assertValidAttrValue(name, value);
   }
   setAttribute(element, name, normalizeAttrValue(value));
 }

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -2,7 +2,7 @@ import {
   assertExclusiveAttrs,
   assertHandlerIsFunction,
   assertValidAttrName,
-  assertValidEventHandlerAttr,
+  assertValidAttrValue,
 } from "../common/errors";
 import {
   getEventHandlerName,
@@ -213,9 +213,6 @@ export function _attr_nonce() {
 }
 
 export function _attr(name: string, value: unknown) {
-  if (MARKO_DEBUG) {
-    assertValidEventHandlerAttr(name, value);
-  }
   return isVoid(value) ? "" : nonVoidAttr(name, value);
 }
 
@@ -391,6 +388,9 @@ function stringAttr(name: string, value: string) {
 }
 
 function nonVoidAttr(name: string, value: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidAttrValue(name, value);
+  }
   switch (typeof value) {
     case "string":
       return " " + name + attrAssignment(value);

--- a/packages/runtime-tags/src/html/content.ts
+++ b/packages/runtime-tags/src/html/content.ts
@@ -1,4 +1,9 @@
+import { assertValidTextValue } from "../common/errors";
+
 export function _unescaped(val: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(val);
+  }
   return val ? val + "" : val === 0 ? "0" : "";
 }
 
@@ -7,6 +12,9 @@ const replaceUnsafeXML = (c: string) => (c === "&" ? "&amp;" : "&lt;");
 const escapeXMLStr = (str: string) =>
   unsafeXMLReg.test(str) ? str.replace(unsafeXMLReg, replaceUnsafeXML) : str;
 export function _escape(val: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(val);
+  }
   return val ? escapeXMLStr(val + "") : val === 0 ? "0" : "";
 }
 
@@ -16,6 +24,9 @@ const escapeScriptStr = (str: string) =>
     ? str.replace(unsafeScriptReg, "\\x3C/script")
     : str;
 export function _escape_script(val: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(val);
+  }
   return val ? escapeScriptStr(val + "") : val === 0 ? "0" : "";
 }
 
@@ -24,6 +35,9 @@ const escapeStyleStr = (str: string) =>
   unsafeStyleReg.test(str) ? str.replace(unsafeStyleReg, "\\3C/style") : str;
 
 export function _escape_style(val: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(val);
+  }
   return val ? escapeStyleStr(val + "") : val === 0 ? "0" : "";
 }
 
@@ -32,5 +46,8 @@ const escapeCommentStr = (str: string) =>
   unsafeCommentReg.test(str) ? str.replace(unsafeCommentReg, "&gt;") : str;
 
 export function _escape_comment(val: unknown) {
+  if (MARKO_DEBUG) {
+    assertValidTextValue(val);
+  }
   return val ? escapeCommentStr(val + "") : val === 0 ? "0" : "";
 }

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -125,6 +125,7 @@ export default {
 
           seen[attr.name] = attr;
           assertValidNativeAttrName(tag, attr);
+          assertNativeAttrValueType(tag, attr);
 
           if (injectNonce && attr.name === "nonce") {
             injectNonce = false;
@@ -1138,6 +1139,38 @@ function assertValidNativeAttrName(
           },
         } as any),
       `\`${attr.name}\` is not a valid attribute, did you mean \`${suggestion}\`?`,
+      Error,
+    );
+  }
+}
+
+function assertNativeAttrValueType(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute,
+) {
+  const { name } = attr;
+  if (
+    name === "class" ||
+    name === "style" ||
+    name === "content" ||
+    isEventOrChangeHandler(name) ||
+    lowercaseEventHandlerReg.test(name)
+  ) {
+    return;
+  }
+
+  if (t.isFunction(attr.value)) {
+    throw tag.hub.buildError(
+      attr,
+      `The \`${name}\` attribute cannot be a function.`,
+      Error,
+    );
+  }
+
+  if (t.isObjectExpression(attr.value)) {
+    throw tag.hub.buildError(
+      attr,
+      `The \`${name}\` attribute cannot be a plain object (it would render as \`[object Object]\`).`,
       Error,
     );
   }


### PR DESCRIPTION
## Problem

A regular native tag attribute can only render a string. Passing a plain object or a function renders useless output:

```marko
<div title={ key: "value" }>    → title="[object Object]"
<div title=() => doThing()>      → title stringifies the function source
```

## Change

Object and function values on a native attribute now error, at **compile time** (literals) and at **runtime** (`MARKO_DEBUG`-only, dynamic values, in the server `nonVoidAttr` and client `_attr` runtimes):

```
> 1 | <div title={ key: "value" }>
      |      ^^^^^^^^^^^^^^^^^^^^^^ The `title` attribute cannot be a plain object (it would render as `[object Object]`).
```

**Excluded:** `class`/`style` (objects), `content`, event handlers, and change handlers (functions); also arrays and any value with a meaningful `toString` (the runtime object check keys off whether the value stringifies to `[object Object]`, so `[1, 2]`, dates, etc. are fine).

### `at-tags-dynamic` fixture fix

Enabling the runtime object check surfaced one existing fixture that was rendering `[object Object]`: its `<hello>` component spread an attribute-tag input (`<div ...col>`) that still contained the nested `@row` group and the `content` render body, producing `row="[object Object]"`. That's never valid output, so the fixture now destructures the structural keys out before spreading:

```marko
for|{ content, row, ...attrs }| of=input.col
  div.col ...attrs
  ...
```

It was the only fixture in the suite rendering `[object Object]`.

## Tests

- `error-native-attr-object`, `error-native-attr-function` (compile).
- `error-native-attr-object-dynamic`, `error-native-attr-function-dynamic` (runtime, SSR + CSR).
- Full `runtime-tags/translator` suite: 8121 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TeeQVUg7MU16nuUVTogSHx