### PR TITLE
feat(runtime-tags): O(1) keyed-selector update for <for> key equality

### DIFF
--- a/.changeset/for-keyed-selector.md
+++ b/.changeset/for-keyed-selector.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Optimize the common "selected row" pattern: when a value from the loop's parent scope — a `<let>`, a `<const>`, or an `input` member — is compared for equality against a `<for>` loop's unique key (e.g. `class=(selected === row.id && "danger")`, `input.selected === row.id`, or `<if=selected === row.id>`), a change to that value now updates only the two affected rows (the one losing the key and the one gaining it) instead of re-running the binding for every row — turning an O(n) update into O(1). Detected automatically at compile time for `of`/`by`, `of` index, `in` name, and `to`/`until` range keys, including multiple such values per loop; no template changes required.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 24357,
-        "brotli": 8968
+        "min": 24880,
+        "brotli": 9203
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 384
       },
       "runtime": {
-        "min": 6459,
-        "brotli": 2820
+        "min": 6480,
+        "brotli": 2845
       },
       "total": {
-        "min": 7124,
-        "brotli": 3204
+        "min": 7145,
+        "brotli": 3229
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6459 (min) 2820 (brotli)
+// size: 6480 (min) 2845 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -379,14 +379,16 @@ function loop(forEach) {
   return (nodeAccessor, template, walks, setup, params) => {
     nodeAccessor = decodeAccessor(nodeAccessor);
     let scopesAccessor = "A" + nodeAccessor,
+      keyedScopesAccessor = "O" + nodeAccessor,
       renderer = _content("", template, walks, setup)();
     return (
       enableBranches(),
       (scope, value) => {
         let referenceNode = scope[nodeAccessor],
           oldScopes = toArray(scope[scopesAccessor]),
-          newScopes = (scope[scopesAccessor] = []),
-          oldLen = oldScopes.length,
+          newScopes = (scope[scopesAccessor] = []);
+        scope[keyedScopesAccessor] = null;
+        let oldLen = oldScopes.length,
           parentNode =
             referenceNode.nodeType > 1
               ? referenceNode.parentNode || oldScopes[0]?.S.parentNode

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 24357 (min) 8968 (brotli)
+// size: 24880 (min) 9203 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -550,6 +550,63 @@ function _for_closure(ownerLoopNodeAccessor, fn) {
         );
     };
   return ((ownerSignal._ = fn), ownerSignal);
+}
+function _for_selector(
+  ownerLoopNodeAccessor,
+  ownerValueAccessor,
+  keyValueAccessor,
+  fn,
+) {
+  ((ownerLoopNodeAccessor = decodeAccessor(ownerLoopNodeAccessor)),
+    (ownerValueAccessor = decodeAccessor(ownerValueAccessor)),
+    keyValueAccessor !== "M" &&
+      (keyValueAccessor = decodeAccessor(keyValueAccessor)));
+  let scopeAccessor = "A" + ownerLoopNodeAccessor,
+    mapAccessor = "O" + ownerLoopNodeAccessor,
+    prevKeyProp = `_${ownerValueAccessor}`,
+    ownerSignal = (ownerScope) => {
+      let scopes = toArray(ownerScope[scopeAccessor]);
+      if (ownerScope.H < runId && scopes.length) {
+        let nextKey = ownerScope[ownerValueAccessor];
+        queueRender(
+          ownerScope,
+          () => {
+            let map = keyedScopes(
+              ownerScope,
+              scopeAccessor,
+              mapAccessor,
+              keyValueAccessor,
+            );
+            if (map && prevKeyProp in map) {
+              let prevScope = map.get(map[prevKeyProp]),
+                nextScope = map.get(nextKey);
+              prevScope !== nextScope &&
+                (runLiveBranch(prevScope, fn), runLiveBranch(nextScope, fn));
+            } else
+              for (let scope of toArray(ownerScope[scopeAccessor]))
+                runLiveBranch(scope, fn);
+            map && (map[prevKeyProp] = nextKey);
+          },
+          -1,
+          0,
+          scopes[0].L,
+        );
+      }
+    };
+  return ((ownerSignal._ = fn), ownerSignal);
+}
+function keyedScopes(ownerScope, scopeAccessor, mapAccessor, keyValueAccessor) {
+  let map = (ownerScope[mapAccessor] ||= /* @__PURE__ */ new Map());
+  if (!map.size)
+    for (let scope of toArray(ownerScope[scopeAccessor])) {
+      let key = scope.M ?? scope[keyValueAccessor];
+      if (key === void 0) return (ownerScope[mapAccessor] = null);
+      ((scope.M = key), map.set(key, scope));
+    }
+  return map;
+}
+function runLiveBranch(scope, fn) {
+  scope && scope.H > 0 && scope.H < runId && fn(scope);
 }
 function _if_closure(ownerConditionalNodeAccessor, branch, fn) {
   ownerConditionalNodeAccessor = decodeAccessor(ownerConditionalNodeAccessor);
@@ -1958,14 +2015,16 @@ function loop(forEach) {
   return (nodeAccessor, template, walks, setup, params) => {
     nodeAccessor = decodeAccessor(nodeAccessor);
     let scopesAccessor = "A" + nodeAccessor,
+      keyedScopesAccessor = "O" + nodeAccessor,
       renderer = _content("", template, walks, setup)();
     return (
       enableBranches(),
       (scope, value) => {
         let referenceNode = scope[nodeAccessor],
           oldScopes = toArray(scope[scopesAccessor]),
-          newScopes = (scope[scopesAccessor] = []),
-          oldLen = oldScopes.length,
+          newScopes = (scope[scopesAccessor] = []);
+        scope[keyedScopesAccessor] = null;
+        let oldLen = oldScopes.length,
           parentNode =
             referenceNode.nodeType > 1
               ? referenceNode.parentNode || oldScopes[0]?.S.parentNode

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7533,
-        "brotli": 3439
+        "min": 7555,
+        "brotli": 3453
       },
       "files": {
         "tags/child.marko": 154,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7205,
-      "brotli": 3309
+      "min": 7227,
+      "brotli": 3299
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7344,
-      "brotli": 3312
+      "min": 7366,
+      "brotli": 3338
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7781,
-        "brotli": 3532
+        "min": 7803,
+        "brotli": 3571
       },
       "files": {
         "tags/child.marko": 745,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8230,
-        "brotli": 3696
+        "min": 8252,
+        "brotli": 3719
       },
       "files": {
         "tags/child.marko": 597,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7731,
-        "brotli": 3512
+        "min": 7753,
+        "brotli": 3530
       },
       "files": {
         "tags/child.marko": 639,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15552,
-        "brotli": 6055
+        "min": 15575,
+        "brotli": 6085
       },
       "files": {
         "tags/sections.marko": 746,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8428,
-      "brotli": 3722
+      "min": 8453,
+      "brotli": 3758
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9223,
-      "brotli": 3948
+      "min": 9246,
+      "brotli": 3966
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7340,
-        "brotli": 3331
+        "min": 7362,
+        "brotli": 3346
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7843,
-      "brotli": 3542
+      "min": 7867,
+      "brotli": 3554
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8203,
-      "brotli": 3677
+      "min": 8226,
+      "brotli": 3700
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7428,
-      "brotli": 3332
+      "min": 7450,
+      "brotli": 3325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7167,
-      "brotli": 3253
+      "min": 7189,
+      "brotli": 3273
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7112,
-      "brotli": 3264
+      "min": 7134,
+      "brotli": 3280
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7243,
-      "brotli": 3296
+      "min": 7265,
+      "brotli": 3321
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,57 @@
+// template.marko
+const $template = "<table><tbody></tbody></table><button class=remove>remove selected</button><button class=rotate>rotate</button><button class=clear>clear</button>";
+const $walks = "D l b b b";
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope.row_id);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected__OR__rows__script = _script("__tests__/template.marko_0_selected_rows", ($scope) => _on($scope["#button/1"], "click", function() {
+	$rows($scope, $scope.rows.filter((row) => row.id !== $scope.selected));
+}));
+const $selected__OR__rows = /* @__PURE__ */ _or(6, $selected__OR__rows__script);
+const $selected = /* @__PURE__ */ _let("selected/4", ($scope) => {
+	$selected__OR__rows($scope);
+	$for_content__selected($scope);
+});
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows__script = _script("__tests__/template.marko_0_rows", ($scope) => _on($scope["#button/2"], "click", function() {
+	$rows($scope, [...$scope.rows.slice(1), $scope.rows?.[0]]);
+}));
+const $rows = /* @__PURE__ */ _let("rows/5", ($scope) => {
+	$for($scope, [$scope.rows, "id"]);
+	$selected__OR__rows($scope);
+	$rows__script($scope);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/3"], "click", function() {
+	$selected($scope, undefined);
+}));
+function $setup($scope) {
+	$selected($scope, undefined);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+	$setup__script($scope);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.js
@@ -1,0 +1,35 @@
+// template.marko
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope.a, $scope._.e === $scope.f && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 4, 5, $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.f);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const(5, ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope.c, row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected__OR__rows = /* @__PURE__ */ _or(6, _script("a3", ($scope) => _on($scope.b, "click", function() {
+	$rows($scope, $scope.f.filter((row) => row.id !== $scope.e));
+})));
+const $selected = /* @__PURE__ */ _let(4, ($scope) => {
+	$selected__OR__rows($scope);
+	$for_content__selected($scope);
+});
+const $for = /* @__PURE__ */ _for_of(0, "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows__script = _script("a2", ($scope) => _on($scope.c, "click", function() {
+	$rows($scope, [...$scope.f.slice(1), $scope.f?.[0]]);
+}));
+const $rows = /* @__PURE__ */ _let(5, ($scope) => {
+	$for($scope, [$scope.f, "id"]);
+	$selected__OR__rows($scope);
+	$rows__script($scope);
+});
+const $setup__script = _script("a1", ($scope) => _on($scope.d, "click", function() {
+	$selected($scope, void 0);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = undefined;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}${_el_resume($scope1_id, "#text/2")}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "5:4", { row_id: ["row.id", "5:8"] });
+	}, "id", $scope0_id, "#tbody/0", 1, 1, 1, "</tbody>", 1);
+	_html(`</table><button class=remove>remove selected</button>${_el_resume($scope0_id, "#button/1")}<button class=rotate>rotate</button>${_el_resume($scope0_id, "#button/2")}<button class=clear>clear</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	_script($scope0_id, "__tests__/template.marko_0_rows");
+	_script($scope0_id, "__tests__/template.marko_0_selected_rows");
+	writeScope($scope0_id, {
+		selected,
+		rows
+	}, "__tests__/template.marko", 0, {
+		selected: "1:6",
+		rows: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/html.bundle.js
@@ -1,0 +1,39 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = void 0;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}${_el_resume($scope1_id, "c")}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 1, 1, "</tbody>", 1);
+	_html(`</table><button class=remove>remove selected</button>${_el_resume($scope0_id, "b")}<button class=rotate>rotate</button>${_el_resume($scope0_id, "c")}<button class=clear>clear</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a1");
+	_script($scope0_id, "a2");
+	_script($scope0_id, "a3");
+	writeScope($scope0_id, {
+		e: selected,
+		f: rows
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/render.debug.md
@@ -1,0 +1,434 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+REMOVE: table > tbody > tr
+INSERT: .danger + tr
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+REMOVE: table > tbody > tr
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/render.md
@@ -1,0 +1,434 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+REMOVE: table > tbody > tr
+INSERT: .danger + tr
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+REMOVE: table > tbody > tr
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector(selector).click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="remove"
+>
+  remove selected
+</button>
+<button
+  class="rotate"
+>
+  rotate
+</button>
+<button
+  class="clear"
+>
+  clear
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/writes.debug.html
@@ -1,0 +1,49 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button
+          class=select>a<!--M_*2 #text/2--></button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button
+          class=select>b<!--M_*3 #text/2--></button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button
+          class=select>c<!--M_*4 #text/2--></button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0--><!--M_}1 #tbody/0 4 3 2-->
+  </tbody>
+</table><button class=remove>remove
+  selected</button><!--M_*1 #button/1--><button
+  class=rotate>rotate</button><!--M_*1 #button/2--><button
+  class=clear>clear</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      rows: [{
+        id: 1,
+        label: "a"
+      }, {
+        id: 2,
+        label: "b"
+      }, {
+        id: 3,
+        label: "c"
+      }]
+    }, {
+      row_id: 1,
+      _: _(1),
+      "#LoopKey": 1
+    }, {
+      row_id: 2,
+      _: _(1),
+      "#LoopKey": 2
+    }, {
+      row_id: 3,
+      _: _(1),
+      "#LoopKey": 3
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko_1_row_id 2 3 4 packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko_0 1 packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko_0_rows 1 packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko_0_selected_rows 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/writes.html
@@ -1,0 +1,43 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a<!--M_*2 c--></button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>b<!--M_*3 c--></button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c<!--M_*4 c--></button><!--M_*4 b--></td>
+    </tr><!--M_*4 a--><!--M_}1 a 4 3 2-->
+  </tbody>
+</table><button class=remove>remove selected</button><!--M_*1 b--><button
+  class=rotate>rotate</button><!--M_*1 c--><button
+  class=clear>clear</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    f: [{
+      id: 1,
+      label: "a"
+    }, {
+      id: 2,
+      label: "b"
+    }, {
+      id: 3,
+      label: "c"
+    }]
+  }, {
+    f: 1,
+    _: _(1),
+    M: 1
+  }, {
+    f: 2,
+    _: _(1),
+    M: 2
+  }, {
+    f: 3,
+    _: _(1),
+    M: 3
+  }], "a0 2 3 4 a1 1 a2 1 a3 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8464,
+      "brotli": 3775
+    }
+  },
+  "html": {
+    "min": 896,
+    "brotli": 394
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/template.marko
@@ -1,0 +1,14 @@
+<let/selected=undefined/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+
+<table><tbody>
+  <for|row| of=rows by="id">
+    <tr class=(selected === row.id && "danger")>
+      <td><button.select onClick() { selected = row.id }>${row.label}</button></td>
+    </tr>
+  </for>
+</tbody></table>
+
+<button.remove onClick() { rows = rows.filter((row) => row.id !== selected) }>remove selected</button>
+<button.rotate onClick() { rows = [...rows.slice(1), rows[0]] }>rotate</button>
+<button.clear onClick() { selected = undefined }>clear</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/test.ts
@@ -1,0 +1,20 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+const clickButton = (selector: string) => (container: Element) =>
+  (container.querySelector(selector) as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    clickSelect(0),
+    clickSelect(2),
+    clickButton("button.rotate"),
+    clickSelect(0),
+    clickButton("button.remove"),
+    clickSelect(1),
+    clickButton("button.clear"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+const $template = "<ul></ul>";
+const $walks = " b";
+const $for_content__selected__OR__row_id__script = _script("__tests__/template.marko_1_selected_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope._.selected === $scope.row_id ? undefined : $scope.row_id);
+}));
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => {
+	_attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger");
+	$for_content__selected__OR__row_id__script($scope);
+});
+const $for_content__selected = /* @__PURE__ */ _for_selector("#ul/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", $for_content__selected__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#ul/0", "<li><button class=toggle> </button></li>", " D D m", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$selected($scope, 1);
+	$rows($scope, [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $for_content__selected__OR__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope._.b === $scope.f ? void 0 : $scope.f);
+}));
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => {
+	_attr_class($scope.a, $scope._.b === $scope.f && "danger");
+	$for_content__selected__OR__row_id__script($scope);
+});
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,26 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}><button class=toggle>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</li>${_el_resume($scope1_id, "#li/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_selected_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "4:4", { row_id: ["row.id", "4:8"] });
+	}, "id", $scope0_id, "#ul/0", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	writeScope($scope0_id, { selected }, "__tests__/template.marko", 0, { selected: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.js
@@ -1,0 +1,26 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}><button class=toggle>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</li>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	writeScope($scope0_id, { b: selected });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/render.debug.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.toggle")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelectorAll("button.toggle")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li
+    class="danger"
+  >
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/render.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.toggle")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelectorAll("button.toggle")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="toggle"
+    >
+      a
+    </button>
+  </li>
+  <li
+    class="danger"
+  >
+    <button
+      class="toggle"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.debug.html
@@ -1,0 +1,21 @@
+<ul>
+  <li class=danger><button class=toggle>a</button><!--M_*2 #button/1--></li>
+  <!--M_*2 #li/0-->
+  <li><button class=toggle>b</button><!--M_*3 #button/1--></li><!--M_*3 #li/0-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/0": [_(2), _(3)],
+      selected: 1
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/template.marko_1_selected_row_id 2 3"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.html
@@ -1,0 +1,19 @@
+<ul>
+  <li class=danger><button class=toggle>a</button><!--M_*2 b--></li>
+  <!--M_*2 a-->
+  <li><button class=toggle>b</button><!--M_*3 b--></li><!--M_*3 a-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3)],
+    b: 1
+  }, {
+    f: 1,
+    _: _(1)
+  }, {
+    f: 2,
+    _: _(1)
+  }], "a0 2 3"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3597,
+      "brotli": 1746
+    }
+  },
+  "html": {
+    "min": 505,
+    "brotli": 302
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/template.marko
@@ -1,0 +1,11 @@
+<let/selected=1/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }]/>
+<ul>
+  <for|row| of=rows by="id">
+    <li class=(selected === row.id && "danger")>
+      <button.toggle onClick() {
+        selected = selected === row.id ? undefined : row.id;
+      }>${row.label}</button>
+    </li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickToggle = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.toggle")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickToggle(0), clickToggle(1)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// template.marko
+const $template = "<ul></ul>";
+const $walks = " b";
+const $for_content__if = /* @__PURE__ */ _if("#text/0", "<strong>*</strong>", "b");
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => $for_content__if($scope, $scope._.selected === $scope.row_id ? 0 : 1));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#ul/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope.row_id);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#ul/0", "<li><!><button class=select> </button></li>", "D%b D m", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$selected($scope, 1);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// template.marko
+const $for_content__if = /* @__PURE__ */ _if(0, "<strong>*</strong>", "b");
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => $for_content__if($scope, $scope._.b === $scope.f ? 0 : 1));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.f);
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html("<li>");
+		_if(() => {
+			if (selected === row.id) {
+				const $scope2_id = _scope_id();
+				_html("<strong>*</strong>");
+				writeScope($scope2_id, {}, "__tests__/template.marko", "6:8");
+				return 0;
+			}
+		}, $scope1_id, "#text/0", 1, 1, 1, 0, 1);
+		_html(`<button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</li>`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "4:4", { row_id: ["row.id", "4:8"] });
+	}, "id", $scope0_id, "#ul/0", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html("<li>");
+		_if(() => {
+			if (selected === row.id) {
+				const $scope2_id = _scope_id();
+				_html("<strong>*</strong>");
+				writeScope($scope2_id, {});
+				return 0;
+			}
+		}, $scope1_id, "a", 1, 1, 1, 0, 1);
+		_html(`<button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</li>`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.debug.md
@@ -1,0 +1,105 @@
+# Render
+```html
+<ul>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(1) > strong
+INSERT: ul > li:nth-of-type(3) > strong
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > li:nth-of-type(1) > strong
+REMOVE: ul > li:nth-of-type(3) > strong
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.md
@@ -1,0 +1,105 @@
+# Render
+```html
+<ul>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(1) > strong
+INSERT: ul > li:nth-of-type(3) > strong
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <strong>
+      *
+    </strong>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      c
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > li:nth-of-type(1) > strong
+REMOVE: ul > li:nth-of-type(3) > strong
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<ul>
+  <li><strong>*</strong><!--M_|2 #text/0 3--><button
+      class=select>a</button><!--M_*2 #button/1--></li>
+  <li><!--M_|4 #text/0--><button class=select>b</button><!--M_*4 #button/1-->
+  </li>
+  <li><!--M_|5 #text/0--><button class=select>c</button><!--M_*5 #button/1-->
+  </li>
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/0": [_(2), _(4), _(5)]
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, 1, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/template.marko_1_row_id 2 4 5"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/writes.html
@@ -1,0 +1,22 @@
+<ul>
+  <li><strong>*</strong><!--M_|2 a 3--><button
+      class=select>a</button><!--M_*2 b--></li>
+  <li><!--M_|4 a--><button class=select>b</button><!--M_*4 b--></li>
+  <li><!--M_|5 a--><button class=select>c</button><!--M_*5 b--></li>
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(4), _(5)]
+  }, {
+    f: 1,
+    _: _(1)
+  }, 1, {
+    f: 2,
+    _: _(1)
+  }, {
+    f: 3,
+    _: _(1)
+  }], "a0 2 4 5"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6568,
+      "brotli": 2971
+    }
+  },
+  "html": {
+    "min": 596,
+    "brotli": 324
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/template.marko
@@ -1,0 +1,12 @@
+<let/selected=1/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+<ul>
+  <for|row| of=rows by="id">
+    <li>
+      <if=selected === row.id>
+        <strong>*</strong>
+      </if>
+      <button.select onClick() { selected = row.id }>${row.label}</button>
+    </li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(2), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// template.marko
+const $template = "<button class=flip>flip</button><ul></ul>";
+const $walks = " b b";
+const $for_content__input_selected__OR__enabled__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope["#li/0"], $scope._.enabled && $scope._.input_selected === $scope.row_id && "sel"), 2);
+const $for_content__input_selected = /* @__PURE__ */ _for_selector("#ul/1", "input_selected", "row_id", $for_content__input_selected__OR__enabled__OR__row_id);
+const $for_content__setup = ($scope) => {
+	$for_content__input_selected._($scope);
+	$for_content__enabled._($scope);
+};
+const $for_content__enabled = /* @__PURE__ */ _for_closure("#ul/1", $for_content__input_selected__OR__enabled__OR__row_id);
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", $for_content__input_selected__OR__enabled__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/1"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $enabled__script = _script("__tests__/template.marko_0_enabled", ($scope) => _on($scope["#button/0"], "click", function() {
+	$enabled($scope, !$scope.enabled);
+}));
+const $enabled = /* @__PURE__ */ _let("enabled/6", ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});
+function $setup($scope) {
+	$enabled($scope, true);
+}
+const $for = /* @__PURE__ */ _for_of("#ul/1", "<li> </li>", " D l", $for_content__setup, $for_content__$params);
+const $input_rows = ($scope, input_rows) => $for($scope, [input_rows, "id"]);
+const $input = ($scope, input) => {
+	$input_rows($scope, input.rows);
+	$input_selected($scope, input.selected);
+};
+const $input_selected = /* @__PURE__ */ _const("input_selected", $for_content__input_selected);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $for_content__input_selected__OR__enabled__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope.a, $scope._.g && $scope._.f === $scope.e && "sel"), 2);
+const $for_content__enabled = /* @__PURE__ */ _for_closure(1, $for_content__input_selected__OR__enabled__OR__row_id);
+const $enabled__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$enabled($scope, !$scope.g);
+}));
+const $enabled = /* @__PURE__ */ _let(6, ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,24 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_rows = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let enabled = true;
+	_html(`<button class=flip>flip</button>${_el_resume($scope0_id, "#button/0")}<ul>`);
+	_for_of(input.rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${enabled && input.selected === row.id ? " class=sel" : ""}>${_escape(row.label)}${_el_resume($scope1_id, "#text/1", $sg__input_rows)}</li>${_el_resume($scope1_id, "#li/0")}`);
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "4:4", { row_id: ["row.id", "4:8"] });
+	}, "id", $scope0_id, "#ul/1", 1, $sg__input_rows, $sg__input_rows, "</ul>", 1);
+	_script($scope0_id, "__tests__/template.marko_0_enabled");
+	writeScope($scope0_id, {
+		input_selected: input.selected,
+		enabled
+	}, "__tests__/template.marko", 0, {
+		input_selected: ["input.selected"],
+		enabled: "1:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/html.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $sg__input_rows = _serialize_guard(_scope_reason(), 0);
+	const $scope0_id = _scope_id();
+	let enabled = true;
+	_html(`<button class=flip>flip</button>${_el_resume($scope0_id, "a")}<ul>`);
+	_for_of(input.rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${input.selected === row.id ? " class=sel" : ""}>${_escape(row.label)}${_el_resume($scope1_id, "b", $sg__input_rows)}</li>${_el_resume($scope1_id, "a")}`);
+		writeScope($scope1_id, {
+			e: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "b", 1, $sg__input_rows, $sg__input_rows, "</ul>", 1);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		f: input.selected,
+		g: enabled
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-csr.debug.md
@@ -1,0 +1,135 @@
+# Render `{"rows":[{"id":1,"label":"a"},{"id":2,"label":"b"},{"id":3,"label":"c"}],"selected":2}`
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "sel" => null
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .sel[class] null => "sel"
+```
+
+# Update `{"rows":[{"id":1,"label":"a"},{"id":2,"label":"b"},{"id":3,"label":"c"}],"selected":3}`
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li
+    class="sel"
+  >
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "sel" => null
+UPDATE: .sel[class] null => "sel"
+```
+
+# Update `{"rows":[{"id":4,"label":"d"},{"id":1,"label":"a"},{"id":2,"label":"b"},{"id":3,"label":"c"}],"selected":4}`
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li
+    class="sel"
+  >
+    d
+  </li>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > .sel
+UPDATE: .sel[class] null => "sel"
+UPDATE: ul > li:nth-of-type(4)[class] "sel" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,77 @@
+# Render `{"rows":[{"id":1,"label":"a"},{"id":2,"label":"b"},{"id":3,"label":"c"}],"selected":2}`
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "sel" => null
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .sel[class] null => "sel"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/render-ssr.md
@@ -1,0 +1,77 @@
+# Render `{"rows":[{"id":1,"label":"a"},{"id":2,"label":"b"},{"id":3,"label":"c"}],"selected":2}`
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "sel" => null
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="sel"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .sel[class] null => "sel"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<button class=flip>flip</button><!--M_*1 #button/0-->
+<ul>
+  <li>a</li><!--M_*2 #li/0-->
+  <li class=sel>b</li><!--M_*3 #li/0-->
+  <li>c</li><!--M_*4 #li/0-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/1": [_(2), _(3), _(4)],
+      input_selected: 2,
+      enabled: !0
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/template.marko_0_enabled 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/__snapshots__/writes.html
@@ -1,0 +1,24 @@
+<button class=flip>flip</button><!--M_*1 a-->
+<ul>
+  <li>a</li><!--M_*2 a-->
+  <li class=sel>b</li><!--M_*3 a-->
+  <li>c</li><!--M_*4 a-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ab: [_(2), _(3), _(4)],
+    f: 2,
+    g: !0
+  }, {
+    e: 1,
+    _: _(1)
+  }, {
+    e: 2,
+    _: _(1)
+  }, {
+    e: 3,
+    _: _(1)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3241,
+      "brotli": 1589
+    }
+  },
+  "html": {
+    "min": 505,
+    "brotli": 317
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/template.marko
@@ -1,0 +1,7 @@
+<let/enabled=true/>
+<button.flip onClick() { enabled = !enabled }>flip</button>
+<ul>
+  <for|row| of=input.rows by="id">
+    <li class=(enabled && input.selected === row.id && "sel")>${row.label}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/test.ts
@@ -1,0 +1,21 @@
+import type { TestConfig } from "../../main.test";
+
+const clickFlip = (container: Element) =>
+  (container.querySelector("button.flip") as HTMLButtonElement).click();
+
+const rows = [
+  { id: 1, label: "a" },
+  { id: 2, label: "b" },
+  { id: 3, label: "c" },
+];
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [
+    { rows, selected: 2 },
+    clickFlip,
+    clickFlip,
+    { rows, selected: 3 },
+    { rows: [{ id: 4, label: "d" }, ...rows], selected: 4 },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,45 @@
+// template.marko
+const $template = "<button class=flip>flip</button><ul></ul>";
+const $walks = " b b";
+const $for_content__enabled__OR__selected__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope["#li/0"], $scope._.enabled && $scope._.selected === $scope.row_id && "danger"), 2);
+const $for_content__enabled = /* @__PURE__ */ _for_closure("#ul/1", $for_content__enabled__OR__selected__OR__row_id);
+const $for_content__setup = ($scope) => {
+	$for_content__enabled._($scope);
+	$for_content__selected._($scope);
+};
+const $for_content__selected = /* @__PURE__ */ _for_selector("#ul/1", "selected", "row_id", $for_content__enabled__OR__selected__OR__row_id);
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", $for_content__enabled__OR__selected__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/1"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $enabled__script = _script("__tests__/template.marko_0_enabled", ($scope) => _on($scope["#button/0"], "click", function() {
+	$enabled($scope, !$scope.enabled);
+}));
+const $enabled = /* @__PURE__ */ _let("enabled/2", ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});
+const $selected = /* @__PURE__ */ _let("selected/3");
+const $for = /* @__PURE__ */ _for_of("#ul/1", "<li> </li>", " D l", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/4", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$enabled($scope, true);
+	$selected($scope, 2);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $for_content__enabled__OR__selected__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope.a, $scope._.c && $scope._.d === $scope.e && "danger"), 2);
+const $for_content__enabled = /* @__PURE__ */ _for_closure(1, $for_content__enabled__OR__selected__OR__row_id);
+const $enabled__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$enabled($scope, !$scope.c);
+}));
+const $enabled = /* @__PURE__ */ _let(2, ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,40 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let enabled = true;
+	let selected = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html(`<button class=flip>flip</button>${_el_resume($scope0_id, "#button/0")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${enabled && selected === row.id ? " class=danger" : ""}>${_escape(row.label)}</li>${_el_resume($scope1_id, "#li/0")}`);
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "6:4", { row_id: ["row.id", "6:8"] });
+	}, "id", $scope0_id, "#ul/1", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_script($scope0_id, "__tests__/template.marko_0_enabled");
+	writeScope($scope0_id, {
+		enabled,
+		selected
+	}, "__tests__/template.marko", 0, {
+		enabled: "1:6",
+		selected: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/html.bundle.js
@@ -1,0 +1,37 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let enabled = true;
+	let selected = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html(`<button class=flip>flip</button>${_el_resume($scope0_id, "a")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}>${_escape(row.label)}</li>${_el_resume($scope1_id, "a")}`);
+		writeScope($scope1_id, {
+			e: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "b", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: enabled,
+		d: selected
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/render.debug.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="danger"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="danger"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/render.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="danger"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.flip").click();
+```
+```html
+<button
+  class="flip"
+>
+  flip
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="danger"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<button class=flip>flip</button><!--M_*1 #button/0-->
+<ul>
+  <li>a</li><!--M_*2 #li/0-->
+  <li class=danger>b</li><!--M_*3 #li/0-->
+  <li>c</li><!--M_*4 #li/0-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/1": [_(2), _(3), _(4)],
+      enabled: !0,
+      selected: 2
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/template.marko_0_enabled 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/__snapshots__/writes.html
@@ -1,0 +1,24 @@
+<button class=flip>flip</button><!--M_*1 a-->
+<ul>
+  <li>a</li><!--M_*2 a-->
+  <li class=danger>b</li><!--M_*3 a-->
+  <li>c</li><!--M_*4 a-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ab: [_(2), _(3), _(4)],
+    c: !0,
+    d: 2
+  }, {
+    e: 1,
+    _: _(1)
+  }, {
+    e: 2,
+    _: _(1)
+  }, {
+    e: 3,
+    _: _(1)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3244,
+      "brotli": 1591
+    }
+  },
+  "html": {
+    "min": 508,
+    "brotli": 318
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/template.marko
@@ -1,0 +1,9 @@
+<let/enabled=true/>
+<let/selected=2/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+<button.flip onClick() { enabled = !enabled }>flip</button>
+<ul>
+  <for|row| of=rows by="id">
+    <li class=(enabled && selected === row.id && "danger")>${row.label}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickFlip = (container: Element) =>
+  (container.querySelector("button.flip") as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickFlip, clickFlip],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,48 @@
+// template.marko
+const $template = "<button class=select>select</button><button class=hover>hover</button><ul></ul>";
+const $walks = " b b b";
+const $for_content__selected__OR__hovered__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope["#li/0"], [$scope._.selected === $scope.row_id && "sel", $scope._.hovered === $scope.row_id && "hov"]), 2);
+const $for_content__selected = /* @__PURE__ */ _for_selector("#ul/2", "selected", "row_id", $for_content__selected__OR__hovered__OR__row_id);
+const $for_content__setup = ($scope) => {
+	$for_content__selected._($scope);
+	$for_content__hovered._($scope);
+};
+const $for_content__hovered = /* @__PURE__ */ _for_selector("#ul/2", "hovered", "row_id", $for_content__selected__OR__hovered__OR__row_id);
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", $for_content__selected__OR__hovered__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/1"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/3", $for_content__selected);
+const $hovered = /* @__PURE__ */ _let("hovered/4", $for_content__hovered);
+const $for = /* @__PURE__ */ _for_of("#ul/2", "<li> </li>", " D l", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/5", ($scope) => $for($scope, [$scope.rows, "id"]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$selected($scope, 3);
+	});
+	_on($scope["#button/1"], "click", function() {
+		$hovered($scope, 3);
+	});
+});
+function $setup($scope) {
+	$selected($scope, 1);
+	$hovered($scope, 2);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+	$setup__script($scope);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/dom.bundle.js
@@ -1,0 +1,14 @@
+// template.marko
+const $for_content__selected__OR__hovered__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope.a, [$scope._.d === $scope.e && "sel", $scope._.e === $scope.e && "hov"]), 2);
+const $for_content__selected = /* @__PURE__ */ _for_selector(2, 3, 4, $for_content__selected__OR__hovered__OR__row_id);
+const $for_content__hovered = /* @__PURE__ */ _for_selector(2, 4, 4, $for_content__selected__OR__hovered__OR__row_id);
+const $selected = /* @__PURE__ */ _let(3, $for_content__selected);
+const $hovered = /* @__PURE__ */ _let(4, $for_content__hovered);
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.a, "click", function() {
+		$selected($scope, 3);
+	});
+	_on($scope.b, "click", function() {
+		$hovered($scope, 3);
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,40 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let hovered = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html(`<button class=select>select</button>${_el_resume($scope0_id, "#button/0")}<button class=hover>hover</button>${_el_resume($scope0_id, "#button/1")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${_attr_class([selected === row.id && "sel", hovered === row.id && "hov"])}>${_escape(row.label)}</li>${_el_resume($scope1_id, "#li/0")}`);
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "7:4", { row_id: ["row.id", "7:8"] });
+	}, "id", $scope0_id, "#ul/2", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		selected,
+		hovered
+	}, "__tests__/template.marko", 0, {
+		selected: "1:6",
+		hovered: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/html.bundle.js
@@ -1,0 +1,37 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let hovered = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html(`<button class=select>select</button>${_el_resume($scope0_id, "a")}<button class=hover>hover</button>${_el_resume($scope0_id, "b")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${_attr_class([selected === row.id && "sel", hovered === row.id && "hov"])}>${_escape(row.label)}</li>${_el_resume($scope1_id, "a")}`);
+		writeScope($scope1_id, {
+			e: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "c", 1, 0, 0, 0, 1);
+	_html("</ul>");
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		d: selected,
+		e: hovered
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/render.debug.md
@@ -1,0 +1,100 @@
+# Render
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li
+    class="sel"
+  >
+    a
+  </li>
+  <li
+    class="hov"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector(sel).click();
+```
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="hov"
+  >
+    b
+  </li>
+  <li
+    class="sel"
+  >
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "sel" => null
+UPDATE: .sel[class] null => "sel"
+```
+
+# Update
+```js
+container.querySelector(sel).click();
+```
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li
+    class="sel hov"
+  >
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "hov" => null
+UPDATE: .sel.hov[class] "sel" => "sel hov"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/render.md
@@ -1,0 +1,100 @@
+# Render
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li
+    class="sel"
+  >
+    a
+  </li>
+  <li
+    class="hov"
+  >
+    b
+  </li>
+  <li>
+    c
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector(sel).click();
+```
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li
+    class="hov"
+  >
+    b
+  </li>
+  <li
+    class="sel"
+  >
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "sel" => null
+UPDATE: .sel[class] null => "sel"
+```
+
+# Update
+```js
+container.querySelector(sel).click();
+```
+```html
+<button
+  class="select"
+>
+  select
+</button>
+<button
+  class="hover"
+>
+  hover
+</button>
+<ul>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+  <li
+    class="sel hov"
+  >
+    c
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(2)[class] "hov" => null
+UPDATE: .sel.hov[class] "sel" => "sel hov"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/writes.debug.html
@@ -1,0 +1,27 @@
+<button class=select>select</button><!--M_*1 #button/0--><button
+  class=hover>hover</button><!--M_*1 #button/1-->
+<ul>
+  <li class=sel>a</li><!--M_*2 #li/0-->
+  <li class=hov>b</li><!--M_*3 #li/0-->
+  <li>c</li><!--M_*4 #li/0-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/2": [_(2), _(3), _(4)],
+      selected: 1,
+      hovered: 2
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/__snapshots__/writes.html
@@ -1,0 +1,25 @@
+<button class=select>select</button><!--M_*1 a--><button
+  class=hover>hover</button><!--M_*1 b-->
+<ul>
+  <li class=sel>a</li><!--M_*2 a-->
+  <li class=hov>b</li><!--M_*3 a-->
+  <li>c</li><!--M_*4 a-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ac: [_(2), _(3), _(4)],
+    d: 1,
+    e: 2
+  }, {
+    e: 1,
+    _: _(1)
+  }, {
+    e: 2,
+    _: _(1)
+  }, {
+    e: 3,
+    _: _(1)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3651,
+      "brotli": 1769
+    }
+  },
+  "html": {
+    "min": 565,
+    "brotli": 329
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/template.marko
@@ -1,0 +1,10 @@
+<let/selected=1/>
+<let/hovered=2/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+<button.select onClick() { selected = 3 }>select</button>
+<button.hover onClick() { hovered = 3 }>hover</button>
+<ul>
+  <for|row| of=rows by="id">
+    <li class=[selected === row.id && "sel", hovered === row.id && "hov"]>${row.label}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (sel: string) => (container: Element) =>
+  (container.querySelector(sel) as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, click("button.select"), click("button.hover")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,51 @@
+// template.marko
+const $template = "<table><tbody></tbody></table><button class=toggle>toggle</button>";
+const $walks = "D l b";
+const $for_content__selected__OR__enabled__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope["#tr/0"], $scope._.enabled && $scope._.selected === $scope.row_id && "danger"), 2);
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "row_id", $for_content__selected__OR__enabled__OR__row_id);
+const $for_content__setup = ($scope) => {
+	$for_content__selected._($scope);
+	$for_content__enabled._($scope);
+};
+const $for_content__enabled = /* @__PURE__ */ _for_closure("#tbody/0", $for_content__selected__OR__enabled__OR__row_id);
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope.row_id);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__enabled__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/2", $for_content__selected);
+const $enabled__script = _script("__tests__/template.marko_0_enabled", ($scope) => _on($scope["#button/1"], "click", function() {
+	$enabled($scope, !$scope.enabled);
+}));
+const $enabled = /* @__PURE__ */ _let("enabled/3", ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/4", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$selected($scope, undefined);
+	$enabled($scope, true);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/dom.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+const $for_content__selected__OR__enabled__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope.a, $scope._.d && $scope._.c === $scope.f && "danger"), 2);
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 2, 5, $for_content__selected__OR__enabled__OR__row_id);
+const $for_content__enabled = /* @__PURE__ */ _for_closure(0, $for_content__selected__OR__enabled__OR__row_id);
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.f);
+}));
+const $selected = /* @__PURE__ */ _let(2, $for_content__selected);
+const $enabled__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
+	$enabled($scope, !$scope.d);
+}));
+const $enabled = /* @__PURE__ */ _let(3, ($scope) => {
+	$for_content__enabled($scope);
+	$enabled__script($scope);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = undefined;
+	let enabled = true;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${enabled && selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "6:4", { row_id: ["row.id", "6:8"] });
+	}, "id", $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html(`</tbody></table><button class=toggle>toggle</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0_enabled");
+	writeScope($scope0_id, {
+		selected,
+		enabled
+	}, "__tests__/template.marko", 0, {
+		selected: "1:6",
+		enabled: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/html.bundle.js
@@ -1,0 +1,38 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = void 0;
+	let enabled = true;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html(`</tbody></table><button class=toggle>toggle</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		c: selected,
+		d: enabled
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/render.debug.md
@@ -1,0 +1,234 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector("button.toggle").click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.toggle").click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/render.md
@@ -1,0 +1,234 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelector("button.toggle").click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.toggle").click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+<button
+  class="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/writes.debug.html
@@ -1,0 +1,32 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+  </tbody>
+</table><button class=toggle>toggle</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4)],
+      enabled: !0
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/template.marko_1_row_id 2 3 4 packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/template.marko_0_enabled 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/__snapshots__/writes.html
@@ -1,0 +1,30 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+  </tbody>
+</table><button class=toggle>toggle</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4)],
+    d: !0
+  }, {
+    f: 1,
+    _: _(1)
+  }, {
+    f: 2,
+    _: _(1)
+  }, {
+    f: 3,
+    _: _(1)
+  }], "a0 2 3 4 a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3811,
+      "brotli": 1814
+    }
+  },
+  "html": {
+    "min": 681,
+    "brotli": 337
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/template.marko
@@ -1,0 +1,13 @@
+<let/selected=undefined/>
+<let/enabled=true/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+
+<table><tbody>
+  <for|row| of=rows by="id">
+    <tr class=(enabled && selected === row.id && "danger")>
+      <td><button.select onClick() { selected = row.id }>${row.label}</button></td>
+    </tr>
+  </for>
+</tbody></table>
+
+<button.toggle onClick() { enabled = !enabled }>toggle</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+const clickToggle = (container: Element) =>
+  (container.querySelector("button.toggle") as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(0), clickToggle, clickToggle, clickSelect(2)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// template.marko
+const $template = "<button class=add>add</button><ul></ul>";
+const $walks = " b b";
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#ul/1", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", $for_content__selected__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/1"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $for = /* @__PURE__ */ _for_of("#ul/1", "<li> </li>", " D l", $for_content__setup, $for_content__$params);
+const $rows__OR__nextId__script = _script("__tests__/template.marko_0_rows_nextId", ($scope) => _on($scope["#button/0"], "click", function() {
+	$rows($scope, [{
+		id: $scope.nextId,
+		label: "new"
+	}, ...$scope.rows]);
+	$selected($scope, $scope.nextId);
+	$nextId($scope, $scope.nextId + 1);
+}));
+const $rows__OR__nextId = /* @__PURE__ */ _or(5, $rows__OR__nextId__script);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => {
+	$for($scope, [$scope.rows, "id"]);
+	$rows__OR__nextId($scope);
+});
+const $selected = /* @__PURE__ */ _let("selected/3", $for_content__selected);
+const $nextId = /* @__PURE__ */ _let("nextId/4", $rows__OR__nextId);
+function $setup($scope) {
+	$rows($scope, [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}]);
+	$selected($scope, 1);
+	$nextId($scope, 3);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.js
@@ -1,0 +1,25 @@
+// template.marko
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(5, ($scope) => _attr_class($scope.a, $scope._.d === $scope.e && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector(1, 3, 4, $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id = /* @__PURE__ */ _const(4, $for_content__selected__OR__row_id);
+const $for_content__row_label = ($scope, row_label) => _text($scope.b, row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $for = /* @__PURE__ */ _for_of(1, "<li> </li>", " D l", $for_content__setup, $for_content__$params);
+const $rows__OR__nextId = /* @__PURE__ */ _or(5, _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$rows($scope, [{
+		id: $scope.e,
+		label: "new"
+	}, ...$scope.c]);
+	$selected($scope, $scope.e);
+	$nextId($scope, $scope.e + 1);
+})));
+const $rows = /* @__PURE__ */ _let(2, ($scope) => {
+	$for($scope, [$scope.c, "id"]);
+	$rows__OR__nextId($scope);
+});
+const $selected = /* @__PURE__ */ _let(3, $for_content__selected);
+const $nextId = /* @__PURE__ */ _let(4, $rows__OR__nextId);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,34 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	let selected = 1;
+	let nextId = 3;
+	_html(`<button class=add>add</button>${_el_resume($scope0_id, "#button/0")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}>${_escape(row.label)}${_el_resume($scope1_id, "#text/1")}</li>${_el_resume($scope1_id, "#li/0")}`);
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "10:4", { row_id: ["row.id", "10:8"] });
+	}, "id", $scope0_id, "#ul/1", 1, 1, 1, "</ul>", 1);
+	_script($scope0_id, "__tests__/template.marko_0_rows_nextId");
+	writeScope($scope0_id, {
+		rows,
+		selected,
+		nextId
+	}, "__tests__/template.marko", 0, {
+		rows: "1:6",
+		selected: "2:6",
+		nextId: "3:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	let selected = 1;
+	let nextId = 3;
+	_html(`<button class=add>add</button>${_el_resume($scope0_id, "a")}<ul>`);
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}>${_escape(row.label)}${_el_resume($scope1_id, "b")}</li>${_el_resume($scope1_id, "a")}`);
+		writeScope($scope1_id, {
+			e: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "b", 1, 1, 1, "</ul>", 1);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: rows,
+		d: selected,
+		e: nextId
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/render.debug.md
@@ -1,0 +1,83 @@
+# Render
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.add").click();
+```
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    new
+  </li>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > .danger
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.add").click();
+```
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    new
+  </li>
+  <li>
+    new
+  </li>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > .danger
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/render.md
@@ -1,0 +1,83 @@
+# Render
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelector("button.add").click();
+```
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    new
+  </li>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > .danger
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelector("button.add").click();
+```
+```html
+<button
+  class="add"
+>
+  add
+</button>
+<ul>
+  <li
+    class="danger"
+  >
+    new
+  </li>
+  <li>
+    new
+  </li>
+  <li>
+    a
+  </li>
+  <li>
+    b
+  </li>
+</ul>
+```
+## Change
+```
+INSERT: ul > .danger
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/writes.debug.html
@@ -1,0 +1,30 @@
+<button class=add>add</button><!--M_*1 #button/0-->
+<ul>
+  <li class=danger>a<!--M_*2 #text/1--></li><!--M_*2 #li/0-->
+  <li>b<!--M_*3 #text/1--></li><!--M_*3 #li/0--><!--M_}1 #ul/1 3 2-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      rows: [{
+        id: 1,
+        label: "a"
+      }, {
+        id: 2,
+        label: "b"
+      }],
+      selected: 1,
+      nextId: 3
+    }, {
+      row_id: 1,
+      _: _(1),
+      "#LoopKey": 1
+    }, {
+      row_id: 2,
+      _: _(1),
+      "#LoopKey": 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/template.marko_0_rows_nextId 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/writes.html
@@ -1,0 +1,28 @@
+<button class=add>add</button><!--M_*1 a-->
+<ul>
+  <li class=danger>a<!--M_*2 b--></li><!--M_*2 a-->
+  <li>b<!--M_*3 b--></li><!--M_*3 a--><!--M_}1 b 3 2-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: [{
+      id: 1,
+      label: "a"
+    }, {
+      id: 2,
+      label: "b"
+    }],
+    d: 1,
+    e: 3
+  }, {
+    e: 1,
+    _: _(1),
+    M: 1
+  }, {
+    e: 2,
+    _: _(1),
+    M: 2
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8243,
+      "brotli": 3710
+    }
+  },
+  "html": {
+    "min": 538,
+    "brotli": 333
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/template.marko
@@ -1,0 +1,13 @@
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }]/>
+<let/selected=1/>
+<let/nextId=3/>
+<button.add onClick() {
+  rows = [{ id: nextId, label: "new" }, ...rows];
+  selected = nextId;
+  nextId++;
+}>add</button>
+<ul>
+  <for|row| of=rows by="id">
+    <li class=(selected === row.id && "danger")>${row.label}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickAdd = (container: Element) =>
+  (container.querySelector("button.add") as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickAdd, clickAdd],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,39 @@
+// template.marko
+const $template = "<table><tbody></tbody></table>";
+const $walks = "D l";
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope.row_id);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$selected($scope, 2);
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "D l", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope.a, $scope._.b === $scope.f && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.f);
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "5:4", { row_id: ["row.id", "5:8"] });
+	}, "id", $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 2;
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/render.debug.md
@@ -1,0 +1,126 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/render.md
@@ -1,0 +1,126 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(2)[class] "danger" => null
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr class=danger>
+      <td><button class=select>b</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4)]
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/template.marko_1_row_id 2 3 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr class=danger>
+      <td><button class=select>b</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4)]
+  }, {
+    f: 1,
+    _: _(1)
+  }, {
+    f: 2,
+    _: _(1)
+  }, {
+    f: 3,
+    _: _(1)
+  }], "a0 2 3 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3579,
+      "brotli": 1739
+    }
+  },
+  "html": {
+    "min": 635,
+    "brotli": 321
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/template.marko
@@ -1,0 +1,10 @@
+<let/selected=2/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+
+<table><tbody>
+  <for|row| of=rows by="id">
+    <tr class=(selected === row.id && "danger")>
+      <td><button.select onClick() { selected = row.id }>${row.label}</button></td>
+    </tr>
+  </for>
+</tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(0), clickSelect(2)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7052,
-      "brotli": 3226
+      "min": 7074,
+      "brotli": 3267
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7674,
-        "brotli": 3510
+        "min": 7696,
+        "brotli": 3509
       },
       "files": {
         "tags/list.marko": 323,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8020,
-        "brotli": 3623
+        "min": 8042,
+        "brotli": 3646
       },
       "files": {
         "tags/child.marko": 544,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,39 @@
+// template.marko
+const $template = "<table><tbody></tbody></table>";
+const $walks = "D l";
+const $for_content__selected__OR__row_user_id = /* @__PURE__ */ _or(7, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_user_id && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "row_user_id", $for_content__selected__OR__row_user_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_user_id__script = _script("__tests__/template.marko_1_row_user_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope.row_user_id);
+}));
+const $for_content__row_user_id = /* @__PURE__ */ _const("row_user_id", ($scope) => {
+	$for_content__selected__OR__row_user_id($scope);
+	$for_content__row_user_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_user_id($scope, $params2[0]?.user?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows, (item) => item.user.id]));
+function $setup($scope) {
+	$selected($scope, undefined);
+	$rows($scope, [
+		{
+			user: { id: 1 },
+			label: "a"
+		},
+		{
+			user: { id: 2 },
+			label: "b"
+		},
+		{
+			user: { id: 3 },
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "D l", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+const $for_content__selected__OR__row_user_id = /* @__PURE__ */ _or(7, ($scope) => _attr_class($scope.a, $scope._.b === $scope.g && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, 6, $for_content__selected__OR__row_user_id);
+const $for_content__row_user_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.g);
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = undefined;
+	let rows = [
+		{
+			user: { id: 1 },
+			label: "a"
+		},
+		{
+			user: { id: 2 },
+			label: "b"
+		},
+		{
+			user: { id: 3 },
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.user.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_user_id");
+		writeScope($scope1_id, {
+			row_user_id: row?.user?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "9:4", { row_user_id: ["row.user.id", "9:8"] });
+	}, (item) => item.user.id, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = void 0;
+	let rows = [
+		{
+			user: { id: 1 },
+			label: "a"
+		},
+		{
+			user: { id: 2 },
+			label: "b"
+		},
+		{
+			user: { id: 3 },
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === row.user.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			g: row?.user?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, (item) => item.user.id, $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.debug.md
@@ -1,0 +1,168 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.md
@@ -1,0 +1,168 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4)]
+    }, {
+      row_user_id: 1,
+      _: _(1)
+    }, {
+      row_user_id: 2,
+      _: _(1)
+    }, {
+      row_user_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/template.marko_1_row_user_id 2 3 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4)]
+  }, {
+    g: 1,
+    _: _(1)
+  }, {
+    g: 2,
+    _: _(1)
+  }, {
+    g: 3,
+    _: _(1)
+  }], "a0 2 3 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3579,
+      "brotli": 1742
+    }
+  },
+  "html": {
+    "min": 622,
+    "brotli": 322
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/template.marko
@@ -1,0 +1,14 @@
+<let/selected=undefined/>
+<let/rows=[
+  { user: { id: 1 }, label: "a" },
+  { user: { id: 2 }, label: "b" },
+  { user: { id: 3 }, label: "c" },
+]/>
+
+<table><tbody>
+  <for|row| of=rows by=(item) => item.user.id>
+    <tr class=(selected === row.user.id && "danger")>
+      <td><button.select onClick() { selected = row.user.id }>${row.label}</button></td>
+    </tr>
+  </for>
+</tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(0), clickSelect(2), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,25 @@
+// template.marko
+const $template = "<table><tbody></tbody></table>";
+const $walks = "D l";
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "#LoopKey", ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope["#LoopKey"] && "danger"));
+const $for_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope["#LoopKey"]);
+}));
+const $for_content__setup = ($scope) => {
+	$for_content__selected._($scope);
+	$for_content__setup__script($scope);
+};
+const $for_content__label = ($scope, label) => _text($scope["#text/2"], label);
+const $for_content__$params = ($scope, $params2) => $for_content__label($scope, $params2[0]);
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows]));
+function $setup($scope) {
+	$selected($scope, undefined);
+	$rows($scope, [
+		"a",
+		"b",
+		"c"
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "D l", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, "M", ($scope) => _attr_class($scope.a, $scope._.b === $scope.M && "danger"));
+const $for_content__setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.M);
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = undefined;
+	let rows = [
+		"a",
+		"b",
+		"c"
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (label, i) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === i ? " class=danger" : ""}><td><button class=select>${_escape(label)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1");
+		writeScope($scope1_id, {
+			"#LoopKey": i,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "5:4", { "#LoopKey": "5:15" });
+	}, 0, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = void 0;
+	let rows = [
+		"a",
+		"b",
+		"c"
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (label, i) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === i ? " class=danger" : ""}><td><button class=select>${_escape(label)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			M: i,
+			_: _scope_with_id($scope0_id)
+		});
+	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/render.debug.md
@@ -1,0 +1,168 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/render.md
@@ -1,0 +1,168 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4)]
+    }, {
+      "#LoopKey": 0,
+      _: _(1)
+    }, {
+      "#LoopKey": 1,
+      _: _(1)
+    }, {
+      "#LoopKey": 2,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-selector-index/template.marko_1 2 3 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>a</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4)]
+  }, {
+    M: 0,
+    _: _(1)
+  }, {
+    M: 1,
+    _: _(1)
+  }, {
+    M: 2,
+    _: _(1)
+  }], "a0 2 3 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3469,
+      "brotli": 1695
+    }
+  },
+  "html": {
+    "min": 622,
+    "brotli": 314
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/template.marko
@@ -1,0 +1,10 @@
+<let/selected=undefined/>
+<let/rows=["a", "b", "c"]/>
+
+<table><tbody>
+  <for|label, i| of=rows>
+    <tr class=(selected === i && "danger")>
+      <td><button.select onClick() { selected = i }>${label}</button></td>
+    </tr>
+  </for>
+</tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(0), clickSelect(2), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope["#li/0"], $scope._._.selected === $scope.row_id && "danger"));
+const $for_content__selected = /* @__PURE__ */ _closure_get("selected", $for_content__selected__OR__row_id, ($scope) => $scope._._);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_2_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._._, $scope.row_id);
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $if_content__for = /* @__PURE__ */ _for_of("#ul/0", "<li><button class=select> </button></li>", " D D m", $for_content__setup, $for_content__$params);
+const $if_content__rows = /* @__PURE__ */ _if_closure("#text/0", 0, ($scope) => $if_content__for($scope, [$scope._.rows, "id"]));
+const $if_content__setup = $if_content__rows;
+const $selected__closure = /* @__PURE__ */ _closure($for_content__selected);
+const $selected = /* @__PURE__ */ _let("selected/4", $selected__closure);
+const $rows = /* @__PURE__ */ _let("rows/5");
+function $setup($scope) {
+	$selected($scope, 1);
+	$rows($scope, [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}]);
+}
+const $if = /* @__PURE__ */ _if("#text/0", "<ul></ul>", " b", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => $input_show($scope, input.show);
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "b%c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope.a, $scope._._.e === $scope.f && "danger"));
+const $for_content__selected = /* @__PURE__ */ _closure_get(4, $for_content__selected__OR__row_id, ($scope) => $scope._._);
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._._, $scope.f);
+}));
+const $selected = /* @__PURE__ */ _let(4, /* @__PURE__ */ _closure($for_content__selected));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0), $si__input_show = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const $selected__closures = new Set();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html("<ul>");
+			forOf(rows, (row) => {
+				const $scope2_id = _scope_id();
+				_html(`<li${selected === row.id ? " class=danger" : ""}><button class=select>${_escape(row.label)}</button>${_el_resume($scope2_id, "#button/1")}</li>${_el_resume($scope2_id, "#li/0")}`);
+				_script($scope2_id, "__tests__/template.marko_2_row_id");
+				_subscribe($selected__closures, writeScope($scope2_id, {
+					row_id: row?.id,
+					_: _scope_with_id($scope1_id)
+				}, "__tests__/template.marko", "5:6", { row_id: ["row.id", "5:10"] }));
+			});
+			_html("</ul>");
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/0", $sg__input_show, $sg__input_show, $sg__input_show, 0, 1);
+	writeScope($scope0_id, {
+		selected: $si__input_show && selected,
+		rows: $si__input_show && rows,
+		"ClosureScopes:selected": $selected__closures
+	}, "__tests__/template.marko", 0, {
+		selected: "1:6",
+		rows: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/html.bundle.js
@@ -1,0 +1,38 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0), $si__input_show = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const $selected__closures = /* @__PURE__ */ new Set();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html("<ul>");
+			forOf(rows, (row) => {
+				const $scope2_id = _scope_id();
+				_html(`<li${selected === row.id ? " class=danger" : ""}><button class=select>${_escape(row.label)}</button>${_el_resume($scope2_id, "b")}</li>${_el_resume($scope2_id, "a")}`);
+				_script($scope2_id, "a0");
+				_subscribe($selected__closures, writeScope($scope2_id, {
+					f: row?.id,
+					_: _scope_with_id($scope1_id)
+				}));
+			});
+			_html("</ul>");
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+			return 0;
+		}
+	}, $scope0_id, "a", $sg__input_show, $sg__input_show, $sg__input_show, 0, 1);
+	writeScope($scope0_id, {
+		e: $si__input_show && selected,
+		f: $si__input_show && rows,
+		Be: $selected__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/render.debug.md
@@ -1,0 +1,81 @@
+# Render `{"show":true}`
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/render.md
@@ -1,0 +1,81 @@
+# Render `{"show":true}`
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li>
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <button
+      class="select"
+    >
+      a
+    </button>
+  </li>
+  <li>
+    <button
+      class="select"
+    >
+      b
+    </button>
+  </li>
+</ul>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: ul > li:nth-of-type(2)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<ul>
+  <li class=danger><button class=select>a</button><!--M_*3 #button/1--></li>
+  <!--M_*3 #li/0-->
+  <li><button class=select>b</button><!--M_*4 #button/1--></li><!--M_*4 #li/0-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ClosureScopes:selected": new Set([_(3), _(4)])
+    }, {
+      _: _(1)
+    }, {
+      row_id: 1,
+      _: _(2)
+    }, {
+      row_id: 2,
+      _: _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/template.marko_2_row_id 3 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/__snapshots__/writes.html
@@ -1,0 +1,20 @@
+<ul>
+  <li class=danger><button class=select>a</button><!--M_*3 b--></li>
+  <!--M_*3 a-->
+  <li><button class=select>b</button><!--M_*4 b--></li><!--M_*4 a-->
+</ul>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Be: new Set([_(3), _(4)])
+  }, {
+    _: _(1)
+  }, {
+    f: 1,
+    _: _(2)
+  }, {
+    f: 2,
+    _: _(2)
+  }], "a0 3 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3524,
+      "brotli": 1732
+    }
+  },
+  "html": {
+    "min": 519,
+    "brotli": 311
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/template.marko
@@ -1,0 +1,11 @@
+<let/selected=1/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }]/>
+<if=input.show>
+  <ul>
+    <for|row| of=rows by="id">
+      <li class=(selected === row.id && "danger")>
+        <button.select onClick() { selected = row.id }>${row.label}</button>
+      </li>
+    </for>
+  </ul>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{ show: true }, clickSelect(1), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,39 @@
+// template.marko
+const $template = "<table><tbody></tbody></table>";
+const $walks = "D l";
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope["#tr/0"], ($scope._.selected?.id === $scope.row_id || $scope._.selected === $scope.row_id) && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_closure("#tbody/0", $for_content__selected__OR__row_id);
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, { id: $scope.row_id });
+}));
+const $for_content__row_id = /* @__PURE__ */ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_of("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup, $for_content__$params);
+const $rows = /* @__PURE__ */ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));
+function $setup($scope) {
+	$selected($scope, { id: 1 });
+	$rows($scope, [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "D l", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+const $for_content__selected__OR__row_id = /* @__PURE__ */ _or(6, ($scope) => _attr_class($scope.a, ($scope._.b?.id === $scope.f || $scope._.b === $scope.f) && "danger"));
+const $for_content__selected = /* @__PURE__ */ _for_closure(0, $for_content__selected__OR__row_id);
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, { id: $scope.f });
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = { id: 1 };
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected.id === row.id || selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "5:4", { row_id: ["row.id", "5:8"] });
+	}, "id", $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.js
@@ -1,0 +1,32 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = { id: 1 };
+	let rows = [
+		{
+			id: 1,
+			label: "a"
+		},
+		{
+			id: 2,
+			label: "b"
+		},
+		{
+			id: 3,
+			label: "c"
+		}
+	];
+	_html("<table><tbody>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected.id === row.id || selected === row.id ? " class=danger" : ""}><td><button class=select>${_escape(row.label)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			_: _scope_with_id($scope0_id)
+		});
+	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/render.debug.md
@@ -1,0 +1,126 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/render.md
@@ -1,0 +1,126 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          a
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          b
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          c
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<table>
+  <tbody>
+    <tr class=danger>
+      <td><button class=select>a</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4)]
+    }, {
+      row_id: 1,
+      _: _(1)
+    }, {
+      row_id: 2,
+      _: _(1)
+    }, {
+      row_id: 3,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/template.marko_1_row_id 2 3 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<table>
+  <tbody>
+    <tr class=danger>
+      <td><button class=select>a</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>b</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>c</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4)]
+  }, {
+    f: 1,
+    _: _(1)
+  }, {
+    f: 2,
+    _: _(1)
+  }, {
+    f: 3,
+    _: _(1)
+  }], "a0 2 3 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3251,
+      "brotli": 1593
+    }
+  },
+  "html": {
+    "min": 635,
+    "brotli": 326
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/template.marko
@@ -1,0 +1,10 @@
+<let/selected={ id: 1 }/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }, { id: 3, label: "c" }]/>
+
+<table><tbody>
+  <for|row| of=rows by="id">
+    <tr class=((selected.id === row.id || selected === row.id) && "danger")>
+      <td><button.select onClick() { selected = { id: row.id } }>${row.label}</button></td>
+    </tr>
+  </for>
+</tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(2), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+const $template = "<table><tbody></tbody></table>";
+const $walks = "D l";
+const $for_content__selected = /* @__PURE__ */ _for_selector("#tbody/0", "selected", "#LoopKey", ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope["#LoopKey"] && "danger"));
+const $for_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
+	$selected($scope._, $scope["#LoopKey"]);
+}));
+const $for_content__setup = ($scope) => {
+	$for_content__selected._($scope);
+	_text($scope["#text/2"], $scope["#LoopKey"]);
+	$for_content__setup__script($scope);
+};
+const $selected = /* @__PURE__ */ _let("selected/1", $for_content__selected);
+const $for = /* @__PURE__ */ _for_to("#tbody/0", "<tr><td><button class=select> </button></td></tr>", " E D n", $for_content__setup);
+function $setup($scope) {
+	$selected($scope, undefined);
+	$for($scope, [
+		4,
+		0,
+		1
+	]);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, "D l", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, "M", ($scope) => _attr_class($scope.a, $scope._.b === $scope.M && "danger"));
+const $for_content__setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$selected($scope._, $scope.M);
+}));
+const $selected = /* @__PURE__ */ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = undefined;
+	_html("<table><tbody>");
+	_for_to(4, 0, 1, (i) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === i ? " class=danger" : ""}><td><button class=select>${_escape(i)}</button>${_el_resume($scope1_id, "#button/1")}</td></tr>${_el_resume($scope1_id, "#tr/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1");
+		writeScope($scope1_id, {
+			"#LoopKey": i,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "4:4", { "#LoopKey": "4:8" });
+	}, 0, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = void 0;
+	_html("<table><tbody>");
+	_for_to(4, 0, 1, (i) => {
+		const $scope1_id = _scope_id();
+		_html(`<tr${selected === i ? " class=danger" : ""}><td><button class=select>${_escape(i)}</button>${_el_resume($scope1_id, "b")}</td></tr>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			M: i,
+			_: _scope_with_id($scope0_id)
+		});
+	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
+	_html("</tbody></table>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/render.debug.md
@@ -1,0 +1,240 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(4)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/render.md
@@ -1,0 +1,240 @@
+# Render
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(1)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```
+
+# Update
+```js
+container.querySelectorAll("button.select")[n].click();
+```
+```html
+<table>
+  <tbody>
+    <tr
+      class="danger"
+    >
+      <td>
+        <button
+          class="select"
+        >
+          0
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          1
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          2
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          3
+        </button>
+      </td>
+    </tr>
+    <tr>
+      <td>
+        <button
+          class="select"
+        >
+          4
+        </button>
+      </td>
+    </tr>
+  </tbody>
+</table>
+```
+## Change
+```
+UPDATE: table > tbody > tr:nth-of-type(4)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/writes.debug.html
@@ -1,0 +1,43 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>0</button><!--M_*2 #button/1--></td>
+    </tr><!--M_*2 #tr/0-->
+    <tr>
+      <td><button class=select>1</button><!--M_*3 #button/1--></td>
+    </tr><!--M_*3 #tr/0-->
+    <tr>
+      <td><button class=select>2</button><!--M_*4 #button/1--></td>
+    </tr><!--M_*4 #tr/0-->
+    <tr>
+      <td><button class=select>3</button><!--M_*5 #button/1--></td>
+    </tr><!--M_*5 #tr/0-->
+    <tr>
+      <td><button class=select>4</button><!--M_*6 #button/1--></td>
+    </tr><!--M_*6 #tr/0-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#tbody/0": [_(2), _(3), _(4), _(5), _(6)]
+    }, {
+      "#LoopKey": 0,
+      _: _(1)
+    }, {
+      "#LoopKey": 1,
+      _: _(1)
+    }, {
+      "#LoopKey": 2,
+      _: _(1)
+    }, {
+      "#LoopKey": 3,
+      _: _(1)
+    }, {
+      "#LoopKey": 4,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-selector-to/template.marko_1 2 3 4 5 6"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/writes.html
@@ -1,0 +1,41 @@
+<table>
+  <tbody>
+    <tr>
+      <td><button class=select>0</button><!--M_*2 b--></td>
+    </tr><!--M_*2 a-->
+    <tr>
+      <td><button class=select>1</button><!--M_*3 b--></td>
+    </tr><!--M_*3 a-->
+    <tr>
+      <td><button class=select>2</button><!--M_*4 b--></td>
+    </tr><!--M_*4 a-->
+    <tr>
+      <td><button class=select>3</button><!--M_*5 b--></td>
+    </tr><!--M_*5 a-->
+    <tr>
+      <td><button class=select>4</button><!--M_*6 b--></td>
+    </tr><!--M_*6 a-->
+  </tbody>
+</table>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Aa: [_(2), _(3), _(4), _(5), _(6)]
+  }, {
+    M: 0,
+    _: _(1)
+  }, {
+    M: 1,
+    _: _(1)
+  }, {
+    M: 2,
+    _: _(1)
+  }, {
+    M: 3,
+    _: _(1)
+  }, {
+    M: 4,
+    _: _(1)
+  }], "a0 2 3 4 5 6"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3469,
+      "brotli": 1695
+    }
+  },
+  "html": {
+    "min": 812,
+    "brotli": 340
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/template.marko
@@ -1,0 +1,9 @@
+<let/selected=undefined/>
+
+<table><tbody>
+  <for|i| to=4>
+    <tr class=(selected === i && "danger")>
+      <td><button.select onClick() { selected = i }>${i}</button></td>
+    </tr>
+  </for>
+</tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const clickSelect = (n: number) => (container: Element) =>
+  (container.querySelectorAll("button.select")[n] as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, clickSelect(0), clickSelect(3), clickSelect(0)],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6976,
-      "brotli": 3170
+      "min": 6998,
+      "brotli": 3174
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6970,
-      "brotli": 3161
+      "min": 6992,
+      "brotli": 3173
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6751,
-      "brotli": 3102
+      "min": 6773,
+      "brotli": 3113
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7117,
-      "brotli": 3268
+      "min": 7139,
+      "brotli": 3287
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7122,
-      "brotli": 3260
+      "min": 7144,
+      "brotli": 3293
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,7 @@
 // template.marko
 const $template = "<div id=target></div>";
 const $walks = " b";
-const $for_content__selected = /* @__PURE__ */ _for_closure("#div/0", ($scope) => _attr($scope["#span/0"], "data-selected", $scope._.selected === $scope["#LoopKey"]));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#div/0", "selected", "#LoopKey", ($scope) => _attr($scope["#span/0"], "data-selected", $scope._.selected === $scope["#LoopKey"]));
 const $for_content__setup = ($scope) => {
 	$for_content__selected._($scope);
 	_text($scope["#text/1"], $scope["#LoopKey"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-const $for_content__selected = /* @__PURE__ */ _for_closure(0, ($scope) => _attr($scope.a, "data-selected", $scope._.b === $scope.M));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, "M", ($scope) => _attr($scope.a, "data-selected", $scope._.b === $scope.M));
 const $selected__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
 	$selected($scope, $scope.b + 1);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2970,
-      "brotli": 1475
+      "min": 3324,
+      "brotli": 1648
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,7 @@
 // template.marko
 const $template = "<select></select>";
 const $walks = " b";
-const $for_content__selected = /* @__PURE__ */ _for_closure("#select/0", ($scope) => _attr($scope["#option/0"], "selected", $scope._.selected === $scope["#LoopKey"]));
+const $for_content__selected = /* @__PURE__ */ _for_selector("#select/0", "selected", "#LoopKey", ($scope) => _attr($scope["#option/0"], "selected", $scope._.selected === $scope["#LoopKey"]));
 const $for_content__setup = ($scope) => {
 	$for_content__selected._($scope);
 	_text($scope["#text/1"], $scope["#LoopKey"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-const $for_content__selected = /* @__PURE__ */ _for_closure(0, ($scope) => _attr($scope.a, "selected", $scope._.b === $scope.M));
+const $for_content__selected = /* @__PURE__ */ _for_selector(0, 1, "M", ($scope) => _attr($scope.a, "selected", $scope._.b === $scope.M));
 const $selected = /* @__PURE__ */ _let(1, $for_content__selected);
 const $setup__script = _script("a0", ($scope) => _on($scope.a, "change", function(e) {
 	$selected($scope, e.target.value);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2957,
-      "brotli": 1467
+      "min": 3311,
+      "brotli": 1638
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7435,
-        "brotli": 3376
+        "min": 7457,
+        "brotli": 3390
       },
       "files": {
         "tags/inner/index.marko": 1003,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7668,
-        "brotli": 3463
+        "min": 7690,
+        "brotli": 3507
       },
       "files": {
         "tags/store.marko": 397,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14484,
-      "brotli": 5591
+      "min": 14506,
+      "brotli": 5604
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8584,
-      "brotli": 3832
+      "min": 8607,
+      "brotli": 3858
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7718,
-      "brotli": 3500
+      "min": 7740,
+      "brotli": 3520
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14656,
-        "brotli": 5757
+        "min": 14680,
+        "brotli": 5747
       },
       "files": {
         "tags/child.marko": 788,

--- a/packages/runtime-tags/src/common/accessor.debug.ts
+++ b/packages/runtime-tags/src/common/accessor.debug.ts
@@ -9,6 +9,7 @@ export enum AccessorPrefix {
   DynamicHTMLLastChild = "DynamicHTMLLastChild:",
   EventAttributes = "EventAttributes:",
   Getter = "Getter:",
+  KeyedScopes = "KeyedScopes:",
   Lifecycle = "Lifecycle:",
   Promise = "Promise:",
   TagVariableChange = "TagVariableChange:",
@@ -68,6 +69,10 @@ export enum ClosureSignalProp {
   ScopeInstancesAccessor = "scopeInstancesAccessor",
   SignalIndexAccessor = "signalIndexAccessor",
   Index = "index",
+}
+
+export enum KeyedScopesProp {
+  PreviousKey = "PreviousKey:",
 }
 
 export enum LoadSignalValue {

--- a/packages/runtime-tags/src/common/accessor.ts
+++ b/packages/runtime-tags/src/common/accessor.ts
@@ -9,6 +9,7 @@ export enum AccessorPrefix {
   DynamicHTMLLastChild = "H",
   EventAttributes = "I",
   Getter = "J",
+  KeyedScopes = "O",
   Lifecycle = "K",
   Promise = "L",
   TagVariableChange = "M",
@@ -68,6 +69,10 @@ export enum ClosureSignalProp {
   ScopeInstancesAccessor = "a",
   SignalIndexAccessor = "b",
   Index = "c",
+}
+
+export enum KeyedScopesProp {
+  PreviousKey = "_",
 }
 
 export enum LoadSignalValue {

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -50,6 +50,7 @@ export {
   AccessorPrefix,
   AccessorProp,
   ClosureSignalProp,
+  KeyedScopesProp,
   PendingRenderProp,
   RendererProp,
 } from "./accessor.debug";

--- a/packages/runtime-tags/src/dom.ts
+++ b/packages/runtime-tags/src/dom.ts
@@ -90,6 +90,7 @@ export {
   _const,
   _el_read,
   _for_closure,
+  _for_selector,
   _hoist,
   _hoist_resume,
   _id,

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -712,12 +712,14 @@ function loop<T extends unknown[] = unknown[]>(
   ) => {
     if (!MARKO_DEBUG) nodeAccessor = decodeAccessor(nodeAccessor as number);
     const scopesAccessor = AccessorPrefix.BranchScopes + nodeAccessor;
+    const keyedScopesAccessor = AccessorPrefix.KeyedScopes + nodeAccessor;
     const renderer = _content("", template, walks, setup)();
     enableBranches();
     return (scope: Scope, value: T) => {
       const referenceNode = scope[nodeAccessor] as Element | Comment | Text;
       const oldScopes = toArray<BranchScope>(scope[scopesAccessor]);
       const newScopes: BranchScope[] = (scope[scopesAccessor] = []);
+      scope[keyedScopesAccessor] = null;
       const oldLen = oldScopes.length;
       const parentNode = (
         referenceNode.nodeType > NodeType.Element

--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -8,6 +8,7 @@ import {
   type BranchScope,
   ClosureSignalProp,
   type EncodedAccessor,
+  KeyedScopesProp,
   type Scope,
 } from "../common/types";
 import { $signal } from "./abort-signal";
@@ -20,6 +21,9 @@ export type Signal<T = unknown, U extends Scope = Scope> = (
   scope: U,
   value: T,
 ) => void;
+type KeyedScopes = Map<unknown, BranchScope> & {
+  [x: `${KeyedScopesProp.PreviousKey}${string}`]: unknown;
+};
 
 export function _let<T>(id: EncodedAccessor, fn?: SignalFn) {
   const valueAccessor = MARKO_DEBUG
@@ -146,6 +150,86 @@ export function _for_closure(
   return ownerSignal;
 }
 
+export function _for_selector(
+  ownerLoopNodeAccessor: EncodedAccessor,
+  ownerValueAccessor: EncodedAccessor,
+  keyValueAccessor: EncodedAccessor,
+  fn: SignalFn,
+): SignalFn {
+  if (!MARKO_DEBUG) {
+    ownerLoopNodeAccessor = decodeAccessor(ownerLoopNodeAccessor as number);
+    ownerValueAccessor = decodeAccessor(ownerValueAccessor as number);
+    if (keyValueAccessor !== AccessorProp.LoopKey) {
+      keyValueAccessor = decodeAccessor(keyValueAccessor as number);
+    }
+  }
+  const scopeAccessor = AccessorPrefix.BranchScopes + ownerLoopNodeAccessor;
+  const mapAccessor = AccessorPrefix.KeyedScopes + ownerLoopNodeAccessor;
+  const prevKeyProp: `${KeyedScopesProp.PreviousKey}${string}` = `${KeyedScopesProp.PreviousKey}${ownerValueAccessor as string}`;
+  const ownerSignal = (ownerScope: Scope) => {
+    const scopes = toArray(ownerScope[scopeAccessor] as BranchScope);
+    if (ownerScope[AccessorProp.Gen] < runId && scopes.length) {
+      const nextKey = ownerScope[ownerValueAccessor];
+      queueRender(
+        ownerScope,
+        () => {
+          const map = keyedScopes(
+            ownerScope,
+            scopeAccessor,
+            mapAccessor,
+            keyValueAccessor,
+          );
+          if (map && prevKeyProp in map) {
+            const prevScope = map.get(map[prevKeyProp]);
+            const nextScope = map.get(nextKey);
+            if (prevScope !== nextScope) {
+              runLiveBranch(prevScope, fn);
+              runLiveBranch(nextScope, fn);
+            }
+          } else {
+            for (const scope of toArray(
+              ownerScope[scopeAccessor] as BranchScope,
+            )) {
+              runLiveBranch(scope, fn);
+            }
+          }
+          if (map) map[prevKeyProp] = nextKey;
+        },
+        -1,
+        0,
+        scopes[0][AccessorProp.Id],
+      );
+    }
+  };
+  ownerSignal._ = fn;
+  return ownerSignal;
+}
+
+function keyedScopes(
+  ownerScope: Scope,
+  scopeAccessor: string,
+  mapAccessor: string,
+  keyValueAccessor: EncodedAccessor,
+): KeyedScopes | null {
+  const map = (ownerScope[mapAccessor] ||= new Map()) as KeyedScopes;
+  if (!map.size) {
+    for (const scope of toArray(ownerScope[scopeAccessor] as BranchScope)) {
+      const key = scope[AccessorProp.LoopKey] ?? scope[keyValueAccessor];
+      if (key === undefined) {
+        return (ownerScope[mapAccessor] = null);
+      }
+      scope[AccessorProp.LoopKey] = key;
+      map.set(key, scope);
+    }
+  }
+  return map;
+}
+
+function runLiveBranch(scope: BranchScope | undefined, fn: SignalFn) {
+  if (scope && scope[AccessorProp.Gen] > 0 && scope[AccessorProp.Gen] < runId) {
+    fn(scope);
+  }
+}
 export function _if_closure(
   ownerConditionalNodeAccessor: EncodedAccessor,
   branch: number,

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -8,6 +8,7 @@ import {
 
 import { WalkCode } from "../../common/types";
 import { assertNoSpreadAttrs } from "../util/assert";
+import { detectForSelector, getForSelectorKey } from "../util/for-selector";
 import { getAccessorPrefix, getAccessorProp } from "../util/get-accessor-char";
 import { getKnownAttrValues } from "../util/get-known-attr-values";
 import { getParentTag } from "../util/get-parent-tag";
@@ -16,12 +17,14 @@ import {
   getOptimizedOnlyChildNodeBinding,
 } from "../util/is-only-child-in-parent";
 import {
+  type Binding,
   BindingType,
   dropNodes,
   getAllTagReferenceNodes,
   getScopeAccessorLiteral,
   kBranchSerializeReason,
   mergeReferences,
+  onFinalizeReferences,
   setBindingDownstream,
   trackParamsReferences,
 } from "../util/references";
@@ -48,6 +51,7 @@ import {
   setClosureSignalBuilder,
   writeHTMLResumeStatements,
 } from "../util/signals";
+import { getMemberExpressionPropString } from "../util/to-property-name";
 import { translateByTarget } from "../util/visitors";
 import * as walks from "../util/walks";
 import * as writer from "../util/writer";
@@ -118,13 +122,14 @@ export default {
     if (paramsBinding) {
       setBindingDownstream(paramsBinding, tagExtra);
 
-      const keyBinding = paramsBinding.propertyAliases.get(
-        forType === "of" ? "1" : "0",
-      );
-
-      if (keyBinding && !getKnownAttrValues(tag.node).by) {
-        keyBinding.type = BindingType.constant;
-        keyBinding.scopeAccessor = getAccessorProp().LoopKey;
+      const byAttr = getKnownAttrValues(tag.node).by;
+      const keyBinding = getLoopKeyBinding(byAttr, paramsBinding, forType!);
+      if (keyBinding) {
+        if (!byAttr) {
+          keyBinding.type = BindingType.constant;
+          keyBinding.scopeAccessor = getAccessorProp().LoopKey;
+        }
+        onFinalizeReferences(() => detectForSelector(bodySection, keyBinding));
       }
     }
     bodySection.sectionAccessor = {
@@ -276,7 +281,17 @@ export default {
         const tagExtra = node.extra!;
         const { referencedBindings } = tagExtra;
         const nodeRef = getOptimizedOnlyChildNodeBinding(tag, tagSection);
-        setClosureSignalBuilder(tag, (_closure, render) => {
+        setClosureSignalBuilder(tag, (closure, render) => {
+          const selectorKeyBinding = getForSelectorKey(bodySection, closure);
+          if (selectorKeyBinding) {
+            return callRuntime(
+              "_for_selector",
+              getScopeAccessorLiteral(nodeRef, true),
+              getScopeAccessorLiteral(closure, true),
+              getScopeAccessorLiteral(selectorKeyBinding, true),
+              render,
+            );
+          }
           return callRuntime(
             "_for_closure",
             getScopeAccessorLiteral(nodeRef, true),
@@ -413,6 +428,69 @@ export function getForType(tag: t.MarkoTag): ForType | undefined {
           return attr.name;
       }
     }
+  }
+}
+
+function getLoopKeyBinding(
+  byAttr: t.Expression | undefined,
+  paramsBinding: Binding | undefined,
+  forType: ForType,
+): Binding | undefined {
+  if (!paramsBinding) return;
+  if (byAttr) {
+    const keyChain = getByKeyChain(byAttr);
+    if (!keyChain) return;
+    let keyBinding = paramsBinding.propertyAliases.get("0");
+    for (const property of keyChain) {
+      keyBinding = keyBinding?.propertyAliases.get(property);
+    }
+    return keyBinding;
+  }
+
+  return paramsBinding.propertyAliases.get(forType === "of" ? "1" : "0");
+}
+
+function getByKeyChain(byAttr: t.Expression): string[] | undefined {
+  if (byAttr.type === "StringLiteral") {
+    return [byAttr.value];
+  }
+  if (
+    byAttr.type === "ArrowFunctionExpression" ||
+    byAttr.type === "FunctionExpression"
+  ) {
+    const itemParam = byAttr.params[0];
+    let body: t.Node | null | undefined = byAttr.body;
+    if (body.type === "BlockStatement") {
+      const [statement] = body.body;
+      body =
+        body.body.length === 1 && statement.type === "ReturnStatement"
+          ? statement.argument
+          : undefined;
+    }
+    if (itemParam?.type === "Identifier" && body) {
+      return getStaticMemberChain(body, itemParam.name);
+    }
+  }
+}
+
+function getStaticMemberChain(
+  node: t.Node,
+  rootName: string,
+): string[] | undefined {
+  const chain: string[] = [];
+  let cur = node;
+  while (
+    cur.type === "MemberExpression" ||
+    cur.type === "OptionalMemberExpression"
+  ) {
+    const property = getMemberExpressionPropString(cur);
+    if (property === undefined) return;
+    chain.push(property);
+    cur = cur.object;
+  }
+
+  if (cur.type === "Identifier" && cur.name === rootName) {
+    return chain.reverse();
   }
 }
 

--- a/packages/runtime-tags/src/translator/util/for-selector.ts
+++ b/packages/runtime-tags/src/translator/util/for-selector.ts
@@ -1,0 +1,117 @@
+import type { types as t } from "@marko/compiler";
+
+import { forEach } from "./optional";
+import {
+  type Binding,
+  BindingType,
+  getCanonicalBinding,
+  getExpressionReads,
+} from "./references";
+import { isDirectClosure, type Section } from "./sections";
+
+const forSelectorsBySection = new WeakMap<
+  Section,
+  { keyBinding: Binding; closures: Set<Binding> }
+>();
+const forSelectorValues = new WeakSet<Binding>();
+
+export function getForSelectorKey(
+  bodySection: Section,
+  closure: Binding,
+): Binding | undefined {
+  const selectors = forSelectorsBySection.get(bodySection);
+  if (selectors?.closures.has(getCanonicalBinding(closure))) {
+    return selectors.keyBinding;
+  }
+}
+
+export function isForSelectorValue(binding: Binding): boolean {
+  return forSelectorValues.has(binding);
+}
+
+export function detectForSelector(
+  bodySection: Section,
+  keyBinding: Binding,
+): void {
+  let closures: Set<Binding> | undefined;
+  for (const expr of keyBinding.reads) {
+    if (expr.section !== bodySection) continue;
+    forEach(expr.referencedBindings, (closure) => {
+      const canonical = getCanonicalBinding(closure);
+      if (
+        closure.type !== BindingType.constant &&
+        isDirectClosure(bodySection, closure) &&
+        !closures?.has(canonical) &&
+        onlyComparesKey(closure, canonical, bodySection, keyBinding)
+      ) {
+        (closures ||= new Set()).add(canonical);
+        forSelectorValues.add(closure);
+      }
+    });
+  }
+  if (closures) {
+    forSelectorsBySection.set(bodySection, { keyBinding, closures });
+  }
+}
+
+function onlyComparesKey(
+  closure: Binding,
+  canonical: Binding,
+  bodySection: Section,
+  keyBinding: Binding,
+): boolean {
+  let found = false;
+  for (
+    let chain: Binding | undefined = closure;
+    chain;
+    chain = chain.upstreamAlias
+  ) {
+    for (const expr of chain.reads) {
+      if (expr.section !== bodySection) continue;
+      let other = false;
+      forEach(getExpressionReads(expr), (read) => {
+        const resolved = read.extra.read;
+        const at = resolved && resolvesTo(resolved, canonical);
+        if (!at) return;
+        if (
+          at === 2 ||
+          resolved.getter ||
+          !readsKey(read.comparedTo?.extra?.read, keyBinding)
+        ) {
+          other = true;
+        } else {
+          found = true;
+        }
+      });
+      if (other) return false;
+    }
+  }
+  return found;
+}
+
+function resolvesTo(
+  read: NonNullable<t.NodeExtra["read"]>,
+  canonical: Binding,
+): 0 | 1 | 2 {
+  let binding: Binding | undefined = read.binding;
+  let through: 0 | 2 = 0;
+  forEach(read.props, (prop) => {
+    if (binding) {
+      if (getCanonicalBinding(binding) === canonical) through = 2;
+      binding = binding.propertyAliases.get(prop);
+    }
+  });
+  return binding && getCanonicalBinding(binding) === canonical ? 1 : through;
+}
+
+function readsKey(read: t.NodeExtra["read"], keyBinding: Binding): boolean {
+  if (!read || read.getter) return false;
+  let binding: Binding | undefined = read.binding;
+  forEach(read.props, (prop) => {
+    binding = binding?.propertyAliases.get(prop);
+  });
+  return (
+    !!binding &&
+    getCanonicalBinding(binding) === getCanonicalBinding(keyBinding)
+  );
+}

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -66,7 +66,10 @@ import {
   type Signal,
 } from "./signals";
 import { createProgramState } from "./state";
-import { toMemberExpression } from "./to-property-name";
+import {
+  getMemberExpressionPropString,
+  toMemberExpression,
+} from "./to-property-name";
 import withPreviousLocation from "./with-previous-location";
 
 export const kBranchSerializeReason = Symbol("branch serialize reason");
@@ -141,6 +144,7 @@ interface Read {
   extra: t.NodeExtra;
   ownVar: boolean;
   getter: Getter | undefined;
+  comparedTo: t.Node | undefined;
 }
 
 interface ExtraRead {
@@ -1295,6 +1299,10 @@ export function finalizeReferences() {
     );
   }
 
+  for (const finalize of getReferenceFinalizers()) {
+    finalize();
+  }
+
   readsByExpression.clear();
   fnReadsByExpression.clear();
 }
@@ -1539,6 +1547,15 @@ const [getReadsByExpression] = createProgramState(
 const [getFunctionReadsByExpression] = createProgramState(
   () => new Map<ReferencedExtra, Map<ReferencedFunctionExtra, OneMany<Read>>>(),
 );
+const [getReferenceFinalizers] = createProgramState<(() => void)[]>(() => []);
+
+export function onFinalizeReferences(finalize: () => void) {
+  getReferenceFinalizers().push(finalize);
+}
+
+export function getExpressionReads(exprExtra: ReferencedExtra) {
+  return getReadsByExpression().get(exprExtra);
+}
 
 export function addRead(
   exprExtra: ReferencedExtra,
@@ -1548,7 +1565,13 @@ export function addRead(
   getter: Getter | undefined,
 ) {
   const readsByExpression = getReadsByExpression();
-  const read: Read = { binding, extra, getter, ownVar: false };
+  const read: Read = {
+    binding,
+    extra,
+    getter,
+    ownVar: false,
+    comparedTo: undefined,
+  };
   binding.reads.add(exprExtra);
   exprExtra.section = section;
   readsByExpression.set(
@@ -1604,6 +1627,14 @@ function addReadToExpression(
     section,
     getter,
   );
+
+  const { parent } = root;
+  if (
+    parent.type === "BinaryExpression" &&
+    (parent.operator === "===" || parent.operator === "!==")
+  ) {
+    read.comparedTo = parent.left === node ? parent.right : parent.left;
+  }
 
   if (!getter && binding.type === BindingType.derived) {
     const babelBinding = root.scope.getBinding(binding.name);
@@ -2273,20 +2304,6 @@ export function createGetterRead(
   getter: Getter,
 ): ExtraRead {
   return { binding, props, ownVar: false, getter };
-}
-
-function getMemberExpressionPropString(
-  expr: t.MemberExpression | t.OptionalMemberExpression,
-) {
-  switch (expr.property.type) {
-    case "StringLiteral":
-      return expr.property.value;
-    case "NumericLiteral":
-      return "" + expr.property.value;
-    case "Identifier":
-      if (expr.computed) return;
-      return expr.property.name;
-  }
 }
 
 export interface ReferencedExtra extends t.NodeExtra {

--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -34,6 +34,7 @@ const pureDOMFunctions = new Set<string>([
   "_closure_get",
   "_or",
   "_for_closure",
+  "_for_selector",
   "_for_in",
   "_for_of",
   "_for_to",

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -9,6 +9,7 @@ import { type AccessorPrefix, AccessorProp } from "../../common/types";
 import { getSectionReturnValueIdentifier } from "../core/return";
 import { scopeIdentifier } from "../visitors/program";
 import { forEachIdentifier } from "./for-each-identifier";
+import { isForSelectorValue } from "./for-selector";
 import { generateUid, generateUidIdentifier } from "./generate-uid";
 import { getAccessorPrefix, getAccessorProp } from "./get-accessor-char";
 import { getDeclaredBindingExpression } from "./get-declared-binding-expression";
@@ -434,6 +435,7 @@ function isPureMemberForwarder(binding: Binding): boolean {
     binding.exposed ||
     binding.aliases.size ||
     binding.assignmentSections ||
+    isForSelectorValue(binding) ||
     getSerializeReason(binding.section, binding) ||
     getSignal(binding.section, binding).hasSideEffect
   ) {

--- a/packages/runtime-tags/src/translator/util/to-property-name.ts
+++ b/packages/runtime-tags/src/translator/util/to-property-name.ts
@@ -1,5 +1,19 @@
 import { types as t } from "@marko/compiler";
 
+export function getMemberExpressionPropString(
+  expr: t.MemberExpression | t.OptionalMemberExpression,
+) {
+  switch (expr.property.type) {
+    case "StringLiteral":
+      return expr.property.value;
+    case "NumericLiteral":
+      return "" + expr.property.value;
+    case "Identifier":
+      if (expr.computed) return;
+      return expr.property.name;
+  }
+}
+
 export function isValidPropertyIdentifier(name: string) {
   return /^[a-z_$][a-z0-9_$]*$/i.test(name);
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When a parent-scope value is only read inside a keyed `<for>` body as an equality against the loop's unique key (e.g. `class=(selected === row.id && "danger")`, `input.selected === row.id`, or `<if=selected === row.id>`), a change to that value can flip at most two rows. This detects the pattern at compile time and drives the binding with a new `_for_selector` signal that resolves the previously-matching and newly-matching rows through a key→branch map cached on the owner scope and re-runs only those two — turning the O(n) "select row" update into O(1) (measures flat from 1k to 20k rows).

- Works for `of`/`by` (string or static-property-chain function `by`), the unkeyed `of` index, `in` name, and `to`/`until` value, with any number of such values per loop. The compared value can be a `<let>`, a `<const>` (including derived expressions), or an `input` member — member aliases a selector picks are materialized into a stored slot instead of compiling as pure forwarders.
- Expressions compile unchanged — re-run rows recompute the comparison from live reads — so create, SSR/resume, and event-handler behavior is identical to `_for_closure`.
- `_for_closure` and non-selector loops are untouched, and `_for_selector` tree-shakes out of bundles that never match. Ineligible shapes (dynamic closures from outer branches, unresolvable property reads like `selected.id === row.id`, non-strict comparisons) keep the existing fan-out.
- The map is dropped (nulled) on loop reconcile and lazily rebuilt: any selection without a primed map — the first ever, the first after resume, or the first after a list change — fans out once, which is always correct; every later one is O(1).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.