### PR TITLE
fix(runtime-tags): warn when a controlled select value matches no option

### DIFF
--- a/.changeset/select-resume-no-match.md
+++ b/.changeset/select-resume-no-match.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Warn in development when a controlled `<select>`'s `value` matches no `<option>`. A single select always forces one option selected, so an unmatched value cannot round-trip through SSR resume (the server serializes which option is selected, not the value) and the controlled value is lost on the client. Both the server and client runtimes now emit a `MARKO_DEBUG` `console.error` so the mistake is surfaced during development.

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<select><option value=a>A</option><option value=b>B</option><option value=c>C</option></select><span> </span>";
+const $walks = " bD l";
+const $value = /* @__PURE__ */ _let("value/2", ($scope) => {
+	_attr_select_value($scope, "#select/0", $scope.value, $valueChange($scope));
+	_text($scope["#text/1"], $scope.value);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_select_value_script($scope, "#select/0"));
+function $setup($scope) {
+	$value($scope, "x");
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = "x";
+	_attr_select_value($scope0_id, "#select/0", value, _resume(function(v) {
+		value = v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option><option${_attr_option_value("c")}>C</option></select>`);
+	});
+	_html(`${_el_resume($scope0_id, "#select/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/render-csr.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<select>
+  <option
+    selected=""
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+  <option
+    value="c"
+  >
+    C
+  </option>
+</select>
+<span>
+  x
+</span>
+```
+## Console
+```
+ERROR "A controlled `<select>`'s `value` has no matching `<option>`:" "x"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,57 @@
+# Render
+```html
+<select>
+  <option
+    selected=""
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+  <option
+    value="c"
+  >
+    C
+  </option>
+</select>
+<span>
+  x
+</span>
+```
+## Console
+```
+ERROR "A controlled `<select>`'s `value` has no matching `<option>`:" "x"
+```
+
+# Update
+```html
+<select>
+  <option
+    selected=""
+    value="a"
+  >
+    A
+  </option>
+  <option
+    value="b"
+  >
+    B
+  </option>
+  <option
+    value="c"
+  >
+    C
+  </option>
+</select>
+<span>
+  a
+</span>
+```
+## Change
+```
+UPDATE: span::text "x" => "a"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/writes.debug.html
@@ -1,0 +1,17 @@
+<select>
+  <option value=a>A</option>
+  <option value=b>B</option>
+  <option value=c>C</option>
+</select><!--M_*1 #select/0--><span>x<!--M_*1 #text/1--></span>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledType:#select/0": 3,
+      "ControlledHandler:#select/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/template.marko
@@ -1,0 +1,7 @@
+<let/value = "x"/>
+<select value=value valueChange(v) { value=v }>
+  <option value="a">A</option>
+  <option value="b">B</option>
+  <option value="c">C</option>
+</>
+<span>${value}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/test.ts
@@ -1,0 +1,15 @@
+import type { TestConfig } from "../../main.test";
+
+// A controlled `<select>` whose `value` matches no `<option>` is a mistake: a
+// single select always forces one option selected, so the browser falls back
+// to the first option and the controlled value cannot round-trip through SSR
+// resume (the server serializes which option is selected, not the value). Both
+// the HTML (server) and DOM (client) runtimes emit a `MARKO_DEBUG`
+// `console.error`, captured under `## Console`. The warning only exists in
+// debug builds, so the optimized build is skipped, and because the unmatched
+// value resumes differently than it renders on the client the SSR and CSR
+// outputs are not equivalent.
+export const config: TestConfig = {
+  skip_optimize: true,
+  equivalent: false,
+};

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -293,6 +293,13 @@ export function _attr_select_value(
     ? ControlledType.SelectValue
     : ControlledType.None;
 
+  if (MARKO_DEBUG && valueChange) {
+    pendingEffects.unshift(
+      () => assertSelectValueMatchesOption(el, normalizedValue, value),
+      scope,
+    );
+  }
+
   if (valueChange && existing) {
     pendingEffects.unshift(
       () => setSelectValue(el, normalizedValue, multiple),
@@ -372,6 +379,28 @@ function getSelectValue(el: HTMLSelectElement, multiple: boolean) {
   return multiple
     ? Array.from(el.selectedOptions, (opt) => opt.value)
     : el.value;
+}
+function assertSelectValueMatchesOption(
+  el: HTMLSelectElement,
+  normalizedValue: string | string[],
+  value: unknown,
+) {
+  const multiple = Array.isArray(normalizedValue);
+  if (multiple ? normalizedValue.some(Boolean) : normalizedValue) {
+    for (const opt of el.options) {
+      if (
+        multiple
+          ? normalizedValue.includes(opt.value)
+          : opt.value === normalizedValue
+      ) {
+        return;
+      }
+    }
+    console.error(
+      "A controlled `<select>`'s `value` has no matching `<option>`:",
+      value,
+    );
+  }
 }
 
 export function _attr_details_or_dialog_open_default(

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -40,12 +40,22 @@ export function _attr_style(value: unknown) {
 
 export function _attr_option_value(value: unknown) {
   const valueAttr = _attr("value", value);
-  return normalizedValueMatches(getContext(kSelectedValue), value)
-    ? valueAttr + " selected"
-    : valueAttr;
+  if (normalizedValueMatches(getContext(kSelectedValue), value)) {
+    if (MARKO_DEBUG) {
+      const matched = getContext(kSelectedValueMatched) as
+        | { value: boolean }
+        | undefined;
+      if (matched) {
+        matched.value = true;
+      }
+    }
+    return valueAttr + " selected";
+  }
+  return valueAttr;
 }
 
 const kSelectedValue = Symbol("selectedValue");
+const kSelectedValueMatched = Symbol("selectedValueMatched");
 export function _attr_select_value(
   scopeId: number,
   nodeAccessor: Accessor,
@@ -64,7 +74,25 @@ export function _attr_select_value(
   }
 
   if (content) {
-    withContext(kSelectedValue, value, content);
+    if (MARKO_DEBUG && valueChange) {
+      const matched = { value: false };
+      withContext(kSelectedValue, value, () =>
+        withContext(kSelectedValueMatched, matched, content),
+      );
+      if (
+        !matched.value &&
+        (Array.isArray(value)
+          ? value.some((v) => normalizeStrAttrValue(v) !== "")
+          : normalizeStrAttrValue(value) !== "")
+      ) {
+        console.error(
+          "A controlled `<select>`'s `value` has no matching `<option>`:",
+          value,
+        );
+      }
+    } else {
+      withContext(kSelectedValue, value, content);
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

A controlled `<select>` (`value` + `valueChange`) whose `value` matches no `<option>` behaves inconsistently between client rendering and SSR resume.

The controlled value itself isn't serialized — the server only marks the matching option `selected`. When the value matches nothing, no option is marked, but a single `<select>` **always forces one option selected**, so the browser falls back to the first option. On resume the runtime can only reconstruct the controlled value from the DOM, so the original (unmatched) value is lost and the binding is silently rewritten to the first option's value — something client rendering never does.

## Approach

This is fundamentally a developer mistake (a controlled value that no option can represent), and the value can't be recovered on resume without serializing it on every controlled select. Rather than mask it with runtime logic, **warn in development**: both the server (HTML) and client (DOM) runtimes now emit a `MARKO_DEBUG` `console.error` when a controlled select's `value` matches no `<option>`, mirroring the existing `<for>` `by` warning.

- DOM: `_attr_select_value` schedules a debug-only check against the rendered options.
- HTML: `_attr_select_value` tracks whether any `<option>` matched while rendering its content, and warns afterward.

The warning is stripped from production builds, so there is **no runtime size impact** (the `.sizes` are unchanged from `main`).

## Fixture

`controllable-select-no-match` (debug-only, `skip_optimize`, `equivalent: false`) captures the `console.error` under `## Console` and documents the resulting SSR-vs-CSR divergence — CSR keeps the value while SSR resume rewrites it to the first option.

## Verification

- Full `runtime-tags` suite: 5141 passing.
- tsc + eslint clean.
- `.sizes` identical to `main` (debug-only code).

### Note

This *warns about* the no-match case rather than fixing the resume behavior, so in production an unmatched controlled value is still rewritten to the first option on resume. That tradeoff was chosen deliberately (see PR discussion) over adding runtime/serialization cost to handle a misuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)