### PR TITLE
fix(runtime-tags): hold hydration effects while stream is blocked on in-order await

### DIFF
--- a/.changeset/hold-effects-blocked-stream.md
+++ b/.changeset/hold-effects-blocked-stream.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a resume crash (`Cannot read properties of undefined (reading 'nodeType')` in `setConditionalRenderer`) when a `<script>` effect flushed before an in-order `<await>` resolved triggered a state update targeting content rendered after the pending `<await>`. Effects are now held on the blocked chunk and flush once its async content completes, so state updates only run against markers that exist in the document.

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,53 @@
+// tags/cart-state.marko
+const $template$1 = "";
+const $walks$1 = "";
+function subscribeCartState(callback) {
+	Promise.resolve().then(() => {
+		callback({ totalQuantity: 30 });
+	});
+	return () => {};
+}
+const $cart$1 = /* @__PURE__ */ _let("cart/0", ($scope) => _return($scope, { cart: $scope.cart }));
+const $setup__script = _script("__tests__/tags/cart-state.marko_0", ($scope) => {
+	{
+		const unsubscribe = subscribeCartState((state) => {
+			$cart$1($scope, state);
+		});
+		$signal($scope, 0).addEventListener("abort", unsubscribe);
+	}
+});
+function $setup$1($scope) {
+	$signalReset($scope, 0);
+	$cart$1($scope, null);
+	$setup__script($scope);
+}
+var cart_state_default = /* @__PURE__ */ _template("__tests__/tags/cart-state.marko", "", "", $setup$1);
+
+// template.marko
+const $template = /* @__PURE__ */ ((_w0) => `${_w0}<header><div><!><a href=/something>Something</a> Test <!></div></header>`)("");
+const $walks = /* @__PURE__ */ ((_w0) => `0${_w0}&E%d%m`)("");
+const $for_content__collection = ($scope, collection) => {
+	_attr($scope["#a/0"], "href", `/something/${collection}`);
+	_text($scope["#text/1"], collection);
+};
+const $for_content__$params = ($scope, $params3) => $for_content__collection($scope, $params3[0]);
+const $await_content__for = /* @__PURE__ */ _for_of("#text/0", "<a> </a>", " D l", 0, $for_content__$params);
+const $await_content__collections = ($scope, collections) => $await_content__for($scope, [collections]);
+const $await_content__$params = ($scope, $params2) => $await_content__collections($scope, $params2[0]);
+const $pattern2 = _var_resume("__tests__/template.marko_0_$pattern/var", ($scope, $pattern) => $cart($scope, $pattern.cart));
+const $if = /* @__PURE__ */ _if("#text/3", "<a href=/go-to>Go</a>", "b", 0, "<button>Go to</button>", "b");
+const $hasHydrate = ($scope, hasHydrate) => $if($scope, !hasHydrate ? 0 : 1);
+const $cart = ($scope, cart) => $hasHydrate($scope, cart !== null);
+const $await_content = /* @__PURE__ */ _await_content("#text/2", "<!><!><!>", "b%c");
+const $await_promise = /* @__PURE__ */ _await_promise("#text/2", $await_content__$params);
+function $setup($scope) {
+	_var($scope, "#childScope/0", $pattern2);
+	$setup$1($scope["#childScope/0"]);
+	$await_content($scope);
+	$await_promise($scope, resolveAfter([
+		1,
+		2,
+		3
+	]));
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/dom.bundle.js
@@ -1,0 +1,22 @@
+// tags/cart-state.marko
+function subscribeCartState(callback) {
+	Promise.resolve().then(() => {
+		callback({ totalQuantity: 30 });
+	});
+	return () => {};
+}
+const $cart$1 = /* @__PURE__ */ _let(0, ($scope) => _return($scope, { cart: $scope.a }));
+const $setup__script = _script("b0", ($scope) => {
+	{
+		const unsubscribe = subscribeCartState((state) => {
+			$cart$1($scope, state);
+		});
+		$signal($scope, 0).addEventListener("abort", unsubscribe);
+	}
+});
+
+// template.marko
+const $pattern2 = _var_resume("a0", ($scope, $pattern) => $cart($scope, $pattern.cart));
+const $if = /* @__PURE__ */ _if(3, "<a href=/go-to>Go</a>", "b", 0, "<button>Go to</button>", "b");
+const $hasHydrate = ($scope, hasHydrate) => $if($scope, !hasHydrate ? 0 : 1);
+const $cart = ($scope, cart) => $hasHydrate($scope, cart !== null);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,54 @@
+// tags/cart-state.marko
+function subscribeCartState(callback) {
+	Promise.resolve().then(() => {
+		callback({ totalQuantity: 30 });
+	});
+	return () => {};
+}
+var cart_state_default = _template("__tests__/tags/cart-state.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let cart = null;
+	const $return = { cart };
+	_script($scope0_id, "__tests__/tags/cart-state.marko_0");
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { cart } = cart_state_default({});
+	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_$pattern/var");
+	const hasHydrate = cart !== null;
+	_html("<header><div>");
+	_await($scope0_id, "#text/2", resolveAfter([
+		1,
+		2,
+		3
+	]), (collections) => {
+		const $scope1_id = _scope_id();
+		forOf(collections, (collection) => {
+			const $scope2_id = _scope_id();
+			_html(`<a${_attr("href", `/something/${collection}`)}>${_escape(collection)}</a>`);
+		});
+	}, 0);
+	_html("<a href=/something>Something</a> Test ");
+	_if(() => {
+		if (!hasHydrate) {
+			const $scope3_id = _scope_id();
+			_html("<a href=/go-to>Go</a>");
+			writeScope($scope3_id, {}, "__tests__/template.marko", "13:6");
+			return 0;
+		} else {
+			const $scope4_id = _scope_id();
+			_html("<button>Go to</button>");
+			writeScope($scope4_id, {}, "__tests__/template.marko", "14:6");
+			return 1;
+		}
+	}, $scope0_id, "#text/3", 1, 1, 1, 0, 1);
+	_html("</div></header>");
+	writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/html.bundle.js
@@ -1,0 +1,47 @@
+// tags/cart-state.marko
+var cart_state_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $return = { cart: null };
+	_script($scope0_id, "b0");
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { cart } = cart_state_default({});
+	_var($scope0_id, "b", $childScope, "a0");
+	const hasHydrate = cart !== null;
+	_html("<header><div>");
+	_await($scope0_id, "c", resolveAfter([
+		1,
+		2,
+		3
+	]), (collections) => {
+		_scope_id();
+		forOf(collections, (collection) => {
+			_scope_id();
+			_html(`<a${_attr("href", `/something/${collection}`)}>${_escape(collection)}</a>`);
+		});
+	}, 0);
+	_html("<a href=/something>Something</a> Test ");
+	_if(() => {
+		if (!hasHydrate) {
+			const $scope3_id = _scope_id();
+			_html("<a href=/go-to>Go</a>");
+			writeScope($scope3_id, {});
+			return 0;
+		} else {
+			const $scope4_id = _scope_id();
+			_html("<button>Go to</button>");
+			writeScope($scope4_id, {});
+			return 1;
+		}
+	}, $scope0_id, "d", 1, 1, 1, 0, 1);
+	_html("</div></header>");
+	writeScope($scope0_id, { a: _existing_scope($childScope) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-csr.debug.md
@@ -1,0 +1,78 @@
+# Render
+```html
+<header>
+  <div>
+    <a
+      href="/something"
+    >
+      Something
+    </a>
+     Test 
+    <a
+      href="/go-to"
+    >
+      Go
+    </a>
+  </div>
+</header>
+```
+
+# Update
+```html
+<header>
+  <div>
+    <a
+      href="/something"
+    >
+      Something
+    </a>
+     Test 
+    <button>
+      Go to
+    </button>
+  </div>
+</header>
+```
+## Change
+```
+INSERT: header > div::text + button
+REMOVE: header > div > button + a
+```
+
+# Update
+```html
+<header>
+  <div>
+    <a
+      href="/something/1"
+    >
+      1
+    </a>
+    <a
+      href="/something/2"
+    >
+      2
+    </a>
+    <a
+      href="/something/3"
+    >
+      3
+    </a>
+    <a
+      href="/something"
+    >
+      Something
+    </a>
+     Test 
+    <button>
+      Go to
+    </button>
+  </div>
+</header>
+```
+## Change
+```
+INSERT: header > div > a
+INSERT: header > div > a:nth-of-type(1) + a
+INSERT: header > div > a:nth-of-type(2) + a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,54 @@
+# Render
+```html
+<header>
+  <div />
+</header>
+```
+
+# Update
+```html
+<header>
+  <div>
+    <a
+      href="/something/1"
+    >
+      1
+    </a>
+    <a
+      href="/something/2"
+    >
+      2
+    </a>
+    <a
+      href="/something/3"
+    >
+      3
+    </a>
+    <a
+      href="/something"
+    >
+      Something
+    </a>
+     Test 
+    <button>
+      Go to
+    </button>
+  </div>
+</header>
+```
+## Change
+```
+INSERT: header > div > a
+INSERT: header > div > a:nth-of-type(1)::text("1")
+INSERT: header > div > a:nth-of-type(1) + a
+INSERT: header > div > a:nth-of-type(2)::text("2")
+INSERT: header > div > a:nth-of-type(2) + a
+INSERT: header > div > a:nth-of-type(3)::text("3")
+INSERT: header > div > a:nth-of-type(3) + a
+INSERT: header > div > a:nth-of-type(4)::text("Something")
+INSERT: header > div > a:nth-of-type(4) + ::text(" Test ")
+INSERT: header > div::text + a
+INSERT: a::text("Go")
+INSERT: header > div::text + button
+REMOVE: header > div > button + a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/render-ssr.md
@@ -1,0 +1,54 @@
+# Render
+```html
+<header>
+  <div />
+</header>
+```
+
+# Update
+```html
+<header>
+  <div>
+    <a
+      href="/something/1"
+    >
+      1
+    </a>
+    <a
+      href="/something/2"
+    >
+      2
+    </a>
+    <a
+      href="/something/3"
+    >
+      3
+    </a>
+    <a
+      href="/something"
+    >
+      Something
+    </a>
+     Test 
+    <button>
+      Go to
+    </button>
+  </div>
+</header>
+```
+## Change
+```
+INSERT: header > div > a
+INSERT: header > div > a:nth-of-type(1)::text("1")
+INSERT: header > div > a:nth-of-type(1) + a
+INSERT: header > div > a:nth-of-type(2)::text("2")
+INSERT: header > div > a:nth-of-type(2) + a
+INSERT: header > div > a:nth-of-type(3)::text("3")
+INSERT: header > div > a:nth-of-type(3) + a
+INSERT: header > div > a:nth-of-type(4)::text("Something")
+INSERT: header > div > a:nth-of-type(4) + ::text(" Test ")
+INSERT: header > div::text + a
+INSERT: a::text("Go")
+INSERT: header > div::text + button
+REMOVE: header > div > button + a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/writes.debug.html
@@ -1,0 +1,27 @@
+<header>
+  <div>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ => [1, {
+        "#scopeOffset/1": 3,
+        "#childScope/0": _(2)
+      }, {
+        "#TagVariable": _(1,
+          "packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/template.marko_0_$pattern/var"
+          )
+      }]]
+    </script>
+
+    <!-- FLUSH -->
+
+    <a href=/something/1>1</a><a href=/something/2>2</a><a
+      href=/something/3>3</a><a href=/something>Something</a> Test <a
+      href=/go-to>Go</a><!--M_|1 #text/3 4-->
+  </div>
+</header>
+<script>
+  M._.r.push(
+    "packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/tags/cart-state.marko_0 2"
+    );
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/__snapshots__/writes.html
@@ -1,0 +1,23 @@
+<header>
+  <div>
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ => [1, {
+        b: 3,
+        a: _(2)
+      }, {
+        T: _(1, "a0")
+      }]]
+    </script>
+
+    <!-- FLUSH -->
+
+    <a href=/something/1>1</a><a href=/something/2>2</a><a
+      href=/something/3>3</a><a href=/something>Something</a> Test <a
+      href=/go-to>Go</a><!--M_|1 d 4-->
+  </div>
+</header>
+<script>
+  M._.r.push("b0 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6785,
+        "brotli": 3007
+      },
+      "files": {
+        "tags/cart-state.marko": 476,
+        "template.marko": 373
+      }
+    }
+  },
+  "html": {
+    "min": 537,
+    "brotli": 316
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/tags/cart-state.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/tags/cart-state.marko
@@ -1,0 +1,15 @@
+static function subscribeCartState(callback: (state: unknown) => void) {
+  Promise.resolve().then(() => {
+    callback({ totalQuantity: 30 });
+  });
+  return () => {};
+}
+<let/cart=null/>
+<script>
+  const unsubscribe = subscribeCartState((state) => {
+    cart = state;
+  });
+  $signal.addEventListener("abort", unsubscribe);
+</script>
+
+<return={ cart }/>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/template.marko
@@ -1,0 +1,18 @@
+import { resolveAfter } from "../../utils/resolve";
+<cart-state/{ cart }/>
+<const/hasHydrate=cart !== null/>
+<header>
+  <div>
+    <await|collections|=resolveAfter([1, 2, 3])>
+      <for|collection| of=collections>
+        <a href=`/something/${collection}`>${collection}</a>
+      </for>
+    </await>
+    <a href="/something">Something</a>
+    Test
+    <if=!hasHydrate><a href="/go-to">Go</a></if>
+    <else>
+      <button>Go to</button>
+    </else>
+  </div>
+</header>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, wait],
+};

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1351,7 +1351,12 @@ export class Chunk {
       needsWalk = true;
     }
 
-    const { effects } = this;
+    // While the stream is blocked on in-order async content, the resume
+    // markers for everything already rendered after that content have not
+    // been written -- running effects now could cascade state updates into
+    // scopes whose nodes aren't in the document yet. Hold effects on the
+    // blocked chunk so they flush once its async content completes.
+    const effects = this.async ? "" : this.effects;
     let { html, scripts } = this;
 
     if (state.needsMainRuntime && !state.hasMainRuntime) {
@@ -1493,7 +1498,8 @@ export class Chunk {
 
     this.html = html;
     this.scripts = scripts;
-    this.effects = this.lastEffect = state.resumes = "";
+    if (!this.async) this.effects = this.lastEffect = "";
+    state.resumes = "";
     return this;
   }
 


### PR DESCRIPTION
## Description

Fixes a streaming-SSR resume crash: `Cannot read properties of undefined (reading 'nodeType')` in `setConditionalRenderer`.

When a flush happens while the stream is blocked on an in-order `<await>` (no `<try>`/`@placeholder`), hydration effects for already-streamed content still flush — including `<script>` effects of components whose subtree is complete. Such an effect can trigger a state update (e.g. via a tag variable `<return>`) that flows into a scope whose content after the pending `<await>` hasn't been streamed yet. Its resume markers aren't in the document, so signals like `<if>`/`<else>` dereference an `undefined` marker node and crash. The `<try>` placeholder path is guarded by the await-counter machinery, but plain in-order awaits had no protection.

The fix holds effects on the blocked chunk in the HTML writer and flushes them once its async content completes, so effects only run when every marker they can reach exists in the document. Data resumes (scope serialization) still flush eagerly, and out-of-order (`<try>` placeholder) streaming is unaffected since its effects go through the reorder path with its existing pending-branch guards.

Includes a reproduction fixture (`if-swap-before-await-resume`): a child tag with a `<script>` subscription resolving on a microtask that writes through a `<return>` tag variable, ahead of an in-order `<await>` followed by `<if>`/`<else>` — crashes before this change, passes after.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AYjFEzWpcSkBypwDJJ4hoJ)_