### PR TITLE
chore: exercise nested state write in push/pop fixture, drop stale TODO

### DIFF
--- a/.changeset/nested-write-fixture.md
+++ b/.changeset/nested-write-fixture.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixture-only change; no release.

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.debug.js
@@ -8,9 +8,7 @@ const $for = /*@__PURE__*/ _for_of("#text/0", " ", " b", 0, $for_content__$param
 const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items]));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	_on($scope["#button/1"], "click", function() {
-		const nextId = $scope.id + 1;
-		$id($scope, nextId);
-		$items($scope, [...$scope.items, nextId]);
+		$items($scope, [...$scope.items, $id($scope, $scope.id + 1)]);
 	});
 	_on($scope["#button/2"], "click", function() {
 		$items($scope, $scope.items.slice(0, -1));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/dom.bundle.js
@@ -6,9 +6,7 @@ const $for = /*@__PURE__*/ _for_of(0, " ", " b", 0, $for_content__$params);
 const $items = /*@__PURE__*/ _let(4, ($scope) => $for($scope, [$scope.e]));
 const $setup__script = _script("a0", ($scope) => {
 	_on($scope.b, "click", function() {
-		const nextId = $scope.d + 1;
-		$id($scope, nextId);
-		$items($scope, [...$scope.e, nextId]);
+		$items($scope, [...$scope.e, $id($scope, $scope.d + 1)]);
 	});
 	_on($scope.c, "click", function() {
 		$items($scope, $scope.e.slice(0, -1));

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7152,
-      "brotli": 3261
+      "min": 7142,
+      "brotli": 3256
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/template.marko
@@ -4,11 +4,6 @@
 
   <for|item| of=items>${item}</for>
 
-  <button id="add" onClick() { 
-    // TODO: nested writes ([...items, id++]) don't work
-    const nextId = id + 1;
-    id = nextId;
-    items = [...items, nextId];
-  }>Add</button>
+  <button id="add" onClick() { items = [...items, ++id]; }>Add</button>
   <button id="remove" onClick() { items = items.slice(0, -1); }>Remove</button>
 </div>


### PR DESCRIPTION
# Description

The `basic-push-pop-list` fixture carried a TODO claiming nested writes (`[...items, id++]`) don't work, with a multi-statement workaround in the add handler. Nested writes compile correctly today: the inner signal call returns the new value, so `items = [...items, ++id]` becomes `$items($scope, [...$scope.items, $id($scope, $scope.id + 1)])`.

This swaps the workaround for the direct nested-write form (using `++id` so the pushed values stay `1, 2, 3`) and removes the TODO. Behavior snapshots (`render.md`, `writes.html`) are byte-identical; only the DOM bundle snapshots and `sizes.json` change, both slightly smaller.

# Checklist:

- [x] I have read the [CLA](https://github.com/marko-js/marko/blob/main/.github/CLA.md) and agree to its terms
- [ ] I have updated the documentation to reflect my changes (n/a, test fixture only)
- [x] I have added/updated tests to cover my changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy

---
_Generated by [Claude Code](https://claude.ai/code/session_0145yt8UHEoERTqhrew3Z9xy)_