### PR TITLE
chore: cover destructured tag variables, drop stale TODOs

### DIFF
--- a/.changeset/destructured-tag-var-fixtures.md
+++ b/.changeset/destructured-tag-var-fixtures.md
@@ -1,0 +1,4 @@
+---
+---
+
+Test coverage and type-level cleanup only; no release.

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,57 @@
+// tags/child.marko
+const $template$1 = "<span>child:<!></span>";
+const $walks$1 = "Db%l";
+const $count$1 = /*@__PURE__*/ _let("count/1", ($scope) => {
+	_return($scope, {
+		count: $scope.count,
+		inc: $_return($scope),
+		countChange: $_return2($scope)
+	});
+	_text($scope["#text/0"], $scope.count);
+});
+function $setup$1($scope) {
+	$count$1($scope, 1);
+}
+function $_return2($scope) {
+	return function(value) {
+		$count$1($scope, value);
+	};
+}
+function $_return($scope) {
+	return function() {
+		$count$1($scope, $scope.count + 1);
+	};
+}
+_resume("__tests__/tags/child.marko_0/_return2", $_return2);
+_resume("__tests__/tags/child.marko_0/_return", $_return);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button class=inc>inc</button><button class=assign>assign</button><div><!>:<!></div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `0${_w0}& b bD%c%l`)($walks$1);
+const $pattern2 = _var_resume("__tests__/template.marko_0_$pattern/var", ($scope, $pattern) => {
+	$count($scope, $pattern.count);
+	$countChange2($scope, $pattern.countChange);
+	$inc($scope, $pattern.inc);
+	$missing2($scope, $pattern.missing);
+});
+const $count__OR__$countChange__script = _script("__tests__/template.marko_0_count_$countChange", ($scope) => _on($scope["#button/3"], "click", function() {
+	$scope.$countChange($scope.count + 10);
+}));
+const $count__OR__$countChange = /*@__PURE__*/ _or(9, $count__OR__$countChange__script, 1, "#scopeOffset/1");
+const $count = /*@__PURE__*/ _const("count", ($scope) => {
+	_text($scope["#text/4"], $scope.count);
+	$count__OR__$countChange($scope);
+});
+const $countChange2 = /*@__PURE__*/ _const("$countChange", $count__OR__$countChange);
+const $inc__script = _script("__tests__/template.marko_0_inc", ($scope) => _on($scope["#button/2"], "click", function() {
+	$scope.inc();
+}));
+const $inc = /*@__PURE__*/ _const("inc", $inc__script);
+const $missing3 = ($scope, missing) => _text($scope["#text/5"], missing);
+const $missing2 = ($scope, $missing) => $missing3($scope, void 0 !== $missing ? $missing : "fallback");
+function $setup($scope) {
+	_var($scope, "#childScope/0", $pattern2);
+	$setup$1($scope["#childScope/0"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.js
@@ -1,0 +1,42 @@
+// tags/child.marko
+const $count$1 = /*@__PURE__*/ _let(1, ($scope) => {
+	_return($scope, {
+		count: $scope.b,
+		inc: $_return($scope),
+		countChange: $_return2($scope)
+	});
+	_text($scope.a, $scope.b);
+});
+function $_return2($scope) {
+	return function(value) {
+		$count$1($scope, value);
+	};
+}
+function $_return($scope) {
+	return function() {
+		$count$1($scope, $scope.b + 1);
+	};
+}
+_resume("b1", $_return2);
+_resume("b0", $_return);
+
+// template.marko
+const $pattern2 = _var_resume("a0", ($scope, $pattern) => {
+	$count($scope, $pattern.count);
+	$countChange2($scope, $pattern.countChange);
+	$inc($scope, $pattern.inc);
+	$missing2($scope, $pattern.missing);
+});
+const $count__OR__$countChange = /*@__PURE__*/ _or(9, _script("a1", ($scope) => _on($scope.d, "click", function() {
+	$scope.i($scope.h + 10);
+})), 1, 1);
+const $count = /*@__PURE__*/ _const(7, ($scope) => {
+	_text($scope.e, $scope.h);
+	$count__OR__$countChange($scope);
+});
+const $countChange2 = /*@__PURE__*/ _const(8, $count__OR__$countChange);
+const $inc = /*@__PURE__*/ _const(10, _script("a2", ($scope) => _on($scope.c, "click", function() {
+	$scope.k();
+})));
+const $missing3 = ($scope, missing) => _text($scope.f, missing);
+const $missing2 = ($scope, $missing) => $missing3($scope, void 0 !== $missing ? $missing : "fallback");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const $return = {
+		count,
+		inc: _resume(function() {
+			count++;
+		}, "__tests__/tags/child.marko_0/_return", $scope0_id),
+		countChange: _resume(function(value) {
+			count = value;
+		}, "__tests__/tags/child.marko_0/_return2", $scope0_id)
+	};
+	_html(`<span>child:<!>${_escape(count)}${_el_resume($scope0_id, "#text/0")}</span>`);
+	writeScope($scope0_id, { count }, "__tests__/tags/child.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { countChange: $countChange, count, inc, missing: $missing } = child_default({});
+	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_$pattern/var");
+	const missing = void 0 !== $missing ? $missing : "fallback";
+	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "#button/2")}<button class=assign>assign</button>${_el_resume($scope0_id, "#button/3")}<div>${_escape(count)}${_el_resume($scope0_id, "#text/4")}:<!>${_escape(missing)}${_el_resume($scope0_id, "#text/5")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_count_$countChange");
+	_script($scope0_id, "__tests__/template.marko_0_inc");
+	writeScope($scope0_id, {
+		count,
+		$countChange,
+		inc,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, {
+		count: "1:10",
+		$countChange: "3:28",
+		inc: "1:17"
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.js
@@ -1,0 +1,38 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const $return = {
+		count,
+		inc: _resume(function() {
+			count++;
+		}, "b0", $scope0_id),
+		countChange: _resume(function(value) {
+			count = value;
+		}, "b1", $scope0_id)
+	};
+	_html(`<span>child:<!>${_escape(count)}${_el_resume($scope0_id, "a")}</span>`);
+	writeScope($scope0_id, { b: count });
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { countChange: $countChange, count, inc, missing: $missing } = child_default({});
+	_var($scope0_id, "b", $childScope, "a0");
+	const missing = void 0 !== $missing ? $missing : "fallback";
+	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "c")}<button class=assign>assign</button>${_el_resume($scope0_id, "d")}<div>${_escape(count)}${_el_resume($scope0_id, "e")}:<!>${_escape(missing)}${_el_resume($scope0_id, "f")}</div>`);
+	_script($scope0_id, "a1");
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, {
+		h: count,
+		i: $countChange,
+		k: inc,
+		a: _existing_scope($childScope)
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/render.debug.md
@@ -1,0 +1,103 @@
+# Render
+```html
+<span>
+  child:1
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  1:fallback
+</div>
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:2
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  2:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "1" => "2"
+UPDATE: span::text@6 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button.assign").click();
+```
+```html
+<span>
+  child:12
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  12:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "2" => "12"
+UPDATE: span::text@6 "2" => "12"
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:13
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  13:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "12" => "13"
+UPDATE: span::text@6 "12" => "13"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/render.md
@@ -1,0 +1,103 @@
+# Render
+```html
+<span>
+  child:1
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  1:fallback
+</div>
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:2
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  2:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "1" => "2"
+UPDATE: span::text@6 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button.assign").click();
+```
+```html
+<span>
+  child:12
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  12:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "2" => "12"
+UPDATE: span::text@6 "2" => "12"
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:13
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<button
+  class="assign"
+>
+  assign
+</button>
+<div>
+  13:fallback
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "12" => "13"
+UPDATE: span::text@6 "12" => "13"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<span>child:<!>1<!--M_*2 #text/0--></span><button
+  class=inc>inc</button><!--M_*1 #button/2--><button
+  class=assign>assign</button><!--M_*1 #button/3-->
+<div>1<!--M_*1 #text/4-->:<!>fallback<!--M_*1 #text/5--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "#scopeOffset/1": 3,
+      count: 1,
+      $countChange: _(2,
+        "packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/tags/child.marko_0/_return2"
+        ),
+      inc: _(2,
+        "packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/tags/child.marko_0/_return"
+        ),
+      "#childScope/0": _(2)
+    }, {
+      "#TagVariable": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/template.marko_0_$pattern/var"
+        ),
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/template.marko_0_count_$countChange 1 packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/template.marko_0_inc 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<span>child:<!>1<!--M_*2 a--></span><button
+  class=inc>inc</button><!--M_*1 c--><button
+  class=assign>assign</button><!--M_*1 d-->
+<div>1<!--M_*1 e-->:<!>fallback<!--M_*1 f--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 3,
+    h: 1,
+    i: _(2, "b1"),
+    k: _(2, "b0"),
+    a: _(2)
+  }, {
+    T: _(1, "a0"),
+    b: 1
+  }], "a1 1 a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3260,
+        "brotli": 1582
+      },
+      "files": {
+        "tags/child.marko": 454,
+        "template.marko": 883
+      }
+    }
+  },
+  "html": {
+    "min": 544,
+    "brotli": 331
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/tags/child.marko
@@ -1,0 +1,11 @@
+<let/count = 1/>
+<return={
+  count,
+  inc() {
+    count++;
+  },
+  countChange(value) {
+    count = value;
+  },
+}/>
+<span>child:${count}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/template.marko
@@ -1,0 +1,4 @@
+<child/{ count, inc, missing = "fallback" }/>
+<button.inc onClick() { inc() }>inc</button>
+<button.assign onClick() { count += 10 }>assign</button>
+<div>${count}:${missing}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+const increment = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("button.inc")!.click();
+};
+
+const assign = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("button.assign")!.click();
+};
+
+export const config: TestConfig = {
+  steps: [{}, increment, assign, increment],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// tags/child/index.marko
+const $template$1 = "<span>child:<!></span>";
+const $walks$1 = "Db%l";
+const $count$1 = /*@__PURE__*/ _let("count/1", ($scope) => {
+	_return($scope, {
+		count: $scope.count,
+		inc: $_return($scope)
+	});
+	_text($scope["#text/0"], $scope.count);
+});
+function $setup$1($scope) {
+	$count$1($scope, 1);
+}
+function $_return($scope) {
+	return function() {
+		$count$1($scope, $scope.count + 1);
+	};
+}
+_resume("__tests__/tags/child/index.marko_0/_return", $_return);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, $setup$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<button class=inc>inc</button><div> </div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b0${_w0}& bD l`)($walks$1);
+const $pattern2 = _var_resume("__tests__/template.marko_0_$pattern/var", ($scope, $pattern) => {
+	$count($scope, $pattern.count);
+	$inc($scope, $pattern.inc);
+});
+const $count = ($scope, count) => _text($scope["#text/3"], count);
+const $inc__script = _script("__tests__/template.marko_0_inc", ($scope) => _on($scope["#button/2"], "click", function() {
+	$scope.inc();
+}));
+const $inc = /*@__PURE__*/ _const("inc", $inc__script);
+function $setup($scope) {
+	_var($scope, "#childScope/0", $pattern2);
+	$setup$1($scope["#childScope/0"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/dom.bundle.js
@@ -1,0 +1,24 @@
+// tags/child/index.marko
+const $count$1 = /*@__PURE__*/ _let(1, ($scope) => {
+	_return($scope, {
+		count: $scope.b,
+		inc: $_return($scope)
+	});
+	_text($scope.a, $scope.b);
+});
+function $_return($scope) {
+	return function() {
+		$count$1($scope, $scope.b + 1);
+	};
+}
+_resume("b0", $_return);
+
+// template.marko
+const $pattern2 = _var_resume("a0", ($scope, $pattern) => {
+	$count($scope, $pattern.count);
+	$inc($scope, $pattern.inc);
+});
+const $count = ($scope, count) => _text($scope.d, count);
+const $inc = /*@__PURE__*/ _const(6, _script("a1", ($scope) => _on($scope.c, "click", function() {
+	$scope.g();
+})));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,31 @@
+// tags/child/index.marko
+var child_default = _template("__tests__/tags/child/index.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const $return = {
+		count,
+		inc: _resume(function() {
+			count++;
+		}, "__tests__/tags/child/index.marko_0/_return", $scope0_id)
+	};
+	_html(`<span>child:<!>${_escape(count)}${_el_resume($scope0_id, "#text/0")}</span>`);
+	writeScope($scope0_id, { count }, "__tests__/tags/child/index.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { count, inc } = child_default({});
+	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_$pattern/var");
+	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "#button/2")}<div>${_escape(count)}${_el_resume($scope0_id, "#text/3")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_inc");
+	writeScope($scope0_id, {
+		inc,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { inc: "3:20" });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/html.bundle.js
@@ -1,0 +1,31 @@
+// tags/child/index.marko
+var child_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 1;
+	const $return = {
+		count,
+		inc: _resume(function() {
+			count++;
+		}, "b0", $scope0_id)
+	};
+	_html(`<span>child:<!>${_escape(count)}${_el_resume($scope0_id, "a")}</span>`);
+	writeScope($scope0_id, { b: count });
+	_resume_branch($scope0_id);
+	return $return;
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $childScope = _peek_scope_id();
+	let { count, inc } = child_default({});
+	_var($scope0_id, "b", $childScope, "a0");
+	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "c")}<div>${_escape(count)}${_el_resume($scope0_id, "d")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		g: inc,
+		a: _existing_scope($childScope)
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/render.debug.md
@@ -1,0 +1,60 @@
+# Render
+```html
+<span>
+  child:1
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  1
+</div>
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:2
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  2
+</div>
+```
+## Change
+```
+UPDATE: div::text "1" => "2"
+UPDATE: span::text@6 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:3
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  3
+</div>
+```
+## Change
+```
+UPDATE: div::text "2" => "3"
+UPDATE: span::text@6 "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/render.md
@@ -1,0 +1,60 @@
+# Render
+```html
+<span>
+  child:1
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  1
+</div>
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:2
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  2
+</div>
+```
+## Change
+```
+UPDATE: div::text "1" => "2"
+UPDATE: span::text@6 "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("button.inc").click();
+```
+```html
+<span>
+  child:3
+</span>
+<button
+  class="inc"
+>
+  inc
+</button>
+<div>
+  3
+</div>
+```
+## Change
+```
+UPDATE: div::text "2" => "3"
+UPDATE: span::text@6 "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/writes.debug.html
@@ -1,0 +1,21 @@
+<span>child:<!>1<!--M_*2 #text/0--></span><button
+  class=inc>inc</button><!--M_*1 #button/2-->
+<div>1<!--M_*1 #text/3--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "#scopeOffset/1": 3,
+      inc: _(2,
+        "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/tags/child/index.marko_0/_return"
+        ),
+      "#childScope/0": _(2)
+    }, {
+      "#TagVariable": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/template.marko_0_$pattern/var"
+        ),
+      count: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/template.marko_0_inc 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<span>child:<!>1<!--M_*2 a--></span><button class=inc>inc</button><!--M_*1 c-->
+<div>1<!--M_*1 d--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 3,
+    g: _(2, "b0"),
+    a: _(2)
+  }, {
+    T: _(1, "a0"),
+    b: 1
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2914,
+        "brotli": 1438
+      },
+      "files": {
+        "tags/child/index.marko": 312,
+        "template.marko": 340
+      }
+    }
+  },
+  "html": {
+    "min": 449,
+    "brotli": 299
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/tags/child/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/tags/child/index.marko
@@ -1,0 +1,8 @@
+<let/count = 1/>
+<return={
+  count,
+  inc() {
+    count++;
+  },
+}/>
+<span>child:${count}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/template.marko
@@ -1,0 +1,5 @@
+import child from "<child>";
+
+<${child}/{ count, inc }/>
+<button.inc onClick() { inc() }>inc</button>
+<div>${count}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+const increment = (container: Element) => {
+  container.querySelector<HTMLButtonElement>("button.inc")!.click();
+};
+
+export const config: TestConfig = {
+  steps: [{}, increment, increment],
+};

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -227,11 +227,7 @@ export function knownTagTranslateHTML(
             getScopeAccessorLiteral(tag.node.extra![kChildOffsetScopeBinding]!),
             peekScopeId,
             t.stringLiteral(
-              getResumeRegisterId(
-                section,
-                (node.var as t.Identifier).extra?.binding, // TODO: node.var is not always an identifier.
-                "var",
-              ),
+              getResumeRegisterId(section, tagVar.extra?.binding, "var"),
             ),
           ),
         ),
@@ -350,10 +346,7 @@ export function knownTagTranslateDOM(
 
   if (node.var) {
     const varBinding = node.var.extra!.binding!;
-    const source = initValue(
-      // TODO: support destructuring
-      varBinding,
-    );
+    const source = initValue(varBinding);
     source.register = true;
     source.buildAssignment = (valueSection, value) => {
       const changeArgs = [

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -472,7 +472,7 @@ export default {
                 t.stringLiteral(
                   getResumeRegisterId(
                     tagSection,
-                    (node.var as t.Identifier).extra?.binding, // TODO: node.var is not always an identifier.
+                    node.var.extra?.binding,
                     "var",
                   ),
                 ),
@@ -496,10 +496,7 @@ export default {
         let tagVarSignal: Signal | undefined;
         if (tag.node.var) {
           const varBinding = tag.node.var.extra!.binding!;
-          tagVarSignal = initValue(
-            // TODO: support destructuring
-            varBinding,
-          );
+          tagVarSignal = initValue(varBinding);
           tagVarSignal.register = true;
           tagVarSignal.buildAssignment = (valueSection, value) => {
             const changeArgs = [


### PR DESCRIPTION
## Description

Four TODOs claimed tag variable handling still needed destructuring support (`known-tag.ts`, `dynamic-tag.ts`), but destructured tag variables on custom and dynamic tags already work end to end. The new `custom-tag-var-destructured` and `dynamic-tag-var-destructured` fixtures lock that in across SSR, resume, and CSR: reactive destructured reads, method calls into child state, assignment through a destructured alias via the `countChange` change protocol, and a destructure default.

With the behavior covered, the stale TODOs are removed and the `node.var as t.Identifier` casts are replaced with direct `extra.binding` access (pattern nodes carry the synthetic pattern binding, so the cast was only a type lie). Compiled output is unchanged; the changeset is empty since there is nothing to release.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy

---
_Generated by [Claude Code](https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy)_