### PR TITLE
perf(runtime-tags): collapse single-source intersections

### DIFF
--- a/.changeset/collapse-single-source-intersections.md
+++ b/.changeset/collapse-single-source-intersections.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Collapse single-source `_or` intersections onto their source signal and inline members read only by the intersection, shrinking the generated DOM bundle.

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.debug.js
@@ -5,25 +5,23 @@ const $pattern2 = ($scope, $pattern) => {
 	$foo2($scope, $pattern.foo);
 	$fooChange2($scope, $pattern.fooChange);
 };
+const $foo__OR__$fooChange__script = _script("__tests__/template.marko_0_foo_$fooChange", ($scope) => _on($scope["#button/0"], "click", function() {
+	$scope.$fooChange($scope.foo + 1);
+}));
+const $foo__OR__$fooChange = $foo__OR__$fooChange__script;
 const $bar = /* @__PURE__ */ _let("bar/3", ($scope) => {
 	_text($scope["#text/2"], $scope.bar);
 	$pattern2($scope, {
 		foo: $scope.bar,
 		fooChange: $foo($scope)
 	});
+	$foo__OR__$fooChange($scope);
 });
 function $setup($scope) {
 	$bar($scope, 0);
 }
-const $foo__OR__$fooChange__script = _script("__tests__/template.marko_0_foo_$fooChange", ($scope) => _on($scope["#button/0"], "click", function() {
-	$scope.$fooChange($scope.foo + 1);
-}));
-const $foo__OR__$fooChange = /* @__PURE__ */ _or(7, $foo__OR__$fooChange__script);
-const $foo2 = /* @__PURE__ */ _const("foo", ($scope) => {
-	_text($scope["#text/1"], $scope.foo);
-	$foo__OR__$fooChange($scope);
-});
-const $fooChange2 = /* @__PURE__ */ _const("$fooChange", $foo__OR__$fooChange);
+const $foo2 = /* @__PURE__ */ _const("foo", ($scope) => _text($scope["#text/1"], $scope.foo));
+const $fooChange2 = /* @__PURE__ */ _const("$fooChange");
 function $foo($scope) {
 	return function(v) {
 		$bar($scope, v);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/__snapshots__/dom.bundle.js
@@ -3,21 +3,19 @@ const $pattern2 = ($scope, $pattern) => {
 	$foo2($scope, $pattern.foo);
 	$fooChange2($scope, $pattern.fooChange);
 };
+const $foo__OR__$fooChange = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$scope.g($scope.f + 1);
+}));
 const $bar = /* @__PURE__ */ _let(3, ($scope) => {
 	_text($scope.c, $scope.d);
 	$pattern2($scope, {
 		foo: $scope.d,
 		fooChange: $foo($scope)
 	});
-});
-const $foo__OR__$fooChange = /* @__PURE__ */ _or(7, _script("a1", ($scope) => _on($scope.a, "click", function() {
-	$scope.g($scope.f + 1);
-})));
-const $foo2 = /* @__PURE__ */ _const(5, ($scope) => {
-	_text($scope.b, $scope.f);
 	$foo__OR__$fooChange($scope);
 });
-const $fooChange2 = /* @__PURE__ */ _const(6, $foo__OR__$fooChange);
+const $foo2 = /* @__PURE__ */ _const(5, ($scope) => _text($scope.b, $scope.f));
+const $fooChange2 = /* @__PURE__ */ _const(6);
 function $foo($scope) {
 	return function(v) {
 		$bar($scope, v);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2971,
-      "brotli": 1474
+      "min": 2855,
+      "brotli": 1422
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.debug.js
@@ -16,12 +16,6 @@ const $for_content__item_id = /* @__PURE__ */ _const("item_id", ($scope) => {
 	$else_content__item_id($scope);
 });
 const $for = /* @__PURE__ */ _for_of("#div/0", "<!><!><!>", "b%c", 0, $for_content__$params);
-const $list = /* @__PURE__ */ _let("list/2", ($scope) => {
-	$list_($scope, $scope.list?.[2]);
-	$list_2($scope, $scope.list?.[0]);
-	$list_3($scope, $scope.list?.[1]);
-	$for($scope, [$scope.list, "id"]);
-});
 const $list_2__OR__list_0__OR__list___script = _script("__tests__/template.marko_0_list_2_list_0_list_1", ($scope) => _on($scope["#button/1"], "click", function() {
 	$list($scope, [
 		$scope.list_2,
@@ -29,10 +23,17 @@ const $list_2__OR__list_0__OR__list___script = _script("__tests__/template.marko
 		$scope.list_1
 	]);
 }));
-const $list_2__OR__list_0__OR__list_ = /* @__PURE__ */ _or(6, $list_2__OR__list_0__OR__list___script, 2);
-const $list_ = /* @__PURE__ */ _const("list_2", $list_2__OR__list_0__OR__list_);
-const $list_2 = /* @__PURE__ */ _const("list_0", $list_2__OR__list_0__OR__list_);
-const $list_3 = /* @__PURE__ */ _const("list_1", $list_2__OR__list_0__OR__list_);
+const $list_2__OR__list_0__OR__list_ = $list_2__OR__list_0__OR__list___script;
+const $list = /* @__PURE__ */ _let("list/2", ($scope) => {
+	$list_($scope, $scope.list?.[2]);
+	$list_2($scope, $scope.list?.[0]);
+	$list_3($scope, $scope.list?.[1]);
+	$for($scope, [$scope.list, "id"]);
+	$list_2__OR__list_0__OR__list_($scope);
+});
+const $list_ = /* @__PURE__ */ _const("list_2");
+const $list_2 = /* @__PURE__ */ _const("list_0");
+const $list_3 = /* @__PURE__ */ _const("list_1");
 function $setup($scope) {
 	$list($scope, [
 		{

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.js
@@ -13,19 +13,20 @@ const $for_content__item_id = /* @__PURE__ */ _const(4, ($scope) => {
 	$else_content__item_id($scope);
 });
 const $for = /* @__PURE__ */ _for_of(0, "<!><!><!>", "b%c", 0, $for_content__$params);
-const $list = /* @__PURE__ */ _let(2, ($scope) => {
-	$list_($scope, $scope.c?.[2]);
-	$list_2($scope, $scope.c?.[0]);
-	$list_3($scope, $scope.c?.[1]);
-	$for($scope, [$scope.c, "id"]);
-});
-const $list_2__OR__list_0__OR__list_ = /* @__PURE__ */ _or(6, _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $list_2__OR__list_0__OR__list_ = _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$list($scope, [
 		$scope.d,
 		$scope.e,
 		$scope.f
 	]);
-})), 2);
-const $list_ = /* @__PURE__ */ _const(3, $list_2__OR__list_0__OR__list_);
-const $list_2 = /* @__PURE__ */ _const(4, $list_2__OR__list_0__OR__list_);
-const $list_3 = /* @__PURE__ */ _const(5, $list_2__OR__list_0__OR__list_);
+}));
+const $list = /* @__PURE__ */ _let(2, ($scope) => {
+	$list_($scope, $scope.c?.[2]);
+	$list_2($scope, $scope.c?.[0]);
+	$list_3($scope, $scope.c?.[1]);
+	$for($scope, [$scope.c, "id"]);
+	$list_2__OR__list_0__OR__list_($scope);
+});
+const $list_ = /* @__PURE__ */ _const(3);
+const $list_2 = /* @__PURE__ */ _const(4);
+const $list_3 = /* @__PURE__ */ _const(5);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7961,
-      "brotli": 3583
+      "min": 7843,
+      "brotli": 3542
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,28 @@
+// template.marko
+const $template = "<ul></ul><button>rev</button>";
+const $walks = " b b";
+const $for_content__item_a__OR__item_b = /* @__PURE__ */ _or(5, ($scope) => _text($scope["#text/0"], $scope.item_a + $scope.item_b));
+const $for_content__item_a = /* @__PURE__ */ _const("item_a", $for_content__item_a__OR__item_b);
+const $for_content__item_b = /* @__PURE__ */ _const("item_b", $for_content__item_a__OR__item_b);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_a($scope, $params2[0]?.a);
+	$for_content__item_b($scope, $params2[0]?.b);
+};
+const $for = /* @__PURE__ */ _for_of("#ul/0", "<li> </li>", "D l", 0, $for_content__$params);
+const $list__script = _script("__tests__/template.marko_0_list", ($scope) => _on($scope["#button/1"], "click", function() {
+	$list($scope, [...$scope.list].reverse());
+}));
+const $list = /* @__PURE__ */ _let("list/2", ($scope) => {
+	$for($scope, [$scope.list]);
+	$list__script($scope);
+});
+function $setup($scope) {
+	$list($scope, [{
+		a: 1,
+		b: 2
+	}, {
+		a: 3,
+		b: 4
+	}]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/dom.bundle.js
@@ -1,0 +1,16 @@
+// template.marko
+const $for_content__item_a__OR__item_b = /* @__PURE__ */ _or(5, ($scope) => _text($scope.a, $scope.d + $scope.e));
+const $for_content__item_a = /* @__PURE__ */ _const(3, $for_content__item_a__OR__item_b);
+const $for_content__item_b = /* @__PURE__ */ _const(4, $for_content__item_a__OR__item_b);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_a($scope, $params2[0]?.a);
+	$for_content__item_b($scope, $params2[0]?.b);
+};
+const $for = /* @__PURE__ */ _for_of(0, "<li> </li>", "D l", 0, $for_content__$params);
+const $list__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$list($scope, [...$scope.c].reverse());
+}));
+const $list = /* @__PURE__ */ _let(2, ($scope) => {
+	$for($scope, [$scope.c]);
+	$list__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let list = [{
+		a: 1,
+		b: 2
+	}, {
+		a: 3,
+		b: 4
+	}];
+	_html("<ul>");
+	_for_of(list, (item) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(item.a + item.b)}${_el_resume($scope1_id, "#text/0")}</li>`);
+		writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
+	}, 0, $scope0_id, "#ul/0", 1, 1, 1, "</ul>", 1);
+	_html(`<button>rev</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0_list");
+	writeScope($scope0_id, { list }, "__tests__/template.marko", 0, { list: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/html.bundle.js
@@ -1,0 +1,22 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let list = [{
+		a: 1,
+		b: 2
+	}, {
+		a: 3,
+		b: 4
+	}];
+	_html("<ul>");
+	_for_of(list, (item) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(item.a + item.b)}${_el_resume($scope1_id, "a")}</li>`);
+		writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", 1, 1, 1, "</ul>", 1);
+	_html(`<button>rev</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: list });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/render.debug.md
@@ -1,0 +1,37 @@
+# Render
+```html
+<ul>
+  <li>
+    3
+  </li>
+  <li>
+    7
+  </li>
+</ul>
+<button>
+  rev
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<ul>
+  <li>
+    7
+  </li>
+  <li>
+    3
+  </li>
+</ul>
+<button>
+  rev
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text "3" => "7"
+UPDATE: ul > li:nth-of-type(2)::text "7" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/render.md
@@ -1,0 +1,37 @@
+# Render
+```html
+<ul>
+  <li>
+    3
+  </li>
+  <li>
+    7
+  </li>
+</ul>
+<button>
+  rev
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<ul>
+  <li>
+    7
+  </li>
+  <li>
+    3
+  </li>
+</ul>
+<button>
+  rev
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text "3" => "7"
+UPDATE: ul > li:nth-of-type(2)::text "7" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/writes.debug.html
@@ -1,0 +1,19 @@
+<ul>
+  <li>3<!--M_*2 #text/0--></li>
+  <li>7<!--M_*3 #text/0--></li><!--M_}1 #ul/0 3 2-->
+</ul><button>rev</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      list: [{
+        a: 1,
+        b: 2
+      }, {
+        a: 3,
+        b: 4
+      }]
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/template.marko_0_list 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/__snapshots__/writes.html
@@ -1,0 +1,17 @@
+<ul>
+  <li>3<!--M_*2 a--></li>
+  <li>7<!--M_*3 a--></li><!--M_}1 a 3 2-->
+</ul><button>rev</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: [{
+      a: 1,
+      b: 2
+    }, {
+      a: 3,
+      b: 4
+    }]
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7243,
+      "brotli": 3296
+    }
+  },
+  "html": {
+    "min": 433,
+    "brotli": 293
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/template.marko
@@ -1,0 +1,7 @@
+<let/list=[{ a: 1, b: 2 }, { a: 3, b: 4 }]/>
+<ul>
+  <for|item| of=list>
+    <li>${item.a + item.b}</li>
+  </for>
+</ul>
+<button onClick() { list = [...list].reverse() }>rev</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+const $template = "<button>inc</button><div> </div>";
+const $walks = " bD l";
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope["#text/1"], $scope.count * 2 + $scope.count * 3);
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope.b, $scope.c * 2 + $scope.c * 3);
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(doubled + tripled)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}<div>${_escape(doubled + tripled)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/render.debug.md
@@ -1,0 +1,9 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  5
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/render.md
@@ -1,0 +1,9 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  5
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>inc</button><!--M_*1 #button/0-->
+<div>5<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>inc</button><!--M_*1 a-->
+<div>5<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2647,
+      "brotli": 1338
+    }
+  },
+  "html": {
+    "min": 366,
+    "brotli": 258
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/template.marko
@@ -1,0 +1,5 @@
+<let/count=1/>
+<const/doubled=count * 2/>
+<const/tripled=count * 3/>
+<button onClick() { count++ }>inc</button>
+<div>${doubled + tripled}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/test.ts
@@ -1,0 +1,2 @@
+import type { TestConfig } from "../../main.test";
+export const config: TestConfig = { steps: [{}] };

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,18 @@
+// template.marko
+const $template = "<button>inc</button><div> </div>";
+const $walks = " bD l";
+const $sum = ($scope, sum) => _text($scope["#text/1"], sum);
+const $y__OR__z = ($scope) => {
+	$sum($scope, $scope.count + 1 + ($scope.count + 2));
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	$y__OR__z($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $sum = ($scope, sum) => _text($scope.b, sum);
+const $y__OR__z = ($scope) => {
+	$sum($scope, $scope.c + 1 + ($scope.c + 2));
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	$y__OR__z($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const y = count + 1;
+	const z = count + 2;
+	const sum = y + z;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(sum)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/html.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const sum = count + 1 + (count + 2);
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}<div>${_escape(sum)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/render.debug.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  7
+</div>
+```
+## Change
+```
+UPDATE: div::text "5" => "7"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  9
+</div>
+```
+## Change
+```
+UPDATE: div::text "7" => "9"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/render.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  7
+</div>
+```
+## Change
+```
+UPDATE: div::text "5" => "7"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  9
+</div>
+```
+## Change
+```
+UPDATE: div::text "7" => "9"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>inc</button><!--M_*1 #button/0-->
+<div>5<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>inc</button><!--M_*1 a-->
+<div>5<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2665,
+      "brotli": 1345
+    }
+  },
+  "html": {
+    "min": 366,
+    "brotli": 258
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/template.marko
@@ -1,0 +1,6 @@
+<let/count=1/>
+<const/y=count + 1/>
+<const/z=count + 2/>
+<const/sum=y + z/>
+<button onClick() { count++ }>inc</button>
+<div>${sum}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+const $template = "<button>inc</button><div> </div>";
+const $walks = " bD l";
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope["#text/1"], $scope.count * 2 * ($scope.count * 3) + $scope.count * 2);
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope.b, $scope.c * 2 * ($scope.c * 3) + $scope.c * 2);
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(doubled * tripled + doubled)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}<div>${_escape(doubled * tripled + doubled)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/render.debug.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  8
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  28
+</div>
+```
+## Change
+```
+UPDATE: div::text "8" => "28"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  60
+</div>
+```
+## Change
+```
+UPDATE: div::text "28" => "60"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/render.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  8
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  28
+</div>
+```
+## Change
+```
+UPDATE: div::text "8" => "28"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  60
+</div>
+```
+## Change
+```
+UPDATE: div::text "28" => "60"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>inc</button><!--M_*1 #button/0-->
+<div>8<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>inc</button><!--M_*1 a-->
+<div>8<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2655,
+      "brotli": 1343
+    }
+  },
+  "html": {
+    "min": 366,
+    "brotli": 258
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/template.marko
@@ -1,0 +1,5 @@
+<let/count=1/>
+<const/doubled=count * 2/>
+<const/tripled=count * 3/>
+<button onClick() { count++ }>inc</button>
+<div>${doubled * tripled + doubled}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<button>inc</button>";
+const $walks = " b";
+const $y__OR__z__script = _script("__tests__/template.marko_0_y_z", ($scope) => document.body.dataset.sum = `${$scope.count + 1 + ($scope.count + 2)}`);
+const $y__OR__z = $y__OR__z__script;
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/1", ($scope) => {
+	$y__OR__z($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $y__OR__z = _script("a0", ($scope) => document.body.dataset.sum = `${$scope.b + 1 + ($scope.b + 2)}`);
+const $count__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.b + 1);
+}));
+const $count = /* @__PURE__ */ _let(1, ($scope) => {
+	$y__OR__z($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const y = count + 1;
+	const z = count + 2;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_y_z");
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, {
+		count,
+		y,
+		z
+	}, "__tests__/template.marko", 0, {
+		count: "1:6",
+		y: "2:8",
+		z: "3:8"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/html.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const y = count + 1;
+	const z = count + 2;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		b: count,
+		c: y,
+		d: z
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/render.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: body[data-sum] "5" => "7"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/render.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: body[data-sum] "5" => "7"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button>inc</button><!--M_*1 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1,
+      y: 2,
+      z: 3
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/template.marko_0_y_z 1 packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button>inc</button><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 1,
+    c: 2,
+    d: 3
+  }], "a0 1 a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2591,
+      "brotli": 1321
+    }
+  },
+  "html": {
+    "min": 354,
+    "brotli": 259
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/template.marko
@@ -1,0 +1,5 @@
+<let/count=1/>
+<const/y=count + 1/>
+<const/z=count + 2/>
+<button onClick() { count++ }>inc</button>
+<script() { document.body.dataset.sum = `${y + z}` }/>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<button>inc</button><div><!> | <!></div>";
+const $walks = " bD%c%l";
+const $shared = /* @__PURE__ */ _const("shared", ($scope) => _text($scope["#text/1"], $scope.shared));
+const $shared__OR__once = ($scope) => {
+	_text($scope["#text/2"], $scope.shared + $scope.count * 3);
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/3", ($scope) => {
+	$shared($scope, $scope.count * 2);
+	$shared__OR__once($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const $shared = /* @__PURE__ */ _const(4, ($scope) => _text($scope.b, $scope.e));
+const $shared__OR__once = ($scope) => {
+	_text($scope.c, $scope.e + $scope.d * 3);
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.d + 1);
+}));
+const $count = /* @__PURE__ */ _let(3, ($scope) => {
+	$shared($scope, $scope.d * 2);
+	$shared__OR__once($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const shared = count * 2;
+	const once = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(shared)}${_el_resume($scope0_id, "#text/1")} | <!>${_escape(shared + once)}${_el_resume($scope0_id, "#text/2")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const shared = count * 2;
+	const once = count * 3;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}<div>${_escape(shared)}${_el_resume($scope0_id, "b")} | <!>${_escape(shared + once)}${_el_resume($scope0_id, "c")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { d: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/render.debug.md
@@ -1,0 +1,45 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  2 | 5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  4 | 10
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "2" => "4"
+UPDATE: div::text@4 "5" => "10"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  6 | 15
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "4" => "6"
+UPDATE: div::text@4 "10" => "15"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/render.md
@@ -1,0 +1,45 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  2 | 5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  4 | 10
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "2" => "4"
+UPDATE: div::text@4 "5" => "10"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  6 | 15
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "4" => "6"
+UPDATE: div::text@4 "10" => "15"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>inc</button><!--M_*1 #button/0-->
+<div>2<!--M_*1 #text/1--> | <!>5<!--M_*1 #text/2--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>inc</button><!--M_*1 a-->
+<div>2<!--M_*1 b--> | <!>5<!--M_*1 c--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2757,
+      "brotli": 1379
+    }
+  },
+  "html": {
+    "min": 386,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/template.marko
@@ -1,0 +1,5 @@
+<let/count=1/>
+<const/shared=count * 2/>
+<const/once=count * 3/>
+<button onClick() { count++ }>inc</button>
+<div>${shared} | ${shared + once}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+const $template = "<button>inc</button><div> </div>";
+const $walks = " bD l";
+const $pos = ($scope, pos) => $pos_x($scope, pos.x);
+const $pos_x__OR__scale = ($scope) => {
+	_text($scope["#text/1"], $scope.pos_x + $scope.count * 10);
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/2", ($scope) => {
+	$pos($scope, {
+		x: $scope.count,
+		y: $scope.count + 1
+	});
+	$pos_x__OR__scale($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+const $pos_x = /* @__PURE__ */ _const("pos_x");
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/dom.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+const $pos = ($scope, pos) => $pos_x($scope, pos.x);
+const $pos_x__OR__scale = ($scope) => {
+	_text($scope.b, $scope.e + $scope.c * 10);
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.c + 1);
+}));
+const $count = /* @__PURE__ */ _let(2, ($scope) => {
+	$pos($scope, {
+		x: $scope.c,
+		y: $scope.c + 1
+	});
+	$pos_x__OR__scale($scope);
+	$count__script($scope);
+});
+const $pos_x = /* @__PURE__ */ _const(4);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const pos = {
+		x: count,
+		y: count + 1
+	};
+	const scale = count * 10;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(pos.x + scale)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/html.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const pos = {
+		x: count,
+		y: count + 1
+	};
+	const scale = count * 10;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}<div>${_escape(pos.x + scale)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/render.debug.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  11
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  22
+</div>
+```
+## Change
+```
+UPDATE: div::text "11" => "22"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  33
+</div>
+```
+## Change
+```
+UPDATE: div::text "22" => "33"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/render.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<button>
+  inc
+</button>
+<div>
+  11
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  22
+</div>
+```
+## Change
+```
+UPDATE: div::text "11" => "22"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  inc
+</button>
+<div>
+  33
+</div>
+```
+## Change
+```
+UPDATE: div::text "22" => "33"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>inc</button><!--M_*1 #button/0-->
+<div>11<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>inc</button><!--M_*1 a-->
+<div>11<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2772,
+      "brotli": 1392
+    }
+  },
+  "html": {
+    "min": 367,
+    "brotli": 258
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/template.marko
@@ -1,0 +1,5 @@
+<let/count=1/>
+<const/pos={ x: count, y: count + 1 }/>
+<const/scale=count * 10/>
+<button onClick() { count++ }>inc</button>
+<div>${pos.x + scale}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,26 @@
+// tags/child.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope["#text/0"], $scope.input_n * 2 + $scope.input_n * 3);
+};
+const $input_n = /* @__PURE__ */ _const("input_n", $doubled__OR__tripled);
+const $input = ($scope, input) => $input_n($scope, input.n);
+var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+
+// template.marko
+const $template = /* @__PURE__ */ ((_w0) => `${_w0}<button>inc</button>`)($template$1);
+const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}& b`)("D l");
+const $n__script = _script("__tests__/template.marko_0_n", ($scope) => _on($scope["#button/1"], "click", function() {
+	$n($scope, $scope.n + 1);
+}));
+const $n = /* @__PURE__ */ _let("n/2", ($scope) => {
+	$input_n($scope["#childScope/0"], $scope.n);
+	$n__script($scope);
+});
+function $setup($scope) {
+	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
+	$n($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.js
@@ -1,0 +1,14 @@
+// tags/child.marko
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope.a, $scope.d * 2 + $scope.d * 3);
+};
+const $input_n = /* @__PURE__ */ _const(3, $doubled__OR__tripled);
+
+// template.marko
+const $n__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$n($scope, $scope.c + 1);
+}));
+const $n = /* @__PURE__ */ _let(2, ($scope) => {
+	$input_n($scope.a, $scope.c);
+	$n__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,26 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const doubled = input.n * 2;
+	const tripled = input.n * 3;
+	_html(`<div>${_escape(doubled + tripled)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 1;
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(1);
+	child_default({ n });
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0_n");
+	writeScope($scope0_id, {
+		n,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
@@ -1,0 +1,24 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.n * 2 + input.n * 3)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 1;
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(1);
+	child_default({ n });
+	_html(`<button>inc</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: n,
+		a: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<div>
+  5
+</div>
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<div>
+  10
+</div>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: div::text "5" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<div>
+  5
+</div>
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<div>
+  10
+</div>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: div::text "5" => "10"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<div>5<!--M_*2 #text/0--></div><button>inc</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 1,
+      "#childScope/0": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/template.marko_0_n 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<div>5<!--M_*2 a--></div><button>inc</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1,
+    a: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2738,
+        "brotli": 1369
+      },
+      "files": {
+        "tags/child.marko": 201,
+        "template.marko": 256
+      }
+    }
+  },
+  "html": {
+    "min": 373,
+    "brotli": 265
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/tags/child.marko
@@ -1,0 +1,3 @@
+<const/doubled=input.n * 2/>
+<const/tripled=input.n * 3/>
+<div>${doubled + tripled}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/template.marko
@@ -1,0 +1,3 @@
+<let/n=1/>
+<child n=n/>
+<button onClick() { n++ }>inc</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,20 @@
+// template.marko
+const $template = "<button>toggle</button><div> </div>";
+const $walks = " bD l";
+const $obj = ($scope, obj) => $obj_label($scope, obj?.label);
+const $obj_label__OR__n = ($scope) => {
+	_text($scope["#text/1"], ($scope.obj_label ?? "none") + ($scope.show ? 1 : 2));
+};
+const $show__script = _script("__tests__/template.marko_0_show", ($scope) => _on($scope["#button/0"], "click", function() {
+	$show($scope, !$scope.show);
+}));
+const $show = /* @__PURE__ */ _let("show/2", ($scope) => {
+	$obj($scope, $scope.show && { label: "hi" });
+	$obj_label__OR__n($scope);
+	$show__script($scope);
+});
+function $setup($scope) {
+	$show($scope, false);
+}
+const $obj_label = /* @__PURE__ */ _const("obj_label");
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/dom.bundle.js
@@ -1,0 +1,14 @@
+// template.marko
+const $obj = ($scope, obj) => $obj_label($scope, obj?.label);
+const $obj_label__OR__n = ($scope) => {
+	_text($scope.b, ($scope.e ?? "none") + ($scope.c ? 1 : 2));
+};
+const $show__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$show($scope, !$scope.c);
+}));
+const $show = /* @__PURE__ */ _let(2, ($scope) => {
+	$obj($scope, $scope.c && { label: "hi" });
+	$obj_label__OR__n($scope);
+	$show__script($scope);
+});
+const $obj_label = /* @__PURE__ */ _const(4);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let show = false;
+	const obj = show && { label: "hi" };
+	const n = show ? 1 : 2;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape((obj?.label ?? "none") + n)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_show");
+	writeScope($scope0_id, { show }, "__tests__/template.marko", 0, { show: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/html.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let show = false;
+	const obj = show;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}<div>${_escape((obj?.label ?? "none") + 2)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: show });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<div>
+  none2
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<div>
+  hi1
+</div>
+```
+## Change
+```
+UPDATE: div::text "none2" => "hi1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<div>
+  none2
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<div>
+  hi1
+</div>
+```
+## Change
+```
+UPDATE: div::text "none2" => "hi1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>toggle</button><!--M_*1 #button/0-->
+<div>none2<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      show: !1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/template.marko_0_show 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>toggle</button><!--M_*1 a-->
+<div>none2<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: !1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2791,
+      "brotli": 1401
+    }
+  },
+  "html": {
+    "min": 374,
+    "brotli": 259
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/template.marko
@@ -1,0 +1,5 @@
+<let/show=false/>
+<const/obj=show && { label: "hi" }/>
+<const/n=show ? 1 : 2/>
+<button onClick() { show = !show }>toggle</button>
+<div>${(obj?.label ?? "none") + n}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+const $template = "<button>increment</button><div>-- <!> -- <!> -- <!> -- <!></div>";
+const $walks = " bDb%c%c%c%l";
+const $doubled = /* @__PURE__ */ _const("doubled", ($scope) => _text($scope["#text/2"], $scope.doubled));
+const $tripled = /* @__PURE__ */ _const("tripled", ($scope) => _text($scope["#text/3"], $scope.tripled));
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope["#text/4"], $scope.doubled + $scope.tripled);
+};
+const $count__script = _script("__tests__/template.marko_0_count", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+const $count = /* @__PURE__ */ _let("count/5", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$doubled($scope, $scope.count * 2);
+	$tripled($scope, $scope.count * 3);
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});
+function $setup($scope) {
+	$count($scope, 1);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/dom.bundle.js
@@ -1,0 +1,16 @@
+// template.marko
+const $doubled = /* @__PURE__ */ _const(6, ($scope) => _text($scope.c, $scope.g));
+const $tripled = /* @__PURE__ */ _const(7, ($scope) => _text($scope.d, $scope.h));
+const $doubled__OR__tripled = ($scope) => {
+	_text($scope.e, $scope.g + $scope.h);
+};
+const $count__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.f + 1);
+}));
+const $count = /* @__PURE__ */ _let(5, ($scope) => {
+	_text($scope.b, $scope.f);
+	$doubled($scope, $scope.f * 2);
+	$tripled($scope, $scope.f * 3);
+	$doubled__OR__tripled($scope);
+	$count__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>increment</button>${_el_resume($scope0_id, "#button/0")}<div>-- <!>${_escape(count)}${_el_resume($scope0_id, "#text/1")} -- <!>${_escape(doubled)}${_el_resume($scope0_id, "#text/2")} -- <!>${_escape(tripled)}${_el_resume($scope0_id, "#text/3")} -- <!>${_escape(doubled + tripled)}${_el_resume($scope0_id, "#text/4")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const doubled = count * 2;
+	const tripled = count * 3;
+	_html(`<button>increment</button>${_el_resume($scope0_id, "a")}<div>-- <!>${_escape(count)}${_el_resume($scope0_id, "b")} -- <!>${_escape(doubled)}${_el_resume($scope0_id, "c")} -- <!>${_escape(tripled)}${_el_resume($scope0_id, "d")} -- <!>${_escape(doubled + tripled)}${_el_resume($scope0_id, "e")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { f: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/render.debug.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 1 -- 2 -- 3 -- 5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 2 -- 4 -- 6 -- 10
+</div>
+```
+## Change
+```
+UPDATE: div::text@3 "1" => "2"
+UPDATE: div::text@8 "2" => "4"
+UPDATE: div::text@13 "3" => "6"
+UPDATE: div::text@18 "5" => "10"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 3 -- 6 -- 9 -- 15
+</div>
+```
+## Change
+```
+UPDATE: div::text@3 "2" => "3"
+UPDATE: div::text@8 "4" => "6"
+UPDATE: div::text@13 "6" => "9"
+UPDATE: div::text@18 "10" => "15"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/render.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 1 -- 2 -- 3 -- 5
+</div>
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 2 -- 4 -- 6 -- 10
+</div>
+```
+## Change
+```
+UPDATE: div::text@3 "1" => "2"
+UPDATE: div::text@8 "2" => "4"
+UPDATE: div::text@13 "3" => "6"
+UPDATE: div::text@18 "5" => "10"
+```
+
+# Update
+```js
+c.querySelector("button").click();
+```
+```html
+<button>
+  increment
+</button>
+<div>
+  -- 3 -- 6 -- 9 -- 15
+</div>
+```
+## Change
+```
+UPDATE: div::text@3 "2" => "3"
+UPDATE: div::text@8 "4" => "6"
+UPDATE: div::text@13 "6" => "9"
+UPDATE: div::text@18 "10" => "15"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button>increment</button><!--M_*1 #button/0-->
+<div>-- <!>1<!--M_*1 #text/1--> -- <!>2<!--M_*1 #text/2--> -- <!>
+        3<!--M_*1 #text/3--> -- <!>5<!--M_*1 #text/4--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/template.marko_0_count 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button>increment</button><!--M_*1 a-->
+<div>-- <!>1<!--M_*1 b--> -- <!>2<!--M_*1 c--> -- <!>3<!--M_*1 d--> -- <!>
+          5<!--M_*1 e--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    f: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2798,
+      "brotli": 1394
+    }
+  },
+  "html": {
+    "min": 441,
+    "brotli": 279
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/template.marko
@@ -1,0 +1,11 @@
+<let/count=1/>
+<const/doubled=count * 2/>
+<const/tripled=count * 3/>
+
+<button onClick() { count++ }>increment</button>
+<div>
+  -- ${count}
+  -- ${doubled}
+  -- ${tripled}
+  -- ${doubled + tripled}
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = { steps: [{}, click, click] };
+
+function click(c: Element) {
+  c.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,8 @@ const $MyTag_content__tag_params = ($scope, $params2) => {
 	$MyTag_content__a($scope, $params2[0]);
 	$MyTag_content__b($scope, $params2[1]);
 };
-const $x__OR__args = /* @__PURE__ */ _or(9, ($scope) => {
+const $args = /* @__PURE__ */ _const("args", ($scope) => $MyTag_content__tag_params($scope["#childScope/0"], [...$scope.args]));
+const $x__OR__args = ($scope) => {
 	let $cgrp;
 	if ($scope.x) {
 		$cgrp = attrTag({ y: 1 });
@@ -21,11 +22,7 @@ const $x__OR__args = /* @__PURE__ */ _or(9, ($scope) => {
 		cgrp: $cgrp,
 		row: attrTag({ r: $scope.x })
 	}]);
-});
-const $args = /* @__PURE__ */ _const("args", ($scope) => {
-	$MyTag_content__tag_params($scope["#childScope/0"], [...$scope.args]);
-	$x__OR__args($scope);
-});
+};
 const $x__script = _script("__tests__/template.marko_0_x", ($scope) => _on($scope["#button/3"], "click", function() {
 	$x($scope, $scope.x + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/dom.bundle.js
@@ -5,7 +5,8 @@ const $MyTag_content__tag_params = ($scope, $params2) => {
 	$MyTag_content__a($scope, $params2[0]);
 	$MyTag_content__b($scope, $params2[1]);
 };
-const $x__OR__args = /* @__PURE__ */ _or(9, ($scope) => {
+const $args = /* @__PURE__ */ _const(8, ($scope) => $MyTag_content__tag_params($scope.a, [...$scope.i]));
+const $x__OR__args = ($scope) => {
 	let $cgrp;
 	if ($scope.h) $cgrp = attrTag({ y: 1 });
 	else $cgrp = attrTag({ y: 2 });
@@ -13,11 +14,7 @@ const $x__OR__args = /* @__PURE__ */ _or(9, ($scope) => {
 		cgrp: $cgrp,
 		row: attrTag({ r: $scope.h })
 	}]);
-});
-const $args = /* @__PURE__ */ _const(8, ($scope) => {
-	$MyTag_content__tag_params($scope.a, [...$scope.i]);
-	$x__OR__args($scope);
-});
+};
 const $x__script = _script("a1", ($scope) => _on($scope.d, "click", function() {
 	$x($scope, $scope.h + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3125,
-      "brotli": 1567
+      "min": 3006,
+      "brotli": 1509
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,18 @@
 // template.marko
 const $template = "<button> </button><!> <!> <!>";
 const $walks = " D l%c%c%b";
+const $y = /* @__PURE__ */ _const("y", ($scope) => _text($scope["#text/2"], $scope.y));
+const $z = /* @__PURE__ */ _const("z", ($scope) => _text($scope["#text/3"], $scope.z));
 const $a = ($scope, a) => _text($scope["#text/4"], a);
-const $y__OR__z = /* @__PURE__ */ _or(8, ($scope) => $a($scope, $scope.y + $scope.z));
-const $y = /* @__PURE__ */ _const("y", ($scope) => {
-	_text($scope["#text/2"], $scope.y);
-	$y__OR__z($scope);
-});
-const $z = /* @__PURE__ */ _const("z", ($scope) => {
-	_text($scope["#text/3"], $scope.z);
-	$y__OR__z($scope);
-});
+const $y__OR__z = ($scope) => {
+	$a($scope, $scope.y + $scope.z);
+};
 const $x__script = _script("__tests__/template.marko_0_x", ($scope) => _on($scope["#button/0"], "click", () => $x($scope, $scope.x + 1) - 1));
 const $x = /* @__PURE__ */ _let("x/5", ($scope) => {
 	_text($scope["#text/1"], $scope.x);
 	$y($scope, $scope.x + 1);
 	$z($scope, $scope.x + 2);
+	$y__OR__z($scope);
 	$x__script($scope);
 });
 function $setup($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/dom.bundle.js
@@ -1,18 +1,15 @@
 // template.marko
+const $y = /* @__PURE__ */ _const(6, ($scope) => _text($scope.c, $scope.g));
+const $z = /* @__PURE__ */ _const(7, ($scope) => _text($scope.d, $scope.h));
 const $a = ($scope, a) => _text($scope.e, a);
-const $y__OR__z = /* @__PURE__ */ _or(8, ($scope) => $a($scope, $scope.g + $scope.h));
-const $y = /* @__PURE__ */ _const(6, ($scope) => {
-	_text($scope.c, $scope.g);
-	$y__OR__z($scope);
-});
-const $z = /* @__PURE__ */ _const(7, ($scope) => {
-	_text($scope.d, $scope.h);
-	$y__OR__z($scope);
-});
+const $y__OR__z = ($scope) => {
+	$a($scope, $scope.g + $scope.h);
+};
 const $x__script = _script("a0", ($scope) => _on($scope.a, "click", () => $x($scope, $scope.f + 1) - 1));
 const $x = /* @__PURE__ */ _let(5, ($scope) => {
 	_text($scope.b, $scope.f);
 	$y($scope, $scope.f + 1);
 	$z($scope, $scope.f + 2);
+	$y__OR__z($scope);
 	$x__script($scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2927,
-      "brotli": 1450
+      "min": 2808,
+      "brotli": 1403
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
@@ -9,14 +9,14 @@ var my_const_default = /* @__PURE__ */ _template("__tests__/tags/my-const.marko"
 // tags/child.marko
 const $template$1 = "";
 const $walks$1 = /* @__PURE__ */ ((_w0) => `0${_w0}&`)("");
-const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);
-const $input__OR__x = /* @__PURE__ */ _or(6, $input__OR__x__script);
-const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x", $input__OR__x));
+const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x"));
 function $setup$1($scope) {
 	_var($scope, "#childScope/0", $x);
 	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 }
 const $input_foo$1 = ($scope, input_foo) => $input_value($scope["#childScope/0"], input_foo);
+const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);
+const $input__OR__x = $input__OR__x__script;
 const $input$1 = /* @__PURE__ */ _const("input", ($scope) => {
 	$input_foo$1($scope, $scope.input.foo);
 	$input__OR__x($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // tags/child.marko
-const $input__OR__x = /* @__PURE__ */ _or(6, _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f));
-const $x = _var_resume("b0", /* @__PURE__ */ _const(5, $input__OR__x));
+const $x = _var_resume("b0", /* @__PURE__ */ _const(5));
+const $input__OR__x = _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f);
 
 // template.marko
 const $output_getter = _el("a0", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2256,
-        "brotli": 1157
+        "min": 1885,
+        "brotli": 992
       },
       "files": {
-        "tags/child.marko": 225,
+        "tags/child.marko": 186,
         "template.marko": 75
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
@@ -9,14 +9,14 @@ var my_const_default = /* @__PURE__ */ _template("__tests__/tags/my-const.marko"
 // tags/child.marko
 const $template$1 = "";
 const $walks$1 = /* @__PURE__ */ ((_w0) => `0${_w0}&`)("");
-const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);
-const $input__OR__x = /* @__PURE__ */ _or(6, $input__OR__x__script);
-const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x", $input__OR__x));
+const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x"));
 function $setup$1($scope) {
 	_var($scope, "#childScope/0", $x);
 	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 }
 const $input_foo = ($scope, input_foo) => $input_value($scope["#childScope/0"], input_foo);
+const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);
+const $input__OR__x = $input__OR__x__script;
 const $input$1 = /* @__PURE__ */ _const("input", ($scope) => {
 	$input_foo($scope, $scope.input.foo);
 	$input__OR__x($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // tags/child.marko
-const $input__OR__x = /* @__PURE__ */ _or(6, _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f));
-const $x = _var_resume("b0", /* @__PURE__ */ _const(5, $input__OR__x));
+const $x = _var_resume("b0", /* @__PURE__ */ _const(5));
+const $input__OR__x = _script("b1", ($scope) => $scope.d.output().innerHTML = $scope.f);
 
 // template.marko
 const $output_getter = _el("a0", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2256,
-        "brotli": 1157
+        "min": 1885,
+        "brotli": 992
       },
       "files": {
-        "tags/child.marko": 225,
+        "tags/child.marko": 186,
         "template.marko": 75
       }
     }

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -61,6 +61,7 @@ import {
 import { finalizeTagDownstreams } from "./set-tag-sections-downstream";
 import {
   getBindingGetterIdentifier,
+  getSignals,
   getSignalValueIdentifier,
   type Signal,
 } from "./signals";
@@ -1224,7 +1225,18 @@ export function finalizeReferences() {
   forEachSection((section) => {
     const { id, bindings } = section;
     const isOwnedBinding = ({ section }: Binding) => section.id === id;
-    let intersections = intersectionsBySection.get(section) || [];
+    let intersections = (intersectionsBySection.get(section) || []).filter(
+      (intersection) => {
+        const collapseSource = getCollapsibleIntersectionSource(
+          intersection,
+          section,
+        );
+        if (collapseSource) {
+          collapsedIntersectionSource.set(intersection, collapseSource);
+        }
+        return !collapseSource;
+      },
+    );
     if (intersections.length) {
       const anchors = new Map<Intersection, Binding | undefined>();
       for (const intersection of intersections) {
@@ -1312,6 +1324,36 @@ export const intersectionMeta = new WeakMap<
   Intersection,
   { id: number; scopeOffset: Binding | undefined }
 >();
+
+export const collapsedIntersectionSource = new WeakMap<Intersection, Binding>();
+
+function getCollapsibleIntersectionSource(
+  intersection: Intersection,
+  section: Section,
+) {
+  let sources: Sources | undefined;
+  for (const member of intersection) {
+    if (!member.sources) return undefined;
+    const isDirectAlias =
+      member.upstreamAlias &&
+      member.property === undefined &&
+      member.excludeProperties === undefined;
+    if (member.section !== section || isDirectAlias) return undefined;
+    sources = mergeSources(sources, member.sources);
+  }
+
+  if (!sources || (sources.state && sources.param)) {
+    return undefined;
+  }
+
+  const source = sources.state || sources.param;
+  return source &&
+    !Array.isArray(source) &&
+    source.section === section &&
+    !source.scopeOffset
+    ? source
+    : undefined;
+}
 
 export function setBindingDownstream(
   binding: Binding,
@@ -1785,7 +1827,11 @@ export function getReadReplacement(
       }
 
       if (isOutputDOM()) {
-        if (
+        const inlined = getSignals(extra.section!).get(readBinding)?.inline
+          ?.value;
+        if (inlined) {
+          replacement = t.cloneNode(inlined, true);
+        } else if (
           signal?.referencedBindings === readBinding &&
           !signal.hasSideEffect
         ) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -19,6 +19,7 @@ import {
   type Binding,
   BindingType,
   bindingUtil,
+  collapsedIntersectionSource,
   getCanonicalBinding,
   getDebugName,
   getDebugNames,
@@ -84,6 +85,8 @@ export interface Signal {
   effectReferencedBindings: ReferencedBindings;
   hasDynamicSubscribers: boolean;
   hasSideEffect: boolean;
+  forcePersist: boolean;
+  inline: { value: t.Expression } | undefined;
   export: boolean;
   extraArgs: t.Expression[] | undefined;
   prependStatements: t.Statement[] | undefined;
@@ -96,7 +99,7 @@ type closureSignalBuilder = (
   closure: Binding,
   render: t.Expression,
 ) => t.Expression;
-const [getSignals] = createSectionState<Map<unknown, Signal>>(
+export const [getSignals] = createSectionState<Map<unknown, Signal>>(
   "signals",
   () => new Map(),
 );
@@ -262,6 +265,8 @@ export function getSignal(
             referencedBindings.hoists)
         ),
         hasDynamicSubscribers: false,
+        forcePersist: false,
+        inline: undefined,
         extraArgs: undefined,
         prependStatements: undefined,
         buildAssignment: undefined,
@@ -273,19 +278,39 @@ export function getSignal(
     } else if (!referencedBindings) {
       signal.build = () => getSignalFn(signal);
     } else if (Array.isArray(referencedBindings)) {
-      subscribe(referencedBindings, signal);
-      signal.build = () => {
-        const { id, scopeOffset } = intersectionMeta.get(referencedBindings)!;
-        return callRuntime(
-          "_or",
-          t.numericLiteral(id),
-          getSignalFn(signal),
-          scopeOffset || referencedBindings.length > 2
-            ? t.numericLiteral(referencedBindings.length - 1)
-            : undefined,
-          scopeOffset && getScopeAccessorLiteral(scopeOffset, true),
-        );
-      };
+      const collapseSource =
+        collapsedIntersectionSource.get(referencedBindings);
+      subscribe(collapseSource || referencedBindings, signal);
+      if (collapseSource) {
+        const sourceSignal = getSignal(section, collapseSource);
+        forEach(referencedBindings, (member) => {
+          const memberSignal = getSignal(section, member);
+          const inline =
+            member.type === BindingType.derived &&
+            !member.upstreamAlias &&
+            member.reads.size === 1 &&
+            sourceSignal.values.find((v) => v.signal === memberSignal);
+          if (inline) {
+            memberSignal.inline = inline;
+          } else {
+            memberSignal.hasSideEffect = memberSignal.forcePersist = true;
+          }
+        });
+        signal.build = () => getSignalFn(signal);
+      } else {
+        signal.build = () => {
+          const { id, scopeOffset } = intersectionMeta.get(referencedBindings)!;
+          return callRuntime(
+            "_or",
+            t.numericLiteral(id),
+            getSignalFn(signal),
+            scopeOffset || referencedBindings.length > 2
+              ? t.numericLiteral(referencedBindings.length - 1)
+              : undefined,
+            scopeOffset && getScopeAccessorLiteral(scopeOffset, true),
+          );
+        };
+      }
     } else if (
       referencedBindings.section !== section &&
       sectionUtil.has(referencedBindings.closureSections, section)
@@ -344,9 +369,8 @@ export function initValue(binding: Binding, isLet = false) {
       binding.property === undefined &&
       binding.excludeProperties === undefined;
     if (
-      isDirectAlias ||
-      !signal.hasSideEffect ||
-      !signalHasStatements(signal)
+      !signal.forcePersist &&
+      (isDirectAlias || !signal.hasSideEffect || !signalHasStatements(signal))
     ) {
       return fn;
     }
@@ -376,6 +400,7 @@ export function initValue(binding: Binding, isLet = false) {
 export function signalHasStatements(signal: Signal): boolean {
   if (
     signal.extraArgs ||
+    signal.forcePersist ||
     signal.render.length ||
     signal.effect.length ||
     signal.values.length ||
@@ -559,6 +584,9 @@ export function getSignalFn(signal: Signal): t.Expression {
   }
 
   for (const value of signal.values) {
+    if (value.signal.inline) {
+      continue;
+    }
     if (signalHasStatements(value.signal)) {
       signal.render.push(
         t.expressionStatement(


### PR DESCRIPTION
## Description

When every member of an `_or` intersection resolves to a single in-section state source, the fan-in node is unnecessary — the dependent can subscribe directly to that source. This resolves the collapse during reference finalization (from the already-computed binding `sources`), stores it on `intersectionMeta`, and has the signal translation consume it.

Because the decision happens before accessor ids are assigned, collapsed intersections no longer claim a scope slot, and members read only by the intersection are inlined at their read site via `getReadReplacement` (so render and `<script>` effect bodies share one path).

Shrinks the generated DOM bundle; render/SSR/CSR output is unchanged.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UkmrWBCDT55gXDjnP2TUQ2)_