### PR TITLE
fix: issue with page entry runtime id missing in marko@5 apps

### DIFF
--- a/.changeset/class-api-page-assets-runtime-id.md
+++ b/.changeset/class-api-page-assets-runtime-id.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Inject the compiler-supplied `runtimeId` when rendering a page entry (`withPageAssets`), matching the Marko 6 runtime.

--- a/packages/runtime-class/src/runtime/helpers/load-tag.js
+++ b/packages/runtime-class/src/runtime/helpers/load-tag.js
@@ -3,20 +3,46 @@
 var flushHereAndAfter = require("../../core-tags/core/__flush_here_and_after__");
 var escapeScript = require("../html/helpers/escape-script-placeholder");
 var FLAG_WILL_RERENDER_IN_BROWSER = 1;
+var DEFAULT_RUNTIME_ID = "M";
 var kAssets = Symbol();
 var kBlockIndex = Symbol();
 var kDeferIndex = Symbol();
 var assetFlush;
 
-exports.withPageAssets = function withPageAssets(typeId, template, runtime) {
+exports.withPageAssets = function withPageAssets(
+  typeId,
+  template,
+  runtime,
+  runtimeId,
+) {
   assetFlush = runtime;
   var flushBeforeInput = { renderBody: flush };
   return createFacade(template, function (input, out) {
-    var hasAssets = !!out.global[kAssets];
+    var g = out.global;
+    if (runtimeId) {
+      // eslint-disable-next-line no-constant-condition
+      if ("MARKO_DEBUG") {
+        if (g.runtimeId !== DEFAULT_RUNTIME_ID && g.runtimeId !== runtimeId) {
+          throw new Error(
+            '$global.runtimeId ("' +
+              g.runtimeId +
+              '") conflicts with the runtimeId this entry was compiled with ("' +
+              runtimeId +
+              '").',
+          );
+        }
+      }
+
+      // The client half of the runtimeId contract is baked into the
+      // compiled browser entry, so the compiled value must win for the
+      // halves to agree.
+      g.runtimeId = runtimeId;
+    }
+    var hasAssets = !!g[kAssets];
     var key = out.___assignedKey;
     var def = out.___assignedComponentDef;
     var component = def && def.___component;
-    addAsset(out.global, typeId);
+    addAsset(g, typeId);
 
     if (hasAssets) {
       if (willRerender(def)) {

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -281,9 +281,17 @@ export const translate = {
       }
 
       if (file.markoOpts.output === "html" && file.markoOpts.entry === "page") {
-        const { linkAssets } = file.markoOpts;
+        const { linkAssets, runtimeId } = file.markoOpts;
         const templateId = file.metadata.marko.id;
         const relPath = resolveRelativePath(file, file.opts.filename);
+        const pageAssetArgs = [
+          t.stringLiteral(templateId),
+          t.identifier("template"),
+          t.identifier("flush"),
+        ];
+        if (runtimeId) {
+          pageAssetArgs.push(t.stringLiteral(runtimeId));
+        }
         linkAssets.onAsset("page", file.opts.filename, templateId);
         path.node.body = [
           t.importDeclaration(
@@ -305,11 +313,7 @@ export const translate = {
           ),
           t.exportAllDeclaration(t.stringLiteral(relPath)),
           t.exportDefaultDeclaration(
-            t.callExpression(t.identifier("withPageAssets"), [
-              t.stringLiteral(templateId),
-              t.identifier("template"),
-              t.identifier("flush"),
-            ]),
+            t.callExpression(t.identifier("withPageAssets"), pageAssetArgs),
           ),
         ];
         path.skip();


### PR DESCRIPTION
Fixes an issue where the `runtimeId` was missing for apps using the new page entry api (latest marko, and @marko/vite). For class api apps the runtime id was not properly propagated.

Inject the compiler-supplied `runtimeId` when rendering a page entry (`withPageAssets`), matching the Marko 6 runtime.
