### PR TITLE
Skip importing and calling empty child template setups

### DIFF
--- a/.changeset/empty-setup-elision.md
+++ b/.changeset/empty-setup-elision.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Skip importing and calling a child template's setup export when compile time analysis proves it is a noop. This compounds: a component whose setup only called such children now exports a noop setup itself, letting its own parents skip the call too.

--- a/.changeset/merge-references-self.md
+++ b/.changeset/merge-references-self.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix analysis of related controllable attributes merging an expression's references into itself, which duplicated its tracked reads.

--- a/.sizes.json
+++ b/.sizes.json
@@ -44,16 +44,16 @@
     {
       "name": "comments",
       "user": {
-        "min": 665,
-        "brotli": 380
+        "min": 646,
+        "brotli": 365
       },
       "runtime": {
         "min": 6480,
         "brotli": 2845
       },
       "total": {
-        "min": 7145,
-        "brotli": 3225
+        "min": 7126,
+        "brotli": 3210
       }
     },
     {

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -1,4 +1,4 @@
-// size: 665 (min) 380 (brotli)
+// size: 646 (min) 365 (brotli)
 //#region packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/tags/comments.marko
 const $template$1 = "<ul></ul>";
 const $if_content__comment_comments = /* @__PURE__ */ _if_closure(
@@ -9,7 +9,6 @@ const $if_content__comment_comments = /* @__PURE__ */ _if_closure(
 const $if_content__setup = ($scope) => {
   $if_content__comment_comments._($scope);
   $if_content__id._($scope);
-  $scope.a;
 };
 const $if_content__id = /* @__PURE__ */ _if_closure(4, 0, ($scope) =>
   $input_path$1($scope.a, $scope._.l),
@@ -65,9 +64,7 @@ const $input_path$1 = /* @__PURE__ */ _const(4, $for_content__input_path);
 //#region packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup($scope) {
-  $scope.a;
-}
+const $setup = () => {};
 const $input_comments = ($scope, input_comments) =>
   $input_comments$1($scope.a, input_comments);
 const $input_path = ($scope, input_path) => $input_path$1($scope.a, input_path);

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -20,12 +20,6 @@ Existing TODO in `_if`, but narrower than it reads: branch index 0 is already el
 
 Existing TODO: `<return value=... valueChange=...>` force-serializes the `TagVariableChange` accessor even when no parent ever assigns the tag variable. Unlike the now-implemented `<let>` equivalent (gated on `binding.assignmentSections` in `core/let.ts`), this needs cross-template information: whether any parent mutates the tag variable is only known at the parent's compile (`mutatesTagVar` in `packages/runtime-tags/src/translator/util/known-tag.ts:147`), so the reason would have to flow through the param serialize reason group protocol rather than a local check.
 
-## Cross-template elision of empty child setup calls (compounding)
-
-`packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts:266` | 2026-07-02 | impact:med | effort:high
-
-A child template whose setup export is empty (`export const $setup = () => {}`, common for presentational leaves where every statement is keyed to an input-driven signal) is still imported and invoked once per instance by every parent (`knownTagTranslateDOM` always calls `callSetup`, `packages/runtime-tags/src/translator/util/known-tag.ts:356`). Eliding it compounds: once a leaf's setup call is dropped, an intermediate component's own setup often becomes empty, letting its parents drop that call too. Needs an analyze-phase-computable `setupEmpty` flag on `domExports` (conservatively provable when no statements will target the `undefined`-keyed signal: no effects/scriptlets without referenced bindings, no tag vars, no static-value signal initializations, and all child custom tags also `setupEmpty`). Related TODO: `packages/runtime-tags/src/translator/visitors/program/index.ts:75` (emit noop exports as undefined).
-
 ## Avoid resume-registering native tag change handlers
 
 `packages/runtime-tags/src/translator/visitors/function.ts:108` | 2026-07-02 | impact:med | effort:high

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,5 @@ var hello_default = /* @__PURE__ */ _template("__tests__/tags/hello.marko", $tem
 // template.marko
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.bundle.debug.js
@@ -23,7 +23,6 @@ const $count = /* @__PURE__ */ _let("count/1", ($scope) => $input($scope["#child
 	valueChange: $valueChange($scope)
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$count($scope, 0);
 }
 function $valueChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/dom.bundle.debug.js
@@ -5,10 +5,7 @@ const $setup$1 = () => {};
 _enable_catch();
 const $placeholder_content = _content_resume("__tests__/tags/recurse.marko_4_content", "LOADING...", "b");
 const $await_content__input_level = /* @__PURE__ */ _closure_get("input_level", ($scope) => $input_level($scope["#childScope/0"], $scope._._._.input_level - 1), ($scope) => $scope._._._, "__tests__/tags/recurse.marko_3_input_level/pending");
-const $await_content__setup = ($scope) => {
-	$await_content__input_level($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $await_content__setup = $await_content__input_level;
 const $await_content = /* @__PURE__ */ _await_content("#text/0", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $await_content__setup);
 const $try_content__await_promise = /* @__PURE__ */ _await_promise("#text/0");
 const $try_content__setup = ($scope) => {
@@ -35,7 +32,6 @@ var recurse_default = /* @__PURE__ */ _template("__tests__/tags/recurse.marko", 
 const $template = /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1);
 const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_level($scope["#childScope/0"], 4);
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
@@ -59,7 +59,6 @@ const $row_content = /* @__PURE__ */ _content_closures(_content_resume("__tests_
 const $item_content2 = _content_resume("__tests__/template.marko_2_content", "bar", "b");
 const $item_content = _content_resume("__tests__/template.marko_1_content", "foo", "b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	let $item;
 	forOf([
 		"red",

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,6 @@ const $item_content = /* @__PURE__ */ _content_closures(/* @__PURE__ */ _content
 	_text($scope["#text/0"], $scope.zzz);
 } });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	let $item;
 	forOf([
 		1,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.bundle.debug.js
@@ -26,7 +26,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$mult($scope, $scope.mult + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	let $item;
 	forOf([
 		1,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/dom.bundle.debug.js
@@ -15,9 +15,7 @@ var custom_tag_default = /* @__PURE__ */ _template("__tests__/tags/custom-tag/in
 // template.marko
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 const $cond = /* @__PURE__ */ _const("cond", ($scope) => {
 	let $x$1, $y$1;
 	if ($scope.cond) {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
@@ -11,9 +11,7 @@ var list_default = /* @__PURE__ */ _template("__tests__/tags/list.marko", $templ
 const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_item($scope["#childScope/0"], attrTags(attrTags(attrTag({ label: "a" }), { label: "b" }), { label: "c" }));
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_item($scope["#childScope/1"], attrTag({ label: "solo" }));
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c");
 const $item_content2 = /* @__PURE__ */ _content("__tests__/template.marko_2_content", "Again", "b");
 const $item_content = /* @__PURE__ */ _content("__tests__/template.marko_1_content", "Hello", "b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_item($scope["#childScope/0"], attrTags(attrTag({ content: $item_content($scope) }), { content: $item_content2($scope) }));
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.bundle.debug.js
@@ -75,9 +75,7 @@ const $f = /* @__PURE__ */ _const("f", $input_c__OR__input_d__OR__input_e__OR__i
 const $g = /* @__PURE__ */ _const("g", $input_c__OR__input_d__OR__input_e__OR__input_f__OR__input_g__OR__input_h);
 const $h = /* @__PURE__ */ _const("h", $input_c__OR__input_d__OR__input_e__OR__input_f__OR__input_g__OR__input_h);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
 	$input_test($scope["#childScope/3"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/4"]);
 	$input_class($scope["#childScope/4"], [
 		"a",
 		false,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
@@ -36,12 +36,9 @@ const $input_color = /* @__PURE__ */ _const("input_color", ($scope) => {
 });
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/5");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input_test($scope["#childScope/2"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
 	$input_style($scope["#childScope/3"], { width: "100px" });
 	$input_test($scope["#childScope/3"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/4"]);
 	$input_style($scope["#childScope/4"], "color: green");
 	$input_test($scope["#childScope/4"]);
 	$dynamicTag($scope, TestTag, () => ({

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/dom.bundle.debug.js
@@ -8,9 +8,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", "<!>
 // template.marko
 const $template = "<!>";
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)("%b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 const $input = /* @__PURE__ */ _const("input", ($scope) => {
 	let $item;
 	forUntil(1, 0, 1, (i) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/__snapshots__/dom.bundle.debug.js
@@ -9,16 +9,13 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // template.marko
 const $template = "<!><!><!>";
 const $walks = "b%c";
-const $await_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
 const $await_content__value = /* @__PURE__ */ _const("value", ($scope) => {
 	$input_x($scope["#childScope/0"], $scope.value);
 	_attr_input_value_default($scope, "#input/1", $scope.value);
 	_text($scope["#text/2"], $scope.value);
 });
 const $await_content__$params = ($scope, $params2) => $await_content__value($scope, $params2[0]);
-const $await_content = /* @__PURE__ */ _await_content("#text/0", /* @__PURE__ */ ((_w0) => `${_w0}<input><span>got: <!></span>`)($template$1), /* @__PURE__ */ ((_w0) => `/${_w0}& bDb%l`)(" b"), $await_content__setup);
+const $await_content = /* @__PURE__ */ _await_content("#text/0", /* @__PURE__ */ ((_w0) => `${_w0}<input><span>got: <!></span>`)($template$1), /* @__PURE__ */ ((_w0) => `/${_w0}& bDb%l`)(" b"));
 const $await_promise = /* @__PURE__ */ _await_promise("#text/0", $await_content__$params);
 function $setup($scope) {
 	$await_content($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 const $clickCount = /* @__PURE__ */ _let("clickCount/1", ($scope) => $text($scope["#childScope/0"], $scope.clickCount));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 const $clickCount = /* @__PURE__ */ _let("clickCount/1", ($scope) => $text($scope["#childScope/0"], $scope.clickCount));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.bundle.debug.js
@@ -24,9 +24,7 @@ const $clickCount = /* @__PURE__ */ _let("clickCount/2", ($scope) => {
 	$text($scope["#childScope/1"], $scope.clickCount);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$onClick$1($scope["#childScope/1"], $onClick2($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 const $clickCount = /* @__PURE__ */ _let("clickCount/1", ($scope) => $text($scope["#childScope/0"], $scope.clickCount));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 const $clickCount = /* @__PURE__ */ _let("clickCount/1", ($scope) => $text($scope["#childScope/0"], $scope.clickCount));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,6 @@ const $if_content__comment_comments = /* @__PURE__ */ _if_closure("#text/4", 0, 
 const $if_content__setup = ($scope) => {
 	$if_content__comment_comments._($scope);
 	$if_content__id._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 };
 const $if_content__id = /* @__PURE__ */ _if_closure("#text/4", 0, ($scope) => $input_path$1($scope["#childScope/0"], $scope._.id));
 const $for_content__id = /* @__PURE__ */ _const("id", ($scope) => {
@@ -48,9 +47,7 @@ var comments_default = /* @__PURE__ */ _template("__tests__/tags/comments.marko"
 // template.marko
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 const $input_comments = ($scope, input_comments) => $input_comments$1($scope["#childScope/0"], input_comments);
 const $input_path = ($scope, input_path) => $input_path$1($scope["#childScope/0"], input_path);
 const $input = ($scope, input) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.debug.js
@@ -11,10 +11,7 @@ const $template = "<button>Push</button><!><!>";
 const $walks = " b%c";
 const $for_content2__outer__OR__inner = /* @__PURE__ */ _or(3, ($scope) => $name($scope["#childScope/0"], `${$scope._.outer}.${$scope.inner}`));
 const $for_content2__outer = /* @__PURE__ */ _for_closure("#text/0", $for_content2__outer__OR__inner);
-const $for_content2__setup = ($scope) => {
-	$for_content2__outer._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $for_content2__setup = $for_content2__outer;
 const $for_content2__inner = /* @__PURE__ */ _const("inner", $for_content2__outer__OR__inner);
 const $for_content2__$params = ($scope, $params3) => $for_content2__inner($scope, $params3[0]);
 const $for_content__for = /* @__PURE__ */ _for_of("#text/0", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $for_content2__setup, $for_content2__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.js
@@ -1,15 +1,11 @@
 // tags/child.marko
 const $template = "<div> </div>";
-const $setup = () => {};
 const $name = ($scope, name) => _text($scope.a, name);
 
 // template.marko
 const $for_content2__outer__OR__inner = /* @__PURE__ */ _or(3, ($scope) => $name($scope.a, `${$scope._.c}.${$scope.c}`));
 const $for_content2__outer = /* @__PURE__ */ _for_closure(0, $for_content2__outer__OR__inner);
-const $for_content2__setup = ($scope) => {
-	$for_content2__outer._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
+const $for_content2__setup = $for_content2__outer;
 const $for_content2__inner = /* @__PURE__ */ _const(2, $for_content2__outer__OR__inner);
 const $for_content2__$params = ($scope, $params3) => $for_content2__inner($scope, $params3[0]);
 const $for_content__for = /* @__PURE__ */ _for_of(0, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $for_content2__setup, $for_content2__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7643,
-        "brotli": 3481
+        "min": 7629,
+        "brotli": 3478
       },
       "files": {
-        "tags/child.marko": 154,
-        "template.marko": 1404
+        "tags/child.marko": 129,
+        "template.marko": 1341
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/__snapshots__/dom.bundle.debug.js
@@ -17,8 +17,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
 	$pattern3($scope, {
 		a: "A",
 		aChange(v) {}

--- a/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/__snapshots__/dom.bundle.debug.js
@@ -11,10 +11,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", "", 
 const $template = "<!><!><!>";
 const $walks = "b%c";
 const $if_content__setter = /* @__PURE__ */ _if_closure("#text/0", 0, ($scope) => $input_valueChange($scope["#childScope/0"], $valueChange($scope)));
-const $if_content__setup = ($scope) => {
-	$if_content__setter._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__setter;
 const $setter2 = /* @__PURE__ */ _const("setter");
 const $if = /* @__PURE__ */ _if("#text/0", "", /* @__PURE__ */ ((_w0) => `/${_w0}&`)(""), $if_content__setup);
 function $setup($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.debug.js
@@ -29,10 +29,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $template = "<button>Toggle</button><div></div><!><!>";
 const $walks = " b b%c";
 const $for_content__write = /* @__PURE__ */ _for_closure("#text/2", ($scope) => $write$1($scope["#childScope/0"], $scope._.write));
-const $for_content__setup = ($scope) => {
-	$for_content__write._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $for_content__setup = $for_content__write;
 const $for_content__item = ($scope, item) => $name($scope["#childScope/0"], item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $for = /* @__PURE__ */ _for_of("#text/2", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1), $for_content__setup, $for_content__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // tags/child.marko
 const $template = "<div> </div><span> </span><p> </p>";
 const $walks = "D lD lD l";
-const $setup = () => {};
 const $input_name__OR__input_write__script = _script("b0", ($scope) => {
 	$scope.g(`mounted ${$scope.f}`);
 	$signal($scope, 0).onabort = () => {
@@ -21,11 +20,7 @@ const $name = /* @__PURE__ */ _const(5, ($scope) => {
 const $write$1 = /* @__PURE__ */ _const(6, $input_name__OR__input_write);
 
 // template.marko
-const $for_content__write = /* @__PURE__ */ _for_closure(2, ($scope) => $write$1($scope.a, $scope._.e));
-const $for_content__setup = ($scope) => {
-	$for_content__write._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
+const $for_content__setup = /* @__PURE__ */ _for_closure(2, ($scope) => $write$1($scope.a, $scope._.e));
 const $for_content__item = ($scope, item) => $name($scope.a, item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $for = /* @__PURE__ */ _for_of(2, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $for_content__setup, $for_content__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7889,
-        "brotli": 3588
+        "min": 7871,
+        "brotli": 3572
       },
       "files": {
-        "tags/child.marko": 745,
-        "template.marko": 922
+        "tags/child.marko": 720,
+        "template.marko": 810
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.debug.js
@@ -31,7 +31,6 @@ const $walks = " b b b b%c";
 const $if_content3__write = /* @__PURE__ */ _closure_get("write", ($scope) => $write$1($scope["#childScope/0"], $scope._._._.write), ($scope) => $scope._._._);
 const $if_content3__setup = ($scope) => {
 	$if_content3__write($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Inner");
 };
 const $if_content2__if = /* @__PURE__ */ _if("#text/1", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1), $if_content3__setup);
@@ -39,7 +38,6 @@ const $if_content2__showInner = /* @__PURE__ */ _closure_get("showInner", ($scop
 const $if_content2__setup = ($scope) => {
 	$if_content2__showInner($scope);
 	$if_content2__write($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Middle");
 };
 const $if_content2__write = /* @__PURE__ */ _closure_get("write", ($scope) => $write$1($scope["#childScope/0"], $scope._._.write), ($scope) => $scope._._);
@@ -48,7 +46,6 @@ const $if_content__showMiddle = /* @__PURE__ */ _if_closure("#text/4", 0, ($scop
 const $if_content__setup = ($scope) => {
 	$if_content__showMiddle._($scope);
 	$if_content__write._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Outer");
 };
 const $if_content__write = /* @__PURE__ */ _if_closure("#text/4", 0, ($scope) => $write$1($scope["#childScope/0"], $scope._.write));

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // tags/child.marko
 const $template = "<div><!> a</div><span><!> a</span><p><!> a</p>";
 const $walks = "D%lD%lD%l";
-const $setup = () => {};
 const $input_name__OR__input_write__script = _script("b0", ($scope) => {
 	$scope.g(`${$scope.f} mounted`);
 	$signal($scope, 0).onabort = () => {
@@ -24,7 +23,6 @@ const $write$1 = /* @__PURE__ */ _const(6, $input_name__OR__input_write);
 const $if_content3__write = /* @__PURE__ */ _closure_get(8, ($scope) => $write$1($scope.a, $scope._._._.i), ($scope) => $scope._._._);
 const $if_content3__setup = ($scope) => {
 	$if_content3__write($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Inner");
 };
 const $if_content2__if = /* @__PURE__ */ _if(1, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $if_content3__setup);
@@ -32,7 +30,6 @@ const $if_content2__showInner = /* @__PURE__ */ _closure_get(7, ($scope) => $if_
 const $if_content2__setup = ($scope) => {
 	$if_content2__showInner($scope);
 	$if_content2__write($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Middle");
 };
 const $if_content2__write = /* @__PURE__ */ _closure_get(8, ($scope) => $write$1($scope.a, $scope._._.i), ($scope) => $scope._._);
@@ -41,7 +38,6 @@ const $if_content__showMiddle = /* @__PURE__ */ _if_closure(4, 0, ($scope) => $i
 const $if_content__setup = ($scope) => {
 	$if_content__showMiddle._($scope);
 	$if_content__write._($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Outer");
 };
 const $if_content__write = /* @__PURE__ */ _if_closure(4, 0, ($scope) => $write$1($scope.a, $scope._.i));

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7660,
-        "brotli": 3367
+        "min": 7648,
+        "brotli": 3365
       },
       "files": {
-        "tags/child.marko": 757,
-        "template.marko": 2290
+        "tags/child.marko": 732,
+        "template.marko": 2185
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.debug.js
@@ -17,10 +17,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";
 const $walks = " b b%c";
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	$input($scope["#childScope/0"], { write: $write($scope) });
-};
+const $if_content__setup = ($scope) => $input($scope["#childScope/0"], { write: $write($scope) });
 const $if = /* @__PURE__ */ _if("#text/2", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("d"), $if_content__setup);
 const $show = /* @__PURE__ */ _let("show/3", ($scope) => $if($scope, $scope.show ? 0 : 1));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<div>a</div><span>b</span><p>c</p>";
-const $setup = () => {};
 const $input__script = _script("b0", ($scope) => {
 	$scope.b.write("mounted");
 	$signal($scope, 0).onabort = () => {
@@ -13,10 +12,7 @@ const $input = /* @__PURE__ */ _const(1, ($scope) => {
 });
 
 // template.marko
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup($scope.a);
-	$input($scope.a, { write: $write($scope) });
-};
+const $if_content__setup = ($scope) => $input($scope.a, { write: $write($scope) });
 const $if = /* @__PURE__ */ _if(2, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("d"), $if_content__setup);
 const $show = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6390,
-        "brotli": 2897
+        "min": 6384,
+        "brotli": 2896
       },
       "files": {
-        "tags/child.marko": 387,
-        "template.marko": 586
+        "tags/child.marko": 362,
+        "template.marko": 545
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.debug.js
@@ -27,7 +27,6 @@ const $for_content2__write = /* @__PURE__ */ _closure_get("write", ($scope) => $
 const $for_content2__setup = ($scope) => {
 	$for_content2__write($scope);
 	$for_content2__outerItem._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 };
 const $for_content2__outerItem__OR__middleItem = /* @__PURE__ */ _or(3, ($scope) => $name($scope["#childScope/0"], `${$scope._.outerItem}.${$scope.middleItem}`));
 const $for_content2__outerItem = /* @__PURE__ */ _for_closure("#text/1", $for_content2__outerItem__OR__middleItem);
@@ -38,7 +37,6 @@ const $for_content__items = /* @__PURE__ */ _for_closure("#text/2", ($scope) => 
 const $for_content__setup = ($scope) => {
 	$for_content__items._($scope);
 	$for_content__write._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 };
 const $for_content__write = /* @__PURE__ */ _for_closure("#text/2", ($scope) => $write$1($scope["#childScope/0"], $scope._.write));
 const $for_content__outerItem = /* @__PURE__ */ _const("outerItem", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<div> </div>";
-const $setup = () => {};
 const $input_name__OR__input_write__script = _script("b0", ($scope) => $signal($scope, 0).onabort = () => {
 	$scope.e(`destroyed ${$scope.d}`);
 });
@@ -19,7 +18,6 @@ const $for_content2__write = /* @__PURE__ */ _closure_get(4, ($scope) => $write$
 const $for_content2__setup = ($scope) => {
 	$for_content2__write($scope);
 	$for_content2__outerItem._($scope);
-	/* @__PURE__ */ $setup($scope.a);
 };
 const $for_content2__outerItem__OR__middleItem = /* @__PURE__ */ _or(3, ($scope) => $name($scope.a, `${$scope._.d}.${$scope.c}`));
 const $for_content2__outerItem = /* @__PURE__ */ _for_closure(1, $for_content2__outerItem__OR__middleItem);
@@ -30,7 +28,6 @@ const $for_content__items = /* @__PURE__ */ _for_closure(2, ($scope) => $for_con
 const $for_content__setup = ($scope) => {
 	$for_content__items._($scope);
 	$for_content__write._($scope);
-	/* @__PURE__ */ $setup($scope.a);
 };
 const $for_content__write = /* @__PURE__ */ _for_closure(2, ($scope) => $write$1($scope.a, $scope._.e));
 const $for_content__outerItem = /* @__PURE__ */ _const(3, ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8343,
-        "brotli": 3739
+        "min": 8335,
+        "brotli": 3748
       },
       "files": {
-        "tags/child.marko": 597,
-        "template.marko": 2169
+        "tags/child.marko": 572,
+        "template.marko": 2099
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.debug.js
@@ -27,10 +27,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $template = "<button>Toggle</button><div></div><!><!>";
 const $walks = " b b%c";
 const $for_content__write = /* @__PURE__ */ _for_closure("#text/2", ($scope) => $write$1($scope["#childScope/0"], $scope._.write));
-const $for_content__setup = ($scope) => {
-	$for_content__write._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $for_content__setup = $for_content__write;
 const $for_content__item = ($scope, item) => $name($scope["#childScope/0"], item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $for = /* @__PURE__ */ _for_of("#text/2", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $for_content__setup, $for_content__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<div> </div>";
-const $setup = () => {};
 const $input_name__OR__input_write__script = _script("b0", ($scope) => {
 	$scope.e(`mounted ${$scope.d}`);
 	$signal($scope, 0).onabort = () => {
@@ -18,11 +17,7 @@ const $name = /* @__PURE__ */ _const(3, ($scope) => {
 const $write$1 = /* @__PURE__ */ _const(4, $input_name__OR__input_write);
 
 // template.marko
-const $for_content__write = /* @__PURE__ */ _for_closure(2, ($scope) => $write$1($scope.a, $scope._.e));
-const $for_content__setup = ($scope) => {
-	$for_content__write._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
+const $for_content__setup = /* @__PURE__ */ _for_closure(2, ($scope) => $write$1($scope.a, $scope._.e));
 const $for_content__item = ($scope, item) => $name($scope.a, item);
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
 const $for = /* @__PURE__ */ _for_of(2, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $for_content__setup, $for_content__$params);

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7839,
-        "brotli": 3560
+        "min": 7819,
+        "brotli": 3551
       },
       "files": {
-        "tags/child.marko": 639,
-        "template.marko": 921
+        "tags/child.marko": 614,
+        "template.marko": 809
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.debug.js
@@ -29,7 +29,6 @@ const $walks = " b b b b%c";
 const $if_content3__write = /* @__PURE__ */ _closure_get("write", ($scope) => $write$1($scope["#childScope/0"], $scope._._._.write), ($scope) => $scope._._._);
 const $if_content3__setup = ($scope) => {
 	$if_content3__write($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Inner");
 };
 const $if_content2__if = /* @__PURE__ */ _if("#text/1", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $if_content3__setup);
@@ -37,7 +36,6 @@ const $if_content2__showInner = /* @__PURE__ */ _closure_get("showInner", ($scop
 const $if_content2__setup = ($scope) => {
 	$if_content2__showInner($scope);
 	$if_content2__write($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Middle");
 };
 const $if_content2__write = /* @__PURE__ */ _closure_get("write", ($scope) => $write$1($scope["#childScope/0"], $scope._._.write), ($scope) => $scope._._);
@@ -46,7 +44,6 @@ const $if_content__showMiddle = /* @__PURE__ */ _if_closure("#text/4", 0, ($scop
 const $if_content__setup = ($scope) => {
 	$if_content__showMiddle._($scope);
 	$if_content__write._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$name($scope["#childScope/0"], "Outer");
 };
 const $if_content__write = /* @__PURE__ */ _if_closure("#text/4", 0, ($scope) => $write$1($scope["#childScope/0"], $scope._.write));

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<p> </p>";
-const $setup = () => {};
 const $input_name__OR__input_write__script = _script("b0", ($scope) => {
 	$scope.e(`${$scope.d} mounted`);
 	$signal($scope, 0).onabort = () => {
@@ -21,7 +20,6 @@ const $write$1 = /* @__PURE__ */ _const(4, $input_name__OR__input_write);
 const $if_content3__write = /* @__PURE__ */ _closure_get(8, ($scope) => $write$1($scope.a, $scope._._._.i), ($scope) => $scope._._._);
 const $if_content3__setup = ($scope) => {
 	$if_content3__write($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Inner");
 };
 const $if_content2__if = /* @__PURE__ */ _if(1, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("D l"), $if_content3__setup);
@@ -29,7 +27,6 @@ const $if_content2__showInner = /* @__PURE__ */ _closure_get(7, ($scope) => $if_
 const $if_content2__setup = ($scope) => {
 	$if_content2__showInner($scope);
 	$if_content2__write($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Middle");
 };
 const $if_content2__write = /* @__PURE__ */ _closure_get(8, ($scope) => $write$1($scope.a, $scope._._.i), ($scope) => $scope._._);
@@ -38,7 +35,6 @@ const $if_content__showMiddle = /* @__PURE__ */ _if_closure(4, 0, ($scope) => $i
 const $if_content__setup = ($scope) => {
 	$if_content__showMiddle._($scope);
 	$if_content__write._($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$name($scope.a, "Outer");
 };
 const $if_content__write = /* @__PURE__ */ _if_closure(4, 0, ($scope) => $write$1($scope.a, $scope._.i));

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7594,
-        "brotli": 3342
+        "min": 7582,
+        "brotli": 3339
       },
       "files": {
-        "tags/child.marko": 635,
-        "template.marko": 2287
+        "tags/child.marko": 610,
+        "template.marko": 2182
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.debug.js
@@ -17,10 +17,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";
 const $walks = " b b%c";
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	$input($scope["#childScope/0"], { write: $write($scope) });
-};
+const $if_content__setup = ($scope) => $input($scope["#childScope/0"], { write: $write($scope) });
 const $if = /* @__PURE__ */ _if("#text/2", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup);
 const $show = /* @__PURE__ */ _let("show/3", ($scope) => $if($scope, $scope.show ? 0 : 1));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<div>child</div>";
-const $setup = () => {};
 const $input__script = _script("b0", ($scope) => {
 	$scope.b.write("mounted");
 	$signal($scope, 0).onabort = () => {
@@ -13,10 +12,7 @@ const $input = /* @__PURE__ */ _const(1, ($scope) => {
 });
 
 // template.marko
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup($scope.a);
-	$input($scope.a, { write: $write($scope) });
-};
+const $if_content__setup = ($scope) => $input($scope.a, { write: $write($scope) });
 const $if = /* @__PURE__ */ _if(2, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup);
 const $show = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6372,
+        "min": 6366,
         "brotli": 2888
       },
       "files": {
-        "tags/child.marko": 369,
-        "template.marko": 586
+        "tags/child.marko": 344,
+        "template.marko": 545
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/__snapshots__/dom.bundle.debug.js
@@ -15,12 +15,10 @@ function formatNumber2(n) {
 	return "$" + n.toFixed(2);
 }
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], {
 		value: 1,
 		format: formatNumber
 	});
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input($scope["#childScope/1"], {
 		value: 1.1111,
 		format: formatNumber2

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
@@ -31,7 +31,6 @@ const $count = /* @__PURE__ */ _let("count/1", ($scope) => {
 	$count__closure($scope);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$count($scope, 0);
 }
 function $onClick($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c");
 const $section_content2 = /* @__PURE__ */ _content("__tests__/template.marko_2_content", "<div>that never changes</div>", "b");
 const $section_content = /* @__PURE__ */ _content("__tests__/template.marko_1_content", "<div>static content</div>", "b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_section($scope["#childScope/0"], attrTags(attrTag({ content: $section_content($scope) }), { content: $section_content2($scope) }));
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/dom.bundle.debug.js
@@ -23,7 +23,6 @@ const $checked = /* @__PURE__ */ _let("checked/2", ($scope) => {
 	_text($scope["#text/1"], String($scope.checked));
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$checked($scope, false);
 }
 function $checkedChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/dom.bundle.debug.js
@@ -38,9 +38,6 @@ const $checkedValue = /* @__PURE__ */ _let("checkedValue/4", ($scope) => {
 });
 const $checkedValueChange3 = /* @__PURE__ */ _const("$checkedValueChange", $checkedValue__OR__$checkedValueChange);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$checkedValue($scope, "a");
 	$checkedValueChange3($scope, $checkedValueChange2($scope));
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.bundle.debug.js
@@ -38,9 +38,6 @@ const $checkedValue = /* @__PURE__ */ _let("checkedValue/4", ($scope) => {
 });
 const $checkedValueChange3 = /* @__PURE__ */ _const("$checkedValueChange", $checkedValue__OR__$checkedValueChange);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$checkedValue($scope, ["a", "b"]);
 	$checkedValueChange3($scope, $checkedValueChange2($scope));
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $open = /* @__PURE__ */ _let("open/2", ($scope) => {
 	_text($scope["#text/1"], String($scope.open));
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$open($scope, false);
 }
 function $openChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $open = /* @__PURE__ */ _let("open/2", ($scope) => {
 	_text($scope["#text/1"], String($scope.open));
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$open($scope, true);
 }
 function $openChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,6 @@ const $value = /* @__PURE__ */ _let("value/2", ($scope) => {
 	_text($scope["#text/1"], $scope.value);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$value($scope, "hello");
 }
 function $valueChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,6 @@ const $value = /* @__PURE__ */ _let("value/2", ($scope) => {
 	_text($scope["#text/1"], $scope.value);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$value($scope, "b");
 }
 function $valueChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $value = /* @__PURE__ */ _let("value/2", ($scope) => {
 	_text($scope["#text/1"], $scope.value);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$value($scope, "hello");
 }
 function $valueChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.bundle.debug.js
@@ -12,9 +12,7 @@ const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $t
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&`)("%c", "%c");
 const $x = /* @__PURE__ */ _let("x/2", ($scope) => $input_value($scope["#childScope/1"], $scope.x));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], 3);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$x($scope, "y");
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,33 @@
+// tags/cell/index.marko
+const $template$2 = "<span class=cell> </span>";
+const $walks$2 = "D l";
+const $setup$2 = () => {};
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $input$1 = ($scope, input) => $input_value($scope, input.value);
+var cell_default = /* @__PURE__ */ _template("__tests__/tags/cell/index.marko", $template$2, "D l", $setup$2, $input$1);
+
+// tags/row/index.marko
+const $template$1 = /* @__PURE__ */ ((_w0, _w1) => `<div class=row>${_w0}${_w1}</div>`)($template$2, $template$2);
+const $walks$1 = /* @__PURE__ */ ((_w0, _w1) => `D/${_w0}&/${_w1}&l`)("D l", "D l");
+const $setup$1 = () => {};
+const $input_name = ($scope, input_name) => $input_value($scope["#childScope/0"], input_name);
+const $input_quantity = ($scope, input_quantity) => $input_value($scope["#childScope/1"], input_quantity);
+const $input = ($scope, input) => {
+	$input_name($scope, input.name);
+	$input_quantity($scope, input.quantity);
+};
+var row_default = /* @__PURE__ */ _template("__tests__/tags/row/index.marko", $template$1, $walks$1, $setup$1, $input);
+
+// template.marko
+const $template = /* @__PURE__ */ ((_w0) => `<button>add</button>${_w0}`)($template$1);
+const $walks = /* @__PURE__ */ ((_w0) => ` b/${_w0}&`)($walks$1);
+const $quantity = /* @__PURE__ */ _let("quantity/2", ($scope) => $input_quantity($scope["#childScope/1"], $scope.quantity));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$quantity($scope, $scope.quantity + 1);
+}));
+function $setup($scope) {
+	$input_name($scope["#childScope/1"], "Widget");
+	$quantity($scope, 2);
+	$setup__script($scope);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// tags/cell/index.marko
+const $input_value = ($scope, input_value) => _text($scope.a, input_value);
+
+// tags/row/index.marko
+const $input_quantity = ($scope, input_quantity) => $input_value($scope.b, input_quantity);
+
+// template.marko
+const $quantity = /* @__PURE__ */ _let(2, ($scope) => $input_quantity($scope.b, $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$quantity($scope, $scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,45 @@
+// tags/cell/index.marko
+var cell_default = _template("__tests__/tags/cell/index.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<span class=cell>${_escape(input.value)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</span>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/cell/index.marko", 0);
+});
+
+// tags/row/index.marko
+var row_default = _template("__tests__/tags/row/index.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div class=row>");
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	cell_default({ value: input.name });
+	const $childScope2 = _peek_scope_id();
+	_set_serialize_reason(_serialize_guard($scope0_reason, 2));
+	cell_default({ value: input.quantity });
+	_html("</div>");
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
+		"#childScope/0": _serialize_if($scope0_reason, 1) && _existing_scope($childScope),
+		"#childScope/1": _serialize_if($scope0_reason, 2) && _existing_scope($childScope2)
+	}, "__tests__/tags/row/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let quantity = 2;
+	_html(`<button>add</button>${_el_resume($scope0_id, "#button/0")}`);
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(10);
+	row_default({
+		name: "Widget",
+		quantity
+	});
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		quantity,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { quantity: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
@@ -1,0 +1,45 @@
+// tags/cell/index.marko
+var cell_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<span class=cell>${_escape(input.value)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</span>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// tags/row/index.marko
+var row_default = _template("c", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div class=row>");
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	cell_default({ value: input.name });
+	const $childScope2 = _peek_scope_id();
+	_set_serialize_reason(_serialize_guard($scope0_reason, 2));
+	cell_default({ value: input.quantity });
+	_html("</div>");
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
+		a: _serialize_if($scope0_reason, 1) && _existing_scope($childScope),
+		b: _serialize_if($scope0_reason, 2) && _existing_scope($childScope2)
+	});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let quantity = 2;
+	_html(`<button>add</button>${_el_resume($scope0_id, "a")}`);
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(10);
+	row_default({
+		name: "Widget",
+		quantity
+	});
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: quantity,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/render.debug.md
@@ -1,0 +1,48 @@
+# Render
+```html
+<button>
+  add
+</button>
+<div
+  class="row"
+>
+  <span
+    class="cell"
+  >
+    Widget
+  </span>
+  <span
+    class="cell"
+  >
+    2
+  </span>
+</div>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  add
+</button>
+<div
+  class="row"
+>
+  <span
+    class="cell"
+  >
+    Widget
+  </span>
+  <span
+    class="cell"
+  >
+    3
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .row > span:nth-of-type(2)::text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/render.md
@@ -1,0 +1,48 @@
+# Render
+```html
+<button>
+  add
+</button>
+<div
+  class="row"
+>
+  <span
+    class="cell"
+  >
+    Widget
+  </span>
+  <span
+    class="cell"
+  >
+    2
+  </span>
+</div>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<button>
+  add
+</button>
+<div
+  class="row"
+>
+  <span
+    class="cell"
+  >
+    Widget
+  </span>
+  <span
+    class="cell"
+  >
+    3
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .row > span:nth-of-type(2)::text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<button>add</button><!--M_*1 #button/0-->
+<div class=row><span class=cell>Widget</span><span
+    class=cell>2<!--M_*4 #text/0--></span></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      quantity: 2,
+      "#childScope/1": _(2)
+    }, {
+      "#childScope/1": _(4)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/writes.html
@@ -1,0 +1,13 @@
+<button>add</button><!--M_*1 a-->
+<div class=row><span class=cell>Widget</span><span
+    class=cell>2<!--M_*4 a--></span></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 2,
+    b: _(2)
+  }, {
+    b: _(4)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2654,
+        "brotli": 1339
+      },
+      "files": {
+        "tags/cell/index.marko": 121,
+        "tags/row/index.marko": 136,
+        "template.marko": 254
+      }
+    }
+  },
+  "html": {
+    "min": 446,
+    "brotli": 280
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/tags/cell/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/tags/cell/index.marko
@@ -1,0 +1,1 @@
+<span class="cell">${input.value}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/tags/row/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/tags/row/index.marko
@@ -1,0 +1,4 @@
+<div class="row">
+  <cell value=input.name/>
+  <cell value=input.quantity/>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/template.marko
@@ -1,0 +1,3 @@
+<let/quantity = 2/>
+<button onClick() { quantity++ }>add</button>
+<row name="Widget" quantity=quantity/>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    (container: Element) =>
+      container.querySelector<HTMLButtonElement>("button")!.click(),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$count($scope, $scope.count + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_onPress($scope["#childScope/1"], $onPress($scope));
 	$count($scope, 0);
 	$log($scope, "");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$count($scope, $scope.count + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$count($scope, 0);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,6 @@ var hello_default = /* @__PURE__ */ _template("__tests__/hello.marko", $template
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b%c");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_name($scope["#childScope/0"], "Frank");
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.debug.js
@@ -24,7 +24,6 @@ const $child_content = _content_resume("__tests__/template.marko_1_content", " "
 const $value__closure = /* @__PURE__ */ _closure($child_content__value);
 const $value = /* @__PURE__ */ _let("value/1", $value__closure);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$valueChange2($scope["#childScope/0"], $valueChange($scope));
 	$rest($scope["#childScope/0"], { content: $child_content($scope) });
 	$value($scope, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
@@ -38,7 +38,6 @@ const $clear__script = _script("__tests__/template.marko_0_clear", ($scope) => _
 const $clear = /* @__PURE__ */ _const("clear", $clear__script);
 function $setup($scope) {
 	_var($scope, "#childScope/0", $store);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], ["Learn Marko", "Make a Website"]);
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,5 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", "", 
 // template.marko
 const $template = /* @__PURE__ */ ((_w0) => `<div>${_w0}</div>`)("");
 const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&l`)("");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
@@ -16,10 +16,7 @@ var list_default = /* @__PURE__ */ _template("__tests__/tags/list.marko", $templ
 const $template = "<button id=o>O</button><button id=c>C</button><!><!>";
 const $walks = " b b%c";
 const $if_content__count = /* @__PURE__ */ _if_closure("#text/2", 0, ($scope) => $count$1($scope["#childScope/0"], $scope._.count));
-const $if_content__setup = ($scope) => {
-	$if_content__count._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__count;
 const $if = /* @__PURE__ */ _if("#text/2", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /* @__PURE__ */ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $count = /* @__PURE__ */ _let("count/4", $if_content__count);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/list.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $for_content__setup = ($scope) => _text($scope.a, $scope.M);
 const $for = /* @__PURE__ */ _for_to(0, "<li>item <!></li>", "Db%l", $for_content__setup);
 const $count$1 = ($scope, count) => $for($scope, [
@@ -11,11 +10,7 @@ const $count$1 = ($scope, count) => $for($scope, [
 
 // template.marko
 const $if_content__count = /* @__PURE__ */ _if_closure(2, 0, ($scope) => $count$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__count._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__count);
 const $outer = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $count = /* @__PURE__ */ _let(4, $if_content__count);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7756,
-        "brotli": 3541
+        "min": 7742,
+        "brotli": 3533
       },
       "files": {
-        "tags/list.marko": 323,
-        "template.marko": 755
+        "tags/list.marko": 298,
+        "template.marko": 645
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
@@ -22,10 +22,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=a>A</button><!><!>";
 const $walks = "b b b%c";
 const $if_content__count = /* @__PURE__ */ _if_closure("#text/2", 0, ($scope) => $count$1($scope["#childScope/0"], $scope._.count));
-const $if_content__setup = ($scope) => {
-	$if_content__count._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__count;
 const $if = /* @__PURE__ */ _if("#text/2", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /* @__PURE__ */ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $count = /* @__PURE__ */ _let("count/4", $if_content__count);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $for_content__setup__script = _script("b0", ($scope) => _lifecycle($scope, { onDestroy: function() {
 	document.getElementById("ref").textContent = "item destroyed";
 } }));
@@ -17,11 +16,7 @@ const $count$1 = ($scope, count) => $for($scope, [
 
 // template.marko
 const $if_content__count = /* @__PURE__ */ _if_closure(2, 0, ($scope) => $count$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__count._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__count);
 const $outer = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $count = /* @__PURE__ */ _let(4, $if_content__count);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8102,
-        "brotli": 3678
+        "min": 8088,
+        "brotli": 3671
       },
       "files": {
-        "tags/child.marko": 544,
-        "template.marko": 755
+        "tags/child.marko": 519,
+        "template.marko": 645
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
@@ -19,7 +19,6 @@ const $for_content2__ref_getter = _hoist_resume("__tests__/template.marko_2_ref/
 const $for_content2__setup__script = _script("__tests__/template.marko_2", ($scope) => _el_read($scope._._["#pre/2"]).innerHTML += `${[...$for_content2__ref_getter($scope)].length}; ${$for_content2__ref_getter($scope)()}\n\t`);
 const $for_content2__setup = ($scope) => {
 	_var($scope, "#childScope/0", $for_content2__ref);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], `${$scope._["#LoopKey"]},${$scope["#LoopKey"]}`);
 	$for_content2__setup__script($scope);
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -31,7 +31,6 @@ const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&0${_w1}&`)("", " b");
 const $api_getter = /* @__PURE__ */ _hoist("api");
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => $api_getter($scope)().setHtml("works"));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { action: $action($scope) });
 	_var($scope, "#childScope/1", $api);
 	$setup$1($scope["#childScope/1"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -24,7 +24,6 @@ const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)("", $template$1
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&0${_w1}&`)("", " b");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml/hoist", "setHtml");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], $setHtml_getter($scope));
 	_var($scope, "#childScope/1", $setHtml);
 	$setup$1($scope["#childScope/1"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
@@ -58,7 +58,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	$setHtml2_getter($scope)()("Hello world");
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_value($scope["#childScope/1"], $setHtml_getter($scope));
 	$if2($scope, true ? 0 : 1);
 	$if3($scope, true ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
@@ -52,7 +52,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	$setHtml2_getter($scope)()("Hello world");
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_value($scope["#childScope/1"], $setHtml_getter($scope));
 	$if2($scope, true ? 0 : 1);
 	$if3($scope, true ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/__snapshots__/dom.bundle.debug.js
@@ -13,7 +13,6 @@ const $x_getter = /* @__PURE__ */ _hoist("x");
 const $x = /* @__PURE__ */ _const("x", ($scope) => _assert_hoist($scope.x));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => $x_getter($scope)());
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_fn($scope["#childScope/0"], () => $x_getter($scope)());
 	$x($scope, 1);
 	$setup__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -11,9 +11,7 @@ const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}<div></div>${_w1}`)("", 
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}& b/${_w1}&`)("", "");
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _el_read($scope["#div/1"]).innerHTML = "works");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { action: $action($scope) });
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input($scope["#childScope/2"], { action: $action2($scope) });
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -11,9 +11,7 @@ const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}<div></div>${_w1}`)("", 
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}& b/${_w1}&`)("", "");
 const $el_getter = _hoist_resume("__tests__/template.marko_0_#div/hoist", "#div/1");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { value: $el_getter($scope) });
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input($scope["#childScope/2"], { value: $el_getter($scope) });
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
@@ -23,7 +23,6 @@ const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, ""
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&0${_w1}&`)(" b", "");
 const $x_getter = _hoist_resume("__tests__/template.marko_0_x/hoist", "x");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { y: $x_getter($scope) });
 	_var($scope, "#childScope/1", $x);
 	$setup$1($scope["#childScope/1"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
@@ -16,10 +16,7 @@ var leaf_default = /* @__PURE__ */ _template("__tests__/tags/leaf.marko", $templ
 const $template = "<button id=o>O</button><button id=n>N</button><!><!>";
 const $walks = " b b%c";
 const $if_content__n = /* @__PURE__ */ _if_closure("#text/2", 0, ($scope) => $n$1($scope["#childScope/0"], $scope._.n));
-const $if_content__setup = ($scope) => {
-	$if_content__n._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__n;
 const $if = /* @__PURE__ */ _if("#text/2", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /* @__PURE__ */ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $n = /* @__PURE__ */ _let("n/4", $if_content__n);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/leaf.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $if_content__input_n = /* @__PURE__ */ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.d));
 const $if$1 = /* @__PURE__ */ _if(0, "<div>n is <!></div>", "Db%l", $if_content__input_n);
 const $n$1 = /* @__PURE__ */ _const(3, ($scope) => {
@@ -10,11 +9,7 @@ const $n$1 = /* @__PURE__ */ _const(3, ($scope) => {
 
 // template.marko
 const $if_content__n = /* @__PURE__ */ _if_closure(2, 0, ($scope) => $n$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__n._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__n);
 const $outer = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $n = /* @__PURE__ */ _let(4, $if_content__n);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6490,
-        "brotli": 2946
+        "min": 6476,
+        "brotli": 2938
       },
       "files": {
-        "tags/leaf.marko": 413,
-        "template.marko": 731
+        "tags/leaf.marko": 388,
+        "template.marko": 621
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.debug.js
@@ -23,10 +23,7 @@ var wrapper_default = /* @__PURE__ */ _template("__tests__/tags/wrapper.marko", 
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=s>S</button><!><!>";
 const $walks = "b b b%c";
 const $if_content__show = /* @__PURE__ */ _if_closure("#text/2", 0, ($scope) => $show$1($scope["#childScope/0"], $scope._.show));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__show;
 const $if = /* @__PURE__ */ _if("#text/2", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /* @__PURE__ */ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $show = /* @__PURE__ */ _let("show/4", $if_content__show);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.js
@@ -3,24 +3,19 @@ const $template$1 = "<p>leaf</p>";
 const $setup__script$1 = _script("b0", ($scope) => _lifecycle($scope, { onDestroy: function() {
 	document.getElementById("ref").textContent = "leaf destroyed";
 } }));
-const $setup$1 = $setup__script$1;
+const $setup = $setup__script$1;
 
 // tags/wrapper.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
-const $if_content__setup$1 = ($scope) => {
-	$setup$1($scope.a);
+const $if_content__setup = ($scope) => {
+	$setup($scope.a);
 };
-const $if$1 = /* @__PURE__ */ _if(0, $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup$1);
+const $if$1 = /* @__PURE__ */ _if(0, $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b"), $if_content__setup);
 const $show$1 = ($scope, show) => $if$1($scope, show ? 0 : 1);
 
 // template.marko
 const $if_content__show = /* @__PURE__ */ _if_closure(2, 0, ($scope) => $show$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__show);
 const $outer = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $show = /* @__PURE__ */ _let(4, $if_content__show);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6635,
-        "brotli": 3001
+        "min": 6621,
+        "brotli": 2993
       },
       "files": {
-        "tags/leaf.marko": 276,
-        "tags/wrapper.marko": 345,
-        "template.marko": 746
+        "tags/leaf.marko": 274,
+        "tags/wrapper.marko": 314,
+        "template.marko": 636
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
@@ -15,10 +15,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=s>S</button><!><!>";
 const $walks = "b b b%c";
 const $if_content__show = /* @__PURE__ */ _if_closure("#text/2", 0, ($scope) => $show$1($scope["#childScope/0"], $scope._.show));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__show;
 const $if = /* @__PURE__ */ _if("#text/2", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$1), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /* @__PURE__ */ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $show = /* @__PURE__ */ _let("show/4", $if_content__show);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $if$1 = /* @__PURE__ */ _if(0, "<p>inner</p>", "b", _script("b0", ($scope) => _lifecycle($scope, { onDestroy: function() {
 	document.getElementById("ref").textContent = "inner destroyed";
 } })));
@@ -8,11 +7,7 @@ const $show$1 = ($scope, show) => $if$1($scope, show ? 0 : 1);
 
 // template.marko
 const $if_content__show = /* @__PURE__ */ _if_closure(2, 0, ($scope) => $show$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /* @__PURE__ */ _if(2, /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__show);
 const $outer = /* @__PURE__ */ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $show = /* @__PURE__ */ _let(4, $if_content__show);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6606,
-        "brotli": 2989
+        "min": 6592,
+        "brotli": 2981
       },
       "files": {
-        "tags/child.marko": 361,
-        "template.marko": 746
+        "tags/child.marko": 336,
+        "template.marko": 636
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.bundle.debug.js
@@ -7,8 +7,5 @@ var baz_default = /* @__PURE__ */ _template("__tests__/tags/baz.marko", $templat
 // template.marko
 const $template = /* @__PURE__ */ ((_w0, _w1) => `<!>${_w0}${_w1}<!>`)($template$1, $template$1);
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `b/${_w0}&/${_w1}&b`)("b", "b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
-}
+const $setup = () => {};
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.bundle.debug.js
@@ -14,9 +14,6 @@ var baz_default = /* @__PURE__ */ _template("__tests__/tags/baz.marko", $templat
 const $template = /* @__PURE__ */ ((_w0, _w1, _w2) => `<!>${_w0}${_w1}${_w2}<!>`)($template$1, $template$1, $template$1);
 const $walks = /* @__PURE__ */ ((_w0, _w1, _w2) => `b/${_w0}&/${_w1}&/${_w2}&%b`)("b", "b", "b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	_text($scope["#text/3"], "b");
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/dom.bundle.debug.js
@@ -19,7 +19,6 @@ const $value = /* @__PURE__ */ _let("value/1", ($scope) => $input($scope["#child
 	valueChange: $valueChange($scope)
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$value($scope, "hi");
 }
 function $valueChange($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$n($scope, 1);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.bundle.debug.js
@@ -14,6 +14,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $Child_content__walks = "D lD l", $Child_content__template = "<div> </div><div> </div>";
 const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}<!>`)($template$1, $Child_content__template);
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&b`)($walks$1, $Child_content__walks);
+const $setup = () => {};
 const $Child_content__input_a = ($scope, input_a) => _text($scope["#text/0"], input_a);
 const $Child_content__input_b = ($scope, input_b) => _text($scope["#text/1"], input_b);
 const $Child_content__$params = ($scope, $params2) => $Child_content__input($scope, $params2[0]);
@@ -21,9 +22,6 @@ const $Child_content__input = ($scope, input) => {
 	$Child_content__input_a($scope, input.a);
 	$Child_content__input_b($scope, input.b);
 };
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
 const $input_a = ($scope, input_a) => {
 	$input_a$1($scope["#childScope/0"], input_a);
 	$Child_content__input_a($scope["#childScope/1"], input_a);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -29,7 +29,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
 const $button_content = /* @__PURE__ */ _content("__tests__/template.marko_1_content", "one", "b");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$buttons($scope["#childScope/0"], attrTag({
 		onClick: $onClick,
 		content: $button_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$rest($scope["#childScope/2"], {
 		row: attrTag({ x: 1 }),
 		other: attrTag({ y: 2 })

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
@@ -21,10 +21,8 @@ var inner_default = /* @__PURE__ */ _template("__tests__/tags/inner/index.marko"
 // tags/child/index.marko
 const $template$1 = /* @__PURE__ */ ((_w0) => `<h1> </h1>${_w0}`)($template$2);
 const $walks$1 = /* @__PURE__ */ ((_w0) => `D l/${_w0}&`)($walks$2);
+const $setup$1 = () => {};
 const $title = ($scope, title) => _text($scope["#text/0"], title);
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/1"]);
-}
 const $rest = ($scope, rest) => $input_stuff($scope["#childScope/1"], rest);
 const $input = ($scope, input) => {
 	(({ title, ...rest }) => $rest($scope, rest))(input);
@@ -52,7 +50,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$cond($scope, !$scope.cond);
 }));
 function $setup($scope) {
-	$setup$1($scope["#childScope/1"]);
 	$title($scope["#childScope/1"], "t");
 	$cond($scope, true);
 	$setup__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$n($scope, 1);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/dom.bundle.debug.js
@@ -10,11 +10,9 @@ var leaf_default = /* @__PURE__ */ _template("__tests__/tags/leaf.marko", $templ
 // tags/mid.marko
 const $template$1 = /* @__PURE__ */ ((_w0) => `<p><!> <!></p>${_w0}`)($template$2);
 const $walks$1 = /* @__PURE__ */ ((_w0) => `D%c%l/${_w0}&`)($walks$2);
+const $setup$1 = () => {};
 const $first = ($scope, first) => _text($scope["#text/0"], first);
 const $keep = ($scope, keep) => _text($scope["#text/1"], keep);
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/2"]);
-}
 const $rest = ($scope, rest) => $input_data($scope["#childScope/2"], rest);
 const $input = ($scope, input) => {
 	$first($scope, input.first);
@@ -40,7 +38,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	$setup$1($scope["#childScope/2"]);
 	$first($scope["#childScope/2"], "f");
 	$n($scope, 1);
 	$setup__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	({ a: 5 });
 	({ a: 6 });
 	$n($scope, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/dom.bundle.debug.js
@@ -52,9 +52,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/2"]);
-	/* @__PURE__ */ $setup$2($scope["#childScope/3"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/4"]);
 	$extras($scope, {
 		b: 2,
 		c: 3

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
@@ -42,7 +42,6 @@ const $store_clear__script = _script("__tests__/template.marko_0_store_clear", (
 const $store_clear = /* @__PURE__ */ _const("store_clear", $store_clear__script);
 function $setup($scope) {
 	_var($scope, "#childScope/0", $store);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], ["Learn Marko", "Make a Website"]);
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$count($scope, undefined);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_valueChange($scope["#childScope/0"], $valueChange($scope));
 	$count($scope, 3);
 	$setup__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$initial($scope, $scope.initial + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$onValue$1($scope["#childScope/0"], $onValue);
 	$initial($scope, 1);
 	$setup__script($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c");
 const $item_content__item__script = _script("__tests__/template.marko_1_item", ($scope) => _el_read($scope["#div/0"]).innerHTML = $scope.item);
 const $item_content = /* @__PURE__ */ _content_closures(/* @__PURE__ */ _content("__tests__/template.marko_1_content", "<div></div>", " b"), { item: $item_content__item__script });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	let $item;
 	forOf([
 		1,

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
@@ -27,7 +27,6 @@ const $myfor_content__i = ($scope, i) => _text($scope["#text/0"], i);
 const $myfor_content__$params = ($scope, $params2) => $myfor_content__i($scope, $params2[0]);
 const $myfor_content = _content_resume("__tests__/template.marko_1_content", " ", " b", 0, $myfor_content__$params);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $myfor_content($scope));
 	$input_to($scope["#childScope/0"], 5);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,6 @@ const $template = /* @__PURE__ */ ((_w0) => `<div></div>${_w0}`)("");
 const $walks = /* @__PURE__ */ ((_w0) => ` b/${_w0}&`)("");
 const $el_getter = _el("__tests__/template.marko_0_#div", "#div/0");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$el($scope["#childScope/1"], $el_getter($scope));
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -31,7 +31,6 @@ const $head_content__setup = ($scope) => {
 };
 const $head_content = /* @__PURE__ */ _content("__tests__/template.marko_1_content", "<button> </button>", " D l", $head_content__setup);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_head($scope["#childScope/0"], attrTag({
 		id: "h",
 		content: $head_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,6 @@ const $mybox_content__setup = ($scope) => {
 };
 const $mybox_content = /* @__PURE__ */ _content("__tests__/template.marko_1_content", "<button type=button class=inc>increment</button><span class=count> </span>", " bD l", $mybox_content__setup);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], {
 		class: "x",
 		content: $mybox_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$cls($scope, $scope.cls === "a" ? "b" : "a");
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$cls($scope, "a");
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,6 @@ const $walks$1 = /* @__PURE__ */ ((_w0) => `0${_w0}&`)("");
 const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x"));
 function $setup$1($scope) {
 	_var($scope, "#childScope/0", $x);
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 }
 const $input_foo$1 = ($scope, input_foo) => $input_value($scope["#childScope/0"], input_foo);
 const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,6 @@ const $walks$1 = /* @__PURE__ */ ((_w0) => `0${_w0}&`)("");
 const $x = _var_resume("__tests__/tags/child.marko_0_x/var", /* @__PURE__ */ _const("x"));
 function $setup$1($scope) {
 	_var($scope, "#childScope/0", $x);
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 }
 const $input_foo = ($scope, input_foo) => $input_value($scope["#childScope/0"], input_foo);
 const $input__OR__x__script = _script("__tests__/tags/child.marko_0_input_x", ($scope) => $scope.input.output().innerHTML = $scope.x);

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/dom.bundle.debug.js
@@ -18,7 +18,6 @@ const $test = /* @__PURE__ */ _const("test", ($scope) => $input($scope["#childSc
 	content: $mybutton_content($scope)
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$test($scope, "foo");
 }
 function $onClick($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/render-effect/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/render-effect/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,6 @@ var render_effect_default = /* @__PURE__ */ _template("__tests__/tags/render-eff
 const $template = "";
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)("");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { value: function() {} });
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.debug.js
@@ -27,7 +27,6 @@ const $count = /* @__PURE__ */ _let("count/3", ($scope) => {
 });
 function $setup($scope) {
 	_var($scope, "#childScope/0", $setCount);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_valueChange($scope["#childScope/0"], $valueChange($scope));
 	$count($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/dom.bundle.debug.js
@@ -10,9 +10,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $input_option = ($scope, input_option) => $input_option$1($scope["#childScope/0"], input_option);
 const $input = ($scope, input) => $input_option($scope, input.option);
 var wrap_default = /* @__PURE__ */ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
@@ -22,7 +20,6 @@ const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 const $option_content = _content_resume("__tests__/template.marko_1_content", "1", "b");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input_option($scope["#childScope/0"], attrTag({ content: $option_content($scope) }));
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/dom.bundle.debug.js
@@ -13,9 +13,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $input_class = ($scope, input_class) => $input_class$1($scope["#childScope/0"], input_class);
 const $input_value = ($scope, input_value) => $input_value$1($scope["#childScope/0"], input_value);
 const $input = ($scope, input) => {
@@ -30,7 +28,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&lD%l`)($walks$1);
 const Wrap = wrap_default;
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input_class($scope["#childScope/0"], "foo");
 	$input_value($scope["#childScope/0"]);
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/dom.bundle.debug.js
@@ -20,9 +20,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $_class = ($scope, _class) => $input_class($scope["#childScope/0"], _class);
 const $rest_option = ($scope, rest_option) => $input_option($scope["#childScope/0"], rest_option);
 const $input = ($scope, input) => {
@@ -39,7 +37,6 @@ const $option_content3 = _content_resume("__tests__/template.marko_3_content", "
 const $option_content2 = _content_resume("__tests__/template.marko_2_content", "Two", "b");
 const $option_content = _content_resume("__tests__/template.marko_1_content", "One", "b");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$rest_option($scope["#childScope/0"], attrTags(attrTags(attrTag({
 		value: 1,
 		content: $option_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/dom.bundle.debug.js
@@ -21,9 +21,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $_class = ($scope, _class) => $input_class($scope["#childScope/0"], _class);
 const $rest = ($scope, rest) => $rest$1($scope["#childScope/0"], (({ class: $class, ...rest }) => rest)(rest));
 const $input = ($scope, input) => {
@@ -40,13 +38,10 @@ const $Wrap_content = _content_resume("__tests__/template.marko_2_content", "Hel
 const $wrap_content = _content_resume("__tests__/template.marko_1_content", "Hello World", "b");
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/3", $Wrap_content);
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$_class($scope["#childScope/0"], "foo");
 	$rest($scope["#childScope/0"], {});
-	$setup$1($scope["#childScope/1"]);
 	$_class($scope["#childScope/1"], "foo");
 	$rest($scope["#childScope/1"], { content: undefined });
-	$setup$1($scope["#childScope/2"]);
 	$_class($scope["#childScope/2"], "foo");
 	$rest($scope["#childScope/2"], { content: $wrap_content($scope) });
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/dom.bundle.debug.js
@@ -14,9 +14,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 const $template$1 = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$2);
 const $walks$1 = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
 function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], "override");
-	/* @__PURE__ */ $setup$2($scope["#childScope/1"]);
 }
 const $input_class = ($scope, input_class) => $input_class$1($scope["#childScope/0"], input_class);
 const $input = /* @__PURE__ */ _const("input", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/dom.bundle.debug.js
@@ -13,10 +13,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$2);
 const $walks$1 = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$2($scope["#childScope/1"]);
-}
+const $setup$1 = () => {};
 const $input_class = ($scope, input_class) => {
 	$input_class$1($scope["#childScope/0"], input_class);
 	$input_class$1($scope["#childScope/1"], input_class);
@@ -37,7 +34,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&lD%l`)($walks$1);
 const Wrap = wrap_default;
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input_class($scope["#childScope/0"], "foo");
 	$input_value($scope["#childScope/0"]);
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/dom.bundle.debug.js
@@ -15,9 +15,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $input = /* @__PURE__ */ _const("input", ($scope) => {
 	const $child_input_spread = {
 		...$scope.input,
@@ -33,7 +31,6 @@ var wrap_default = /* @__PURE__ */ _template("__tests__/tags/wrap.marko", $templ
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1);
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { class: "foo" });
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/dom.bundle.debug.js
@@ -13,9 +13,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$2 = $template$3;
 const $walks$2 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$2($scope) {
-	/* @__PURE__ */ $setup$3($scope["#childScope/0"]);
-}
+const $setup$2 = () => {};
 const $value = ($scope, value) => $input_value($scope["#childScope/0"], value);
 const $rest_class$1 = ($scope, rest_class) => $input_class($scope["#childScope/0"], rest_class);
 const $input$1 = ($scope, input) => {
@@ -29,7 +27,6 @@ var wrap_default = /* @__PURE__ */ _template("__tests__/tags/wrap.marko", $templ
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$2);
 function $setup$1($scope) {
-	$setup$2($scope["#childScope/0"]);
 	$value($scope["#childScope/0"], "abcd");
 }
 const $rest_class = ($scope, rest_class) => $rest_class$1($scope["#childScope/0"], rest_class);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/dom.bundle.debug.js
@@ -21,9 +21,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // template.marko
 const $template = $template$1;
 const $walks = /* @__PURE__ */ ((_w0) => `/${_w0}&`)("b b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 const $input = /* @__PURE__ */ _const("input", ($scope) => {
 	const $child_input_spread = {
 		"data-foo": 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.debug.js
@@ -25,10 +25,7 @@ const $walks$1 = "b%c";
 const $setup$1 = () => {};
 _resume_dynamic_tag();
 const $_classspandiv_content__input_foo = /* @__PURE__ */ _closure_get("input_foo", ($scope) => $foo($scope["#childScope/0"], $scope._.input_foo));
-const $_classspandiv_content__setup = ($scope) => {
-	$_classspandiv_content__input_foo($scope);
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-};
+const $_classspandiv_content__setup = $_classspandiv_content__input_foo;
 const $_classspandiv_content = _content_resume("__tests__/tags/wrap.marko_1_content", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template$2), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $_classspandiv_content__setup);
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/0", $_classspandiv_content);
 const $input_class__OR__rest = /* @__PURE__ */ _or(6, ($scope) => $dynamicTag($scope, $scope._class ? "span" : "div", () => ({

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $for_content__item__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
 const $for_content__item = /* @__PURE__ */ _const(5, ($scope) => {
 	_attrs($scope, "a", $scope.f);
@@ -18,11 +17,7 @@ const $foo = ($scope, foo) => $for($scope, [foo]);
 // tags/wrap.marko
 _resume_dynamic_tag();
 const $_classspandiv_content__input_foo = /* @__PURE__ */ _closure_get(3, ($scope) => $foo($scope.a, $scope._.d));
-const $_classspandiv_content__setup = ($scope) => {
-	$_classspandiv_content__input_foo($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("c0", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $_classspandiv_content__setup));
+const $dynamicTag = /* @__PURE__ */ _dynamic_tag(0, _content_resume("c0", /* @__PURE__ */ ((_w0) => `<!>${_w0}<!>`)($template), /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b%c"), $_classspandiv_content__input_foo));
 
 // template.marko
 const $desc_content2 = _content_resume("a1", "Two", "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14777,
-        "brotli": 5791
+        "min": 14753,
+        "brotli": 5784
       },
       "files": {
-        "tags/child.marko": 788,
-        "tags/wrap.marko": 520,
+        "tags/child.marko": 763,
+        "tags/wrap.marko": 390,
         "template.marko": 153
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/dom.bundle.debug.js
@@ -21,11 +21,9 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // template.marko
 const $template = /* @__PURE__ */ ((_w0) => `<div id=known>${_w0}</div><div id=dynamic><!></div>`)($template$1);
 const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&lD%l`)("b b");
+const $setup = () => {};
 const Child = child_default;
 _resume_dynamic_tag();
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
 const $input = /* @__PURE__ */ _const("input", ($scope) => {
 	$_class($scope["#childScope/0"], $scope.input.class);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/dom.bundle.debug.js
@@ -13,9 +13,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $value = ($scope, value) => $input_value($scope["#childScope/0"], value);
 const $rest_class = ($scope, rest_class) => $input_class($scope["#childScope/0"], rest_class);
 const $input = ($scope, input) => {
@@ -31,13 +29,10 @@ const $walks = /* @__PURE__ */ ((_w0, _w1, _w2) => `D/${_w0}&lD/${_w1}&lD/${_w2}
 const Wrap = wrap_default;
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/3");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$rest_class($scope["#childScope/0"], "foo");
 	$value($scope["#childScope/0"]);
-	$setup$1($scope["#childScope/1"]);
 	$rest_class($scope["#childScope/1"], "foo");
 	$value($scope["#childScope/1"], undefined);
-	$setup$1($scope["#childScope/2"]);
 	$rest_class($scope["#childScope/2"], "foo");
 	$value($scope["#childScope/2"], "abcd");
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/dom.bundle.debug.js
@@ -13,9 +13,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/tags/child.marko", $tem
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /* @__PURE__ */ ((_w0) => `/${_w0}&`)(" b");
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $input_class = ($scope, input_class) => $input_class$1($scope["#childScope/0"], input_class);
 const $input_value = ($scope, input_value) => $input_value$1($scope["#childScope/0"], input_value);
 const $input = ($scope, input) => {
@@ -30,7 +28,6 @@ const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&lD%l`)($walks$1);
 const Wrap = wrap_default;
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input_class($scope["#childScope/0"], "foo");
 	$input_value($scope["#childScope/0"]);
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/__snapshots__/dom.bundle.debug.js
@@ -7,9 +7,7 @@ var child_default = /* @__PURE__ */ _template("__tests__/child.marko", $template
 // template.marko
 const $template = /* @__PURE__ */ ((_w0) => `<!>${_w0}<div class=page>Page</div>`)($template$1);
 const $walks = /* @__PURE__ */ ((_w0) => `b/${_w0}&b`)("b");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
+const $setup = () => {};
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // page.css

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,6 @@ const foo = "div";
 const Bar = "div";
 const $dynamicTag = /* @__PURE__ */ _dynamic_tag("#text/1");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$dynamicTag($scope, Bar);
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/__snapshots__/dom.bundle.debug.js
@@ -16,8 +16,6 @@ var greeting_default = /* @__PURE__ */ _template("__tests__/tags/util/greeting.m
 const $template = /* @__PURE__ */ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$1);
 const $walks = /* @__PURE__ */ ((_w0, _w1) => `/${_w0}&/${_w1}&`)("b", $walks$1);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_name($scope["#childScope/1"], "Marko");
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.debug.js
@@ -3,10 +3,7 @@ const $template$1 = "<div>d<!><!></div>";
 const $walks$1 = "Db%b%l";
 const $setup$1 = () => {};
 const $if_content__input_depth = /* @__PURE__ */ _if_closure("#text/1", 0, ($scope) => $input_depth($scope["#childScope/0"], $scope._.input_depth - 1));
-const $if_content__setup = ($scope) => {
-	$if_content__input_depth._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__input_depth;
 const $if = /* @__PURE__ */ _if("#text/1", $template$1, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks$1), $if_content__setup);
 const $input_depth = /* @__PURE__ */ _const("input_depth", ($scope) => {
 	_text($scope["#text/0"], $scope.input_depth);
@@ -27,7 +24,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$n($scope, $scope.n + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$n($scope, 2);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.js
@@ -1,13 +1,8 @@
 // tags/tree/index.marko
 const $template = "<div>d<!><!></div>";
 const $walks = "Db%b%l";
-const $setup = () => {};
 const $if_content__input_depth = /* @__PURE__ */ _if_closure(1, 0, ($scope) => $input_depth($scope.a, $scope._.e - 1));
-const $if_content__setup = ($scope) => {
-	$if_content__input_depth._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /* @__PURE__ */ _if(1, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $if_content__setup);
+const $if = /* @__PURE__ */ _if(1, $template, /* @__PURE__ */ ((_w0) => `/${_w0}&`)($walks), $if_content__input_depth);
 const $input_depth = /* @__PURE__ */ _const(4, ($scope) => {
 	_text($scope.a, $scope.e);
 	$if($scope, $scope.e ? 0 : 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6392,
-        "brotli": 2904
+        "min": 6378,
+        "brotli": 2896
       },
       "files": {
-        "tags/tree/index.marko": 645,
+        "tags/tree/index.marko": 510,
         "template.marko": 271
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,6 @@ const $template = /* @__PURE__ */ ((_w0) => `<section>${_w0}</section><div> </di
 const $walks = /* @__PURE__ */ ((_w0) => `D/${_w0}&lD l`)("b");
 const $count = /* @__PURE__ */ _let("count/2", ($scope) => _text($scope["#text/1"], $scope.count));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$count($scope, 0);
 }
 var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -29,6 +29,7 @@ import {
   startSection,
 } from "../util/sections";
 import { getSerializeGuard } from "../util/serialize-guard";
+import { addSetupStatement } from "../util/setup-statements";
 import {
   addStatement,
   addValue,
@@ -112,6 +113,9 @@ export default {
     }
 
     bodySection.upstreamExpression = valueAttr.value.extra;
+
+    // The content renderer is initialized unconditionally in setup.
+    addSetupStatement(section);
   },
   translate: translateByTarget({
     html: {

--- a/packages/runtime-tags/src/translator/core/const.ts
+++ b/packages/runtime-tags/src/translator/core/const.ts
@@ -15,7 +15,8 @@ import {
   trackVarReferences,
 } from "../util/references";
 import runtimeInfo from "../util/runtime-info";
-import { getSection } from "../util/sections";
+import { getOrCreateSection, getSection } from "../util/sections";
+import { addSetupExpr } from "../util/setup-statements";
 import { addValue, initValue } from "../util/signals";
 import translateVar from "../util/translate-var";
 
@@ -83,7 +84,10 @@ export default {
         }
       }
       if (!valueExtra.nullable) binding.nullable = false;
-      if (!upstreamAlias) setBindingDownstream(binding, valueExtra);
+      if (!upstreamAlias) {
+        setBindingDownstream(binding, valueExtra);
+        addSetupExpr(getOrCreateSection(tag), valueAttr.value);
+      }
     }
   },
   translate: {

--- a/packages/runtime-tags/src/translator/core/debug.ts
+++ b/packages/runtime-tags/src/translator/core/debug.ts
@@ -9,7 +9,8 @@ import {
 import { assertNoBodyContent } from "../util/assert";
 import { isOutputHTML } from "../util/marko-config";
 import runtimeInfo from "../util/runtime-info";
-import { getSection } from "../util/sections";
+import { getOrCreateSection, getSection } from "../util/sections";
+import { addSetupExpr } from "../util/setup-statements";
 import { addStatement } from "../util/signals";
 import withPreviousLocation from "../util/with-previous-location";
 
@@ -33,6 +34,8 @@ export default {
           "The [`<debug>` tag](https://markojs.com/docs/reference/core-tag#debug) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value).",
         );
     }
+
+    addSetupExpr(getOrCreateSection(tag), valueAttr?.value);
   },
   translate: {
     exit(tag) {

--- a/packages/runtime-tags/src/translator/core/id.ts
+++ b/packages/runtime-tags/src/translator/core/id.ts
@@ -16,7 +16,8 @@ import {
 } from "../util/references";
 import { callRuntime } from "../util/runtime";
 import runtimeInfo from "../util/runtime-info";
-import { getSection } from "../util/sections";
+import { getOrCreateSection, getSection } from "../util/sections";
+import { addSetupExpr } from "../util/setup-statements";
 import { addValue, initValue } from "../util/signals";
 import { scopeIdentifier } from "../visitors/program";
 
@@ -63,6 +64,9 @@ export default {
     if (binding) {
       setBindingDownstream(binding, !!valueAttr && evaluate(valueAttr.value));
     }
+
+    // The id is initialized in setup unless keyed by the value's references.
+    addSetupExpr(getOrCreateSection(tag), valueAttr?.value);
   },
   translate: {
     exit(tag) {

--- a/packages/runtime-tags/src/translator/core/log.ts
+++ b/packages/runtime-tags/src/translator/core/log.ts
@@ -9,7 +9,8 @@ import {
 import { assertNoBodyContent } from "../util/assert";
 import { isOutputHTML } from "../util/marko-config";
 import runtimeInfo from "../util/runtime-info";
-import { getSection } from "../util/sections";
+import { getOrCreateSection, getSection } from "../util/sections";
+import { addSetupExpr } from "../util/setup-statements";
 import { addStatement } from "../util/signals";
 
 export default {
@@ -39,6 +40,8 @@ export default {
           "The [`<log>` tag](https://markojs.com/docs/reference/core-tag#log) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value).",
         );
     }
+
+    addSetupExpr(getOrCreateSection(tag), valueAttr.value);
   },
   translate: {
     exit(tag) {

--- a/packages/runtime-tags/src/translator/core/return.ts
+++ b/packages/runtime-tags/src/translator/core/return.ts
@@ -17,6 +17,7 @@ import { isControlFlowTag } from "../util/is-core-tag";
 import { callRuntime } from "../util/runtime";
 import { getOrCreateSection, getSection } from "../util/sections";
 import { addSerializeReason } from "../util/serialize-reasons";
+import { addSetupExpr } from "../util/setup-statements";
 import { addStatement, setSectionSerializedValue } from "../util/signals";
 import { createSectionState } from "../util/state";
 import { translateByTarget } from "../util/visitors";
@@ -72,10 +73,12 @@ export default {
 
     if (attrs.valueChange) {
       (attrs.valueChange.extra ??= {}).isEffect = true;
+      addSetupExpr(section, attrs.valueChange);
       // TODO: this should be based on the parent actually mutating the tag variable.
       addSerializeReason(section, true, getAccessorProp().TagVariableChange);
     }
 
+    addSetupExpr(section, attrs.value);
     section.returnValueExpr = attrs.value.extra ??= {};
   },
   translate: translateByTarget({

--- a/packages/runtime-tags/src/translator/core/script.ts
+++ b/packages/runtime-tags/src/translator/core/script.ts
@@ -12,7 +12,8 @@ import { assertNoBodyContent } from "../util/assert";
 import { isOutputDOM } from "../util/marko-config";
 import { dropNodes, getAllTagReferenceNodes } from "../util/references";
 import runtimeInfo from "../util/runtime-info";
-import { getSection } from "../util/sections";
+import { getOrCreateSection, getSection } from "../util/sections";
+import { addSetupExpr } from "../util/setup-statements";
 import { addHTMLEffectCall, addStatement } from "../util/signals";
 import { skip, traverseContains } from "../util/traverse";
 import { isScopeIdentifier, scopeIdentifier } from "../visitors/program";
@@ -79,6 +80,7 @@ export default {
         }
         seenValueAttr = true;
         (attr.value.extra ??= {}).isEffect = true;
+        addSetupExpr(getOrCreateSection(tag), attr.value);
         getProgram().node.extra.isInteractive = true;
       } else {
         throw tag.hub.buildError(

--- a/packages/runtime-tags/src/translator/core/show.ts
+++ b/packages/runtime-tags/src/translator/core/show.ts
@@ -34,6 +34,7 @@ import {
   addSerializeExpr,
   getSerializeReason,
 } from "../util/serialize-reasons";
+import { addSetupStatement } from "../util/setup-statements";
 import { addValue, getSignal } from "../util/signals";
 import analyzeTagNameType, { TagNameType } from "../util/tag-name-type";
 import { translateByTarget } from "../util/visitors";
@@ -101,6 +102,9 @@ export default {
       if (tagExtra[kStaticDisplay] === undefined) {
         mergeReferences(tagSection, tag.node, [display]);
         addSerializeExpr(tagSection, tagExtra, kStatefulReason);
+      } else {
+        // A statically hidden `<show>` still writes its display in setup.
+        addSetupStatement(tagSection);
       }
     },
     exit(tag) {

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -38,6 +38,7 @@ import {
   addSerializeExpr,
   getSerializeReason,
 } from "../util/serialize-reasons";
+import { addSetupStatement } from "../util/setup-statements";
 import { addStatement } from "../util/signals";
 import {
   checkStyleInterpolations,
@@ -92,6 +93,8 @@ export default {
 
     if (names) {
       analyzeDynamicStyle(tag, names);
+      // Dynamic styles write their shell and nonce statements in setup.
+      addSetupStatement(getOrCreateSection(tag));
     }
   },
   translate: translateByTarget({

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -64,6 +64,7 @@ import {
   getSerializeSourcesForExprs,
 } from "./serialize-reasons";
 import { setTagDownstream } from "./set-tag-sections-downstream";
+import { addSetupExpr, addSetupStatement } from "./setup-statements";
 import {
   addStatement,
   getResumeRegisterId,
@@ -144,6 +145,8 @@ export function knownTagAnalyze(
   ));
 
   if (varBinding) {
+    // Tag variables emit a `_var` statement in the parent's setup.
+    addSetupStatement(section);
     const mutatesTagVar = !!(
       tag.node.var!.type === "Identifier" &&
       tag.scope.getBinding(tag.node.var.name)?.constantViolations.length
@@ -338,7 +341,7 @@ export function knownTagTranslateDOM(
     preferredName?: string,
     directContent?: boolean,
   ) => t.Identifier,
-  callSetup: (section: Section, childBinding: Binding) => void,
+  callSetup: ((section: Section, childBinding: Binding) => void) | undefined,
 ) {
   const tagSection = getSection(tag);
   const { node } = tag;
@@ -376,7 +379,7 @@ export function knownTagTranslateDOM(
       ),
     );
   }
-  callSetup(tagSection, childScopeBinding);
+  callSetup?.(tagSection, childScopeBinding);
 
   if (propTree) {
     writeParamsToSignals(tag, propTree, getTagName(tag) || "tag", {
@@ -450,6 +453,7 @@ function analyzeParams(
       const argValueExtra = (arg.extra ??= {});
       known[i++] = { value: argValueExtra };
       rootAttrExprs.add(argValueExtra);
+      addSetupExpr(section, arg);
     }
   }
 
@@ -638,6 +642,8 @@ function analyzeAttrs(
       } else {
         remaining.delete("content");
         known.content = { value: undefined }; // TODO: update when supporting default params
+        // The content signal call is applied unconditionally in setup.
+        addSetupStatement(section);
       }
     }
   }
@@ -667,6 +673,7 @@ function analyzeAttrs(
         remaining.delete(attr.name);
         known[attr.name] = { value: attrExtra };
         rootAttrExprs.add(attrExtra);
+        addSetupExpr(section, attr.value);
         setBindingDownstream(templateExportAttr.binding, attrExtra);
         // A cross template child that only ever invokes this input makes the
         // attribute `invokeOnly`. Same program prop trees may still be
@@ -734,9 +741,21 @@ function analyzeAttrs(
     } else {
       dropNodes(spreadReferenceNodes);
     }
-  } else if (restReferenceNodes) {
-    inputExpr.value = mergeReferences(section, tag.node, restReferenceNodes);
-    setBindingDownstream(propTree.rest!.binding, inputExpr.value);
+  } else {
+    if (restReferenceNodes) {
+      inputExpr.value = mergeReferences(section, tag.node, restReferenceNodes);
+      setBindingDownstream(propTree.rest!.binding, inputExpr.value);
+    }
+
+    if (remaining.size) {
+      // Unset props are applied with no value (and no references) in setup.
+      addSetupStatement(section);
+    }
+
+    if (propTree.rest && !propTree.rest.props) {
+      // The rest signal call is keyed by the tag's merged references.
+      addSetupExpr(section, tag.node);
+    }
   }
 
   dropNodes(dropReferenceNodes);

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -803,6 +803,10 @@ export function mergeReferences<T extends t.Node>(
   for (const node of nodes) {
     if (!node) continue;
     const extra = (node.extra ??= {});
+    // The target can appear in its own node list (eg related controllable
+    // attrs); merging it into itself would create a `merged` cycle and
+    // double its reads.
+    if (extra === targetExtra) continue;
     extra.merged = targetExtra;
     if (isReferencedExtra(extra)) {
       const additionalReads = readsByExpression.get(extra);

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -59,6 +59,7 @@ import {
   type SerializeReason,
 } from "./serialize-reasons";
 import { finalizeTagDownstreams } from "./set-tag-sections-downstream";
+import { addSetupStatement } from "./setup-statements";
 import {
   getBindingGetterIdentifier,
   getSignals,
@@ -903,6 +904,11 @@ export function finalizeReferences() {
       );
       expr.referencedBindings = exprBindings.referencedBindings;
       expr.lazyBindings = exprBindings.lazyBindings;
+      if (!exprBindings.referencedBindings) {
+        // With no resolved references, any statement this expression keys
+        // lands in its section's setup signal.
+        addSetupStatement(expr.section);
+      }
       forEach(exprBindings.lazyBindings, (binding) => {
         binding.forcePersist = true;
       });

--- a/packages/runtime-tags/src/translator/util/setup-statements.ts
+++ b/packages/runtime-tags/src/translator/util/setup-statements.ts
@@ -1,0 +1,46 @@
+import type { types as t } from "@marko/compiler";
+
+import type { Section } from "./sections";
+import { createSectionState } from "./state";
+
+/**
+ * Tracks, during analyze, whether translate will add statements to a
+ * section's setup signal (the signal keyed by no referenced bindings).
+ * Sites that key statements by an expression's resolved references register
+ * the expression with `addSetupExpr`; sites that always target the setup
+ * signal call `addSetupStatement`. Expressions that resolve references
+ * through `mergeReferences` are covered centrally by `finalizeReferences`.
+ *
+ * This lets a template's analyze phase prove its setup export is a noop so
+ * parent templates can skip importing and calling it. The proof is checked
+ * when the template itself is translated (see `visitors/program/dom.ts`).
+ */
+
+const [getSetupInfo] = createSectionState("setupStatements", () => ({
+  forced: false,
+  exprs: new Set<t.NodeExtra>(),
+}));
+
+export function addSetupStatement(section: Section) {
+  getSetupInfo(section).forced = true;
+}
+
+export function addSetupExpr(section: Section, node: t.Node | undefined) {
+  if (node) {
+    getSetupInfo(section).exprs.add((node.extra ??= {}));
+  } else {
+    getSetupInfo(section).forced = true;
+  }
+}
+
+export function sectionHasSetupStatements(section: Section) {
+  const info = getSetupInfo(section);
+  if (info.forced) return true;
+  for (let extra of info.exprs) {
+    while (extra.merged) extra = extra.merged;
+    if (!extra.pruned && !extra.referencedBindings) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -25,6 +25,7 @@ import {
   addSerializeExpr,
   getSerializeReason,
 } from "../util/serialize-reasons";
+import { addSetupExpr } from "../util/setup-statements";
 import { addStatement } from "../util/signals";
 import type { TemplateVisitor } from "../util/visitors";
 import * as walks from "../util/walks";
@@ -76,6 +77,7 @@ export default {
         section,
       ));
       analyzeSiblingText(placeholder);
+      addSetupExpr(section, node.value);
       addSerializeExpr(section, valueExtra, nodeBinding);
     }
   },

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -174,10 +174,20 @@ export default {
         }
       });
 
-      writeSignals(section);
+      const written = writeSignals(section);
       writeRegisteredFns();
 
-      if (!getSetup(section)) {
+      const setup = getSetup(section);
+      if (domExports.setupEmpty && setup && written.has(setup)) {
+        // Parent templates have skipped calling the setup export based on
+        // the analyze phase proving it would be a noop; a non noop setup
+        // here means that proof was wrong and must fail loudly.
+        throw program.buildCodeFrameError(
+          "Marko internal error: analysis marked this template's setup export as empty but translation produced statements for it. Please open an issue with a reproduction.",
+        );
+      }
+
+      if (!setup) {
         program.node.body.unshift(
           t.exportNamedDeclaration(
             t.variableDeclaration("const", [

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -27,6 +27,7 @@ import {
 import { resolveRelativeToEntry } from "../../util/resolve-relative-to-entry";
 import { getCompatRuntimeFile, getRuntimePath } from "../../util/runtime";
 import { startSection } from "../../util/sections";
+import { sectionHasSetupStatements } from "../../util/setup-statements";
 import type { TemplateVisitor } from "../../util/visitors";
 import programDOM from "./dom";
 import programHTML from "./html";
@@ -43,6 +44,7 @@ declare module "@marko/compiler/dist/types" {
       template: string;
       walks: string;
       setup: string;
+      setupEmpty?: true;
       params: BindingPropTree | undefined;
     };
     styleFile?: string;
@@ -95,6 +97,13 @@ export default {
       const paramsBinding = programExtra.binding;
       if (paramsBinding && !paramsBinding.pruned) {
         programExtra.domExports!.params = getBindingPropTree(paramsBinding);
+      }
+
+      const section = programExtra.section!;
+      if (!section.hoistedTo && !sectionHasSetupStatements(section)) {
+        // The setup export will be a noop, letting parent templates skip
+        // importing and calling it (checked when this template translates).
+        programExtra.domExports!.setupEmpty = true;
       }
     },
   },

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -33,6 +33,7 @@ import {
 import { callRuntime } from "../../util/runtime";
 import { createScopeReadExpression } from "../../util/scope-read";
 import { getOrCreateSection } from "../../util/sections";
+import { addSetupStatement } from "../../util/setup-statements";
 import { addStatement, getSignal } from "../../util/signals";
 import { createProgramState } from "../../util/state";
 import type { TemplateVisitor } from "../../util/visitors";
@@ -90,6 +91,14 @@ export default {
           BindingType.dom,
           getOrCreateSection(tag),
         );
+      }
+
+      if (tagExtra.tagNameLoad || !childExtra.domExports?.setupEmpty) {
+        // The child's setup call lands in this section's setup unless the
+        // child template proved its setup export is a noop (a mid analysis
+        // child, eg a circular reference, has no flag yet and is assumed to
+        // have a setup). Load tags always wire up `_load_setup`.
+        addSetupStatement(getOrCreateSection(tag));
       }
 
       knownTagAnalyze(
@@ -269,18 +278,20 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
       childExports.params,
       (binding, preferredName) =>
         getSignal(programSection, binding, preferredName).identifier,
-      (section, childBinding) => {
-        addStatement(
-          "render",
-          section,
-          undefined,
-          t.expressionStatement(
-            t.callExpression(t.identifier(childExports.setup), [
-              createScopeReadExpression(childBinding, section),
-            ]),
-          ),
-        );
-      },
+      childExports.setupEmpty
+        ? undefined
+        : (section, childBinding) => {
+            addStatement(
+              "render",
+              section,
+              undefined,
+              t.expressionStatement(
+                t.callExpression(t.identifier(childExports.setup), [
+                  createScopeReadExpression(childBinding, section),
+                ]),
+              ),
+            );
+          },
     );
 
     write`${t.identifier(childExports.template)}`;
@@ -296,24 +307,26 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
           (directContent && binding.directContentExport) || binding.export!,
           preferredName,
         ),
-      (section, childBinding) => {
-        addStatement(
-          "render",
-          section,
-          undefined,
-          t.expressionStatement(
-            t.callExpression(
-              importOrSelfReferenceName(
-                file,
-                relativePath,
-                childExports.setup,
-                tagName,
+      childExports.setupEmpty
+        ? undefined
+        : (section, childBinding) => {
+            addStatement(
+              "render",
+              section,
+              undefined,
+              t.expressionStatement(
+                t.callExpression(
+                  importOrSelfReferenceName(
+                    file,
+                    relativePath,
+                    childExports.setup,
+                    tagName,
+                  ),
+                  [createScopeReadExpression(childBinding, section)],
+                ),
               ),
-              [createScopeReadExpression(childBinding, section)],
-            ),
-          ),
-        );
-      },
+            );
+          },
     );
 
     write`${importNamed(file, relativePath, childExports.template, `${tagName}_template`)}`;

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -59,6 +59,7 @@ import {
   addSerializeExpr,
   getSerializeReason,
 } from "../../util/serialize-reasons";
+import { addSetupStatement } from "../../util/setup-statements";
 import {
   addStatement,
   addValue,
@@ -109,6 +110,9 @@ export default {
     enter(tag) {
       assertAttributesOrArgs(tag);
       const { node } = tag;
+      // Dynamic tags (and locally invoked define bodies) initialize their
+      // renderer with statements that can land in setup.
+      addSetupStatement(getOrCreateSection(tag));
       const definedBodySection = node.extra?.defineBodySection;
       if (definedBodySection) {
         knownTagAnalyze(

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -48,6 +48,7 @@ import {
   addSerializeExpr,
   getSerializeReason,
 } from "../../util/serialize-reasons";
+import { addSetupExpr, addSetupStatement } from "../../util/setup-statements";
 import { addHTMLEffectCall, addStatement } from "../../util/signals";
 import {
   toMemberExpression,
@@ -297,6 +298,28 @@ export default {
                   textPlaceholders.slice(1),
                 ),
           );
+          addSetupExpr(tagSection, textPlaceholders[0]);
+        }
+
+        if (injectNonce) {
+          // A nonce statement with no references is written in setup.
+          addSetupStatement(tagSection);
+        }
+
+        if (relatedControllable?.attrs[1]) {
+          // Controllable change handlers register an effect in setup.
+          addSetupStatement(tagSection);
+        }
+
+        for (const name in seen) {
+          const attr = seen[name];
+          if (
+            isEventHandler(name) ||
+            name === "content" ||
+            !evaluate(attr.value).confident
+          ) {
+            addSetupExpr(tagSection, attr.value);
+          }
         }
 
         addSerializeExpr(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When analysis proves a child template's setup export is a noop, parents now skip importing and calling it. This compounds: a component whose setup only called such children exports a noop setup itself, so its own parents skip the call too. The child still emits the stub export, keeping dynamic tags, load tags, and `_template` untouched, and the server output is unchanged.

Analysis tracks everything that lands in a section's setup signal (`util/setup-statements.ts`): expressions whose references resolve empty are detected centrally in `finalizeReferences`, with explicit marks at the statement sites not keyed by a tracked expression. If analysis ever claims empty while translation produces setup statements, the template's own compile fails loudly instead of breaking at runtime.

Also fixes `mergeReferences` merging an expression into itself when the target appears in its own node list (related controllable attrs), which duplicated its tracked reads and created a `merged` self-cycle.

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCeCNkdgSAmMUq4xVQ63yX)_