### PR TITLE
fix(runtime-tags): guard `_on` against undefined element during resume

### DIFF
--- a/.changeset/guard-on-undefined-resume-element.md
+++ b/.changeset/guard-on-undefined-resume-element.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Guard `_on` against an `undefined` element during resume. A torn or partially-delivered streamed `<await>`/`<try>` chunk can run a boundary's event-binding effect before its node has been walked, leaving the element unresolved. Previously `_on` threw `TypeError: Cannot read properties of undefined (reading '$<event>')`, which aborted the remaining resume effects and left the rest of the page un-hydrated. `_on` now skips binding when the element is missing (with a dev-mode warning), degrading gracefully instead of crashing the page. See [#3174](https://github.com/marko-js/marko/issues/3174).

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 24257,
-        "brotli": 8956
+        "min": 24262,
+        "brotli": 8952
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 120
       },
       "runtime": {
-        "min": 4010,
-        "brotli": 1774
+        "min": 4015,
+        "brotli": 1773
       },
       "total": {
-        "min": 4173,
-        "brotli": 1894
+        "min": 4178,
+        "brotli": 1893
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 79
       },
       "runtime": {
-        "min": 2543,
-        "brotli": 1278
+        "min": 2548,
+        "brotli": 1275
       },
       "total": {
-        "min": 2632,
-        "brotli": 1357
+        "min": 2637,
+        "brotli": 1354
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 393
       },
       "runtime": {
-        "min": 6531,
-        "brotli": 2849
+        "min": 6536,
+        "brotli": 2855
       },
       "total": {
-        "min": 7213,
-        "brotli": 3242
+        "min": 7218,
+        "brotli": 3248
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 104
       },
       "runtime": {
-        "min": 2748,
-        "brotli": 1345
+        "min": 2753,
+        "brotli": 1347
       },
       "total": {
-        "min": 2870,
-        "brotli": 1449
+        "min": 2875,
+        "brotli": 1451
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6531 (min) 2849 (brotli)
+// size: 6536 (min) 2855 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -99,8 +99,9 @@ function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  element &&
+    (element["$" + type] === void 0 &&
+      defaultDelegator(element, type, handleDelegated),
     (element["$" + type] = handler || null));
 }
 /* @__NO_SIDE_EFFECTS__ */

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2748 (min) 1345 (brotli)
+// size: 2753 (min) 1347 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -22,8 +22,9 @@ function isNotVoid(value) {
   return value != null && value !== !1;
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  element &&
+    (element["$" + type] === void 0 &&
+      defaultDelegator(element, type, handleDelegated),
     (element["$" + type] = handler || null));
 }
 /* @__NO_SIDE_EFFECTS__ */

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 4010 (min) 1774 (brotli)
+// size: 4015 (min) 1773 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -81,8 +81,9 @@ let decodeAccessor = (num) =>
     );
   };
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  element &&
+    (element["$" + type] === void 0 &&
+      defaultDelegator(element, type, handleDelegated),
     (element["$" + type] = handler || null));
 }
 /* @__NO_SIDE_EFFECTS__ */

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2543 (min) 1278 (brotli)
+// size: 2548 (min) 1275 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -19,8 +19,9 @@ let decodeAccessor = (num) =>
   runRender = (render) => render.c(render.b, render.d),
   catchEnabled;
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  element &&
+    (element["$" + type] === void 0 &&
+      defaultDelegator(element, type, handleDelegated),
     (element["$" + type] = handler || null));
 }
 /* @__NO_SIDE_EFFECTS__ */

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 24257 (min) 8956 (brotli)
+// size: 24262 (min) 8952 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -379,8 +379,9 @@ function push(opt, item) {
     : item;
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  element &&
+    (element["$" + type] === void 0 &&
+      defaultDelegator(element, type, handleDelegated),
     (element["$" + type] = handler || null));
 }
 /* @__NO_SIDE_EFFECTS__ */

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68068,
-        "brotli": 21137
+        "min": 68073,
+        "brotli": 21142
       },
       "files": {
         "components/custom-tag.marko": 1121,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65808,
-        "brotli": 20243
+        "min": 65813,
+        "brotli": 20236
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67268,
-        "brotli": 20832
+        "min": 67273,
+        "brotli": 20862
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-in-components-in-tags-dir/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66851,
-        "brotli": 20594
+        "min": 66856,
+        "brotli": 20596
       },
       "files": {
         "tags/components/hello-internal.marko": 941,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66754,
-        "brotli": 20605
+        "min": 66759,
+        "brotli": 20579
       },
       "files": {
         "components/class-script.marko": 1016,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65808,
-        "brotli": 20243
+        "min": 65813,
+        "brotli": 20236
       },
       "files": {
         "components/tags-counter.marko": 691,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67589,
-        "brotli": 20964
+        "min": 67594,
+        "brotli": 20986
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67219,
-        "brotli": 20835
+        "min": 67224,
+        "brotli": 20844
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66113,
-        "brotli": 20377
+        "min": 66118,
+        "brotli": 20368
       },
       "files": {
         "components/tags-layout.marko": 850,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65785,
-        "brotli": 20233
+        "min": 65790,
+        "brotli": 20215
       },
       "files": {
         "components/tags-layout.marko": 708,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67697,
-        "brotli": 20991
+        "min": 67702,
+        "brotli": 21069
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67003,
-        "brotli": 20703
+        "min": 67008,
+        "brotli": 20705
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66162,
-        "brotli": 20426
+        "min": 66167,
+        "brotli": 20380
       },
       "files": {
         "components/tags-layout.marko": 922,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68052,
-        "brotli": 21140
+        "min": 68057,
+        "brotli": 21146
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3239,
-      "brotli": 1571
+      "min": 3244,
+      "brotli": 1572
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2819,
-      "brotli": 1405
+      "min": 2824,
+      "brotli": 1401
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3037,
-      "brotli": 1514
+      "min": 3042,
+      "brotli": 1507
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2856,
-      "brotli": 1433
+      "min": 2861,
+      "brotli": 1434
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2713,
+      "min": 2718,
       "brotli": 1367
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2716,
-      "brotli": 1377
+      "min": 2721,
+      "brotli": 1372
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2894,
-      "brotli": 1436
+      "min": 2899,
+      "brotli": 1434
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3051,
-      "brotli": 1522
+      "min": 3056,
+      "brotli": 1517
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5877,
-      "brotli": 2679
+      "min": 5882,
+      "brotli": 2678
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2898,
-      "brotli": 1433
+      "min": 2903,
+      "brotli": 1428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1967,
+      "min": 1972,
       "brotli": 1018
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7959,
-      "brotli": 3372
+      "min": 7964,
+      "brotli": 3380
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6760,
-      "brotli": 2974
+      "min": 6765,
+      "brotli": 2973
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9440,
-      "brotli": 3982
+      "min": 9445,
+      "brotli": 3985
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13370,
-        "brotli": 5132
+        "min": 13375,
+        "brotli": 5134
       },
       "files": {
         "tags/hello/index.marko": 196,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6398,
-        "brotli": 2606
+        "min": 6403,
+        "brotli": 2609
       },
       "files": {
         "tags/hello/index.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3308,
-      "brotli": 1655
+      "min": 3313,
+      "brotli": 1652
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2938,
+      "min": 2943,
       "brotli": 1463
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3313,
-      "brotli": 1631
+      "min": 3318,
+      "brotli": 1629
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2825,
-      "brotli": 1423
+      "min": 2830,
+      "brotli": 1420
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10619,
-      "brotli": 4419
+      "min": 10624,
+      "brotli": 4422
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6792,
-      "brotli": 3014
+      "min": 6797,
+      "brotli": 3016
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7489,
-      "brotli": 3303
+      "min": 7494,
+      "brotli": 3304
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7642,
+      "min": 7647,
       "brotli": 3359
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+const $template = "<div id=start>start</div><!><div id=end>end</div>";
+const $walks = "b%c";
+_enable_catch();
+const $await_content__setup__script = _script("__tests__/template.marko_3", ($scope) => _on($scope["#button/0"], "click", function() {
+	console.log("clicked");
+}));
+const $await_content__setup = $await_content__setup__script;
+const $await_content__v = ($scope, v) => _text($scope["#text/1"], v);
+const $await_content__$params = ($scope, $params2) => $await_content__v($scope, $params2[0]);
+const $placeholder_content = _content_resume("__tests__/template.marko_2_content", "loading", "b");
+const $await_content = /* @__PURE__ */ _await_content("#text/0", "<button id=a> </button>", " D l", $await_content__setup);
+const $try_content__await_promise = /* @__PURE__ */ _await_promise("#text/0", $await_content__$params);
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("v", 1));
+};
+const $try = /* @__PURE__ */ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+_enable_catch();
+const $await_content__setup = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	console.log("clicked");
+}));
+const $placeholder_content = _content_resume("a1", "loading", "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div id=start>start</div>");
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("v", 1), (v) => {
+			const $scope3_id = _scope_id();
+			_html(`<button id=a>${_escape(v)}</button>${_el_resume($scope3_id, "#button/0")}`);
+			_script($scope3_id, "__tests__/template.marko_3");
+			writeScope($scope3_id, {}, "__tests__/template.marko", "12:4");
+		});
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_2_content", () => {
+		_scope_reason();
+		const $scope2_id = _scope_id();
+		_html("loading");
+	}, $scope0_id) }) });
+	_html("<div id=end>end</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/html.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div id=start>start</div>");
+	_try($scope0_id, "a", _content_resume("a2", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("v", 1), (v) => {
+			const $scope3_id = _scope_id();
+			_html(`<button id=a>${_escape(v)}</button>${_el_resume($scope3_id, "a")}`);
+			_script($scope3_id, "a0");
+			writeScope($scope3_id, {});
+		});
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a1", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading");
+	}, $scope0_id) }) });
+	_html("<div id=end>end</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-csr.debug.md
@@ -1,0 +1,56 @@
+# Render
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<div
+  id="end"
+>
+  end
+</div>
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+loading
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #start + ::text("loading")
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<button
+  id="a"
+>
+  v
+</button>
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #start + #a
+REMOVE: #a + ::text("loading")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-csr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-csr.md
@@ -1,0 +1,56 @@
+# Render
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<div
+  id="end"
+>
+  end
+</div>
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+loading
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #start + ::text("loading")
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<button
+  id="a"
+>
+  v
+</button>
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #start + #a
+REMOVE: #a + ::text("loading")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<div
+  id="start"
+>
+  start
+</div>
+loading
+<div
+  id="end"
+>
+  end
+</div>
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<button
+  id="a"
+>
+  v
+</button>
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #a::text("v")
+REMOVE: ::text("loading")
+INSERT: #start + #a
+```
+## Console
+```
+ERROR "Skipped binding \"onClick\": its target element was not resolved during resume."
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/render-ssr.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<div
+  id="start"
+>
+  start
+</div>
+loading
+<div
+  id="end"
+>
+  end
+</div>
+```
+
+# Update
+```html
+<div
+  id="start"
+>
+  start
+</div>
+<button
+  id="a"
+>
+  v
+</button>
+<div
+  id="end"
+>
+  end
+</div>
+```
+## Change
+```
+INSERT: #a::text("v")
+REMOVE: ::text("loading")
+INSERT: #start + #a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/writes.debug.html
@@ -1,0 +1,33 @@
+<div id=start>start</div>
+<!--M_[--><!--M_!^2-->loading<!--M_!2--><!--M_]1 #text/0 2-->
+<div id=end>end</div>
+<style M_>
+  t {
+    display: none
+  }
+</style>
+<t M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/template.marko_2_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t M_=b><!--M_[--><button
+    id=a>v</button><!--M_*4 #button/0--><!--M_]2 #text/0 4--></t>
+<script>
+  M._.j.b = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/template.marko_3 4"
+      )
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/__snapshots__/writes.html
@@ -1,0 +1,27 @@
+<div id=start>start</div><!--M_[--><!--M_!^2-->loading<!--M_!2--><!--M_]1 a 2-->
+<div id=end>end</div>
+<style M_>
+  t {
+    display: none
+  }
+</style>
+<t M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    C: "a",
+    Q: _(1, "a1")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t M_=b><!--M_[--><button id=a>v</button><!--M_*4 a--><!--M_]2 a 4--></t>
+<script>
+  M._.j.b = _ => {
+    _.push("a0 4")
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6682,
+      "brotli": 2946
+    }
+  },
+  "html": {
+    "min": 1113,
+    "brotli": 622
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/template.marko
@@ -1,0 +1,17 @@
+import { resolveAfter } from "../../utils/resolve";
+
+// A <try>/<await> boundary whose streamed content binds an event handler.
+// With `tear_stream: true` the chunk is delivered partially so the boundary's
+// resume effects run before all of its node markers are present, modelling a
+// torn/partial network delivery.
+
+<div id="start">start</div>
+
+<try>
+  <@placeholder>loading</@placeholder>
+  <await|v|=resolveAfter("v", 1)>
+    <button id="a" onClick() { console.log("clicked"); }>${v}</button>
+  </await>
+</try>
+
+<div id="end">end</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-event-handler-torn-delivery/test.ts
@@ -1,0 +1,23 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+// REGRESSION TEST for the streamed-resume event-binding crash.
+//
+// A <try>/<await> boundary whose streamed content binds an event handler.
+// With `tear_stream: true` the chunk is delivered partially: the branch's
+// markers arrive (so the boundary resumes and its effects are un-gated) but
+// the element-resume marker is missing, so the node accessor is never walked.
+//
+// Before the fix, the event-binding effect ran against an undefined element
+// and threw `TypeError: Cannot read properties of undefined (reading
+// '$click')` in `_on`, aborting the rest of the resume pass — the crash that
+// can surface intermittently with streamed <try>/<await> boundaries.
+//
+// After the fix (`_on` skips an unresolved element), resume completes: the
+// element renders and the handler is simply left unbound rather than crashing
+// the page. This test passes only with the fix in place.
+export const config: TestConfig = {
+  equivalent: false,
+  tear_stream: true,
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7629,
-      "brotli": 3289
+      "min": 7634,
+      "brotli": 3292
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6893,
-      "brotli": 3057
+      "min": 6898,
+      "brotli": 3060
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3866,
-      "brotli": 1820
+      "min": 3871,
+      "brotli": 1818
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7629,
-      "brotli": 3289
+      "min": 7634,
+      "brotli": 3292
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2838,
-        "brotli": 1413
+        "min": 2843,
+        "brotli": 1425
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2838,
-        "brotli": 1414
+        "min": 2843,
+        "brotli": 1427
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2970,
-        "brotli": 1456
+        "min": 2975,
+        "brotli": 1458
       },
       "files": {
         "tags/my-button.marko": 420,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2865,
-        "brotli": 1424
+        "min": 2870,
+        "brotli": 1428
       },
       "files": {
         "tags/my-button.marko": 344,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2838,
-        "brotli": 1413
+        "min": 2843,
+        "brotli": 1425
       },
       "files": {
         "tags/my-button.marko": 249,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3308,
-        "brotli": 1644
+        "min": 3313,
+        "brotli": 1655
       },
       "files": {
         "tags/my-button.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1363
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6207,
-      "brotli": 2819
+      "min": 6212,
+      "brotli": 2817
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6205,
-      "brotli": 2809
+      "min": 6210,
+      "brotli": 2806
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2818,
-      "brotli": 1405
+      "min": 2823,
+      "brotli": 1403
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2919,
-      "brotli": 1470
+      "min": 2924,
+      "brotli": 1460
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6237,
-      "brotli": 2828
+      "min": 6242,
+      "brotli": 2829
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2824,
-      "brotli": 1426
+      "min": 2829,
+      "brotli": 1428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2680,
-      "brotli": 1372
+      "min": 2685,
+      "brotli": 1351
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2931,
-      "brotli": 1471
+      "min": 2936,
+      "brotli": 1465
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2983,
-      "brotli": 1488
+      "min": 2988,
+      "brotli": 1486
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2924,
-      "brotli": 1476
+      "min": 2929,
+      "brotli": 1475
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3006,
-      "brotli": 1481
+      "min": 3011,
+      "brotli": 1479
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7530,
-        "brotli": 3445
+        "min": 7535,
+        "brotli": 3447
       },
       "files": {
         "tags/child.marko": 154,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13954,
+        "min": 13959,
         "brotli": 5389
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3175,
-      "brotli": 1594
+      "min": 3180,
+      "brotli": 1595
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4748,
+      "min": 4753,
       "brotli": 2188
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3184,
-      "brotli": 1572
+      "min": 3189,
+      "brotli": 1577
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6245,
-      "brotli": 2847
+      "min": 6250,
+      "brotli": 2848
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7200,
-      "brotli": 3280
+      "min": 7205,
+      "brotli": 3312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7341,
+      "min": 7346,
       "brotli": 3316
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5875,
-      "brotli": 2686
+      "min": 5880,
+      "brotli": 2683
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6150,
-      "brotli": 2792
+      "min": 6155,
+      "brotli": 2793
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2833,
-      "brotli": 1425
+      "min": 2838,
+      "brotli": 1431
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3866,
-        "brotli": 1866
+        "min": 3871,
+        "brotli": 1863
       },
       "files": {
         "tags/counter.marko": 478,

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9327,
-        "brotli": 3561
+        "min": 9332,
+        "brotli": 3565
       },
       "files": {
         "tags/FancyButton.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3806,
-      "brotli": 1808
+      "min": 3811,
+      "brotli": 1812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4457,
-      "brotli": 2061
+      "min": 4462,
+      "brotli": 2058
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4343,
-      "brotli": 2018
+      "min": 4348,
+      "brotli": 2014
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2882,
-      "brotli": 1438
+      "min": 2887,
+      "brotli": 1433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7452,
-      "brotli": 3265
+      "min": 7457,
+      "brotli": 3267
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2021,
-      "brotli": 1042
+      "min": 2026,
+      "brotli": 1044
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7778,
-        "brotli": 3528
+        "min": 7783,
+        "brotli": 3532
       },
       "files": {
         "tags/child.marko": 745,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7631,
-        "brotli": 3354
+        "min": 7636,
+        "brotli": 3359
       },
       "files": {
         "tags/child.marko": 757,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6114,
-      "brotli": 2785
+      "min": 6119,
+      "brotli": 2788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6301,
-        "brotli": 2860
+        "min": 6306,
+        "brotli": 2861
       },
       "files": {
         "tags/child.marko": 387,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8227,
-        "brotli": 3695
+        "min": 8232,
+        "brotli": 3697
       },
       "files": {
         "tags/child.marko": 597,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7728,
-        "brotli": 3510
+        "min": 7733,
+        "brotli": 3513
       },
       "files": {
         "tags/child.marko": 639,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7565,
-        "brotli": 3338
+        "min": 7570,
+        "brotli": 3336
       },
       "files": {
         "tags/child.marko": 635,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6096,
+      "min": 6101,
       "brotli": 2777
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6283,
-        "brotli": 2847
+        "min": 6288,
+        "brotli": 2851
       },
       "files": {
         "tags/child.marko": 369,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6176,
-      "brotli": 2805
+      "min": 6181,
+      "brotli": 2806
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2827,
-      "brotli": 1424
+      "min": 2832,
+      "brotli": 1425
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2912,
-        "brotli": 1458
+        "min": 2917,
+        "brotli": 1454
       },
       "files": {
         "tags/display-intersection.marko": 229,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2921,
-        "brotli": 1453
+        "min": 2926,
+        "brotli": 1456
       },
       "files": {
         "tags/counter.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15550,
-        "brotli": 6057
+        "min": 15555,
+        "brotli": 6060
       },
       "files": {
         "tags/sections.marko": 827,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2696,
-      "brotli": 1371
+      "min": 2701,
+      "brotli": 1363
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5889,
-      "brotli": 2691
+      "min": 5894,
+      "brotli": 2694
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2694,
-      "brotli": 1362
+      "min": 2699,
+      "brotli": 1359
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2748,
-      "brotli": 1387
+      "min": 2753,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2990,
+      "min": 2995,
       "brotli": 1472
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2814,
-      "brotli": 1431
+      "min": 2819,
+      "brotli": 1428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3234,
-        "brotli": 1625
+        "min": 3239,
+        "brotli": 1621
       },
       "files": {
         "tags/outer.marko": 162,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8865,
-        "brotli": 3353
+        "min": 8870,
+        "brotli": 3354
       },
       "files": {
         "tags/checkbox.marko": 267,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8932,
-      "brotli": 3399
+      "min": 8937,
+      "brotli": 3402
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4708,
-      "brotli": 2094
+      "min": 4713,
+      "brotli": 2088
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9119,
-        "brotli": 3420
+        "min": 9124,
+        "brotli": 3423
       },
       "files": {
         "tags/radio.marko": 261,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9122,
-        "brotli": 3423
+        "min": 9127,
+        "brotli": 3427
       },
       "files": {
         "tags/checkbox.marko": 267,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8838,
+        "min": 8843,
         "brotli": 3338
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10504,
+        "min": 10509,
         "brotli": 3936
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8258,
-      "brotli": 3567
+      "min": 8263,
+      "brotli": 3574
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8844,
+        "min": 8849,
         "brotli": 3346
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8888,
-      "brotli": 3381
+      "min": 8893,
+      "brotli": 3384
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8911,
-      "brotli": 3385
+      "min": 8916,
+      "brotli": 3390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13579,
-      "brotli": 5181
+      "min": 13584,
+      "brotli": 5180
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6075,
-      "brotli": 2537
+      "min": 6080,
+      "brotli": 2528
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4479,
+      "min": 4484,
       "brotli": 1997
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9244,
-      "brotli": 3977
+      "min": 9249,
+      "brotli": 3983
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11848,
-        "brotli": 4429
+        "min": 11853,
+        "brotli": 4435
       },
       "files": {
         "tags/my-select.marko": 246,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4460,
-      "brotli": 1990
+      "min": 4465,
+      "brotli": 1988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8832,
-        "brotli": 3333
+        "min": 8837,
+        "brotli": 3336
       },
       "files": {
         "tags/my-textarea.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2884,
-      "brotli": 1440
+      "min": 2889,
+      "brotli": 1441
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3416,
+        "min": 3421,
         "brotli": 1689
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2701,
-      "brotli": 1372
+      "min": 2706,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13509,
-        "brotli": 5185
+        "min": 13514,
+        "brotli": 5188
       },
       "files": {
         "tags/custom-tag.marko": 686,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13495,
+        "min": 13500,
         "brotli": 5189
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13408,
-        "brotli": 5151
+        "min": 13413,
+        "brotli": 5156
       },
       "files": {
         "tags/custom-tag.marko": 469,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3050,
-        "brotli": 1483
+        "min": 3055,
+        "brotli": 1482
       },
       "files": {
         "tags/counter.marko": 396,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3039,
-        "brotli": 1514
+        "min": 3044,
+        "brotli": 1517
       },
       "files": {
         "tags/child.marko": 387,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2793,
-        "brotli": 1401
+        "min": 2798,
+        "brotli": 1402
       },
       "files": {
         "tags/child.marko": 283,

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1968
+      "min": 4711,
+      "brotli": 1970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6363,
+      "min": 6368,
       "brotli": 2882
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13321,
-        "brotli": 5107
+        "min": 13326,
+        "brotli": 5111
       },
       "files": {
         "tags/child.marko": 413,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2750,
-      "brotli": 1395
+      "min": 2755,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2722,
-      "brotli": 1374
+      "min": 2727,
+      "brotli": 1375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2722,
-      "brotli": 1376
+      "min": 2727,
+      "brotli": 1371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6627,
-      "brotli": 3018
+      "min": 6632,
+      "brotli": 3015
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6228,
-      "brotli": 2851
+      "min": 6233,
+      "brotli": 2848
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2722,
-      "brotli": 1372
+      "min": 2727,
+      "brotli": 1373
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2704,
-      "brotli": 1364
+      "min": 2709,
+      "brotli": 1365
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7568,
-        "brotli": 3124
+        "min": 7573,
+        "brotli": 3131
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2927,
-      "brotli": 1454
+      "min": 2932,
+      "brotli": 1466
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7339,
-        "brotli": 3334
+        "min": 7344,
+        "brotli": 3339
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6072,
+      "min": 6077,
       "brotli": 2750
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5870,
-      "brotli": 2729
+      "min": 5875,
+      "brotli": 2731
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3190,
+      "min": 3195,
       "brotli": 1592
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6050,
-      "brotli": 2704
+      "min": 6055,
+      "brotli": 2703
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2697,
+      "min": 2702,
       "brotli": 1367
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13275,
-      "brotli": 5094
+      "min": 13280,
+      "brotli": 5096
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13144,
-      "brotli": 5038
+      "min": 13149,
+      "brotli": 5040
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14097,
-        "brotli": 5402
+        "min": 14102,
+        "brotli": 5406
       },
       "files": {
         "tags/custom-tag.marko": 343,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13914,
-        "brotli": 5338
+        "min": 13919,
+        "brotli": 5336
       },
       "files": {
         "tags/custom-tag.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2982,
-      "brotli": 1474
+      "min": 2987,
+      "brotli": 1476
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6356,
-        "brotli": 2876
+        "min": 6361,
+        "brotli": 2880
       },
       "files": {
         "tags/inner.marko": 167,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13939,
-        "brotli": 5354
+        "min": 13944,
+        "brotli": 5355
       },
       "files": {
         "tags/child.marko": 323,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14180,
+        "min": 14185,
         "brotli": 5423
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13279,
-        "brotli": 5094
+        "min": 13284,
+        "brotli": 5098
       },
       "files": {
         "tags/my-tag.marko": 515,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6259,
-      "brotli": 2569
+      "min": 6264,
+      "brotli": 2574
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13959,
-        "brotli": 5342
+        "min": 13964,
+        "brotli": 5345
       },
       "files": {
         "tags/custom-tag.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13120,
-      "brotli": 5017
+      "min": 13125,
+      "brotli": 5018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6259,
-      "brotli": 2569
+      "min": 6264,
+      "brotli": 2574
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2896,
-        "brotli": 1441
+        "min": 2901,
+        "brotli": 1439
       },
       "files": {
         "tags/counter.marko": 396,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13383,
-        "brotli": 5115
+        "min": 13388,
+        "brotli": 5114
       },
       "files": {
         "tags/counter.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6644,
-      "brotli": 2998
+      "min": 6649,
+      "brotli": 3006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3407,
-      "brotli": 1683
+      "min": 3412,
+      "brotli": 1684
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2834,
-      "brotli": 1385
+      "min": 2839,
+      "brotli": 1389
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2829,
-      "brotli": 1423
+      "min": 2834,
+      "brotli": 1422
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2939,
-      "brotli": 1462
+      "min": 2944,
+      "brotli": 1461
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7975,
-      "brotli": 3614
+      "min": 7980,
+      "brotli": 3603
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8201,
-      "brotli": 3676
+      "min": 8206,
+      "brotli": 3680
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7511,
-      "brotli": 3321
+      "min": 7516,
+      "brotli": 3322
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7179,
+      "min": 7184,
       "brotli": 3262
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7109,
-      "brotli": 3260
+      "min": 7114,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7049,
+      "min": 7054,
       "brotli": 3226
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2019,
-      "brotli": 1034
+      "min": 2024,
+      "brotli": 1035
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2914,
-      "brotli": 1458
+      "min": 2919,
+      "brotli": 1464
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7114,
-      "brotli": 3265
+      "min": 7119,
+      "brotli": 3267
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1979,
-      "brotli": 1023
+      "min": 1984,
+      "brotli": 1028
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1991,
-      "brotli": 1027
+      "min": 1996,
+      "brotli": 1029
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1991,
+      "min": 1996,
       "brotli": 1029
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7119,
-      "brotli": 3262
+      "min": 7124,
+      "brotli": 3275
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13829,
+        "min": 13834,
         "brotli": 5290
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14484,
+        "min": 14489,
         "brotli": 5548
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13563,
-        "brotli": 5181
+        "min": 13568,
+        "brotli": 5184
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2740,
-      "brotli": 1395
+      "min": 2745,
+      "brotli": 1380
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8994,
+      "min": 8999,
       "brotli": 3737
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2841,
-      "brotli": 1427
+      "min": 2846,
+      "brotli": 1423
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8983,
-      "brotli": 3728
+      "min": 8988,
+      "brotli": 3729
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2744,
-      "brotli": 1391
+      "min": 2749,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3151,
-      "brotli": 1567
+      "min": 3156,
+      "brotli": 1565
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5871,
-      "brotli": 2684
+      "min": 5876,
+      "brotli": 2683
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6006,
-      "brotli": 2734
+      "min": 6011,
+      "brotli": 2732
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3042,
-      "brotli": 1514
+      "min": 3047,
+      "brotli": 1513
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3029,
-      "brotli": 1507
+      "min": 3034,
+      "brotli": 1509
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2809,
+      "min": 2814,
       "brotli": 1409
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2809,
+      "min": 2814,
       "brotli": 1409
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6420,
-      "brotli": 2918
+      "min": 6425,
+      "brotli": 2920
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8854,
-        "brotli": 3341
+        "min": 8859,
+        "brotli": 3342
       },
       "files": {
         "tags/my-input.marko": 352,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1985,
-      "brotli": 1034
+      "min": 1990,
+      "brotli": 1032
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4730,
-        "brotli": 1983
+        "min": 4735,
+        "brotli": 1984
       },
       "files": {
         "tags/child.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3191,
-      "brotli": 1602
+      "min": 3196,
+      "brotli": 1600
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2722,
-        "brotli": 1375
+        "min": 2727,
+        "brotli": 1372
       },
       "files": {
         "tags/child/index.marko": 104,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7456,
-        "brotli": 3381
+        "min": 7461,
+        "brotli": 3418
       },
       "files": {
         "tags/inner/index.marko": 1078,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2722,
-        "brotli": 1375
+        "min": 2727,
+        "brotli": 1372
       },
       "files": {
         "tags/child/index.marko": 110,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2846,
-        "brotli": 1438
+        "min": 2851,
+        "brotli": 1433
       },
       "files": {
         "tags/leaf.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2722,
-        "brotli": 1375
+        "min": 2727,
+        "brotli": 1372
       },
       "files": {
         "tags/child-b/index.marko": 112,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2937,
-        "brotli": 1469
+        "min": 2942,
+        "brotli": 1466
       },
       "files": {
         "tags/child-a/index.marko": 240,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2830,
-      "brotli": 1423
+      "min": 2835,
+      "brotli": 1419
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7665,
-        "brotli": 3469
+        "min": 7670,
+        "brotli": 3471
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3121,
-        "brotli": 1539
+        "min": 3126,
+        "brotli": 1532
       },
       "files": {
         "tags/child.marko": 355,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3355,
-        "brotli": 1658
+        "min": 3360,
+        "brotli": 1657
       },
       "files": {
         "tags/let-global.marko": 574,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3082,
-      "brotli": 1526
+      "min": 3087,
+      "brotli": 1527
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3453,
-        "brotli": 1645
+        "min": 3458,
+        "brotli": 1636
       },
       "files": {
         "tags/child.marko": 1433,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3101,
-      "brotli": 1529
+      "min": 3106,
+      "brotli": 1523
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3044,
-      "brotli": 1506
+      "min": 3049,
+      "brotli": 1501
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2923,
-      "brotli": 1439
+      "min": 2928,
+      "brotli": 1438
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2687,
-      "brotli": 1359
+      "min": 2692,
+      "brotli": 1360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2993,
-      "brotli": 1486
+      "min": 2998,
+      "brotli": 1480
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2972,
-      "brotli": 1471
+      "min": 2977,
+      "brotli": 1474
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3037,
-      "brotli": 1505
+      "min": 3042,
+      "brotli": 1507
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6317,
-        "brotli": 2831
+        "min": 6322,
+        "brotli": 2836
       },
       "files": {
         "tags/child.marko": 353,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6572,
-      "brotli": 2907
+      "min": 6577,
+      "brotli": 2910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2965,
-      "brotli": 1480
+      "min": 2970,
+      "brotli": 1479
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2978,
-      "brotli": 1464
+      "min": 2983,
+      "brotli": 1463
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3092,
-      "brotli": 1531
+      "min": 3097,
+      "brotli": 1525
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4214,
-      "brotli": 1976
+      "min": 4219,
+      "brotli": 1973
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3312,
-        "brotli": 1593
+        "min": 3317,
+        "brotli": 1590
       },
       "files": {
         "tags/2counters.marko": 951,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13946,
-      "brotli": 5325
+      "min": 13951,
+      "brotli": 5327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14463,
-      "brotli": 5588
+      "min": 14468,
+      "brotli": 5592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6303,
+        "min": 6308,
         "brotli": 2583
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5515,
-        "brotli": 2346
+        "min": 5520,
+        "brotli": 2340
       },
       "files": {
         "tags/my-box.marko": 207,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6303,
+        "min": 6308,
         "brotli": 2583
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7082,
-        "brotli": 2919
+        "min": 7087,
+        "brotli": 2916
       },
       "files": {
         "tags/my-box.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13560,
-        "brotli": 5211
+        "min": 13565,
+        "brotli": 5208
       },
       "files": {
         "tags/render-input.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5495,
-        "brotli": 2336
+        "min": 5500,
+        "brotli": 2331
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6370,
-      "brotli": 2597
+      "min": 6375,
+      "brotli": 2600
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8759,
-        "brotli": 3326
+        "min": 8764,
+        "brotli": 3329
       },
       "files": {
         "tags/my-img.marko": 235,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2747,
-      "brotli": 1389
+      "min": 2752,
+      "brotli": 1384
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8581,
-      "brotli": 3846
+      "min": 8586,
+      "brotli": 3872
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3665,
-      "brotli": 1763
+      "min": 3670,
+      "brotli": 1767
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4766,
-        "brotli": 1997
+        "min": 4771,
+        "brotli": 1996
       },
       "files": {
         "tags/my-button.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2711,
-      "brotli": 1383
+      "min": 2716,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2727,
-      "brotli": 1369
+      "min": 2732,
+      "brotli": 1370
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2794,
-      "brotli": 1377
+      "min": 2799,
+      "brotli": 1379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7717,
-      "brotli": 3524
+      "min": 7722,
+      "brotli": 3526
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3416,
+        "min": 3421,
         "brotli": 1689
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3344,
-      "brotli": 1612
+      "min": 3349,
+      "brotli": 1606
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2783,
-      "brotli": 1403
+      "min": 2788,
+      "brotli": 1398
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2712,
-      "brotli": 1373
+      "min": 2717,
+      "brotli": 1371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5611,
-      "brotli": 2373
+      "min": 5616,
+      "brotli": 2365
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2777,
-      "brotli": 1399
+      "min": 2782,
+      "brotli": 1400
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1970,
-      "brotli": 1018
+      "min": 1975,
+      "brotli": 1019
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2952,
-      "brotli": 1462
+      "min": 2957,
+      "brotli": 1461
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2932,
-      "brotli": 1424
+      "min": 2937,
+      "brotli": 1420
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4960,
-      "brotli": 2063
+      "min": 4965,
+      "brotli": 2065
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8813,
-      "brotli": 3335
+      "min": 8818,
+      "brotli": 3339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9132,
-      "brotli": 3449
+      "min": 9137,
+      "brotli": 3453
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6339,
-        "brotli": 2592
+        "min": 6344,
+        "brotli": 2598
       },
       "files": {
         "tags/child.marko": 132,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6339,
-      "brotli": 2593
+      "min": 6344,
+      "brotli": 2596
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6335,
-        "brotli": 2584
+        "min": 6340,
+        "brotli": 2588
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1969
+      "min": 4711,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14633,
-        "brotli": 5737
+        "min": 14638,
+        "brotli": 5743
       },
       "files": {
         "tags/child.marko": 788,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4755,
-        "brotli": 1996
+        "min": 4760,
+        "brotli": 2000
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4756,
-      "brotli": 1996
+      "min": 4761,
+      "brotli": 1999
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13466,
+        "min": 13471,
         "brotli": 5171
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1961,
-      "brotli": 1017
+      "min": 1966,
+      "brotli": 1018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2712,
-      "brotli": 1373
+      "min": 2717,
+      "brotli": 1374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2693,
-      "brotli": 1361
+      "min": 2698,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14343,
-        "brotli": 5489
+        "min": 14348,
+        "brotli": 5493
       },
       "files": {
         "tags/a/index.marko": 376,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13821,
-      "brotli": 5315
+      "min": 13826,
+      "brotli": 5314
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2975,
-      "brotli": 1494
+      "min": 2980,
+      "brotli": 1490
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2993,
-      "brotli": 1484
+      "min": 2998,
+      "brotli": 1482
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6069,
-        "brotli": 2758
+        "min": 6074,
+        "brotli": 2763
       },
       "files": {
         "tags/child.marko": 178,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6301,
-        "brotli": 2856
+        "min": 6306,
+        "brotli": 2861
       },
       "files": {
         "tags/tree/index.marko": 645,

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3518,
-      "brotli": 1707
+      "min": 3523,
+      "brotli": 1706
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2634,
-      "brotli": 1336
+      "min": 2639,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2720,
-      "brotli": 1378
+      "min": 2725,
+      "brotli": 1376
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3219,
-      "brotli": 1595
+      "min": 3224,
+      "brotli": 1594
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4706,
-      "brotli": 1968
+      "min": 4711,
+      "brotli": 1970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3345,
-      "brotli": 1652
+      "min": 3350,
+      "brotli": 1651
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2761,
-      "brotli": 1396
+      "min": 2766,
+      "brotli": 1393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2910,
-      "brotli": 1459
+      "min": 2915,
+      "brotli": 1458
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6861,
-      "brotli": 3066
+      "min": 6866,
+      "brotli": 3064
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6861,
-      "brotli": 3066
+      "min": 6866,
+      "brotli": 3064
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1993,
-      "brotli": 1024
+      "min": 1998,
+      "brotli": 1026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6648,
-        "brotli": 2999
+        "min": 6653,
+        "brotli": 3002
       },
       "files": {
         "tags/counter.marko": 708,

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2823,
-      "brotli": 1421
+      "min": 2828,
+      "brotli": 1420
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9581,
-      "brotli": 4039
+      "min": 9586,
+      "brotli": 4041
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7056,
-      "brotli": 3172
+      "min": 7061,
+      "brotli": 3171
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2986,
+      "min": 2991,
       "brotli": 1486
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2986,
+      "min": 2991,
       "brotli": 1486
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4367,
+      "min": 4372,
       "brotli": 2002
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3505,
-      "brotli": 1670
+      "min": 3510,
+      "brotli": 1669
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4361,
-      "brotli": 1998
+      "min": 4366,
+      "brotli": 1996
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4017,
-      "brotli": 1880
+      "min": 4022,
+      "brotli": 1878
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4326,
-      "brotli": 1941
+      "min": 4331,
+      "brotli": 1939
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4332,
-      "brotli": 1947
+      "min": 4337,
+      "brotli": 1945
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4059,
-      "brotli": 1894
+      "min": 4064,
+      "brotli": 1890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13567,
-      "brotli": 5218
+      "min": 13572,
+      "brotli": 5215
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2041,
-      "brotli": 1045
+      "min": 2046,
+      "brotli": 1049
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1967,
-      "brotli": 1019
+      "min": 1972,
+      "brotli": 1022
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4737,
-      "brotli": 1988
+      "min": 4742,
+      "brotli": 1989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2692,
-      "brotli": 1374
+      "min": 2697,
+      "brotli": 1371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2717,
-      "brotli": 1368
+      "min": 2722,
+      "brotli": 1366
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -53,6 +53,12 @@ export type TestConfig = {
   error_compiler?: true | string[];
   /** Compiles the fixture with a custom `runtimeId` compiler option. */
   runtime_id?: string;
+  /**
+   * Streams each chunk's resume `<script>` before its content nodes (after
+   * the initial flush), modelling a torn/partial network delivery where a
+   * resume payload runs against DOM that is not yet fully present.
+   */
+  tear_stream?: boolean;
 };
 
 describe("runtime-tags/translator", () => {
@@ -269,7 +275,7 @@ function testFixtures(interop?: true) {
             const browser = createBrowser(runner.assets, config.load_order);
             browsers.push(browser);
             const { window } = browser;
-            const flushNext = browser.stream(chunks);
+            const flushNext = browser.stream(chunks, config.tear_stream);
             const flushAndRun = async () => {
               hasFlush = flushNext();
               await browser.runAsyncScripts();

--- a/packages/runtime-tags/src/__tests__/utils/create-browser.ts
+++ b/packages/runtime-tags/src/__tests__/utils/create-browser.ts
@@ -166,7 +166,7 @@ export default function createBrowser(dir?: string, loadOrder?: string[]) {
         deferred.forEach(qmt);
       }
     },
-    stream(chunks: string[]): () => boolean {
+    stream(chunks: string[], tear?: boolean): () => boolean {
       const { document } = window;
       document.open();
 
@@ -178,27 +178,61 @@ export default function createBrowser(dir?: string, loadOrder?: string[]) {
         const walker = parsed.createTreeWalker(parsed);
         const targetNodes = new WeakMap<Node, Node>([[parsed, document]]);
         let node: Node | null;
+        let flushCount = 0;
+
+        const appendClone = (src: Node) => {
+          // Appending an inline <script> to a `runScripts: "dangerously"`
+          // document executes it synchronously, so the order in which these
+          // are appended is the order in which resume payloads run.
+          const clone = document.importNode(src, isInlineScript(src));
+          targetNodes.set(src, clone);
+          (targetNodes.get(src.parentNode!) as ParentNode).appendChild(clone);
+        };
 
         return () => {
+          // Collect this flush's nodes (TreeWalker yields parents before
+          // children, so the order is safe to replay).
+          const collected: Node[] = [];
+          let hitFlush = false;
           while ((node = walker.nextNode())) {
             if (
               node.nodeType === 8 /* Node.COMMENT_NODE */ &&
               (node as Comment).data === "%%FLUSH%%"
             ) {
-              return true;
+              hitFlush = true;
+              break;
             }
-
-            const isInline = isInlineScript(node);
-            const clone = document.importNode(node, isInline);
-            targetNodes.set(node, clone);
-            (targetNodes.get(node.parentNode!) as ParentNode).appendChild(
-              clone,
-            );
-
-            if (isInline) {
+            collected.push(node);
+            if (isInlineScript(node)) {
+              // The inline script's text child is deep-cloned with it; skip
+              // it so it isn't appended (and re-executed) on its own.
               walker.nextNode();
             }
           }
+
+          if (tear && flushCount++ > 0) {
+            // Partial delivery: deliver this flush's content and its branch
+            // markers, but drop the element-resume markers (`<!--M_*N …-->`).
+            // The branch still resumes (its end marker arrives, un-gating the
+            // boundary's effects), but the element accessors those markers
+            // would populate stay unwalked — so an effect (e.g. an event
+            // binding via `_on`) runs against a scope whose node is undefined.
+            // Models a real browser where a chunk is torn mid-content. The
+            // first flush (initial render setup) is left intact.
+            for (const n of collected) {
+              if (
+                n.nodeType === 8 /* Node.COMMENT_NODE */ &&
+                /\w+_\*/.test((n as Comment).data)
+              ) {
+                continue;
+              }
+              appendClone(n);
+            }
+          } else {
+            for (const n of collected) appendClone(n);
+          }
+
+          if (hitFlush) return true;
           document.close();
           return false;
         };

--- a/packages/runtime-tags/src/dom/event.ts
+++ b/packages/runtime-tags/src/dom/event.ts
@@ -12,6 +12,20 @@ export function _on<
     | undefined
     | ((ev: GlobalEventHandlersEventMap[T], target: Element) => void),
 >(element: Element, type: T, handler: H) {
+  if (!element) {
+    // The element can be unresolved when a streamed boundary's resume
+    // effects run before its nodes were walked (a torn/partial delivery
+    // desync). Binding to a missing node is meaningless, so skip rather
+    // than throwing — which would otherwise abort the remaining resume
+    // effects and leave the rest of the page un-hydrated.
+    if (MARKO_DEBUG) {
+      console.error(
+        `Skipped binding "on${type[0].toUpperCase() + type.slice(1)}": its target element was not resolved during resume.`,
+      );
+    }
+    return;
+  }
+
   if (MARKO_DEBUG) {
     assertHandlerIsFunction(
       "on" + type[0].toUpperCase() + type.slice(1),


### PR DESCRIPTION
## Summary

Fixes the intermittent `TypeError: Cannot read properties of undefined (reading '$click' / '$change' / '$focusout')` thrown by `_on` during SSR hydration, reported in #3174.

When a streamed `<await>`/`<try>` boundary is delivered in a torn or partial chunk, the boundary's effects can be un-gated and run **before** the element's resume marker has been walked, leaving the node accessor `undefined`. `_on` then threw — and because the resume effect loop has no `try`/`catch`, that aborted the *remaining* resume effects and left the rest of the page un-hydrated.

## Fix

`_on` now skips binding when the element is unresolved (with a `MARKO_DEBUG` diagnostic), so resume degrades gracefully — the element still renders, only that one handler is left unbound — instead of crashing the page. This is the guard floated in #3174, and it contains the blast radius to the single affected binding.

```ts
if (!element) {
  if (MARKO_DEBUG) console.error(`Skipped binding "on${…}": its target element was not resolved during resume.`);
  return;
}
```

## Regression test

The nested-`<await>` repro in #3174 passes in jsdom — the production trigger is timing/delivery-dependent and intermittent. To get a **deterministic** regression test, this adds an opt-in `tear_stream` mode to the test harness (`create-browser.ts`) that models a partially-delivered chunk: the branch markers arrive (un-gating the boundary's effects) but the element-resume marker (`<!--M_*N …-->`) does not, so `_on` is reached with an undefined element.

The new `await-event-handler-torn-delivery` fixture **crashes without the guard and passes with it**.

## Notes

- This is the defensive fix. The deeper root-cause work (canonical-scope handling in `render.m` — options A/B in #3174) is left as follow-up.
- The `sizes.json` updates reflect the small (~5 bytes minified) runtime growth in bundles that include `_on`.
- Full `runtime-tags` suite passes (8276).

Refs #3174

🤖 Generated with [Claude Code](https://claude.com/claude-code)
