### PR TITLE
fix: report code-frame error for computed keys in destructure patterns

### DIFF
--- a/.changeset/destructure-computed-key-error.md
+++ b/.changeset/destructure-computed-key-error.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Report a code-frame compile error for unsupported keys in destructuring patterns. Previously a computed key with an identifier expression (`{ [key]: value }`) was silently treated as a literal property name, producing mismatched server/client values, and other computed keys threw a raw error with no template location.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko:1:11
+    > 1 | <const/{ ["cou" + "nt"]: count } = input/>
+        |           ^^^^^^^^^^^^ Only identifier and string literal keys are supported when destructuring.
+      2 | <div>${count}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko:1:11
+    > 1 | <const/{ ["cou" + "nt"]: count } = input/>
+        |           ^^^^^^^^^^^^ Only identifier and string literal keys are supported when destructuring.
+      2 | <div>${count}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko:1:11
+    > 1 | <const/{ ["cou" + "nt"]: count } = input/>
+        |           ^^^^^^^^^^^^ Only identifier and string literal keys are supported when destructuring.
+      2 | <div>${count}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko:1:11
+    > 1 | <const/{ ["cou" + "nt"]: count } = input/>
+        |           ^^^^^^^^^^^^ Only identifier and string literal keys are supported when destructuring.
+      2 | <div>${count}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/template.marko
@@ -1,0 +1,2 @@
+<const/{ ["cou" + "nt"]: count } = input/>
+<div>${count}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key-expression/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko:2:11
+      1 | static const KEY = "count";
+    > 2 | <const/{ [KEY]: count } = input/>
+        |           ^^^ Only identifier and string literal keys are supported when destructuring.
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko:2:11
+      1 | static const KEY = "count";
+    > 2 | <const/{ [KEY]: count } = input/>
+        |           ^^^ Only identifier and string literal keys are supported when destructuring.
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko:2:11
+      1 | static const KEY = "count";
+    > 2 | <const/{ [KEY]: count } = input/>
+        |           ^^^ Only identifier and string literal keys are supported when destructuring.
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko:2:11
+      1 | static const KEY = "count";
+    > 2 | <const/{ [KEY]: count } = input/>
+        |           ^^^ Only identifier and string literal keys are supported when destructuring.
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/template.marko
@@ -1,0 +1,3 @@
+static const KEY = "count";
+<const/{ [KEY]: count } = input/>
+<div>${count}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-destructure-computed-key/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -657,13 +657,15 @@ function createBindingsAndTrackReferences(
         } else {
           let key: string;
 
-          if (prop.key.type === "Identifier") {
+          if (!prop.computed && prop.key.type === "Identifier") {
             key = prop.key.name;
           } else if (prop.key.type === "StringLiteral") {
             key = prop.key.value;
           } else {
-            // TODO: it should be a computed value
-            throw new Error("computed keys not supported in object pattern");
+            throw scope.path.hub.buildError(
+              prop.key,
+              "Only identifier and string literal keys are supported when destructuring.",
+            );
           }
 
           if (hasRest) {


### PR DESCRIPTION
## Description

Object-pattern analysis classified keys with `prop.key.type === "Identifier"` without checking `prop.computed`, so `{ [key]: value }` in a destructure (tag variables, tag params) was silently treated as the literal property name: HTML output destructured the computed key correctly while DOM/resume output read the literal property, diverging between server and client with no diagnostic. Other computed keys (`{ ["a" + "b"]: value }`) threw a raw `Error` with no template location.

Unsupported pattern keys now produce a located code-frame error ("Only identifier and string literal keys are supported when destructuring."). Statically-known string literal keys (computed or not) keep working. Covered by the `error-destructure-computed-key` and `error-destructure-computed-key-expression` fixtures; before the fix the first compiled without error and the second threw without a code frame.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy

---
_Generated by [Claude Code](https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy)_