### PR TITLE
docs: overhaul AGENTS.md guides and add agent-feedback system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,46 @@
 # Marko Monorepo
 
+Marko compiles `.marko` templates into optimized server (streaming HTML) and client (fine-grained DOM) JavaScript. npm workspaces; Node >= 22. Primary development happens in `packages/runtime-tags`.
+
 ## Packages
 
-### [`packages/compiler`](packages/compiler)
+- [`packages/compiler`](packages/compiler/AGENTS.md) — `@marko/compiler`. Translator-agnostic: parses `.marko` into a (patched) Babel AST, then hands off to a translator for codegen.
+- [`packages/runtime-tags`](packages/runtime-tags/AGENTS.md) — `marko@6` / `@marko/runtime-tags`. The Marko 6 runtime **and** its translator. **Primary development.**
+- [`packages/runtime-class`](packages/runtime-class/AGENTS.md) — `marko@5` / `@marko/runtime-class`. Marko 5, in maintenance; its translator wraps the class-API translator with runtime-tags' interop layer.
 
-`@marko/compiler` compiles `.marko` into `.js` using installed babel-based `translator` from either `packages/runtime-class` or `packages/runtime-tags`.
+A "translator" is the Babel-plugin half of a runtime package; the compiler loads it as `<pkg>/translator`. "Marko 6" is the runtime-tags version — the compiler stays 5.x.
 
-API: `src/index.js`.
-Config: `src/config.js`.
+## Commands
 
-### [`packages/runtime-class`](packages/runtime-class)
+All from repo root. Tests and tooling run directly from TS source (`~ts` Babel register hook; package `exports` point at `src/` until publish), so no build step is needed to iterate.
 
-Package names: `marko@5`, `@marko/runtime-class`
+```sh
+npm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run; bail: stops at first failure
+npm run test:update -- --grep "..."                      # regenerate snapshots (review the diff!)
+npm run compile -- -t "" -o dom -d foo.marko             # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)
+npm run build                                            # all packages -> dist/ + .d.ts
+npm run build:sizes                                      # bundle-size table; diffs vs .sizes.json
+npm run lint                                             # eslint + prettier check + cspell
+npm run format                                           # eslint --fix + prettier --write
+npm run change                                           # add a changeset (required for user-facing changes)
+```
 
-See [`packages/runtime-class/AGENTS.md`](packages/runtime-class/AGENTS.md).
+`npm run compile` is the fastest way to inspect what the translator generates. (`-t ""` works around a broken default for that flag — see `agent-feedback/dx.md`.)
 
-### [`packages/runtime-tags`](packages/runtime-tags)
+## Repo invariants
 
-Package names: `marko@6`, `@marko/runtime-tags`
+- **Babel is patched.** `patches/` (applied by patch-package on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping a `@babel/*` version requires regenerating its patch.
+- **Bundle size is a feature.** The pre-commit hook runs lint-staged, a full build, and `build:sizes`, staging `.sizes.json`/`.sizes/` — that diff is the size impact of the change. Commits are slow by design.
+- **Snapshots and sizes are generated.** Never hand-edit `__snapshots__/**`, fixture `sizes.json`, or `.sizes*`; regenerate with `npm run test:update` and the commit hook.
+- **CI** (`.github/workflows/ci.yml`): build + lint on Node 26; tests on Node 22/24/26 (`MARKO_DEBUG=1`, c8 coverage). Releases go out via changesets on push to `main`.
+- `cspell` checks all `.md`/`.ts`/`.js`/`.marko` files — add genuinely new terms to `cspell.json`.
 
-See [`packages/runtime-tags/AGENTS.md`](packages/runtime-tags/AGENTS.md).
+## Conventions
 
-## File Organization
+Organize files top-down (progressive disclosure): public API/exports first, then orchestration, helpers, and low-level detail last — use function-declaration hoisting.
 
-### Top-down structure (progressive disclosure)
+Marko language reference: <https://markojs.com/llms.txt> lists every docs page; append `.md` to any docs URL for markdown.
 
-Files should be organized from most important to least important:
+## Agent feedback
 
-1. Public API (exports)
-2. High-level orchestration logic
-3. Helper functions
-4. Low-level implementation details
-
-Use function declaration hoisting to enable this structure.
+Anything actionable but out of scope for the current task — a suspected bug, cleanup, a perf/size win, tooling friction, or code that was confusing — must be recorded in [`agent-feedback/`](agent-feedback/README.md) before finishing. Don't silently drop it, and don't fix it inside an unrelated diff.

--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -1,0 +1,32 @@
+# Agent Feedback
+
+Actionable observations that were **out of scope for the task that surfaced them**. If something is in scope, fix it instead. Do not expand a task's diff to fix issues recorded here.
+
+## When to add an entry
+
+While working on any task, record anything a future contributor should act on:
+
+- a suspected bug you couldn't pursue → `bugs.md`
+- duplication, dead code, inconsistency, refactor opportunities → `cleanup.md`
+- runtime speed or bundle size opportunities → `perf.md`
+- friction in builds, tests, tooling, or repo workflows → `dx.md`
+- code or docs that were confusing, and what would have clarified them → `unclear.md`
+
+## Rules
+
+1. **Search the category file first.** If an entry already covers it, don't duplicate; append a corroborating sentence only if you have new information.
+2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering your analysis. Never reference "my earlier analysis" or conversation context.
+3. **Append to the end** of the category file.
+4. Entries are **removed when resolved** (delete, don't mark done; git history is the archive).
+5. Verify claims before recording. A guess is not feedback.
+
+## Entry format
+
+```md
+## <one-line imperative summary>
+
+`<primary/file/path.ts:line>` | 2026-07-02 | impact:<low|med|high> | effort:<low|med|high>
+
+<2–6 sentences: the problem, why it matters, and a concrete suggested direction.
+Additional file paths inline as needed.>
+```

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1,0 +1,3 @@
+# Suspected Bugs
+
+Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -1,0 +1,3 @@
+# Cleanup
+
+Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -1,0 +1,9 @@
+# Developer Experience
+
+Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
+
+## Fix the broken default translator in `npm run compile`
+
+`scripts/inspect-compiled-output.ts:22` | 2026-07-02 | impact:med | effort:low
+
+The `-t`/`--translator` option defaults to the string `"tags"`, so the fallback at `scripts/inspect-compiled-output.ts:41` (`args.values.translator || "@marko/runtime-tags/translator"`) never fires, and every invocation without an explicit `-t` dies with `Cannot find module 'tags'`. Either default the option to `""` or map shorthand values (`tags` → `@marko/runtime-tags/translator`, `class` → `marko/translator`). The root `AGENTS.md` documents the `-t ""` workaround; update it when fixing.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -1,0 +1,3 @@
+# Performance
+
+Runtime speed and bundle size opportunities. Format and rules: [README.md](README.md).

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -1,0 +1,3 @@
+# Unclear Code & Docs
+
+Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).

--- a/cspell.json
+++ b/cspell.json
@@ -18,6 +18,8 @@
     "vnode",
     "vnodes",
     "codegen",
+    "codemods",
+    "backticked",
     "morphdom",
     "renderbody",
     "tagname",

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -1,0 +1,22 @@
+# `@marko/compiler`
+
+Translator-agnostic compiler: parses `.marko` into a Babel AST (custom node types like `MarkoTag`, `MarkoAttribute` — added to Babel by the root `patches/`), runs migrate/transform passes, then hands the AST to a **translator** (`@marko/runtime-tags/translator` or `marko/translator`) for codegen. Stays at v5.x; language changes belong in the translators, not here.
+
+## Map
+
+- `src/index.js` — public API: `compile[File][Sync](src, filename, config)` → `{ code, map, meta, ast }`, `configure`, `taglib`, `types`.
+- `src/config.js` — config defaults. Key options: `output` (`"html"` | `"dom"` | `"source"` | `"migrate"`), `optimize`, `translator`, `modules` (`"esm"`/`"cjs"`), `optimizeKnownTemplates`, `errorRecovery`, `cache`, `fileSystem`.
+- `src/babel-plugin/` — pipeline core. Stages: `parse → migrate → transform → analyze` (cached per template) then `translate` on a clone. Each stage merges visitors from taglibs + the translator.
+- `src/taglib/` — tag registry/discovery: built-in HTML/SVG/MathML JSON taglibs, `marko.json` / `marko-tag.json` discovery walking up from the template, `buildLookup`.
+- `src/babel-utils/` — the helper API for translator authors (`assert*`, `diagnostic*`, `import*`, `parse*`, `getTagDef`, `isNativeTag`, `resolveTagImport`, ...). Exported as `@marko/compiler/babel-utils`.
+- `internal/babel/index.ts` — the single controlled Babel entry, re-exported as `@marko/compiler/internal/babel`. All Babel access (here and in translators) goes through it, never `@babel/*` directly.
+
+## Translator contract
+
+A translator module exports: `translate` (required visitor), `taglibs` (required, `[[id, props]]`), optional `transform` / `analyze` visitors, `tagDiscoveryDirs`, `optionalTaglibs`, `preferAPI` (`"tags"` | `"class"`), and `getRuntimeEntryFiles(output, optimize)`. Loading is resolved from `config.translator` or auto-detected from the app's dependencies (`util/try-load-translator.js`, default logic in `config.js`).
+
+## Notes
+
+- `output: "source"` / `"migrate"` re-print `.marko` source (tooling/codemods) — no translator codegen.
+- Bumping any `@babel/*` version requires regenerating the corresponding patch in root `patches/` (patch-package); the custom AST types and generated `dist/types.d.ts` (`npm run build-babel-types -w @marko/compiler`) depend on them.
+- Adding a core tag in a translator shows up in taglib-lookup expectations here and in `packages/runtime-class/test/taglib-lookup/`.

--- a/packages/runtime-class/AGENTS.md
+++ b/packages/runtime-class/AGENTS.md
@@ -11,7 +11,7 @@ The package is organized into four layers:
 | `src/runtime/vdom/`    | CSR runtime: virtual DOM, morphdom reconciliation, component lifecycle |
 | `src/translator/`      | Babel-based compiler that transforms `.marko` into SSR/CSR JavaScript  |
 
-The compiler/translator entry is `src/translator/index.js`.
+The compiler/translator entry is `src/translator/index.js`, but the package's exported translator (`src/translator.js`) wraps it with `createInteropTranslator` from `@marko/runtime-tags/translator`, so Marko 5 projects can mix in Marko 6 (Tags API) components. Interop behavior changes are usually made in `packages/runtime-tags/src/translator/interop/`, not here.
 
 Note: published as both `marko@5` and `@marko/runtime-class`.
 

--- a/packages/runtime-tags/AGENTS.md
+++ b/packages/runtime-tags/AGENTS.md
@@ -1,142 +1,36 @@
 # Marko 6 (runtime & translator)
 
-## Architecture
+Published as `marko@6` and `@marko/runtime-tags`. Contains both the runtime and the Babel translator that generates code against it; most changes touch both halves plus test fixtures.
 
-The package is organized into four layers:
+## Layout
 
-| Directory         | Purpose                                                               |
-| ----------------- | --------------------------------------------------------------------- |
-| `src/common/`     | Types, constants, and utils used by both DOM / HTML runtimes          |
-| `src/html/`       | SSR runtime: streaming HTML, serialization                            |
-| `src/dom/`        | CSR runtime: reactivity, DOM manipulation, resumability               |
-| `src/translator/` | Babel-based compiler that transforms `.marko` into ssr/csr javascript |
+| Directory         | Purpose                                                                                                                |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `src/common/`     | Types, accessor enums, helpers shared by both runtimes                                                                 |
+| `src/dom/`        | CSR runtime: scopes, signals, control flow, resume, scheduling                                                         |
+| `src/html/`       | SSR runtime: streaming writer, value serializer, resume boilerplate                                                    |
+| `src/translator/` | Babel translator: `core/` (built-in tags), `visitors/` (per AST node), `util/` (analysis), `interop/` (Marko 5 compat) |
 
-Runtime entries are `src/html.ts` and `src/dom.ts`.
-The compiler/translator entry is `src/translator/index.ts`. The translator is further organized into:
+Entries: `src/dom.ts`, `src/html.ts`, `src/translator/index.ts`. Type stubs for core tags: `tags/*.d.marko`.
 
-- `core/` — implementations for built-in tags (`if`, `for`, `let`, etc.)
-- `visitors/` — AST traversal visitors (program, tag, attribute, etc.)
-- `util/` — shared compiler utilities (signals, sections, walks, references, etc.)
-- `interop/` — Marko 5 compat layer
+## Vocabulary
 
-Note: publish aliases `@marko/runtime-tags` and `marko`@6.
+These terms appear everywhere; get them straight before editing.
 
-## Naming Conventions
+- **Section** (`translator/util/sections.ts`) — a compile-time render unit: the program body or any tag body that renders independently (an `<if>`/`<for>` branch, custom tag content). Per-section compiler state lives in `createSectionState(key, init)` getter/setter pairs.
+- **Binding** (`translator/util/references.ts` — largest file in the package) — a reactive value (`let`, `input`, `param`, `derived`, `dom`, ...) with tracked reads, aliases, closures, and assignments. `finalizeReferences()` (program analyze-exit) computes the reactivity graph and what must serialize.
+- **Signal** — compile time (`translator/util/signals.ts`): the update function emitted per binding per section, including the HTML-side resume statements. Runtime (`dom/signals.ts`): `(scope, value) => void` functions that dirty-check and queue renders.
+- **Scope** (`dom/scope.ts`) — a plain object holding one render instance's state, keyed by accessor chars. Branch scopes are created/destroyed by control flow.
+- **Renderer / branch** (`dom/renderer.ts`, `dom/control-flow.ts`) — a renderer is a template blueprint; branches are its live DOM instances.
+- **Walks** (`translator/util/walks.ts`, `dom/walker.ts`) — a run-length-encoded string of DOM-traversal ops; the client replays it to locate nodes instead of querying. `<!>` marker comments are emitted where structure is dynamic.
+- **Serialization / resume** (`html/serializer.ts`, `dom/resume.ts`) — SSR serializes scopes into an inline script; the client _resumes_ (attaches to existing DOM and state) instead of re-rendering. `translator/util/serialize-reasons.ts` decides what serializes and why.
+- **Accessors** (`common/accessor.debug.ts`) — enum property keys for runtime objects. Prod values are single chars, each enum restarting at `"a"` (deliberate, for gzip); debug values are readable strings.
 
-### Underscore-prefixed runtime API (`_name`)
+## Translator
 
-Functions exported as part of the runtime API (functions called from compiler-generated code) use a leading underscore prefix:
+Phases run in order: `migrate → transform → analyze → translate`. `analyze` builds sections/bindings; `translate` emits code. Node visitors live in `visitors/` and are split per phase by `extractVisitors` (`util/visitors.ts`); `visitors/tag/index.ts` dispatches to `native-tag.ts` / `custom-tag.ts` / `dynamic-tag.ts` / `attribute-tag.ts` or a tag definition's own hooks.
 
-```ts
-export function _let(...) { ... }
-export function _attr(...) { ... }
-export function _text(...) { ... }
-```
-
-These are **not** "private" in the traditional sense. The underscore means these are internal runtime API entry points which are public to generated code, but not meant for direct use by application authors.
-
-### Internal object properties via accessor enums
-
-Internal properties on runtime objects (renderers, pending renders, closure signals, etc.) use enum-based computed keys defined in `src/common/accessor.ts` / `src/common/accessor.debug.ts`:
-
-```ts
-renderer[RendererProp.Id];
-render[PendingRenderProp.Scope];
-closureSignal[ClosureSignalProp.Index];
-```
-
-Each unique object type gets its own enum so all enums can start from `"a"`, `"b"`, `"c"` — maximizing gzip compression. The debug variants use descriptive strings (`"id"`, `"scope"`, etc.) swapped in by the `remap-debug` build plugin.
-
-## `MARKO_DEBUG` Pattern
-
-Debug-only code is gated behind the `MARKO_DEBUG` global constant. The build tooling strips these blocks in production, so they have zero runtime cost.
-
-```ts
-if (MARKO_DEBUG) {
-  if (!element) {
-    throw new Error("Expected element to exist");
-  }
-}
-```
-
-This pattern is used for:
-
-- **Validation and assertions** — checking invariants that should hold in production
-- **Descriptive names** — providing readable accessor/property names during development
-- **Error messages** — detailed diagnostics that would bloat production bundles
-
-Any file with `.debug.*` will also be replaced with an adjacent non dedbug counter part.
-e.g.
-
-- `accessor.ts` — production values (single characters: `"a"`, `"b"`, `"c"`)
-- `accessor.debug.ts` — development values (readable strings: `"ConditionalScope"`, `"LoopScopeArray"`)
-
-## Function Style
-
-### `function` declarations vs arrow functions
-
-- **Named exports and top-level functions**: use `function` declarations
-- **Inline callbacks, closures, and anonymous functions**: use arrow functions
-- **Extract closures when possible**: if a closure does not need to capture local state, prefer a hoisted file-level `function` declaration with a self-documenting name
-- **Balance performance and readability**: keep inline closures only when they must close over local values, or when extraction would make the call site less clear
-
-### Self-modifying functions
-
-Some initialization functions replace themselves after first invocation to become no-ops or change behavior:
-
-```ts
-export let _enable_catch = () => {
-  _enable_catch = () => {}; // no-op after first call
-  // ... actual setup code ...
-};
-```
-
-### Monkeypatching via wrapper pattern
-
-Functions are sometimes wrapped by reassigning the module-level binding:
-
-```ts
-runRender = ((runRender) => (render) => {
-  // ... wrapper logic ...
-  runRender(render);
-})(runRender);
-```
-
-## State and Reactivity
-
-### Signal pattern
-
-Signals are functions with the signature `(scope: Scope, value: unknown) => void`. They are the core reactivity primitive:
-
-```ts
-type SignalFn = (scope: Scope, value: unknown) => void;
-```
-
-### Scope objects
-
-Scopes are plain objects with dynamic property access via computed string keys built from enum prefixes and accessor indices:
-
-```ts
-scope[AccessorProp.Id];
-scope[AccessorPrefix.BranchScopes + nodeAccessor];
-```
-
-### Section state (translator)
-
-The translator uses a `createSectionState()` factory to create getter/setter pairs for per-section compiler state:
-
-```ts
-const [getSignals, setSignals] = createSectionState<Signal[]>(
-  "signals",
-  () => [],
-);
-```
-
-## Translator Conventions
-
-### Visitor phases
-
-Core tag definitions follow a multi-phase visitor pattern with `analyze`, `translate`, and `migrate`:
+Core tags are one file per tag in `core/`, registered in `core/index.ts`:
 
 ```ts
 export default {
@@ -145,54 +39,69 @@ export default {
     html(tag) { ... },
     dom(tag) { ... },
   }),
-  migrate(tag) { ... },
 } as Tag;
 ```
 
-### `callRuntime()`
+- `callRuntime("_name", ...args)` (`util/runtime.ts`) references runtime helpers with automatic imports; DOM helpers listed in `pureDOMFunctions` get `/*@__PURE__*/`.
+- Validate early with `assertNoArgs` / `assertNoParams` / `assertNoSpreadAttrs` (`util/assert.ts`). Compile errors use `path.buildCodeFrameError` with backticked names and a markojs.com docs link — `core/if.ts` is the canonical style.
+- `util/marko-config.ts` provides `isOutputHTML` / `isOutputDOM` / `isOptimize`.
+- `util/optional.ts` (`Opt`/`Sorted` list algebra) underpins reference tracking; `util/known-tag.ts` holds native HTML tag/attribute metadata.
 
-All references to runtime functions from generated code go through the `callRuntime()` helper, which handles import management:
+## Runtime conventions
 
-```ts
-callRuntime("_if", condition, body);
-```
-
-### Assertion helpers
-
-The translator provides assertion functions for tag validation:
-
-```ts
-assertNoArgs(tag);
-assertNoParams(tag);
-assertNoSpreadAttrs(tag);
-```
-
-These produce compiler errors with source locations via `buildCodeFrameError`.
-
-## Error Handling
-
-- Debug-only validation wrapped in `if (MARKO_DEBUG)` blocks
-- Translator errors include source locations via Babel's `buildCodeFrameError`
-- Descriptive error messages with documentation links in the translator
-- Runtime errors in production are minimal — most validation happens at compile time
+- **`_name` exports** are runtime API called by generated code — public to codegen, not to app authors. Renames must update `callRuntime` call sites and `pureDOMFunctions`.
+- **`MARKO_DEBUG`** gates all validation, descriptive names, and detailed error messages (`if (MARKO_DEBUG) { ... }`); builds strip these. It is `true` in tests via the `~ts` register hook. Runtime error helpers live in `common/errors.ts`.
+- **`.debug.ts` pairs**: source imports the `.debug` module (e.g. `common/types.ts` imports `./accessor.debug`); the production build remaps `X.debug` → `X.ts`. Both files must export identical member names — mirror any accessor enum change in `accessor.ts` **and** `accessor.debug.ts` (the other pair is `html/inlined-runtimes[.debug].ts`).
+- **Self-modifying functions**: features like `_enable_catch` or `enableBranches` reassign module-level bindings on first call so unused features cost nothing. Preserve this pattern; don't "simplify" it away.
+- Named/top-level functions use `function` declarations; arrows only for closures that must capture. Extract non-capturing closures into named file-level functions.
 
 ## Testing
 
-- **Fixture-based**: test fixtures contain `.marko` templates with expected output
-- **Multi-mode snapshots**: separate expected output for CSR (`dom.expected/`), SSR (`html.expected/`), and resume/hydration
-- **Snapshot directories**: `__snapshots__/` alongside test fixtures
-- **Test files**: `test.ts` files co-located with fixture templates
+Fixture-based snapshot tests driven by `src/__tests__/main.test.ts`. ~800 fixtures in `src/__tests__/fixtures/`, plus `fixtures-interop/` (Marko 5 ↔ 6 mixing, suite name `translator-interop`). A dir suffixed `.skip` is ignored.
 
 ```sh
-npm test -- --grep "runtime-tags.*" # all tests (uses mocha)
-npm test -- --grep "runtime-tags.* <fixture> " # specific fixture
-npm test -- --grep "runtime-tags.* <fixture> compile" # compiled outputs only
-npm test -- --grep "runtime-tags.* <fixture> render" # render outputs only
-
-npm run test:update -- --grep "runtime-tags.*" # all tests snapshot update
-npm run test:update -- --grep "runtime-tags.* <fixture> " # fixture snapshot update
-
-npm test -- --grep "translator-interop.*" # interop tests (run after the base tags runtime tests pass)
+npm test -- --grep "runtime-tags/translator <fixture> "  # one fixture (note trailing space)
+npm run test:update -- --grep "runtime-tags/translator <fixture> "  # regenerate its snapshots
+npm test -- --grep "translator-interop"                  # interop suite (run after base suite passes)
 ```
 
-Prefer running specific fixtures when possible. Running the entire suite takes time!
+Run scoped; the full suite is slow and `bail: true` stops everything at the first failure anyway.
+
+### Fixture anatomy
+
+```
+fixtures/<name>/
+  template.marko    # entry (required); custom tags under tags/
+  test.ts           # optional: export const config: TestConfig = { ... }
+  sizes.json        # generated compiled-size tracking
+  __snapshots__/    # generated; optimize = base name, debug variant = *.debug.*
+    dom.bundle[.debug].js       # compiled CSR output
+    html.bundle[.debug].js      # compiled SSR output
+    render[.debug].md           # per-step rendered HTML + granular mutation log
+    writes[.debug].html         # SSR stream chunks (joined by <!-- FLUSH -->)
+```
+
+`TestConfig` (see `main.test.ts`): `steps` (`[initialInput, ...]` where later steps are input updates, `(container) => {}` interactions, or async `Wait`/`Flush`/`Throws` controls), `error_compiler` (expect compile failure), `equivalent: false` (separate `render-ssr`/`render-csr` snapshots), `skip_optimize` / `skip_dom` / `skip_html` / `skip_csr` / `skip_ssr`, `runtime_id`. Each fixture runs in `debug` and `optimize` modes; CSR only runs in `debug`.
+
+To add a fixture: create the dir + `template.marko` (+ `test.ts` with steps exercising the behavior), run `test:update` scoped to it, then **read the generated snapshots as part of your change** — the mutation log in `render.md` shows update granularity (an unexpected extra `UPDATE:`/re-render is a regression), and the `.bundle.js` diff shows generated-code cost.
+
+## Workflows
+
+**New/changed core tag** (see the `<show>` tag commit for a full example):
+
+1. `translator/core/<tag>.ts` + register in `core/index.ts` (and `util/is-core-tag.ts`).
+2. Runtime helpers in `src/dom/` / `src/html/`, exported from `src/dom.ts` / `src/html.ts`; add to `util/runtime.ts` lists as needed.
+3. Several small fixtures covering static values, dynamic updates, nesting, and interaction with `<for>`/`<if>`.
+4. `npm run change` — user-facing changes need a changeset.
+5. Expect broad snapshot/`sizes.json` churn and an update to `packages/runtime-class/test/taglib-lookup/fixtures/getTagsSorted/expected.json` (interop taglib lookup).
+
+**Changing generated output**: iterate with `npm run compile -- -t "" -o dom -d file.marko` (and `-o html`), then `test:update` and audit snapshot diffs — output shape changes ripple through hundreds of fixtures; verify a sample by hand, don't rubber-stamp.
+
+**Changing runtime behavior**: find the covering fixtures by grepping `__tests__/fixtures` for the runtime helper or syntax; extend `steps` before touching the runtime so the mutation log captures the before/after.
+
+## Gotchas
+
+- `translator/util/references.ts` imports `toAccess` from `html/serializer.ts` — serializer key encoding changes affect the translator.
+- Adding an accessor enum member: keep `accessor.ts` / `accessor.debug.ts` in lockstep (same members, char vs. readable string values).
+- Size regressions count as review findings: check the fixture `sizes.json` diffs and root `.sizes.json` (updated by the pre-commit hook).
+- Language semantics questions (what a tag/attribute should do) are answered by the docs, not inferred: <https://markojs.com/llms.txt>.


### PR DESCRIPTION
## Description

Rewrites the root and runtime-tags `AGENTS.md` around verified workflows (scoped fixture testing, compiled-output inspection, snapshot review, core-tag checklist), adds a compiler `AGENTS.md` covering the translator contract, and adds a top-level `agent-feedback/` folder where contributors and agents record actionable but out-of-scope observations (bugs, cleanup, perf, dx, unclear code) in a dense standardized format.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TCVC75Sm7Vk3sqMMiM6M7p)_