### PR TITLE
fix(runtime-tags): only mark templates as embeds when linkAssets is configured

### DIFF
--- a/.changeset/embed-requires-link-assets.md
+++ b/.changeset/embed-requires-link-assets.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Only treat a non-page template as an `embed` (with a randomized, non-idempotent render id) when the `linkAssets` compiler option is configured. Without it — as in most test and SSR-only setups — every template keeps a deterministic render id, so server integration tests that render templates directly stay idempotent.

--- a/packages/runtime-tags/src/__tests__/translator-api.test.ts
+++ b/packages/runtime-tags/src/__tests__/translator-api.test.ts
@@ -190,4 +190,33 @@ describe("runtime-tags/translator-api", () => {
       }
     });
   });
+
+  describe("embed determination", () => {
+    const compileHTML = (src: string, linkAssets: boolean) =>
+      compiler.compileSync(src, path.join(__dirname, "tmp.marko"), {
+        ...baseConfig,
+        cache: new Map(),
+        output: "html",
+        ...(linkAssets
+          ? { linkAssets: { runtime: "asset-runtime", onAsset() {} } }
+          : {}),
+      }).code;
+
+    // A template renders as an "embed" (with a randomized, non-idempotent render
+    // id to avoid scope-id collisions between sibling renders) unless the third
+    // `_template` argument marks it as a page. A non-page template is only an
+    // embed for asset-linked builds; without `linkAssets` it stays deterministic.
+    const isEmbed = (code: string) => !/\}, 1\);\s*$/.test(code.trimEnd());
+
+    it("treats a non-page template as an embed only when linkAssets is set", () => {
+      assert.equal(isEmbed(compileHTML("<div>Hello</div>", true)), true);
+      assert.equal(isEmbed(compileHTML("<div>Hello</div>", false)), false);
+    });
+
+    it("never treats a page (html/body/head) template as an embed", () => {
+      const page = "<html><body><div>Hi</div></body></html>";
+      assert.equal(isEmbed(compileHTML(page, true)), false);
+      assert.equal(isEmbed(compileHTML(page, false)), false);
+    });
+  });
 });

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -6,6 +6,7 @@ import {
   usedSharedUid,
 } from "../../util/generate-uid";
 import isStatic from "../../util/is-static";
+import { getMarkoOpts } from "../../util/marko-config";
 import { forEach } from "../../util/optional";
 import {
   BindingType,
@@ -170,7 +171,14 @@ export default {
           "_template",
           t.stringLiteral(program.hub.file.metadata.marko.id),
           contentId ? t.identifier(contentId) : contentFn,
-          program.node.extra!.page ? t.numericLiteral(1) : undefined,
+          // A non-page template renders as an "embed" with a randomized render
+          // id so that multiple can be placed in the same document without their
+          // scope ids colliding. That only matters for real builds that link
+          // client assets; without `linkAssets` (eg. most test/SSR-only setups)
+          // treat every template as a page so its render id stays deterministic.
+          program.node.extra!.page || !getMarkoOpts().linkAssets
+            ? t.numericLiteral(1)
+            : undefined,
         ),
       );
 


### PR DESCRIPTION
## Description

The `_template` HTML runtime marks a non-page template (one without an `html`/`body`/`head` document and that doesn't render a page child) as an **embed**, giving it a randomly generated render id. This avoids scope-id collisions when several such templates are rendered into the same document — a real concern for asset-linked application builds where multiple independent renders can share one page.

The random id is non-idempotent, though, which is a hiccup for server integration tests: they render templates directly (as they would be rendered as part of a page) and get a different render id on every render, so most templates end up looking like embeds when they wouldn't be in practice.

The `linkAssets` compiler option is the signal that a build is a real, asset-linked app build — it's required for the `entry`/`load` features and is generally not configured in test or SSR-only setups. This change gates the embed marker on it: a non-page template is only treated as an embed when `linkAssets` is configured. Without it, every template keeps the deterministic `DEFAULT_RENDER_ID`, so those renders stay idempotent.

The change is a single condition at the HTML `_template` codegen site (`translator/visitors/program/html.ts`). Because the fixture test suite always configures `linkAssets`, every existing snapshot and size is byte-for-byte unchanged and the full suite passes (8309 tests); a focused `translator-api` test covers the new behavior across the `linkAssets` × page/non-page combinations.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PA7VuUMBQ8e4cmCEQZqtJB)_