### PR TITLE
fix(runtime-class): flush Class API inline scripts across tags interop

### DIFF
--- a/.changeset/fix-interop-class-script-flush.md
+++ b/.changeset/fix-interop-class-script-flush.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix Class API inline scripts (`out.script(...)`) being dropped when a Class API component renders inside a Tags API parent.

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
@@ -17,7 +17,7 @@ exports.p = function (htmlCompat) {
   const writeClassAPIResultToTagsAPI = ({ out }) => {
     const { writer } = out._state;
     htmlCompat.write(writer._content);
-    htmlCompat.writeScript(writer._script);
+    htmlCompat.writeScript(writer._scripts);
     writer._content = writer._scripts = "";
 
     if (out.___components) {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,36 @@
+// components/class-script.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/components/class-script.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.script("window.__classInteropScript = true");
+	out.be("div", { "id": "class-api" }, "0", _component, null, 1);
+	out.t("class content", _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+const $template = "<div id=tags-api> </div><!><!>";
+const $walks = "D l%c";
+const $n = /* @__PURE__ */ _let("n/2", ($scope) => _text($scope["#text/0"], $scope.n));
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
+function $setup($scope) {
+	$n($scope, 0);
+	$dynamicTag($scope, _marko_template);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/dom.bundle.js
@@ -1,0 +1,24 @@
+// components/class-script.marko
+var import_vdom = require_vdom();
+var import_const_element = /* @__PURE__ */ __toESM(require_const_element());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+const _marko_node = (0, import_const_element.default)("div", { "id": "class-api" }, 1).t("class content");
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.script("window.__classInteropScript = true");
+	out.n(_marko_node, _component);
+}, {
+	t: _marko_componentType,
+	i: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,25 @@
+// components/class-script.marko
+var import_html = require_html();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/components/class-script.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.script("window.__classInteropScript = true");
+	out.w("<div id=class-api>");
+	out.w("class content");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<div id=tags-api>${_escape(n)}</div>`);
+	_dynamic_tag($scope0_id, "#text/1", _marko_template, {}, 0, 0, 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.js
@@ -1,0 +1,20 @@
+// components/class-script.marko
+var import_html = require_html();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.script("window.__classInteropScript = true");
+	out.w("<div id=class-api>class content</div>");
+}, {
+	t: _marko_componentType,
+	i: true
+}, {});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div id=tags-api>${_escape(0)}</div>`);
+	_dynamic_tag($scope0_id, "b", _marko_template, {}, 0, 0, 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/render.debug.md
@@ -1,0 +1,13 @@
+# Render
+```html
+<div
+  id="tags-api"
+>
+  0
+</div>
+<div
+  id="class-api"
+>
+  class content
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/render.md
@@ -1,0 +1,13 @@
+# Render
+```html
+<div
+  id="tags-api"
+>
+  0
+</div>
+<div
+  id="class-api"
+>
+  class content
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/writes.debug.html
@@ -1,0 +1,24 @@
+<div id=tags-api>0</div><!--M#_0-->
+<div id=class-api>class content</div><!--M/-->
+<script>
+  window.__classInteropScript = true;
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    m5c: "_0",
+    m5i: {}
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/components/class-script.marko"
+    ]
+  });
+  M._.r.push("$compat_setScope 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/writes.html
@@ -1,0 +1,22 @@
+<div id=tags-api>0</div><!--M#_0-->
+<div id=class-api>class content</div><!--M/-->
+<script>
+  window.__classInteropScript = true;
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    m5c: "_0",
+    m5i: {}
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/components/class-script.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/components/class-script.marko
@@ -1,0 +1,2 @@
+$ out.script("window.__classInteropScript = true");
+<div id="class-api">class content</div>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 66754,
+        "brotli": 20605
+      },
+      "files": {
+        "components/class-script.marko": 1016,
+        "v:template.marko.hydrate-6.js": 108,
+        "v:template.marko.hydrate-5.js": 104
+      }
+    }
+  },
+  "html": {
+    "min": 532,
+    "brotli": 346
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/template.marko
@@ -1,0 +1,3 @@
+<let/n=0/>
+<div id="tags-api">${n}</div>
+<class-script/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// `out.script` is a server-only API, so this fixture exercises the
+// class -> tags HTML script flushing path and skips client rendering.
+export const config: TestConfig = {
+  skip_csr: true,
+  steps: [{}],
+};


### PR DESCRIPTION
When a Class API component renders inside a Tags API parent, the compat layer read `writer._script` (undefined) instead of `writer._scripts`, silently dropping inline scripts produced via `out.script(...)`.

Adds an interop fixture covering inline scripts crossing the boundary.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KutpQ6F91ZnmLDNjGp4fLR)_