### PR TITLE
refactor(runtime-tags): colocate finalize logic via auto-registering hooks

### DIFF
--- a/.changeset/finalize-hooks.md
+++ b/.changeset/finalize-hooks.md
@@ -1,0 +1,4 @@
+---
+---
+
+refactor: add auto-registering finalize-phase hooks so feature finalize logic colocates with the feature instead of living in references.ts (no behavior change).

--- a/packages/runtime-tags/src/translator/util/finalize.ts
+++ b/packages/runtime-tags/src/translator/util/finalize.ts
@@ -1,0 +1,102 @@
+import type { Section } from "./sections";
+import { createProgramState, createSectionState } from "./state";
+
+/**
+ * Extension points for {@link finalizeReferences}.
+ *
+ * `finalizeReferences` runs a fixed sequence of resolution passes. Rather than
+ * accumulating every feature's finalize logic in `references.ts`, a feature
+ * declares its per-compile state with {@link createFinalizeState} /
+ * {@link createSectionFinalizeState} and passes the finalize logic alongside it.
+ * The hook is registered automatically the first time that state is created in a
+ * compile, so it runs iff the feature is used — with no import-order dependency
+ * and no manual registration. `finalizeReferences` drains each phase at the
+ * matching point in its pipeline via {@link runFinalize} /
+ * {@link runFinalizeSection}.
+ */
+export const enum FinalizePhase {
+  /** Per section, before binding sources are resolved. */
+  Downstreams,
+  /**
+   * Once, after bindings, sources, assignments, hoists, and closures are
+   * resolved. Serialize reasons may still be added here — they are finalized per
+   * section in a later pass.
+   */
+  Resolved,
+  /**
+   * Per section (deepest first), before that section's serialize reasons are
+   * finalized.
+   */
+  KnownTags,
+}
+
+const [getOnceHooks] = createProgramState(
+  () => new Map<FinalizePhase, Set<() => void>>(),
+);
+const [getSectionHooks] = createProgramState(
+  () => new Map<FinalizePhase, Set<(section: Section) => void>>(),
+);
+
+export function runFinalize(phase: FinalizePhase) {
+  getOnceHooks()
+    .get(phase)
+    ?.forEach((run) => run());
+}
+
+export function runFinalizeSection(phase: FinalizePhase, section: Section) {
+  getSectionHooks()
+    .get(phase)
+    ?.forEach((run) => run(section));
+}
+
+/**
+ * Program state whose `finalize` runs once during `phase`. The hook is registered
+ * the first time the state is created in a compile.
+ */
+export function createFinalizeState<T>(
+  phase: FinalizePhase,
+  init: () => T,
+  finalize: (state: T) => void,
+) {
+  return createProgramState<T>(() => {
+    const state = init();
+    addHook(getOnceHooks(), phase, () => finalize(state));
+    return state;
+  });
+}
+
+/**
+ * Section state whose `finalize` runs per section during `phase`. The per-section
+ * hook is registered the first time any section's state is created in a compile.
+ */
+export function createSectionFinalizeState<T>(
+  key: string,
+  phase: FinalizePhase,
+  init: (section: Section) => T,
+  finalize: (section: Section, state: T) => void,
+) {
+  const [isRegistered, setRegistered] = createProgramState(() => false);
+  const [getState] = createSectionState<T>(key, (section) => {
+    if (!isRegistered()) {
+      setRegistered(true);
+      addHook(getSectionHooks(), phase, (section) =>
+        finalize(section, getState(section)),
+      );
+    }
+    return init(section);
+  });
+  return [getState] as const;
+}
+
+function addHook<T>(
+  map: Map<FinalizePhase, Set<T>>,
+  phase: FinalizePhase,
+  run: T,
+) {
+  const existing = map.get(phase);
+  if (existing) {
+    existing.add(run);
+  } else {
+    map.set(phase, new Set([run]));
+  }
+}

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -8,6 +8,7 @@ import {
   getKnownFromPropTree,
   hasAllKnownProps,
 } from "./binding-prop-tree";
+import { createSectionFinalizeState, FinalizePhase } from "./finalize";
 import { generateUidIdentifier } from "./generate-uid";
 import { getTagName } from "./get-tag-name";
 import { isOptimize } from "./marko-config";
@@ -70,7 +71,6 @@ import {
   setBindingSerializedValue,
   writeHTMLResumeStatements,
 } from "./signals";
-import { createSectionState } from "./state";
 import {
   toMemberExpression,
   toObjectProperty,
@@ -91,9 +91,11 @@ interface KnownExprs {
   value?: t.NodeExtra;
 }
 
-const [getKnownTags] = createSectionState(
+const [getKnownTags] = createSectionFinalizeState(
   "known tags",
+  FinalizePhase.KnownTags,
   () => [] as t.MarkoTagExtra[],
+  finalizeKnownTags,
 );
 
 const kContentSection = Symbol("known tag content section");
@@ -364,7 +366,7 @@ export function knownTagTranslateDOM(
   }
 }
 
-export function finalizeKnownTags(section: Section) {
+function finalizeKnownTags(section: Section) {
   for (const tagExtra of getKnownTags(section)) {
     const scopeBinding = tagExtra[kChildScopeBinding];
     const knownExprs = tagExtra[kKnownExprs];

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -4,15 +4,14 @@ import { optimize } from "@marko/compiler/config";
 
 import { decodeAccessor } from "../../common/helpers";
 import { toAccess } from "../../html/serializer";
-import { finalizeFunctionRegistry } from "../visitors/function";
 import { scopeIdentifier } from "../visitors/program";
+import { FinalizePhase, runFinalize, runFinalizeSection } from "./finalize";
 import { forEachIdentifierPath } from "./for-each-identifier";
 import { generateUid } from "./generate-uid";
 import { getAccessorPrefix } from "./get-accessor-char";
 import { getExprRoot, getFnParent, getFnRoot, getMarkoRoot } from "./get-root";
 import { isEventOrChangeHandler } from "./is-event-or-change-handler";
 import isInvokedFunction from "./is-invoked-function";
-import { finalizeKnownTags } from "./known-tag";
 import { isOptimize, isOutputDOM } from "./marko-config";
 import {
   addSorted,
@@ -59,7 +58,6 @@ import {
   mergeSerializeReasons,
   type SerializeReason,
 } from "./serialize-reasons";
-import { finalizeTagDownstreams } from "./set-tag-sections-downstream";
 import {
   getBindingGetterIdentifier,
   getSignalValueIdentifier,
@@ -950,7 +948,9 @@ export function finalizeReferences() {
     }
   }
 
-  forEachSection(finalizeTagDownstreams);
+  forEachSection((section) =>
+    runFinalizeSection(FinalizePhase.Downstreams, section),
+  );
 
   for (const binding of bindings) {
     const { name, section } = binding;
@@ -1173,7 +1173,7 @@ export function finalizeReferences() {
     });
   });
 
-  finalizeFunctionRegistry();
+  runFinalize(FinalizePhase.Resolved);
   const referencedExprs = new Set<ReferencedExtra>();
   for (const binding of bindings) {
     for (const expr of binding.reads) {
@@ -1214,7 +1214,7 @@ export function finalizeReferences() {
 
   forEachSection(finalizeParamSerializeReasonGroups);
   forEachSectionReverse((section) => {
-    finalizeKnownTags(section);
+    runFinalizeSection(FinalizePhase.KnownTags, section);
     finalizeSerializeReason(section);
     // TODO: this duplication is needed when a known tag is circular. We should find a better way.
     finalizeParamSerializeReasonGroups(section);

--- a/packages/runtime-tags/src/translator/util/set-tag-sections-downstream.ts
+++ b/packages/runtime-tags/src/translator/util/set-tag-sections-downstream.ts
@@ -1,16 +1,18 @@
 import { types as t } from "@marko/compiler";
 import { isAttributeTag } from "@marko/compiler/babel-utils";
 
+import { createSectionFinalizeState, FinalizePhase } from "./finalize";
 import { getTagName } from "./get-tag-name";
 import { analyzeAttributeTags, getAttrTagPaths } from "./nested-attribute-tags";
 import { concat, forEach, includes, type Opt } from "./optional";
 import type { Binding } from "./references";
 import { getSection, getSectionForBody, type Section } from "./sections";
-import { createSectionState } from "./state";
 
-const [getTagDownstreams] = createSectionState(
+const [getTagDownstreams] = createSectionFinalizeState(
   "tag-downstreams",
+  FinalizePhase.Downstreams,
   () => new Map<t.NodePath<t.MarkoTag>, Binding>(),
+  finalizeTagDownstreams,
 );
 
 export function setTagDownstream(
@@ -22,7 +24,7 @@ export function setTagDownstream(
   }
 }
 
-export function finalizeTagDownstreams(section: Section) {
+function finalizeTagDownstreams(section: Section) {
   for (const [tag, binding] of getTagDownstreams(section)) {
     crawlSectionsAndSetBinding(tag, binding);
   }

--- a/packages/runtime-tags/src/translator/visitors/function.ts
+++ b/packages/runtime-tags/src/translator/visitors/function.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import { getFile, getTemplateId } from "@marko/compiler/babel-utils";
 
+import { createFinalizeState, FinalizePhase } from "../util/finalize";
 import { generateUid } from "../util/generate-uid";
 import { getAttributeTagParent } from "../util/get-parent-tag";
 import {
@@ -22,12 +23,30 @@ import {
   mergeSerializeReasons,
   type SerializeReason,
 } from "../util/serialize-reasons";
-import { createProgramState } from "../util/state";
 import analyzeTagNameType, { TagNameType } from "../util/tag-name-type";
 import type { TemplateVisitor } from "../util/visitors";
 
-const [getReferencesByFn] = createProgramState(
+const [getReferencesByFn] = createFinalizeState(
+  // Once bindings are resolved, fold each registered function's referenced
+  // serialize reasons into its registration. Colocated with the function visitor
+  // and self-registered so `finalizeReferences` doesn't need to know about it.
+  FinalizePhase.Resolved,
   () => new Map<RegisteredFnExtra, Set<t.NodeExtra>>(),
+  (referencesByFn) => {
+    for (const [fnExtra, exprExtras] of referencesByFn) {
+      let reason: undefined | SerializeReason;
+      for (const exprExtra of exprExtras) {
+        reason = mergeSerializeReasons(
+          reason,
+          getAllSerializeReasonsForExtra(getCanonicalExtra(exprExtra)),
+        );
+      }
+
+      if (reason) {
+        registerFunction(fnExtra, reason);
+      }
+    }
+  },
 );
 
 export default {
@@ -74,22 +93,6 @@ export default {
     }
   },
 } satisfies TemplateVisitor<t.Function>;
-
-export function finalizeFunctionRegistry() {
-  for (const [fnExtra, exprExtras] of getReferencesByFn()) {
-    let reason: undefined | SerializeReason;
-    for (const exprExtra of exprExtras) {
-      reason = mergeSerializeReasons(
-        reason,
-        getAllSerializeReasonsForExtra(getCanonicalExtra(exprExtra)),
-      );
-    }
-
-    if (reason) {
-      registerFunction(fnExtra, reason);
-    }
-  }
-}
 
 function canIgnoreRegister(
   markoRoot: MarkoExprRootPath,


### PR DESCRIPTION
`finalizeReferences` had become the place every feature's finalize logic accumulated. This adds finalize-phase hooks so a feature can keep its finalize logic in its own module, and — critically — makes registration reliable by tying it to the feature's per-compile **state lifecycle** rather than to module-load timing.

### Mechanism (`util/finalize.ts`)
```ts
export const enum FinalizePhase { Downstreams, Resolved, KnownTags }

// program state whose finalize runs once during `phase`
export function createFinalizeState(phase, init, finalize) { ... }
// section state whose finalize runs per-section during `phase`
export function createSectionFinalizeState(key, phase, init, finalize) { ... }

export function runFinalize(phase) { ... }                  // finalizeReferences drains
export function runFinalizeSection(phase, section) { ... }
```

A feature declares its per-compile state with the finalize logic attached; the hook registers automatically the **first time that state is created in a compile**. So it:
- runs **iff the feature is used** (state created ⇔ feature active),
- has **no import-order dependency** (unlike registering at module load, which silently breaks if a module isn't eagerly imported),
- needs **no manual registration call**.

### Migrated to self-register (removed from `references.ts`)
- `finalizeFunctionRegistry` → `createFinalizeState` in `visitors/function.ts` (also drops the `references → function` import cycle)
- `finalizeTagDownstreams` → `createSectionFinalizeState` in `util/set-tag-sections-downstream.ts`
- `finalizeKnownTags` → `createSectionFinalizeState` in `util/known-tag.ts`

`references.ts` no longer imports any of these — it just drains the phases at the right pipeline points.

### Left explicit (intentional)
`finalizeParamSerializeReasonGroups` stays a direct call: it's core serialize-reason logic (it processes `section.serializeReason(s)` and interleaves per-section with the core `finalizeSerializeReason`), not feature logic with a natural home.

Pure refactor — each finalize runs at the same point, just via its hook. Full runtime-tags suite (4745 tests) passes with no snapshot changes.

### Follow-up
This sets up the controllable-`<let>` change (#3293): once this lands, that PR registers its finalize from `core/let.ts` via `createFinalizeState` with zero `references.ts` edits.