### PR TITLE
fix(runtime-class): route dynamic tags importing tags components through compat

### DIFF
--- a/.changeset/fix-interop-dynamic-tag-class-to-tags.md
+++ b/.changeset/fix-interop-dynamic-tag-class-to-tags.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix a crash when a Class API component renders an imported Tags API component through a dynamic tag (`<${TagsComponent}/>`).

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -8,6 +8,7 @@ import {
   isDynamicTag,
   isMacroTag,
   isNativeTag,
+  loadFileForImport,
   loadFileForTag,
   parseExpression,
   parseStatements,
@@ -147,6 +148,39 @@ export const analyze = {
       if (childFile?.ast.program.extra?.featureType === "tags") {
         tag.node.extra.featureType = "tags";
         (file.path.node.extra ??= {}).needsCompat = true;
+      }
+    } else if (isDynamicTag(tag)) {
+      // A dynamic `<${expr}/>` whose name references an imported Tags API
+      // template crosses the interop boundary and must be rendered through the
+      // compat dynamic tag, the same as a statically named tags import. This
+      // mirrors the Tags API translator, which resolves the whole name
+      // expression (identifiers, conditionals, etc.) to detect the boundary.
+      const markIfTagsImport = (scope, name) => {
+        const binding = name && scope.getBinding(name);
+        if (binding && binding.kind === "module" && binding.identifier.loc) {
+          const childFile = loadFileForImport(
+            file,
+            binding.path.parent.source.value,
+          );
+          if (childFile?.ast.program.extra?.featureType === "tags") {
+            (tag.node.extra ??= {}).featureType = "tags";
+            (file.path.node.extra ??= {}).needsCompat = true;
+            return true;
+          }
+        }
+      };
+
+      const namePath = tag.get("name");
+      if (namePath.isIdentifier()) {
+        markIfTagsImport(namePath.scope, namePath.node.name);
+      } else {
+        namePath.traverse({
+          ReferencedIdentifier(idPath) {
+            if (markIfTagsImport(idPath.scope, idPath.node.name)) {
+              idPath.stop();
+            }
+          },
+        });
       }
     }
 

--- a/packages/runtime-class/src/translator/tag/custom-tag.js
+++ b/packages/runtime-class/src/translator/tag/custom-tag.js
@@ -26,12 +26,16 @@ export default function (path, isNullable) {
   let tagIdentifier;
 
   if (node.extra?.featureType === "tags") {
-    path.set(
-      "name",
-      path.scope.hasBinding(name.value)
-        ? t.identifier(name.value)
-        : importDefault(file, node.extra.relativePath, name.value),
-    );
+    // A dynamic `<${tagName}>` already references the imported template
+    // binding directly; only a static tag name needs to be resolved to one.
+    if (t.isStringLiteral(name)) {
+      path.set(
+        "name",
+        path.scope.hasBinding(name.value)
+          ? t.identifier(name.value)
+          : importDefault(file, node.extra.relativePath, name.value),
+      );
+    }
     return dynamicTag(path);
   }
 

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,41 @@
+// components/tags-child.marko
+var import_vdom = require_vdom();
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count__script = _script("__tests__/components/tags-child.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 0);
+}
+var tags_child_default = /* @__PURE__ */ _template("__tests__/components/tags-child.marko", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { n: 0 };
+	},
+	inc() {
+		this.state.n++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", { "id": "class" }, "0", _component, null, 1, { "onclick": _componentDef.d("click", "inc", false) });
+	out.t(state.n, _component);
+	out.ee();
+	(0, import_dynamic_tag.default)(out, tags_child_default, null, null, null, null, _componentDef, "1");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,0 +1,38 @@
+// components/tags-child.marko
+var import_vdom = require_vdom();
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	_text($scope.b, $scope.c);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 0);
+}
+var tags_child_default = /* @__PURE__ */ _template("b", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { n: 0 };
+	},
+	inc() {
+		this.state.n++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", { "id": "class" }, "0", _component, null, 1, { "onclick": _componentDef.d("click", "inc", false) });
+	out.t(state.n, _component);
+	out.ee();
+	(0, import_dynamic_tag.default)(out, tags_child_default, null, null, null, null, _componentDef, "1");
+}, { t: _marko_componentType }, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,37 @@
+// components/tags-child.marko
+var import_html = require_html();
+var tags_child_default = _template("__tests__/components/tags-child.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/components/tags-child.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/components/tags-child.marko", 0, { count: "2:6" });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_escape_xml = require_escape_xml();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {
+	onCreate() {
+		this.state = { n: 0 };
+	},
+	inc() {
+		this.state.n++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<button id=class>");
+	out.w((0, import_escape_xml.x)(state.n));
+	out.w("</button>");
+	(0, import_dynamic_tag.default)(out, tags_child_default, null, null, null, null, _componentDef, "1");
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/html.bundle.js
@@ -1,0 +1,31 @@
+// components/tags-child.marko
+var import_html = require_html();
+var tags_child_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_escape_xml = require_escape_xml();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "a", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button id=class>${(0, import_escape_xml.x)(state.n)}</button>`);
+	(0, import_dynamic_tag.default)(out, tags_child_default, null, null, null, null, _componentDef, "1");
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, { t: _marko_componentType }, {
+	onCreate() {
+		this.state = { n: 0 };
+	},
+	inc() {
+		this.state.n++;
+	}
+});

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/render.debug.md
@@ -1,0 +1,76 @@
+# Render
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #class::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  id="tags"
+>
+  2
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/render.md
@@ -1,0 +1,76 @@
+# Render
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  0
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #class::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  1
+</button>
+<button
+  id="tags"
+>
+  2
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<!--M#s0--><button id=class>0</button><!--F#1--><button
+  id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><!--F/--><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+      m5c: "s0-1",
+      count: 0
+    }],
+    "$compat_setScope 1 packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/components/tags-child.marko_0_count 1"
+  ];
+  M.s.w();
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/template.marko"
+    ]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<!--M#s0--><button id=class>0</button><!--F#1--><button
+  id=tags>0<!--Ms*1 b--></button><!--Ms*1 a--><!--F/--><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+    m5c: "s0-1",
+    c: 0
+  }], "$C_s 1 b0 1"];
+  M.s.w();
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": ["a"]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/components/tags-child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/components/tags-child.marko
@@ -1,0 +1,3 @@
+// use tags
+<let/count = 0/>
+<button id="tags" onClick() { count++ }>${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 65706,
+        "brotli": 20172
+      },
+      "files": {
+        "components/tags-child.marko": 519,
+        "template.marko": 1097
+      }
+    }
+  },
+  "html": {
+    "min": 511,
+    "brotli": 335
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/template.marko
@@ -1,0 +1,8 @@
+import TagsChild from "<tags-child>";
+class {
+  onCreate() { this.state = { n: 0 }; }
+  inc() { this.state.n++; }
+}
+<button id="class" onClick("inc")>${state.n}</button>
+<${TagsChild}/>
+<init-components/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickClass(c: Element) {
+  (c.querySelector("#class") as HTMLButtonElement).click();
+}
+
+function clickTags(c: Element) {
+  (c.querySelector("#tags") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickTags, clickClass, clickTags],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,42 @@
+// components/tags-child.marko
+var import_vdom = require_vdom();
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count__script = _script("__tests__/components/tags-child.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 0);
+}
+var tags_child_default = /* @__PURE__ */ _template("__tests__/components/tags-child.marko", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { show: true };
+	},
+	toggle() {
+		this.state.show = !this.state.show;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", { "id": "class" }, "0", _component, null, 1, { "onclick": _componentDef.d("click", "toggle", false) });
+	out.t("toggle", _component);
+	out.ee();
+	const _tagName = state.show && tags_child_default;
+	(0, import_dynamic_tag.default)(out, _tagName, null, null, null, null, _componentDef, "1");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,0 +1,38 @@
+// components/tags-child.marko
+var import_vdom = require_vdom();
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	_text($scope.b, $scope.c);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 0);
+}
+var tags_child_default = /* @__PURE__ */ _template("b", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { show: true };
+	},
+	toggle() {
+		this.state.show = !this.state.show;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", { "id": "class" }, "0", _component, null, 1, { "onclick": _componentDef.d("click", "toggle", false) });
+	out.t("toggle", _component);
+	out.ee();
+	(0, import_dynamic_tag.default)(out, state.show && tags_child_default, null, null, null, null, _componentDef, "1");
+}, { t: _marko_componentType }, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,37 @@
+// components/tags-child.marko
+var import_html = require_html();
+var tags_child_default = _template("__tests__/components/tags-child.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/components/tags-child.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/components/tags-child.marko", 0, { count: "2:6" });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {
+	onCreate() {
+		this.state = { show: true };
+	},
+	toggle() {
+		this.state.show = !this.state.show;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<button id=class>");
+	out.w("toggle");
+	out.w("</button>");
+	const _tagName = state.show && tags_child_default;
+	(0, import_dynamic_tag.default)(out, _tagName, null, null, null, null, _componentDef, "1");
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// components/tags-child.marko
+var import_html = require_html();
+var tags_child_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "a", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<button id=class>toggle</button>");
+	(0, import_dynamic_tag.default)(out, state.show && tags_child_default, null, null, null, null, _componentDef, "1");
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, { t: _marko_componentType }, {
+	onCreate() {
+		this.state = { show: true };
+	},
+	toggle() {
+		this.state.show = !this.state.show;
+	}
+});

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/render.debug.md
@@ -1,0 +1,71 @@
+# Render
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+```
+## Change
+```
+REMOVE: #class + #tags
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+## Change
+```
+INSERT: #class + #tags
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/render.md
@@ -1,0 +1,71 @@
+# Render
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+
+# Update
+```js
+c.querySelector("#tags").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  1
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+```
+## Change
+```
+REMOVE: #class + #tags
+```
+
+# Update
+```js
+c.querySelector("#class").click();
+```
+```html
+<button
+  id="class"
+>
+  toggle
+</button>
+<button
+  id="tags"
+>
+  0
+</button>
+```
+## Change
+```
+INSERT: #class + #tags
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<!--M#s0--><button id=class>toggle</button><!--F#1--><button
+  id=tags>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--><!--F/--><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+      m5c: "s0-1",
+      count: 0
+    }],
+    "$compat_setScope 1 packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/components/tags-child.marko_0_count 1"
+  ];
+  M.s.w();
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/template.marko"
+    ]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<!--M#s0--><button id=class>toggle</button><!--F#1--><button
+  id=tags>0<!--Ms*1 b--></button><!--Ms*1 a--><!--F/--><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+    m5c: "s0-1",
+    c: 0
+  }], "$C_s 1 b0 1"];
+  M.s.w();
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": ["a"]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/components/tags-child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/components/tags-child.marko
@@ -1,0 +1,3 @@
+// use tags
+<let/count = 0/>
+<button id="tags" onClick() { count++ }>${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 65747,
+        "brotli": 20170
+      },
+      "files": {
+        "components/tags-child.marko": 519,
+        "template.marko": 1144
+      }
+    }
+  },
+  "html": {
+    "min": 516,
+    "brotli": 336
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/template.marko
@@ -1,0 +1,8 @@
+import TagsChild from "<tags-child>";
+class {
+  onCreate() { this.state = { show: true }; }
+  toggle() { this.state.show = !this.state.show; }
+}
+<button id="class" onClick("toggle")>toggle</button>
+<${state.show && TagsChild}/>
+<init-components/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickTags(c: Element) {
+  (c.querySelector("#tags") as HTMLButtonElement).click();
+}
+
+function toggle(c: Element) {
+  (c.querySelector("#class") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickTags, toggle, toggle],
+};


### PR DESCRIPTION
A Class API component rendering an imported Tags API component via a dynamic tag (`<${TagsComponent}/>`, including conditional name expressions) crashed with `Cannot read properties of undefined (reading 'boundary')`.

The class compiler only detected the tags/class interop boundary for statically named tags, so dynamic forms fell through to the plain `render-tag` helper and the tags renderer ran without a compat boundary. It now resolves the full dynamic tag name expression (mirroring the Tags API translator) so any name referencing an imported tags template is flagged `needsCompat` and rendered through the compat-aware dynamic tag.

Adds regression fixtures for the identifier and conditional forms.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KutpQ6F91ZnmLDNjGp4fLR)_