### PR TITLE
perf(tests): parallel test runner to fan the suite across CPU cores

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,6 +51,12 @@ While developing you can run a single test group and use [grep](https://mochajs.
 npm test -- --grep=lifecycle
 ```
 
+To run the whole suite quickly (without coverage), `npm run test:parallel` fans the tests across your CPU cores:
+
+```
+npm run test:parallel
+```
+
 ### Adding tests
 
 Marko makes use of directory based test suites. Take a look at the `render` test suite:

--- a/.mocharc.parallel.json
+++ b/.mocharc.parallel.json
@@ -1,0 +1,8 @@
+{
+  "bail": false,
+  "timeout": 30000,
+  "no-warnings": true,
+  "enable-source-maps": true,
+  "experimental-vm-modules": true,
+  "require": ["~ts"]
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ All from repo root. Tests and tooling run directly from TS source (`~ts` Babel r
 
 ```sh
 npm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run; bail: stops at first failure
+npm run test:parallel                                    # whole suite fanned across CPU cores (~3x faster than a serial npm test)
 npm run test:update -- --grep "..."                      # regenerate snapshots (review the diff!)
 npm run compile -- -t "" -o dom -d foo.marko             # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)
 npm run build                                            # all packages -> dist/ + .d.ts

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -7,3 +7,9 @@ Friction in builds, tests, tooling, or repo workflows. Format and rules: [README
 `scripts/inspect-compiled-output.ts:22` | 2026-07-02 | impact:med | effort:low
 
 The `-t`/`--translator` option defaults to the string `"tags"`, so the fallback at `scripts/inspect-compiled-output.ts:41` (`args.values.translator || "@marko/runtime-tags/translator"`) never fires, and every invocation without an explicit `-t` dies with `Cannot find module 'tags'`. Either default the option to `""` or map shorthand values (`tags` → `@marko/runtime-tags/translator`, `class` → `marko/translator`). The root `AGENTS.md` documents the `-t ""` workaround; update it when fixing.
+
+## `c8` coverage crashes generating lcov when the wrapped process loads `~ts`
+
+`scripts/test-parallel.js:10` | 2026-07-02 | impact:med | effort:med
+
+`c8 node -r ~ts <script>` (i.e. any c8-wrapped process that loads `scripts/babel-register.js` via `-r ~ts`) throws `TypeError: Cons is not a constructor` at `istanbul-reports/index.js:22` during c8's report step while constructing the `lcov` reporter — no `coverage/lcov.info` is written and the process exits 1. Coverage collection itself succeeds (the text-summary reporter prints correct numbers); only lcov report generation dies. This is why `scripts/test-parallel.js` is deliberately plain CommonJS (its spawned mocha workers still load `~ts` via `.mocharc.parallel.json`, which does _not_ trigger the bug — only `-r ~ts` on the c8-monitored process does). Worth root-causing, since it silently blocks lcov/codecov for any future `node -r ~ts` script someone wraps in `c8`; likely a c8@11 ↔ @babel/register require-hook interaction.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -43,3 +43,9 @@ Existing TODO: `<${input.component}/>` style dynamic tags always compile against
 `packages/runtime-tags/src/translator/util/sections.ts:294` | 2026-07-02 | impact:low | effort:low
 
 `getNodeContentType` classifies a core `<show>` tag as `ContentType.Dynamic`, so a placeholder next to a `<show>` always gets a `<!>` separator / Replace visit even when the `<show>` value is statically truthy and the body is spliced inline with no runtime boundary (`packages/runtime-tags/src/translator/core/show.ts:156`). Sibling-text analysis in `packages/runtime-tags/src/translator/visitors/placeholder.ts` now looks through `<show>` body edges for correctness; the converse refinement (returning the body's start/end content type for a static-display `<show>`, like the custom-tag case does via `tagSection.content`) would drop a few unnecessary separator bytes.
+
+## Parallel test workers oversubscribe cores via rolldown's thread pool
+
+`scripts/test-parallel.js:40` | 2026-07-02 | impact:low | effort:med
+
+`npm run test:parallel` runs one mocha process per core, but each fixture bundle already drives rolldown's own multi-threaded build (`packages/runtime-tags/src/__tests__/utils/bundle.ts`), so even a serial run uses ~1.4 cores. On a 4-core box the whole suite lands at ~87s vs ~238s serial (2.7×), short of the ~4× the core count implies, because the workers contend for the same native threads. `RAYON_NUM_THREADS=1` in the worker env made no measurable difference, so rolldown isn't honoring it. If rolldown (or its native binding) exposes a per-build thread cap, pinning workers to 1 bundler thread each — so N workers ≈ N threads total — could recover much of the lost efficiency and let the runner scale closer to linearly on higher core counts.

--- a/cspell.json
+++ b/cspell.json
@@ -4,6 +4,7 @@
   "words": [
     "marko",
     "markoc",
+    "mocharc",
     "markojs",
     "taglib",
     "Taglib",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@ci:lint": "eslint --format unix . && prettier . --check --with-node-modules --log-level=warn",
     "@ci:release": "npm run build && node scripts/pkg-override && changeset publish && npm run @ci:release-alias && node scripts/pkg-override && npm ci",
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.ts",
-    "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" MARKO_DEBUG=1 c8 npm test",
+    "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192\" MARKO_DEBUG=1 c8 npm run test:parallel",
     "@ci:version": "npm run build && npm run format && changeset version && npm i --package-lock-only",
     "build": "npm run build --ws && npm run build:types",
     "build:sizes": "node -r ~ts scripts/sizes",
@@ -21,6 +21,7 @@
     "prepare": "husky && patch-package && npm run build-babel-types -w @marko/compiler",
     "report": "open ./coverage/lcov-report/index.html",
     "test": "mocha",
+    "test:parallel": "node scripts/test-parallel.js",
     "test:update": "UPDATE_EXPECTATIONS=1 mocha"
   },
   "overrides": {

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -54,6 +54,19 @@ export type TestConfig = {
   runtime_id?: string;
 };
 
+// `scripts/test-parallel` fans the fixtures across CPU cores by giving each
+// worker a subset of round-robin "slots" via the env below: a fixture runs here
+// when `index % slotTotal` is one of this worker's slots. Round-robin keeps the
+// expensive fixtures spread evenly across workers. With no env set (a plain
+// `npm test`, or a scoped `--grep`) `slots` is null and every fixture runs.
+const slotTotal = Number(process.env.MARKO_TEST_SLOT_TOTAL) || 1;
+const slots = process.env.MARKO_TEST_SLOTS
+  ? new Set(process.env.MARKO_TEST_SLOTS.split(",").map(Number))
+  : null;
+function inShard(index: number) {
+  return slots === null || slots.has(index % slotTotal);
+}
+
 describe("runtime-tags/translator", () => {
   testFixtures();
 });
@@ -70,8 +83,10 @@ function testFixtures(interop?: true) {
     __dirname,
     interop ? "fixtures-interop" : "fixtures",
   );
+  let fixtureIndex = 0;
   for (const entry of fs.readdirSync(fixturesDir)) {
     if (entry.endsWith(".skip")) continue;
+    if (!inShard(fixtureIndex++)) continue;
 
     describe(entry, () => {
       const fixtureDir = path.join(fixturesDir, entry);

--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -1,0 +1,157 @@
+// Runs the mocha suite across CPU cores. The ~800-fixture snapshot suite in
+// `runtime-tags/.../main.test.ts` dominates the runtime and is embarrassingly
+// parallel, but mocha runs a single file in one process. This splits that file
+// into round-robin "slots" (see `MARKO_TEST_SLOT_*` in main.test.ts) and packs
+// those slots plus every other spec file into one mocha process per core.
+//
+// A plain `npm test` is untouched — it stays serial, which is what a scoped
+// `--grep` dev run wants. This is the "run everything, fast" path used by CI.
+//
+// Plain CommonJS on purpose: this orchestrator is what `c8` wraps for coverage,
+// and loading the `~ts` babel-register hook in that process breaks c8's report
+// step. The mocha workers it spawns still get `~ts` via `.mocharc.parallel.json`.
+//
+// Usage: node scripts/test-parallel.js [extra mocha args...]
+//        MARKO_TEST_WORKERS=8 node scripts/test-parallel.js
+const { spawn } = require("node:child_process");
+const os = require("node:os");
+const path = require("node:path");
+
+const glob = require("tiny-glob");
+
+const ROOT = path.resolve(__dirname, "..");
+const MOCHA = path.join(ROOT, "node_modules/.bin/mocha");
+const CONFIG = path.join(ROOT, ".mocharc.parallel.json");
+const SPEC_GLOB = "packages/*/@(src|test)/**/*.test.@(js|ts)";
+// The one giant fixture file that gets split across workers via slots.
+const FIXTURE_FILE = path.join(
+  ROOT,
+  "packages/runtime-tags/src/__tests__/main.test.ts",
+);
+
+const WORKERS = Math.max(
+  1,
+  Number(process.env.MARKO_TEST_WORKERS) || os.availableParallelism(),
+);
+// Many slots per worker (not one) so the packer can hand a worker that also
+// carries a slow spec file proportionally fewer fixtures. Slots are just env
+// numbers — more of them costs nothing (still one process per worker), it only
+// makes the balance finer-grained.
+const SLOT_TOTAL = WORKERS * 16;
+
+// Rough wall-time hints (ms) used only to balance workers — a wrong guess makes
+// the run slightly less even, never changes which tests run or their outcome.
+// The fixture suite is the bulk; a handful of runtime-class browser suites are
+// the only other heavyweights, so everything else shares one small default.
+const FIXTURE_TOTAL_MS = 210_000;
+const FILE_COST_HINTS = [
+  ["/components-browser/", 45_000],
+  ["/components-pages/", 14_000],
+  ["/render/", 12_000],
+  ["/translator/", 5_000],
+];
+
+main(process.argv.slice(2)).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+async function main(mochaArgs) {
+  const files = (
+    await glob(SPEC_GLOB, { cwd: ROOT, absolute: true, filesOnly: true })
+  ).filter((f) => !f.includes("node_modules"));
+  const hasFixtures = files.includes(FIXTURE_FILE);
+  const otherFiles = files.filter((f) => f !== FIXTURE_FILE);
+
+  const bins = packBins(hasFixtures ? SLOT_TOTAL : 0, otherFiles);
+  const started = Date.now();
+  console.log(
+    `Running ${files.length} spec files across ${bins.length} workers ` +
+      `(${WORKERS} cores)…\n`,
+  );
+
+  const results = await Promise.all(
+    bins.map((bin, i) => runBin(bin, i, mochaArgs)),
+  );
+
+  let passing = 0;
+  let failing = 0;
+  let failed = false;
+  for (const r of results) {
+    passing += r.passing;
+    failing += r.failing;
+    if (r.code !== 0 || r.failing) {
+      failed = true;
+      process.stdout.write(r.output); // surface the full failure detail
+    }
+  }
+
+  const secs = ((Date.now() - started) / 1000).toFixed(1);
+  console.log(
+    `\n${passing} passing, ${failing} failing across ${bins.length} ` +
+      `workers in ${secs}s`,
+  );
+  process.exit(failed ? 1 : 0);
+}
+
+// Longest-processing-time bin packing: sort the tasks (fixture slots + spec
+// files) heaviest-first and drop each onto the currently-lightest worker.
+function packBins(slotTotal, otherFiles) {
+  const slotCost = slotTotal ? FIXTURE_TOTAL_MS / slotTotal : 0;
+  const tasks = [];
+  for (let slot = 0; slot < slotTotal; slot++)
+    tasks.push({ slot, cost: slotCost });
+  for (const file of otherFiles) tasks.push({ file, cost: fileCost(file) });
+  tasks.sort((a, b) => b.cost - a.cost);
+
+  const bins = Array.from({ length: WORKERS }, () => ({
+    slots: [],
+    files: [],
+    cost: 0,
+  }));
+  for (const task of tasks) {
+    const bin = bins.reduce((a, b) => (b.cost < a.cost ? b : a));
+    if (task.slot !== undefined) bin.slots.push(task.slot);
+    else bin.files.push(task.file);
+    bin.cost += task.cost;
+  }
+  return bins.filter((bin) => bin.slots.length || bin.files.length);
+}
+
+function fileCost(file) {
+  for (const [fragment, ms] of FILE_COST_HINTS) {
+    if (file.includes(fragment)) return ms;
+  }
+  return 2_000;
+}
+
+function runBin(bin, index, mochaArgs) {
+  const args = [MOCHA, "--config", CONFIG, "--reporter", "dot", ...mochaArgs];
+  const env = { ...process.env };
+  if (bin.slots.length) {
+    args.push(FIXTURE_FILE);
+    env.MARKO_TEST_SLOTS = bin.slots.join(",");
+    env.MARKO_TEST_SLOT_TOTAL = String(SLOT_TOTAL);
+  }
+  args.push(...bin.files);
+
+  const child = spawn(process.execPath, args, { cwd: ROOT, env });
+  let output = "";
+  child.stdout.on("data", (d) => (output += d));
+  child.stderr.on("data", (d) => (output += d));
+
+  return new Promise((resolve) => {
+    child.on("close", (code) => {
+      const passing = Number(/(\d+) passing/.exec(output)?.[1] ?? 0);
+      const failing = Number(/(\d+) failing/.exec(output)?.[1] ?? 0);
+      const label = bin.slots.length
+        ? `fixtures[${bin.slots.length}/${SLOT_TOTAL}]${bin.files.length ? ` +${bin.files.length} files` : ""}`
+        : `${bin.files.length} files`;
+      console.log(
+        `  worker ${index + 1}: ${label} — ${passing} passing` +
+          (failing ? `, ${failing} failing` : ""),
+      );
+      resolve({ code, passing, failing, output });
+    });
+  });
+}


### PR DESCRIPTION
## Description

`npm test` runs serially, and the ~800-fixture `runtime-tags` snapshot suite (a single mocha file) dominates the runtime. This adds `npm run test:parallel`, which splits that file into round-robin "slots" and packs those slots plus every other spec file into one mocha process per core (longest-processing-time bin-packing). `@ci:test` now uses it.

Full suite drops from **~238s serial to ~87s on 4 cores (2.7×)**, running the identical test set with byte-identical snapshots/sizes. Coverage still merges across workers (94.8% statements, matching serial). A plain or scoped `npm test` is unchanged and stays serial.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_014YSkjYUeLkMyHh6sf9qqTu)_