### PR TITLE
fix(runtime-tags): link closest branch on resume for lifecycle-only components

### DIFF
--- a/.changeset/lifecycle-resume-closest-branch.md
+++ b/.changeset/lifecycle-resume-closest-branch.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix `<lifecycle>` `onDestroy` not running after resume when it is the only interactive feature of a component nested in control flow. The lifecycle cleanup is registered through `$signal` at runtime, which requires the scope to resume with its closest branch linked; the section is now marked so that link is serialized.

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,32 @@
+// tags/child.marko
+const $template$1 = "<p>child</p>";
+const $walks$1 = "b";
+const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => _lifecycle($scope, {
+	onMount: function() {
+		document.getElementById("ref").textContent = "Mounted";
+	},
+	onDestroy: function() {
+		document.getElementById("ref").textContent = "Destroyed";
+	}
+}));
+const $setup$1 = $setup__script;
+var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $template$1, "b", $setup$1);
+
+// template.marko
+const $template = "<div id=ref>initial</div><button id=toggle>Toggle</button><!><!>";
+const $walks = "b b%c";
+const $if_content__setup = ($scope) => {
+	$setup$1($scope["#childScope/0"]);
+};
+const $if = /* @__PURE__ */ _if("#text/1", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup);
+const $show__script = _script("__tests__/template.marko_0_show", ($scope) => _on($scope["#button/0"], "click", function() {
+	$show($scope, !$scope.show);
+}));
+const $show = /* @__PURE__ */ _let("show/2", ($scope) => {
+	$if($scope, $scope.show ? 0 : 1);
+	$show__script($scope);
+});
+function $setup($scope) {
+	$show($scope, true);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/dom.bundle.js
@@ -1,0 +1,24 @@
+// tags/child.marko
+const $template = "<p>child</p>";
+const $setup__script = _script("b0", ($scope) => _lifecycle($scope, {
+	onMount: function() {
+		document.getElementById("ref").textContent = "Mounted";
+	},
+	onDestroy: function() {
+		document.getElementById("ref").textContent = "Destroyed";
+	}
+}));
+const $setup = $setup__script;
+
+// template.marko
+const $if_content__setup = ($scope) => {
+	$setup($scope.a);
+};
+const $if = /* @__PURE__ */ _if(1, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup);
+const $show__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$show($scope, !$scope.c);
+}));
+const $show = /* @__PURE__ */ _let(2, ($scope) => {
+	$if($scope, $scope.c ? 0 : 1);
+	$show__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<p>child</p>");
+	_script($scope0_id, "__tests__/tags/child.marko_0");
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let show = true;
+	_html(`<div id=ref>initial</div><button id=toggle>Toggle</button>${_el_resume($scope0_id, "#button/0")}`);
+	_if(() => {
+		if (show) {
+			const $scope1_id = _scope_id();
+			child_default({});
+			writeScope($scope1_id, {}, "__tests__/template.marko", "4:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/1", 1, 1, 1, 0, 1);
+	_script($scope0_id, "__tests__/template.marko_0_show");
+	writeScope($scope0_id, { show }, "__tests__/template.marko", 0, { show: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/html.bundle.js
@@ -1,0 +1,27 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<p>child</p>");
+	_script($scope0_id, "b0");
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let show = true;
+	_html(`<div id=ref>initial</div><button id=toggle>Toggle</button>${_el_resume($scope0_id, "a")}`);
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			child_default({});
+			writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "b", 1, 1, 1, 0, 1);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: show });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/render.debug.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<div
+  id="ref"
+>
+  Mounted
+</div>
+<button
+  id="toggle"
+>
+  Toggle
+</button>
+<p>
+  child
+</p>
+```
+
+# Update
+```js
+container.querySelector("#toggle").click();
+```
+```html
+<div
+  id="ref"
+>
+  Destroyed
+</div>
+<button
+  id="toggle"
+>
+  Toggle
+</button>
+```
+## Change
+```
+REMOVE: #toggle + p
+REMOVE: #ref::text("Mounted")
+INSERT: #ref::text("Destroyed")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/render.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<div
+  id="ref"
+>
+  Mounted
+</div>
+<button
+  id="toggle"
+>
+  Toggle
+</button>
+<p>
+  child
+</p>
+```
+
+# Update
+```js
+container.querySelector("#toggle").click();
+```
+```html
+<div
+  id="ref"
+>
+  Destroyed
+</div>
+<button
+  id="toggle"
+>
+  Toggle
+</button>
+```
+## Change
+```
+REMOVE: #toggle + p
+REMOVE: #ref::text("Mounted")
+INSERT: #ref::text("Destroyed")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<div id=ref>initial</div><button id=toggle>Toggle</button><!--M_*1 #button/0-->
+<p>child</p><!--M_|1 #text/1 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      show: !0
+    }, 1, {
+      "#ClosestBranchId": 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/tags/child.marko_0 3 packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/template.marko_0_show 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<div id=ref>initial</div><button id=toggle>Toggle</button><!--M_*1 a-->
+<p>child</p><!--M_|1 b 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: !0
+  }, 1, {
+    G: 2
+  }], "b0 3 a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6254,
+        "brotli": 2798
+      },
+      "files": {
+        "tags/child.marko": 353,
+        "template.marko": 440
+      }
+    }
+  },
+  "html": {
+    "min": 420,
+    "brotli": 285
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/tags/child.marko
@@ -1,0 +1,5 @@
+<p>child</p>
+<lifecycle
+  onMount() { document.getElementById("ref").textContent = "Mounted"; }
+  onDestroy() { document.getElementById("ref").textContent = "Destroyed"; }
+/>

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/template.marko
@@ -1,0 +1,6 @@
+<let/show=true/>
+<div#ref>initial</div>
+<button#toggle onClick() { show = !show }>Toggle</button>
+<if=show>
+  <child/>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+// A child component whose only interactive feature is a `<lifecycle>` (no
+// `let`, no closures, no source `$signal`). Its `onDestroy` cleanup is wired
+// through `$signal` at runtime, which requires the scope to resume with its
+// closest branch linked. Toggling the `<if>` off after resume must run the
+// cleanup, matching client-side rendering.
+function toggle(container: Element) {
+  container.querySelector<HTMLButtonElement>("#toggle")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, toggle],
+};

--- a/packages/runtime-tags/src/translator/core/lifecycle.ts
+++ b/packages/runtime-tags/src/translator/core/lifecycle.ts
@@ -35,6 +35,9 @@ export default {
       getAllTagReferenceNodes(tag.node),
     );
     tagExtra.isEffect = true;
+    // `_lifecycle` registers cleanup via `$signal` at runtime, so the scope
+    // must resume with its closest branch linked.
+    section.hasAbortSignal = true;
 
     if (node.attributes.length === 0) {
       throw tag


### PR DESCRIPTION
## Problem

A component whose only interactive feature is a `<lifecycle>` tag — no `let`, no closures, no source-level `$signal` — loses its `onDestroy` cleanup after **SSR + resume** when it is nested in control flow (`<if>`/`<for>`). Client-only rendering works correctly, so this is a resume-only divergence.

### Repro

```marko
// template.marko
<let/show=true/>
<div#ref>initial</div>
<button#toggle onClick() { show = !show }>Toggle</button>
<if=show>
  <child/>
</if>
```

```marko
// tags/child.marko
<p>child</p>
<lifecycle
  onMount() { document.getElementById("ref").textContent = "Mounted"; }
  onDestroy() { document.getElementById("ref").textContent = "Destroyed"; }
/>
```

Toggling the `<if>` off after resume:
- **CSR:** `#ref` → "Destroyed" ✓
- **SSR + resume:** `#ref` stays "Mounted" ✗ — `onDestroy` never runs.

## Root cause

`_lifecycle` registers its cleanup at runtime via `$signal(scope, accessor).onabort = …`. `$signal` only registers the scope into its branch's teardown set when `scope[ClosestBranch]` is set. On resume, `ClosestBranch` is populated only from a serialized `ClosestBranchId`, which the translator emits only when the section is deemed to need it:

```
resumeClosestBranch = !isBranch && (hasAbortSignal || referencedClosures || hasLet)
```

`<lifecycle>` uses `$signal` only at DOM runtime — never in template source — so `hasAbortSignal` stayed `false`, the link was never serialized, and the resumed scope had no closest branch. (`_lifecycle` is the only construct affected: controlled inputs use GC'd element listeners, and dynamic-closure cleanup is already covered by `referencedClosures`.)

## Fix

Mark the lifecycle's section as having an abort signal so the closest-branch link is serialized. Adds a regression fixture whose SSR and CSR mutation logs must match (it fails without the fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTgmDYu49wQNwQCxRicL3d)_