### PR TITLE
refactor(runtime-tags): guard split-brain runtime keys and accessor pair

### DIFF
--- a/.changeset/guard-split-brain-runtime-keys.md
+++ b/.changeset/guard-split-brain-runtime-keys.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Share the inline-runtime `RuntimeKey` enum between the SSR writer and the DOM resume reader so the two sides can no longer drift, and add a test asserting `accessor.ts` and `accessor.debug.ts` stay structurally in sync (identical member names, unique values). No change to generated output.

--- a/packages/runtime-tags/src/__tests__/debug-parity.test.ts
+++ b/packages/runtime-tags/src/__tests__/debug-parity.test.ts
@@ -1,0 +1,49 @@
+import * as assert from "assert/strict";
+
+import * as prodAccessor from "../common/accessor";
+import * as debugAccessor from "../common/accessor.debug";
+
+// `accessor.ts` and `accessor.debug.ts` are hand-maintained twins: the
+// build/test tooling swaps one for the other by filename, but nothing verifies
+// they stay in sync. Runtime code imports only the `.debug` variant, so
+// TypeScript never type-checks the production file. A member that drifts (or a
+// duplicate value that collides two scope keys) corrupts resume/hydration and
+// only in optimized builds, so assert parity explicitly here rather than
+// relying on a fixture happening to exercise the affected accessor.
+
+type AnyEnum = Record<string, string>;
+
+describe("runtime-tags/debug parity", () => {
+  describe("accessor.ts <-> accessor.debug.ts", () => {
+    it("export the same set of enums", () => {
+      assert.deepEqual(
+        Object.keys(prodAccessor).sort(),
+        Object.keys(debugAccessor).sort(),
+      );
+    });
+
+    for (const enumName of Object.keys(debugAccessor)) {
+      const prodEnum = (prodAccessor as Record<string, AnyEnum>)[enumName];
+      const debugEnum = (debugAccessor as Record<string, AnyEnum>)[enumName];
+
+      describe(enumName, () => {
+        it("has identical member names across both variants", () => {
+          assert.deepEqual(
+            Object.keys(prodEnum ?? {}).sort(),
+            Object.keys(debugEnum).sort(),
+          );
+        });
+
+        it("has unique production values (no scope-key collisions)", () => {
+          const values = Object.values(prodEnum ?? {});
+          assert.equal(new Set(values).size, values.length);
+        });
+
+        it("has unique debug values", () => {
+          const values = Object.values(debugEnum);
+          assert.equal(new Set(values).size, values.length);
+        });
+      });
+    }
+  });
+});

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -40,6 +40,16 @@ export enum ResumeSymbol {
   BranchEndSingleNodeOnlyChildInParent = "}",
 }
 
+// Property names on the inline runtime object. The HTML writer concatenates
+// these (prefixed with ".") into resume scripts while the DOM `RenderData`
+// reads them back, so both sides must agree — keep them in this one place.
+export enum RuntimeKey {
+  Walk = "w",
+  Resume = "r",
+  Ready = "b",
+  Scripts = "j",
+}
+
 export interface AwaitCounter {
   m?: (effects: unknown[]) => unknown[];
   i: number;

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -8,6 +8,7 @@ import {
   type BranchScope,
   type EncodedAccessor,
   ResumeSymbol,
+  RuntimeKey,
   type Scope,
 } from "../common/types";
 import { runEffects, skipDestroyedRenders } from "./queue";
@@ -32,13 +33,13 @@ export interface RenderData {
   // Marked nodes to visit
   v: Comment[];
   // Resumes
-  r?: ResumeData;
+  [RuntimeKey.Resume]?: ResumeData;
   // Walk
-  w(): void;
+  [RuntimeKey.Walk](): void;
   // Deserialize scopes and run scripts ("m" for marko)
   m?(effects: unknown[]): unknown[];
   // Blocking resumes keyed by ready id.
-  b?: Record<string, ResumeData>;
+  [RuntimeKey.Ready]?: Record<string, ResumeData>;
   /* --- Used by inline runtime --- */
 
   // Document
@@ -48,7 +49,7 @@ export interface RenderData {
   // Reorder-runtime
   x: never;
   // Reordered scripts
-  j?: never;
+  [RuntimeKey.Scripts]?: never;
   // Await counter lookup
   p?: Record<string | number, AwaitCounter>;
 }

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -14,6 +14,7 @@ import {
   AccessorProp,
   type Falsy,
   ResumeSymbol,
+  RuntimeKey,
 } from "../common/types";
 import { RendererProp } from "../common/types";
 import { attrAssignment } from "./attrs";
@@ -58,12 +59,6 @@ enum Mark {
   ReorderMarker = "#",
 }
 
-enum RuntimeKey {
-  Walk = ".w",
-  Resume = ".r",
-  Ready = ".b",
-  Scripts = ".j",
-}
 export function getChunk(): Chunk | undefined {
   return $chunk;
 }
@@ -971,6 +966,7 @@ export class State implements SerializeState {
     this.hasReadyRuntime = true;
     return (
       this.runtimePrefix +
+      "." +
       RuntimeKey.Ready +
       "={" +
       readyKey +
@@ -981,7 +977,7 @@ export class State implements SerializeState {
   }
 
   readyAccess(readyKey: string) {
-    return this.runtimePrefix + RuntimeKey.Ready + toAccess(readyKey);
+    return this.runtimePrefix + "." + RuntimeKey.Ready + toAccess(readyKey);
   }
 
   nextReorderId() {
@@ -1325,13 +1321,18 @@ export class Chunk {
       if (state.hasWrittenResume) {
         scripts = concatScripts(
           scripts,
-          runtimePrefix + RuntimeKey.Resume + ".push(" + state.resumes + ")",
+          runtimePrefix +
+            "." +
+            RuntimeKey.Resume +
+            ".push(" +
+            state.resumes +
+            ")",
         );
       } else {
         state.hasWrittenResume = true;
         scripts = concatScripts(
           scripts,
-          runtimePrefix + RuntimeKey.Resume + "=[" + state.resumes + "]",
+          runtimePrefix + "." + RuntimeKey.Resume + "=[" + state.resumes + "]",
         );
       }
     }
@@ -1399,7 +1400,7 @@ export class Chunk {
             state.hasWrittenResume = true;
             scripts = concatScripts(
               scripts,
-              runtimePrefix + RuntimeKey.Resume + "=[]",
+              runtimePrefix + "." + RuntimeKey.Resume + "=[]",
             );
           }
 
@@ -1417,6 +1418,7 @@ export class Chunk {
           scripts,
           reorderScripts &&
             runtimePrefix +
+              "." +
               RuntimeKey.Scripts +
               toAccess(reorderId!) +
               "=_=>{" +
@@ -1438,7 +1440,10 @@ export class Chunk {
     }
 
     if (needsWalk) {
-      scripts = concatScripts(scripts, runtimePrefix + RuntimeKey.Walk + "()");
+      scripts = concatScripts(
+        scripts,
+        runtimePrefix + "." + RuntimeKey.Walk + "()",
+      );
     }
 
     this.html = html;


### PR DESCRIPTION
## What

Removes a "split-brain" spot in `runtime-tags` where the same knowledge lived in two independent places with nothing keeping them in sync:

- **`RuntimeKey` (inline-runtime property names).** The `w`/`r`/`b`/`j` keys were defined as an enum local to `html/writer.ts`, while `dom/resume.ts` re-declared the same keys by hand in its `RenderData` interface. The enum now lives in `common/types.ts` (with the other shared protocol enums) and both sides reference it — `RenderData` binds its keys via computed property names. Values are dotless and the writer prepends `.` at each use site, so **generated output is byte-identical**.

Plus a guard for the `accessor` debug pair:

- **`accessor` parity.** Runtime code imports only `accessor.debug.ts` and relies on a build-time filename swap to substitute `accessor.ts`, so TypeScript never type-checks the production file. Added `debug-parity.test.ts` asserting both expose identical enum member names with unique values — a missing member or a duplicate value (which would collide two scope keys) can otherwise slip past fixtures that don't happen to touch that accessor.

## Notes

I considered a similar check for the `inlined-runtimes.ts` / `.debug.ts` pair but left it out: the only thing that can drift there is *behavior* between the readable and hand-minified copies, and that's already covered — the fixture suite runs every template in both `debug` and `optimize` modes, exercising the debug and production inline runtimes respectively.

## Testing

- `tsc -b` clean; lint/prettier clean.
- New parity test: 19/19 passing.
- All `async-*` fixtures (reorder/resume/ready paths) pass in both `debug` and `optimize` modes, confirming the `RuntimeKey` change altered no output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)