### PR TITLE
fix(runtime-tags): separate placeholder text at the edge of a `<show>` body

### DIFF
--- a/.changeset/show-placeholder-sibling-text.md
+++ b/.changeset/show-placeholder-sibling-text.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a placeholder at the edge of a `<show>` body merging with the text adjacent to the `<show>` tag. Because `<show>` inlines its body into the parent, a template like `<strong>+ <show=cond>${value}</show></strong>` serialized the static `+ ` prefix and the placeholder value as a single text node with no `<!>` separator, so the first client-side update overwrote the whole node and deleted the static text. Sibling-text analysis now looks through `<show>` body boundaries in both directions.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -37,3 +37,9 @@ The `onlyChildInParent`/`singleChild` optimizations (reuse the parent element as
 `packages/runtime-tags/src/translator/util/tag-name-type.ts:187` | 2026-07-02 | impact:med | effort:med
 
 Existing TODO: `<${input.component}/>` style dynamic tags always compile against the fully general `_dynamic_tag` runtime, which includes string-tag (native element) handling, attr normalization for both shapes, and `attrTags` merging. When analysis can prove the value is never a string (e.g. it only ever receives template imports), a slimmer helper skipping the native-element path could be emitted, and conversely an always-string value could compile like a native tag with a dynamic name.
+
+## See through statically-shown `<show>` bodies in `getNodeContentType`
+
+`packages/runtime-tags/src/translator/util/sections.ts:294` | 2026-07-02 | impact:low | effort:low
+
+`getNodeContentType` classifies a core `<show>` tag as `ContentType.Dynamic`, so a placeholder next to a `<show>` always gets a `<!>` separator / Replace visit even when the `<show>` value is statically truthy and the body is spliced inline with no runtime boundary (`packages/runtime-tags/src/translator/core/show.ts:156`). Sibling-text analysis in `packages/runtime-tags/src/translator/visitors/placeholder.ts` now looks through `<show>` body edges for correctness; the converse refinement (returning the body's start/end content type for a static-display `<show>`, like the custom-tag case does via `tagSection.content`) would drop a few unnecessary separator bytes.

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/dom.bundle.debug.js
@@ -1,6 +1,6 @@
 // template.marko
-const $template = "<button>reveal</button><!> <!><!>";
-const $walks = " b%b b%c";
+const $template = "<button>reveal</button><!><!><!><!>";
+const $walks = " b%b%b%c";
 const $show = /* @__PURE__ */ _show("#text/3", "#text/1");
 const $reveal = /* @__PURE__ */ _let("reveal/7", ($scope) => $show($scope, $scope.reveal));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+const $template = "<strong>+ <!></strong><span><!> dmg</span><em>+ <!><!><!></em><b>+ <!></b><button>inc</button>";
+const $walks = "Db%lD%lDb%b%b%lDb%l b";
+const $count = /* @__PURE__ */ _let("count/7", ($scope) => {
+	_text($scope["#text/0"], $scope.count);
+	_text($scope["#text/1"], $scope.count);
+	_text($scope["#text/3"], $scope.count);
+	_text($scope["#text/5"], $scope.count);
+});
+const $show = /* @__PURE__ */ _show("#text/4", "#text/2");
+const $vis = /* @__PURE__ */ _let("vis/8", ($scope) => $show($scope, $scope.vis));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/6"], "click", function() {
+	$count($scope, $scope.count + 5);
+	$vis($scope, !$scope.vis);
+}));
+function $setup($scope) {
+	$count($scope, 3);
+	$vis($scope, true);
+	$setup__script($scope);
+}
+var template_default = /* @__PURE__ */ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const $count = /* @__PURE__ */ _let(7, ($scope) => {
+	_text($scope.a, $scope.h);
+	_text($scope.b, $scope.h);
+	_text($scope.d, $scope.h);
+	_text($scope.f, $scope.h);
+});
+const $show = /* @__PURE__ */ _show(4, 2);
+const $vis = /* @__PURE__ */ _let(8, ($scope) => $show($scope, $scope.i));
+const $setup__script = _script("a0", ($scope) => _on($scope.g, "click", function() {
+	$count($scope, $scope.h + 5);
+	$vis($scope, !$scope.i);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 3;
+	let vis = true;
+	_html("<strong>+ ");
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "#text/0")}`);
+	_html("</strong><span>");
+	_html(`${_escape(count)}${_el_resume($scope0_id, "#text/1")}`);
+	_html(" dmg</span><em>+ ");
+	_show_start(vis, 1);
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "#text/3")}`);
+	_show_end($scope0_id, "#text/4", vis);
+	_html("</em><b>+ ");
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "#text/5")}`);
+	_html(`</b><button>inc</button>${_el_resume($scope0_id, "#button/6")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		count,
+		vis
+	}, "__tests__/template.marko", 0, {
+		count: "1:6",
+		vis: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/html.bundle.js
@@ -1,0 +1,24 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 3;
+	let vis = true;
+	_html("<strong>+ ");
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "a")}`);
+	_html("</strong><span>");
+	_html(`${_escape(count)}${_el_resume($scope0_id, "b")}`);
+	_html(" dmg</span><em>+ ");
+	_show_start(vis, 1);
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "d")}`);
+	_show_end($scope0_id, "e", vis);
+	_html("</em><b>+ ");
+	_html(`<!>${_escape(count)}${_el_resume($scope0_id, "f")}`);
+	_html(`</b><button>inc</button>${_el_resume($scope0_id, "g")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		h: count,
+		i: vis
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/render.debug.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<strong>
+  + 3
+</strong>
+<span>
+  3 dmg
+</span>
+<em>
+  + 3
+</em>
+<b>
+  + 3
+</b>
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<strong>
+  + 8
+</strong>
+<span>
+  8 dmg
+</span>
+<em>
+  + 
+</em>
+<b>
+  + 8
+</b>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: strong::text@2 "3" => "8"
+UPDATE: span::text@0 "3" => "8"
+UPDATE: #document-fragment::text "3" => "8"
+UPDATE: b::text@2 "3" => "8"
+REMOVE: em::text + ::text("8")
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<strong>
+  + 13
+</strong>
+<span>
+  13 dmg
+</span>
+<em>
+  + 13
+</em>
+<b>
+  + 13
+</b>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: strong::text@2 "8" => "13"
+UPDATE: span::text@0 "8" => "13"
+UPDATE: b::text@2 "8" => "13"
+INSERT: em::text@0 + ::text("13")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/render.md
@@ -1,0 +1,77 @@
+# Render
+```html
+<strong>
+  + 3
+</strong>
+<span>
+  3 dmg
+</span>
+<em>
+  + 3
+</em>
+<b>
+  + 3
+</b>
+<button>
+  inc
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<strong>
+  + 8
+</strong>
+<span>
+  8 dmg
+</span>
+<em>
+  + 
+</em>
+<b>
+  + 8
+</b>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: strong::text@2 "3" => "8"
+UPDATE: span::text@0 "3" => "8"
+UPDATE: #document-fragment::text "3" => "8"
+UPDATE: b::text@2 "3" => "8"
+REMOVE: em::text + ::text("8")
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<strong>
+  + 13
+</strong>
+<span>
+  13 dmg
+</span>
+<em>
+  + 13
+</em>
+<b>
+  + 13
+</b>
+<button>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: strong::text@2 "8" => "13"
+UPDATE: span::text@0 "8" => "13"
+UPDATE: b::text@2 "8" => "13"
+INSERT: em::text@0 + ::text("13")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<strong>+ <!>3<!--M_*1 #text/0--></strong><span>3<!--M_*1 #text/1-->
+  dmg</span><em>+ <!--M_[-->
+  <!>3<!--M_*1 #text/3--><!--M_]1 #text/4 2-->
+</em><b>+ <!>3<!--M_*1 #text/5--></b><button>inc</button><!--M_*1 #button/6-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 3,
+      vis: !0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<strong>+ <!>3<!--M_*1 a--></strong><span>3<!--M_*1 b--> dmg</span><em>+
+  <!--M_[-->
+  <!>3<!--M_*1 d--><!--M_]1 e 2-->
+</em><b>+ <!>3<!--M_*1 f--></b><button>inc</button><!--M_*1 g-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    h: 3,
+    i: !0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 4429,
+      "brotli": 2126
+    }
+  },
+  "html": {
+    "min": 492,
+    "brotli": 305
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/template.marko
@@ -1,0 +1,7 @@
+<let/count=3/>
+<let/vis=true/>
+<strong>+ <show=true>${count}</show></strong>
+<span><show=true>${count}</show> dmg</span>
+<em>+ <show=vis>${count}</show></em>
+<b>+ <show=true><show=true>${count}</show></show></b>
+<button onClick() { count += 5; vis = !vis }>inc</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -3,6 +3,7 @@ import { types as t } from "@marko/compiler";
 import { isNotVoid, isVoid } from "../../common/helpers";
 import { WalkCode } from "../../common/types";
 import evaluate from "../util/evaluate";
+import { isCoreTagName } from "../util/is-core-tag";
 import { isNonHTMLText } from "../util/is-non-html-text";
 import { isOutputHTML } from "../util/marko-config";
 import normalizeStringExpression from "../util/normalize-string-expression";
@@ -227,7 +228,19 @@ function buildEscapedTextExpression(value: t.Expression): t.Expression {
 function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
   const placeholderExtra = placeholder.node.extra!;
   let prev = placeholder.getPrevSibling();
-  while (prev.node) {
+  let prevParent: t.NodePath = placeholder.parentPath;
+  for (;;) {
+    if (!prev.node) {
+      // A `<show>` body is inlined into its parent, so a placeholder at the
+      // edge of the body renders directly against the tag's own siblings.
+      const showTag = getInlinedBodyTag(prevParent);
+      if (showTag) {
+        prev = showTag.getPrevSibling();
+        prevParent = showTag.parentPath;
+        continue;
+      }
+      break;
+    }
     const contentType = getNodeContentType(
       prev as t.NodePath<t.Statement>,
       "endType",
@@ -244,11 +257,21 @@ function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
       break;
     }
   }
-  if (!prev.node && t.isProgram(placeholder.parent)) {
+  if (!prev.node && prevParent.isProgram()) {
     return (placeholderExtra[kSiblingText] = SiblingText.Before);
   }
   let next = placeholder.getNextSibling();
-  while (next.node) {
+  let nextParent: t.NodePath = placeholder.parentPath;
+  for (;;) {
+    if (!next.node) {
+      const showTag = getInlinedBodyTag(nextParent);
+      if (showTag) {
+        next = showTag.getNextSibling();
+        nextParent = showTag.parentPath;
+        continue;
+      }
+      break;
+    }
     const contentType = getNodeContentType(
       next as t.NodePath<t.Statement>,
       "startType",
@@ -265,11 +288,23 @@ function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
       break;
     }
   }
-  if (!next.node && t.isProgram(placeholder.parent)) {
+  if (!next.node && nextParent.isProgram()) {
     return (placeholderExtra[kSiblingText] = SiblingText.After);
   }
 
   return (placeholderExtra[kSiblingText] = SiblingText.None);
+}
+
+// Returns the owner tag when `parent` is the body of a tag that inlines its
+// content into the surrounding section (currently only `<show>`), meaning the
+// body's edge nodes render adjacent to the tag's siblings.
+function getInlinedBodyTag(parent: t.NodePath) {
+  if (parent.isMarkoTagBody()) {
+    const tag = parent.parentPath;
+    if (tag.isMarkoTag() && isCoreTagName(tag, "show")) {
+      return tag;
+    }
+  }
 }
 
 function isStaticText(node?: t.Node) {


### PR DESCRIPTION
## Description

Because `<show>` inlines its body into the parent section, a placeholder at the start (or end) of the body renders directly against whatever precedes (or follows) the tag. Sibling-text analysis only scanned within the `<show>` body, classified such a placeholder as having no sibling text, and skipped the `<!>` separator.

As a result a template like:

```marko
<strong>+ <show=cond>${value}</show></strong>
```

serialized the static `+ ` prefix and the placeholder value as a single merged text node. The resume marker then resolved to the merged node and the first client-side update overwrote the whole node, deleting the static prefix. The suffix direction had the same defect for client-side rendering, where the walk would `Get` a text node merged with trailing static text.

Sibling-text analysis now continues through `<show>` body edges in both directions (including nested `<show>` tags) into the tag's own siblings, and applies the template-root rules against the outermost hopped parent.

Added a `show-text-prefix-placeholder` fixture covering the static-prefix, suffix, and nested cases across HTML/DOM and SSR/CSR.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KGwfbqMoiU7VVGMUXWUSE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGwfbqMoiU7VVGMUXWUSE4)_