### PR TITLE
refactor(runtime-tags): always delegate events from the document

### DIFF
--- a/.changeset/delegate-events-from-document.md
+++ b/.changeset/delegate-events-from-document.md
@@ -1,0 +1,6 @@
+---
+"marko": patch
+"@marko/runtime-tags": patch
+---
+
+Always delegate native events from the `document` rather than each element's root node. This removes the `getRootNode()` lookup from the delegation path and shrinks the runtime.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 24283,
-        "brotli": 8960
+        "min": 24192,
+        "brotli": 8911
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 120
       },
       "runtime": {
-        "min": 4010,
-        "brotli": 1774
+        "min": 3938,
+        "brotli": 1744
       },
       "total": {
-        "min": 4173,
-        "brotli": 1894
+        "min": 4101,
+        "brotli": 1864
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 79
       },
       "runtime": {
-        "min": 2543,
-        "brotli": 1278
+        "min": 2471,
+        "brotli": 1246
       },
       "total": {
-        "min": 2632,
-        "brotli": 1357
+        "min": 2560,
+        "brotli": 1325
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 393
       },
       "runtime": {
-        "min": 6531,
-        "brotli": 2849
+        "min": 6459,
+        "brotli": 2820
       },
       "total": {
-        "min": 7213,
-        "brotli": 3242
+        "min": 7141,
+        "brotli": 3213
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 104
       },
       "runtime": {
-        "min": 2748,
-        "brotli": 1345
+        "min": 2676,
+        "brotli": 1317
       },
       "total": {
-        "min": 2870,
-        "brotli": 1449
+        "min": 2798,
+        "brotli": 1421
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,8 +1,9 @@
-// size: 6531 (min) 2849 (brotli)
+// size: 6459 (min) 2820 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
-  defaultDelegator = /* @__PURE__ */ createDelegator(),
+  delegate = (type, handler) =>
+    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
   parsers = {},
   nextScopeId = 1e6,
   collectingScopes,
@@ -99,17 +100,8 @@ function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  (element["$" + type] === void 0 && delegate(type, handleDelegated),
     (element["$" + type] = handler || null));
-}
-/* @__NO_SIDE_EFFECTS__ */
-function createDelegator() {
-  let kEvents = Symbol();
-  return function (node, type, handler) {
-    ((node = node.getRootNode())[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, !0), 1);
-  };
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,8 +1,9 @@
-// size: 2748 (min) 1345 (brotli)
+// size: 2676 (min) 1317 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
-  defaultDelegator = /* @__PURE__ */ createDelegator(),
+  delegate = (type, handler) =>
+    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
   isScheduled,
   channel,
   registeredValues = {},
@@ -22,17 +23,8 @@ function isNotVoid(value) {
   return value != null && value !== !1;
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  (element["$" + type] === void 0 && delegate(type, handleDelegated),
     (element["$" + type] = handler || null));
-}
-/* @__NO_SIDE_EFFECTS__ */
-function createDelegator() {
-  let kEvents = Symbol();
-  return function (node, type, handler) {
-    ((node = node.getRootNode())[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, !0), 1);
-  };
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,8 +1,9 @@
-// size: 4010 (min) 1774 (brotli)
+// size: 3938 (min) 1744 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
-  defaultDelegator = /* @__PURE__ */ createDelegator(),
+  delegate = (type, handler) =>
+    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
   parsers = {},
   nextScopeId = 1e6,
   collectingScopes,
@@ -81,17 +82,8 @@ let decodeAccessor = (num) =>
     );
   };
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  (element["$" + type] === void 0 && delegate(type, handleDelegated),
     (element["$" + type] = handler || null));
-}
-/* @__NO_SIDE_EFFECTS__ */
-function createDelegator() {
-  let kEvents = Symbol();
-  return function (node, type, handler) {
-    ((node = node.getRootNode())[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, !0), 1);
-  };
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,8 +1,9 @@
-// size: 2543 (min) 1278 (brotli)
+// size: 2471 (min) 1246 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
-  defaultDelegator = /* @__PURE__ */ createDelegator(),
+  delegate = (type, handler) =>
+    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
   isScheduled,
   channel,
   registeredValues = {},
@@ -19,17 +20,8 @@ let decodeAccessor = (num) =>
   runRender = (render) => render.c(render.b, render.d),
   catchEnabled;
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  (element["$" + type] === void 0 && delegate(type, handleDelegated),
     (element["$" + type] = handler || null));
-}
-/* @__NO_SIDE_EFFECTS__ */
-function createDelegator() {
-  let kEvents = Symbol();
-  return function (node, type, handler) {
-    ((node = node.getRootNode())[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, !0), 1);
-  };
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 24283 (min) 8960 (brotli)
+// size: 24192 (min) 8911 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -20,7 +20,8 @@ let empty = [],
   },
   decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
-  defaultDelegator = /* @__PURE__ */ createDelegator(),
+  delegate = (type, handler) =>
+    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
   R = /[^\p{L}\p{N}]/gu,
   parsers = {},
   nextScopeId = 1e6,
@@ -89,7 +90,6 @@ let empty = [],
   readyIds,
   isResuming,
   inputType = "",
-  controllableDelegate = /* @__PURE__ */ createDelegator(),
   _dynamic_tag = function (nodeAccessor, getContent, getTagVar, inputIsArgs) {
     nodeAccessor = decodeAccessor(nodeAccessor);
     let childScopeAccessor = "A" + nodeAccessor,
@@ -382,17 +382,8 @@ function push(opt, item) {
     : item;
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 &&
-    defaultDelegator(element, type, handleDelegated),
+  (element["$" + type] === void 0 && delegate(type, handleDelegated),
     (element["$" + type] = handler || null));
-}
-/* @__NO_SIDE_EFFECTS__ */
-function createDelegator() {
-  let kEvents = Symbol();
-  return function (node, type, handler) {
-    ((node = node.getRootNode())[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, !0), 1);
-  };
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
@@ -1301,8 +1292,8 @@ function _attr_details_or_dialog_open_script(scope, nodeAccessor) {
 }
 function syncControllableFormInput(el, hasChanged, onChange) {
   ((el._ = onChange),
-    controllableDelegate(el, "input", handleChange),
-    el.form && controllableDelegate(el.form, "reset", handleFormReset),
+    delegate("input", handleChange),
+    el.form && delegate("reset", handleFormReset),
     isResuming && hasChanged(el) && queueMicrotask(onChange));
 }
 function handleChange(ev) {

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -8,13 +8,12 @@ import {
   type Scope,
 } from "../common/types";
 import { _attr, normalizeAttrValue } from "./dom";
-import { createDelegator } from "./event";
+import { delegate } from "./event";
 import { pendingEffects, run, runId } from "./queue";
 import { resolveCursorPosition } from "./resolve-cursor-position";
 import { isResuming } from "./resume";
 
 let inputType = "";
-const controllableDelegate = createDelegator();
 
 export function _attr_input_checked_default(
   scope: Scope,
@@ -464,9 +463,9 @@ function syncControllableFormInput<
   onChange: (ev?: Event) => void,
 ) {
   (el as any)._ = onChange;
-  controllableDelegate(el, "input", handleChange);
+  delegate("input", handleChange);
   if ((el as any).form) {
-    controllableDelegate((el as any).form, "reset", handleFormReset);
+    delegate("reset", handleFormReset);
   }
 
   if (isResuming && hasChanged(el)) {

--- a/packages/runtime-tags/src/dom/event.ts
+++ b/packages/runtime-tags/src/dom/event.ts
@@ -2,7 +2,6 @@ import { assertHandlerIsFunction } from "../common/errors";
 import { rendering } from "./queue";
 
 type EventNames = keyof GlobalEventHandlersEventMap;
-const defaultDelegator = createDelegator();
 
 export function _on<
   T extends EventNames,
@@ -20,28 +19,15 @@ export function _on<
   }
 
   if ((element as any)["$" + type] === undefined) {
-    defaultDelegator(element, type, handleDelegated);
+    delegate(type, handleDelegated);
   }
 
   (element as any)["$" + type] = handler || null;
 }
 
-/* @__NO_SIDE_EFFECTS__ */
-export function createDelegator() {
-  const kEvents = Symbol();
-  return function ensureDelegated(
-    node: Node,
-    type: string,
-    handler: EventListener,
-  ) {
-    ((
-      (node = node.getRootNode()) as Document & {
-        [kEvents]?: Record<string, 1>;
-      }
-    )[kEvents] ||= {})[type] ||=
-      (node.addEventListener(type, handler, true), 1);
-  };
-}
+export const delegate = (type: string, handler: EventListener) =>
+  ((handler as any)[type] ||=
+    (document.addEventListener(type, handler, true), 1));
 
 function handleDelegated(ev: GlobalEventHandlersEventMap[EventNames]) {
   let target = !rendering && (ev.target as ParentNode | null);


### PR DESCRIPTION
Delegates native events from the `document` directly instead of resolving each element's root with `getRootNode()`. Delegation state is now tracked on the shared handler function (`handler[type]`), so each event type still registers its capture listener exactly once — which lets the per-root `Symbol`, the `createDelegator` factory, and the node argument all go away.

This also means delegation is unconditionally rooted at the `document` (no per-shadow-root listeners).

### Runtime size (brotli)

| benchmark | before | after |
| --- | --- | --- |
| counter | 1774 | 1744 |
| counter 💧 | 1278 | 1246 |
| comments | 2849 | 2820 |
| comments 💧 | 1345 | 1317 |

---
_Generated by [Claude Code](https://claude.ai/code/session_01KViXQnVR2m1JBopUu7sa1H)_