### PR TITLE
fix: make binding default values first class

### DIFF
--- a/.changeset/param-top-level-default.md
+++ b/.changeset/param-top-level-default.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix default values on top level tag parameters (eg `<my-tag|a, b = a|>`) being dropped in the DOM output, which caused a crash or stale content client side. Default values in tag parameters and destructured tag variables are now represented uniformly in the compiler and defaulted values are consistently resumable. Defaults whose fallback needs no state compile to native parameter defaults in the DOM output, and defaults on unused bindings are pruned from it entirely.

--- a/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/__snapshots__/dom.bundle.debug.js
@@ -1,15 +1,15 @@
 // template.marko
 const $template = "<button>inc <!></button><div><!>|<!>|<!></div>";
 const $walks = " Db%lD%c%c%l";
+const $second2 = ($scope, second = "dflt") => _text($scope["#text/3"], second);
+const $second3 = $second2;
 const $pattern2 = ($scope, $pattern) => {
 	(([, , ...others]) => $others($scope, others))($pattern);
 	$first($scope, $pattern[0]);
-	$second2($scope, $pattern[1]);
+	$second3($scope, $pattern[1]);
 };
 const $others = ($scope, others) => _text($scope["#text/4"], others.join(","));
 const $first = ($scope, first) => _text($scope["#text/2"], first);
-const $second3 = ($scope, second) => _text($scope["#text/3"], second);
-const $second2 = ($scope, $second) => $second3($scope, void 0 !== $second ? $second : "dflt");
 const $input_list = $pattern2;
 const $n = /*@__PURE__*/ _let("n/13", ($scope) => _text($scope["#text/1"], $scope.n));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/dom.bundle.debug.js
@@ -2,8 +2,8 @@
 const $Wrap_content__walks = "D%c%l", $Wrap_content__template = "<div><!>|<!></div>";
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<button>inc</button>${_w0}${_w1}<!>`)($Wrap_content__template, $Wrap_content__template);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => ` b/${_w0}&/${_w1}&b`)($Wrap_content__walks, $Wrap_content__walks);
-const $Wrap_content__a = ($scope, a) => _text($scope["#text/0"], a);
-const $Wrap_content__$a = ($scope, $a) => $Wrap_content__a($scope, void 0 !== $a ? $a : 1);
+const $Wrap_content__a = ($scope, a = 1) => _text($scope["#text/0"], a);
+const $Wrap_content__$a = $Wrap_content__a;
 const $Wrap_content__b = ($scope, b) => _text($scope["#text/1"], b);
 const $Wrap_content__tag_param_ = ($scope, $temp) => {
 	$Wrap_content__$a($scope, $temp[0]);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/dom.bundle.js
@@ -1,6 +1,6 @@
 // template.marko
-const $Wrap_content__a = ($scope, a) => _text($scope.a, a);
-const $Wrap_content__$a = ($scope, $a) => $Wrap_content__a($scope, void 0 !== $a ? $a : 1);
+const $Wrap_content__a = ($scope, a = 1) => _text($scope.a, a);
+const $Wrap_content__$a = $Wrap_content__a;
 const $Wrap_content__b = ($scope, b) => _text($scope.b, b);
 const $Wrap_content__tag_param_ = ($scope, $temp) => {
 	$Wrap_content__$a($scope, $temp[0]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.debug.js
@@ -29,11 +29,13 @@ var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $templ
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button class=inc>inc</button><button class=assign>assign</button><div><!>:<!></div>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `0${_w0}& b bD%c%l`)($walks$1);
+const $missing2 = ($scope, missing = "fallback") => _text($scope["#text/5"], missing);
+const $missing3 = $missing2;
 const $pattern2 = _var_resume("__tests__/template.marko_0_$pattern/var", ($scope, $pattern) => {
 	$count($scope, $pattern.count);
 	$countChange2($scope, $pattern.countChange);
 	$inc($scope, $pattern.inc);
-	$missing2($scope, $pattern.missing);
+	$missing3($scope, $pattern.missing);
 });
 const $count__OR__$countChange__script = _script("__tests__/template.marko_0_count_$countChange", ($scope) => _on($scope["#button/3"], "click", function() {
 	$scope.$countChange($scope.count + 10);
@@ -48,8 +50,6 @@ const $inc__script = _script("__tests__/template.marko_0_inc", ($scope) => _on($
 	$scope.inc();
 }));
 const $inc = /*@__PURE__*/ _const("inc", $inc__script);
-const $missing3 = ($scope, missing) => _text($scope["#text/5"], missing);
-const $missing2 = ($scope, $missing) => $missing3($scope, void 0 !== $missing ? $missing : "fallback");
 function $setup($scope) {
 	_var($scope, "#childScope/0", $pattern2);
 	$setup$1($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/dom.bundle.js
@@ -21,11 +21,13 @@ _resume("b1", $_return2);
 _resume("b0", $_return);
 
 // template.marko
+const $missing2 = ($scope, missing = "fallback") => _text($scope.f, missing);
+const $missing3 = $missing2;
 const $pattern2 = _var_resume("a0", ($scope, $pattern) => {
 	$count($scope, $pattern.count);
 	$countChange2($scope, $pattern.countChange);
 	$inc($scope, $pattern.inc);
-	$missing2($scope, $pattern.missing);
+	$missing3($scope, $pattern.missing);
 });
 const $count__OR__$countChange = /*@__PURE__*/ _or(9, _script("a1", ($scope) => _on($scope.d, "click", function() {
 	$scope.i($scope.h + 10);
@@ -38,5 +40,3 @@ const $countChange2 = /*@__PURE__*/ _const(8, $count__OR__$countChange);
 const $inc = /*@__PURE__*/ _const(10, _script("a2", ($scope) => _on($scope.c, "click", function() {
 	$scope.k();
 })));
-const $missing3 = ($scope, missing) => _text($scope.f, missing);
-const $missing2 = ($scope, $missing) => $missing3($scope, void 0 !== $missing ? $missing : "fallback");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.debug.js
@@ -24,8 +24,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $childScope = _peek_scope_id();
 	let { countChange: $countChange, count, inc, missing: $missing } = child_default({});
-	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_$pattern/var");
 	const missing = void 0 !== $missing ? $missing : "fallback";
+	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_$pattern/var");
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "#button/2")}<button class=assign>assign</button>${_el_resume($scope0_id, "#button/3")}<div>${_escape(count)}${_el_resume($scope0_id, "#text/4")}:<!>${_escape(missing)}${_el_resume($scope0_id, "#text/5")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0_count_$countChange");
 	_script($scope0_id, "__tests__/template.marko_0_inc");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/__snapshots__/html.bundle.js
@@ -24,8 +24,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $childScope = _peek_scope_id();
 	let { countChange: $countChange, count, inc, missing: $missing } = child_default({});
-	_var($scope0_id, "b", $childScope, "a0");
 	const missing = void 0 !== $missing ? $missing : "fallback";
+	_var($scope0_id, "b", $childScope, "a0");
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "c")}<button class=assign>assign</button>${_el_resume($scope0_id, "d")}<div>${_escape(count)}${_el_resume($scope0_id, "e")}:<!>${_escape(missing)}${_el_resume($scope0_id, "f")}</div>`);
 	_script($scope0_id, "a1");
 	_script($scope0_id, "a2");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3249,
-        "brotli": 1580
+        "min": 3228,
+        "brotli": 1573
       },
       "files": {
         "tags/child.marko": 454,
-        "template.marko": 883
+        "template.marko": 821
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,43 @@
+// template.marko
+const $template = "<div id=a><!>:<!></div><div id=b><!>:<!></div><button id=clear>clear</button><button id=inc>inc</button>";
+const $walks = "D%c%lD%c%l b b";
+const $fallback3 = ($scope, fallback) => _text($scope["#text/1"], fallback);
+const $x__OR__$fallback = /*@__PURE__*/ _or(12, ($scope) => $fallback3($scope, void 0 !== $scope.item ? $scope.item : $scope.x * 10));
+const $other3 = ($scope, other) => _text($scope["#text/2"], other);
+const $x__OR__$other = /*@__PURE__*/ _or(13, ($scope) => $other3($scope, void 0 !== $scope.$other ? $scope.$other : $scope.x + 100));
+const $x = /*@__PURE__*/ _let("x/6", ($scope) => {
+	$x__OR__$fallback($scope);
+	$x__OR__$other($scope);
+});
+const $source = /*@__PURE__*/ _let("source/7", ($scope) => {
+	$item($scope, $scope.source.item);
+	$other2($scope, $scope.source.other);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/4"], "click", function() {
+		$source($scope, {});
+	});
+	_on($scope["#button/5"], "click", function() {
+		$x($scope, $scope.x + 1);
+	});
+});
+function $setup($scope) {
+	$x($scope, 1);
+	$source($scope, {
+		item: "i",
+		other: "o"
+	});
+	$setup__script($scope);
+}
+const $item = /*@__PURE__*/ _const("item", ($scope) => {
+	_text($scope["#text/0"], String($scope.item));
+	$x__OR__$fallback($scope);
+});
+const $other2 = /*@__PURE__*/ _const("$other", ($scope) => {
+	$raw($scope, $scope.$other);
+	$x__OR__$other($scope);
+});
+const $raw = ($scope) => {
+	_text($scope["#text/3"], String($scope.$other));
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/dom.bundle.js
@@ -1,0 +1,32 @@
+// template.marko
+const $fallback3 = ($scope, fallback) => _text($scope.b, fallback);
+const $x__OR__$fallback = /*@__PURE__*/ _or(12, ($scope) => $fallback3($scope, void 0 !== $scope.i ? $scope.i : $scope.g * 10));
+const $other3 = ($scope, other) => _text($scope.c, other);
+const $x__OR__$other = /*@__PURE__*/ _or(13, ($scope) => $other3($scope, void 0 !== $scope.k ? $scope.k : $scope.g + 100));
+const $x = /*@__PURE__*/ _let(6, ($scope) => {
+	$x__OR__$fallback($scope);
+	$x__OR__$other($scope);
+});
+const $source = /*@__PURE__*/ _let(7, ($scope) => {
+	$item($scope, $scope.h.item);
+	$other2($scope, $scope.h.other);
+});
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.e, "click", function() {
+		$source($scope, {});
+	});
+	_on($scope.f, "click", function() {
+		$x($scope, $scope.g + 1);
+	});
+});
+const $item = /*@__PURE__*/ _const(8, ($scope) => {
+	_text($scope.a, String($scope.i));
+	$x__OR__$fallback($scope);
+});
+const $other2 = /*@__PURE__*/ _const(10, ($scope) => {
+	$raw($scope, $scope.k);
+	$x__OR__$other($scope);
+});
+const $raw = ($scope) => {
+	_text($scope.d, String($scope.k));
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,28 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = 1;
+	let source = {
+		item: "i",
+		other: "o"
+	};
+	const { item } = source;
+	const { item: $fallback } = source;
+	const fallback = void 0 !== $fallback ? $fallback : x * 10;
+	const { other: $other } = source;
+	const other = void 0 !== $other ? $other : x + 100;
+	const { other: raw } = source;
+	_html(`<div id=a>${_escape(String(item))}${_el_resume($scope0_id, "#text/0")}:<!>${_escape(fallback)}${_el_resume($scope0_id, "#text/1")}</div><div id=b>${_escape(other)}${_el_resume($scope0_id, "#text/2")}:<!>${_escape(String(raw))}${_el_resume($scope0_id, "#text/3")}</div><button id=clear>clear</button>${_el_resume($scope0_id, "#button/4")}<button id=inc>inc</button>${_el_resume($scope0_id, "#button/5")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		x,
+		item,
+		$other
+	}, "__tests__/template.marko", 0, {
+		x: "1:6",
+		item: "5:10",
+		$other: "9:10"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/html.bundle.js
@@ -1,0 +1,24 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = 1;
+	let source = {
+		item: "i",
+		other: "o"
+	};
+	const { item } = source;
+	const { item: $fallback } = source;
+	const fallback = void 0 !== $fallback ? $fallback : x * 10;
+	const { other: $other } = source;
+	const other = void 0 !== $other ? $other : 101;
+	const { other: raw } = source;
+	_html(`<div id=a>${_escape(String(item))}${_el_resume($scope0_id, "a")}:<!>${_escape(fallback)}${_el_resume($scope0_id, "b")}</div><div id=b>${_escape(other)}${_el_resume($scope0_id, "c")}:<!>${_escape(String(raw))}${_el_resume($scope0_id, "d")}</div><button id=clear>clear</button>${_el_resume($scope0_id, "e")}<button id=inc>inc</button>${_el_resume($scope0_id, "f")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		g: x,
+		i: item,
+		k: $other
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/render.debug.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<div
+  id="a"
+>
+  i:i
+</div>
+<div
+  id="b"
+>
+  o:o
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+
+# Update
+```js
+container.querySelector("#clear").click();
+```
+```html
+<div
+  id="a"
+>
+  undefined:10
+</div>
+<div
+  id="b"
+>
+  101:undefined
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: #a::text@0 "i" => "undefined"
+UPDATE: #b::text@4 "o" => "undefined"
+UPDATE: #a::text@10 "i" => "10"
+UPDATE: #b::text@0 "o" => "101"
+```
+
+# Update
+```js
+container.querySelector("#inc").click();
+```
+```html
+<div
+  id="a"
+>
+  undefined:20
+</div>
+<div
+  id="b"
+>
+  102:undefined
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: #a::text@10 "10" => "20"
+UPDATE: #b::text@0 "101" => "102"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/render.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<div
+  id="a"
+>
+  i:i
+</div>
+<div
+  id="b"
+>
+  o:o
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+
+# Update
+```js
+container.querySelector("#clear").click();
+```
+```html
+<div
+  id="a"
+>
+  undefined:10
+</div>
+<div
+  id="b"
+>
+  101:undefined
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: #a::text@0 "i" => "undefined"
+UPDATE: #b::text@4 "o" => "undefined"
+UPDATE: #a::text@10 "i" => "10"
+UPDATE: #b::text@0 "o" => "101"
+```
+
+# Update
+```js
+container.querySelector("#inc").click();
+```
+```html
+<div
+  id="a"
+>
+  undefined:20
+</div>
+<div
+  id="b"
+>
+  102:undefined
+</div>
+<button
+  id="clear"
+>
+  clear
+</button>
+<button
+  id="inc"
+>
+  inc
+</button>
+```
+## Change
+```
+UPDATE: #a::text@10 "10" => "20"
+UPDATE: #b::text@0 "101" => "102"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<div id=a>i<!--M_*1 #text/0-->:<!>i<!--M_*1 #text/1--></div>
+<div id=b>o<!--M_*1 #text/2-->:<!>o<!--M_*1 #text/3--></div><button
+  id=clear>clear</button><!--M_*1 #button/4--><button
+  id=inc>inc</button><!--M_*1 #button/5-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      x: 1,
+      item: "i",
+      $other: "o"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<div id=a>i<!--M_*1 a-->:<!>i<!--M_*1 b--></div>
+<div id=b>o<!--M_*1 c-->:<!>o<!--M_*1 d--></div><button
+  id=clear>clear</button><!--M_*1 e--><button id=inc>inc</button><!--M_*1 f-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: 1,
+    i: "i",
+    k: "o"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2700,
-      "brotli": 1362
+      "min": 3085,
+      "brotli": 1508
     }
   },
   "html": {
-    "min": 442,
-    "brotli": 285
+    "min": 500,
+    "brotli": 301
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/template.marko
@@ -1,0 +1,16 @@
+<let/x=1/>
+<let/source = { item: "i", other: "o" }/>
+
+// Plain alias first, defaulted alias second.
+<const/{ item } = source/>
+<const/{ item: fallback = x * 10 } = source/>
+
+// Defaulted alias first, plain alias second.
+<const/{ other = x + 100 } = source/>
+<const/{ other: raw } = source/>
+
+<div id="a">${String(item)}:${fallback}</div>
+<div id="b">${other}:${String(raw)}</div>
+
+<button id="clear" onClick() { source = {} }>clear</button>
+<button id="inc" onClick() { x++ }>inc</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-alias-default/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickClear(container: Element) {
+  (container.querySelector("#clear") as HTMLButtonElement).click();
+}
+
+function clickInc(container: Element) {
+  (container.querySelector("#inc") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickClear, clickInc],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,29 @@
+// template.marko
+const $template = "<div id=out><!>:<!>:<!></div><button id=update>u</button>";
+const $walks = "D%c%c%l b";
+const $list = /*@__PURE__*/ _let("list/4", ($scope) => {
+	$list_($scope, $scope.list?.[0]);
+	$list_2($scope, $scope.list?.[1]);
+});
+const $pattern4 = ($scope, $pattern) => (([, ...rest]) => $rest($scope, rest))($pattern);
+const $list_ = /*@__PURE__*/ _const("list_0", ($scope) => $pattern4($scope, $scope.list_0));
+const $pattern6 = ($scope, $pattern2) => $temp2($scope, $pattern2[0]);
+const $list_2 = /*@__PURE__*/ _const("list_1", ($scope) => $pattern6($scope, $scope.list_1));
+const $obj = /*@__PURE__*/ _let("obj/7", ($scope) => $kept($scope, $scope.obj.kept));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/3"], "click", function() {
+	$obj($scope, {});
+	$list($scope, [[{ n: 1 }, { n: 2 }], [{ c: "C" }]]);
+}));
+function $setup($scope) {
+	$list($scope, [[{ n: 1 }], []]);
+	$obj($scope, { kept: "k" });
+	$setup__script($scope);
+}
+const $kept = /*@__PURE__*/ _const("kept", ($scope) => _text($scope["#text/1"], String($scope.kept)));
+const $rest = ($scope, rest) => $rest_length($scope, rest.length);
+const $rest_length = ($scope, rest_length) => _text($scope["#text/0"], rest_length);
+const $pattern5 = ($scope, $pattern3 = {}) => $c2($scope, $pattern3.c);
+const $c3 = ($scope, c = "c") => _text($scope["#text/2"], c);
+const $c2 = $c3;
+const $temp2 = $pattern5;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/dom.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+const $list = /*@__PURE__*/ _let(4, ($scope) => {
+	$list_($scope, $scope.e?.[0]);
+	$list_2($scope, $scope.e?.[1]);
+});
+const $pattern4 = ($scope, $pattern) => (([, ...rest]) => $rest($scope, rest))($pattern);
+const $list_ = /*@__PURE__*/ _const(5, ($scope) => $pattern4($scope, $scope.f));
+const $pattern6 = ($scope, $pattern2) => $temp2($scope, $pattern2[0]);
+const $list_2 = /*@__PURE__*/ _const(6, ($scope) => $pattern6($scope, $scope.g));
+const $obj = /*@__PURE__*/ _let(7, ($scope) => $kept($scope, $scope.h.kept));
+const $setup__script = _script("a0", ($scope) => _on($scope.d, "click", function() {
+	$obj($scope, {});
+	$list($scope, [[{ n: 1 }, { n: 2 }], [{ c: "C" }]]);
+}));
+const $kept = /*@__PURE__*/ _const(11, ($scope) => _text($scope.b, String($scope.l)));
+const $rest = ($scope, rest) => $rest_length($scope, rest.length);
+const $rest_length = ($scope, rest_length) => _text($scope.a, rest_length);
+const $pattern5 = ($scope, $pattern3 = {}) => $c2($scope, $pattern3.c);
+const $c3 = ($scope, c = "c") => _text($scope.c, c);
+const $c2 = $c3;
+const $temp2 = $pattern5;

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let list = [[{ n: 1 }], []];
+	let obj = { kept: "k" };
+	const [$skipped, ...rest] = list[0];
+	const skipped = void 0 !== $skipped ? $skipped : { n: 0 };
+	const { ignored: $ignored, kept } = obj;
+	const ignored = void 0 !== $ignored ? $ignored : 1;
+	const [$temp] = list[1];
+	const { b: $b, c: $c } = void 0 !== $temp ? $temp : {};
+	const b = void 0 !== $b ? $b : kept;
+	const c = void 0 !== $c ? $c : "c";
+	_html(`<div id=out>${_escape(rest.length)}${_el_resume($scope0_id, "#text/0")}:<!>${_escape(String(kept))}${_el_resume($scope0_id, "#text/1")}:<!>${_escape(c)}${_el_resume($scope0_id, "#text/2")}</div><button id=update>u</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/html.bundle.js
@@ -1,0 +1,16 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let list = [[{ n: 1 }], []];
+	let obj = { kept: "k" };
+	const [$skipped, ...rest] = list[0];
+	const { ignored: $ignored, kept } = obj;
+	const [$temp] = list[1];
+	const { b: $b, c: $c } = void 0 !== $temp ? $temp : {};
+	const c = void 0 !== $c ? $c : "c";
+	_html(`<div id=out>${_escape(rest.length)}${_el_resume($scope0_id, "a")}:<!>${_escape(String(kept))}${_el_resume($scope0_id, "b")}:<!>${_escape(c)}${_el_resume($scope0_id, "c")}</div><button id=update>u</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/render.debug.md
@@ -1,0 +1,36 @@
+# Render
+```html
+<div
+  id="out"
+>
+  0:k:c
+</div>
+<button
+  id="update"
+>
+  u
+</button>
+```
+
+# Update
+```js
+container.querySelector("#update").click();
+```
+```html
+<div
+  id="out"
+>
+  1:undefined:C
+</div>
+<button
+  id="update"
+>
+  u
+</button>
+```
+## Change
+```
+UPDATE: #out::text@0 "0" => "1"
+UPDATE: #out::text@12 "c" => "C"
+UPDATE: #out::text@2 "k" => "undefined"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/render.md
@@ -1,0 +1,36 @@
+# Render
+```html
+<div
+  id="out"
+>
+  0:k:c
+</div>
+<button
+  id="update"
+>
+  u
+</button>
+```
+
+# Update
+```js
+container.querySelector("#update").click();
+```
+```html
+<div
+  id="out"
+>
+  1:undefined:C
+</div>
+<button
+  id="update"
+>
+  u
+</button>
+```
+## Change
+```
+UPDATE: #out::text@0 "0" => "1"
+UPDATE: #out::text@12 "c" => "C"
+UPDATE: #out::text@2 "k" => "undefined"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/writes.debug.html
@@ -1,0 +1,9 @@
+<div id=out>0<!--M_*1 #text/0-->:<!>k<!--M_*1 #text/1-->:<!>c<!--M_*1 #text/2-->
+</div><button id=update>u</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/__snapshots__/writes.html
@@ -1,0 +1,7 @@
+<div id=out>0<!--M_*1 a-->:<!>k<!--M_*1 b-->:<!>c<!--M_*1 c--></div><button
+  id=update>u</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = ["a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2700,
-      "brotli": 1362
+      "min": 2968,
+      "brotli": 1484
     }
   },
   "html": {
-    "min": 442,
-    "brotli": 285
+    "min": 404,
+    "brotli": 263
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/template.marko
@@ -1,0 +1,13 @@
+<let/list=[[{ n: 1 }], []]/>
+<let/obj={ kept: "k" }/>
+
+// Dead defaults must prune without pinning their source to the pattern.
+<const/[skipped = { n: 0 }, ...rest] = list[0]/>
+<const/{ ignored = 1, kept } = obj/>
+<const/[{ b = kept, c = "c" } = {}] = list[1]/>
+
+<div id="out">${rest.length}:${String(kept)}:${c}</div>
+<button id="update" onClick() {
+  obj = {};
+  list = [[{ n: 1 }, { n: 2 }], [{ c: "C" }]];
+}>u</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-unused-default/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function clickUpdate(container: Element) {
+  (container.querySelector("#update") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickUpdate],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.debug.js
@@ -2,10 +2,10 @@
 const $template = "<button>before</button>";
 const $walks = " b";
 const updateText = $updateText;
-const $pattern2 = ($scope, $pattern) => $onClick2($scope, $pattern.onClick);
-const $onClick3__script = _script("__tests__/template.marko_0_onClick", ($scope) => _on($scope["#button/0"], "click", $scope.onClick));
-const $onClick3 = /*@__PURE__*/ _const("onClick", $onClick3__script);
-const $onClick2 = ($scope, $onClick) => $onClick3($scope, void 0 !== $onClick ? $onClick : updateText);
+const $onClick2__script = _script("__tests__/template.marko_0_onClick", ($scope) => _on($scope["#button/0"], "click", $scope.onClick));
+const $onClick2 = /*@__PURE__*/ _const("onClick", $onClick2__script);
+const $onClick3 = ($scope, $onClick = updateText) => $onClick2($scope, $onClick);
+const $pattern2 = ($scope, $pattern) => $onClick3($scope, $pattern.onClick);
 function $setup($scope) {
 	$pattern2($scope, {});
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-const $onClick3 = /*@__PURE__*/ _const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d)));
+const $onClick2 = /*@__PURE__*/ _const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d)));
 function $updateText(ev) {
 	ev.target.textContent = "after";
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/__snapshots__/dom.bundle.debug.js
@@ -2,20 +2,20 @@
 const $ChildA_content__walks = "D%c%l", $ChildA_content__template = "<div class=a><!> <!></div>", $ChildB_content__walks = "D%c%l", $ChildB_content__template = "<div class=b><!> <!></div>";
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2, _w3, _w4, _w5) => `<!>${_w0}${_w1}${_w2}${_w3}${_w4}${_w5}<!>`)($ChildA_content__template, $ChildA_content__template, $ChildA_content__template, $ChildB_content__template, $ChildB_content__template, $ChildB_content__template);
 const $walks = /*@__PURE__*/ ((_w0, _w1, _w2, _w3, _w4, _w5) => `b/${_w0}&/${_w1}&/${_w2}&/${_w3}&/${_w4}&/${_w5}&b`)($ChildA_content__walks, $ChildA_content__walks, $ChildA_content__walks, $ChildB_content__walks, $ChildB_content__walks, $ChildB_content__walks);
-const $ChildB_content__$pattern = ($scope, $pattern2) => $ChildB_content__$bar($scope, $pattern2.bar);
-const $ChildB_content__bar = ($scope, bar) => _text($scope["#text/0"], bar);
-const $ChildB_content__$bar = ($scope, $bar2) => $ChildB_content__bar($scope, void 0 !== $bar2 ? $bar2 : 1);
-const $ChildB_content__$foo = ($scope, foo) => $ChildB_content__$pattern($scope, void 0 !== foo ? foo : { bar: 2 });
+const $ChildB_content__$pattern = ($scope, $pattern2 = { bar: 2 }) => $ChildB_content__$bar($scope, $pattern2.bar);
+const $ChildB_content__bar = ($scope, bar = 1) => _text($scope["#text/0"], bar);
+const $ChildB_content__$bar = $ChildB_content__bar;
+const $ChildB_content__$foo = $ChildB_content__$pattern;
 const $ChildB_content__foo = ($scope, foo) => {
 	_text($scope["#text/1"], typeof foo);
 	$ChildB_content__$foo($scope, foo);
 };
 const $ChildB_content__$params = ($scope, $params3) => $ChildB_content__input($scope, $params3[0]);
 const $ChildB_content__input = ($scope, input) => $ChildB_content__foo($scope, input.foo);
-const $ChildA_content__$pattern = ($scope, $pattern) => $ChildA_content__$bar($scope, $pattern.bar);
-const $ChildA_content__bar = ($scope, bar) => _text($scope["#text/0"], bar);
-const $ChildA_content__$bar = ($scope, $bar) => $ChildA_content__bar($scope, void 0 !== $bar ? $bar : 1);
-const $ChildA_content__$foo = ($scope, foo) => $ChildA_content__$pattern($scope, void 0 !== foo ? foo : { bar: 2 });
+const $ChildA_content__$pattern = ($scope, $pattern = { bar: 2 }) => $ChildA_content__$bar($scope, $pattern.bar);
+const $ChildA_content__bar = ($scope, bar = 1) => _text($scope["#text/0"], bar);
+const $ChildA_content__$bar = $ChildA_content__bar;
+const $ChildA_content__$foo = $ChildA_content__$pattern;
 const $ChildA_content__foo = ($scope, foo) => {
 	_text($scope["#text/1"], typeof foo);
 	$ChildA_content__$foo($scope, foo);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,72 @@
+// tags/child.marko
+const $template$1 = "<!><!><!><!>";
+const $walks$1 = "b%b%c";
+const $setup$1 = () => {};
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, 0, 1);
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag("#text/1", 0, 0, 1);
+const $input_content = ($scope, input_content) => {
+	$dynamicTag($scope, input_content, () => ["one"]);
+	$dynamicTag2($scope, input_content, () => ["two", 0]);
+};
+const $input = ($scope, input) => $input_content($scope, input.content);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+
+// template.marko
+const $Local_content__walks = "D%c%l", $Local_content__template = "<div id=local><!>:<!></div>";
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<!>${_w0}${_w1}<ul></ul><button id=x>x</button><button id=y>y</button>`)($template$1, $Local_content__template);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `b/${_w0}&/${_w1}& b b b`)($walks$1, $Local_content__walks);
+const $Local_content__b = ($scope, b) => _text($scope["#text/1"], b);
+const $Local_content__y__OR__$b = /*@__PURE__*/ _or(5, ($scope) => $Local_content__b($scope, void 0 !== $scope.$b2 ? $scope.$b2 : $scope._.y + 100));
+const $Local_content__y = /*@__PURE__*/ _closure_get("y", $Local_content__y__OR__$b);
+const $Local_content__setup = /*@__PURE__*/ _child_setup($Local_content__y);
+const $Local_content__$b = /*@__PURE__*/ _const("$b2", $Local_content__y__OR__$b);
+const $Local_content__a = ($scope, a) => _text($scope["#text/0"], a);
+const $Local_content__$params = ($scope, $params3) => {
+	$Local_content__a($scope, $params3[0]);
+	$Local_content__$b($scope, $params3[1]);
+};
+const $for_content__label = ($scope, label) => _text($scope["#text/0"], label);
+const $for_content__x__OR__$label = /*@__PURE__*/ _or(4, ($scope) => $for_content__label($scope, void 0 !== $scope.$label ? $scope.$label : $scope._.x));
+const $for_content__x = /*@__PURE__*/ _for_closure("#ul/2", $for_content__x__OR__$label);
+const $for_content__setup = $for_content__x;
+const $for_content__$label = /*@__PURE__*/ _const("$label", $for_content__x__OR__$label);
+const $for_content__$params = ($scope, $params4) => $for_content__$label($scope, ($params4?.[0]).label);
+const $child_content__b = ($scope, b) => _text($scope["#text/1"], b);
+const $child_content__x__OR__$b = /*@__PURE__*/ _or(5, ($scope) => $child_content__b($scope, void 0 !== $scope.$b ? $scope.$b : $scope._.x * 10));
+const $child_content__x = /*@__PURE__*/ _closure_get("x", $child_content__x__OR__$b);
+const $child_content__setup = $child_content__x;
+const $child_content__$b = /*@__PURE__*/ _const("$b", $child_content__x__OR__$b);
+const $child_content__a = ($scope, a) => _text($scope["#text/0"], a);
+const $child_content__$params = ($scope, $params2) => {
+	$child_content__a($scope, $params2[0]);
+	$child_content__$b($scope, $params2[1]);
+};
+const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1_content", "<div id=known><!>:<!></div>", "D%c%l", $child_content__setup, $child_content__$params);
+const $x__closure = /*@__PURE__*/ _closure($child_content__x);
+const $x = /*@__PURE__*/ _let("x/5", ($scope) => {
+	$x__closure($scope);
+	$for_content__x($scope);
+});
+const $y__closure = /*@__PURE__*/ _closure($Local_content__y);
+const $y = /*@__PURE__*/ _let("y/6", $y__closure);
+const $for = /*@__PURE__*/ _for_of("#ul/2", "<li> </li>", "D l", $for_content__setup, $for_content__$params);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/3"], "click", function() {
+		$x($scope, $scope.x + 1);
+	});
+	_on($scope["#button/4"], "click", function() {
+		$y($scope, $scope.y + 1);
+	});
+});
+function $setup($scope) {
+	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
+	$input_content($scope["#childScope/0"], $child_content($scope));
+	$Local_content__setup._($scope["#childScope/1"], $scope);
+	$Local_content__a($scope["#childScope/1"], "L");
+	$Local_content__$b($scope["#childScope/1"], void 0);
+	$x($scope, 1);
+	$y($scope, 1);
+	$for($scope, [[{}, { label: "a" }]]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/dom.bundle.js
@@ -1,0 +1,24 @@
+// template.marko
+const $Local_content__b = ($scope, b) => _text($scope.b, b);
+const $Local_content__y__OR__$b = /*@__PURE__*/ _or(5, ($scope) => $Local_content__b($scope, void 0 !== $scope.e ? $scope.e : $scope._.g + 100));
+const $Local_content__y = /*@__PURE__*/ _closure_get(8, $Local_content__y__OR__$b);
+const $for_content__label = ($scope, label) => _text($scope.a, label);
+const $for_content__x__OR__$label = /*@__PURE__*/ _or(4, ($scope) => $for_content__label($scope, void 0 !== $scope.d ? $scope.d : $scope._.f));
+const $for_content__x = /*@__PURE__*/ _for_closure(2, $for_content__x__OR__$label);
+const $child_content__b = ($scope, b) => _text($scope.b, b);
+const $child_content__x__OR__$b = /*@__PURE__*/ _or(5, ($scope) => $child_content__b($scope, void 0 !== $scope.e ? $scope.e : $scope._.f * 10));
+const $child_content__x = /*@__PURE__*/ _closure_get(7, $child_content__x__OR__$b);
+const $x__closure = /*@__PURE__*/ _closure($child_content__x);
+const $x = /*@__PURE__*/ _let(5, ($scope) => {
+	$x__closure($scope);
+	$for_content__x($scope);
+});
+const $y = /*@__PURE__*/ _let(6, /* @__PURE__ */ _closure($Local_content__y));
+const $setup__script = _script("a2", ($scope) => {
+	_on($scope.d, "click", function() {
+		$x($scope, $scope.f + 1);
+	});
+	_on($scope.e, "click", function() {
+		$y($scope, $scope.g + 1);
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,63 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_dynamic_tag($scope0_id, "#text/0", input.content, ["one"], 0, 1, $sg__input_content);
+	_dynamic_tag($scope0_id, "#text/1", input.content, ["two", 0], 0, 1, $sg__input_content);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $x__closures = new Set();
+	const $y__closures = new Set();
+	let x = 1;
+	let y = 1;
+	child_default({ content: _content("__tests__/template.marko_1_content", (a, $b) => {
+		const $scope1_reason = _scope_reason();
+		const b = void 0 !== $b ? $b : x * 10;
+		const $scope1_id = _scope_id();
+		_html(`<div id=known>${_escape(a)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}:<!>${_escape(b)}${_el_resume($scope1_id, "#text/1")}</div>`);
+		_subscribe($x__closures, writeScope($scope1_id, {
+			$b,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "4:2", { $b: "4:11" }));
+		_resume_branch($scope1_id);
+	}) });
+	const Local = { content: _content("__tests__/template.marko_3_content", (a, $b2) => {
+		const $scope3_id = _scope_id();
+		const $scope3_reason = _scope_reason();
+		const b = void 0 !== $b2 ? $b2 : y + 100;
+		_html(`<div id=local>${_escape(a)}${_el_resume($scope3_id, "#text/0", _serialize_guard($scope3_reason, 0))}:<!>${_escape(b)}${_el_resume($scope3_id, "#text/1")}</div>`);
+		_subscribe($y__closures, writeScope($scope3_id, {
+			$b2,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "8:2", { $b2: "8:18" }));
+		_resume_branch($scope3_id);
+	}) };
+	Local.content("L");
+	_html("<ul>");
+	_for_of([{}, { label: "a" }], ({ label: $label }) => {
+		const $scope2_id = _scope_id();
+		const label = void 0 !== $label ? $label : x;
+		_html(`<li>${_escape(label)}${_el_resume($scope2_id, "#text/0")}</li>`);
+		writeScope($scope2_id, {
+			$label,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "14:4", { $label: "14:10" });
+	}, 0, $scope0_id, "#ul/2", 1, 0, 0, 0, 1);
+	_html(`</ul><button id=x>x</button>${_el_resume($scope0_id, "#button/3")}<button id=y>y</button>${_el_resume($scope0_id, "#button/4")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		x,
+		y,
+		"ClosureScopes:x": $x__closures,
+		"ClosureScopes:y": $y__closures
+	}, "__tests__/template.marko", 0, {
+		x: "1:6",
+		y: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/html.bundle.js
@@ -1,0 +1,58 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_dynamic_tag($scope0_id, "a", input.content, ["one"], 0, 1, $sg__input_content);
+	_dynamic_tag($scope0_id, "b", input.content, ["two", 0], 0, 1, $sg__input_content);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $x__closures = /* @__PURE__ */ new Set();
+	const $y__closures = /* @__PURE__ */ new Set();
+	let x = 1;
+	let y = 1;
+	child_default({ content: _content("a0", (a, $b) => {
+		const $scope1_reason = _scope_reason();
+		const b = void 0 !== $b ? $b : x * 10;
+		const $scope1_id = _scope_id();
+		_html(`<div id=known>${_escape(a)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}:<!>${_escape(b)}${_el_resume($scope1_id, "b")}</div>`);
+		_subscribe($x__closures, writeScope($scope1_id, {
+			e: $b,
+			_: _scope_with_id($scope0_id)
+		}));
+		_resume_branch($scope1_id);
+	}) });
+	({ content: _content("a1", (a, $b2) => {
+		const $scope3_id = _scope_id();
+		const $scope3_reason = _scope_reason();
+		const b = void 0 !== $b2 ? $b2 : 101;
+		_html(`<div id=local>${_escape(a)}${_el_resume($scope3_id, "a", _serialize_guard($scope3_reason, 0))}:<!>${_escape(b)}${_el_resume($scope3_id, "b")}</div>`);
+		_subscribe($y__closures, writeScope($scope3_id, {
+			e: $b2,
+			_: _scope_with_id($scope0_id)
+		}));
+		_resume_branch($scope3_id);
+	}) }).content("L");
+	_html("<ul>");
+	_for_of([{}, { label: "a" }], ({ label: $label }) => {
+		const $scope2_id = _scope_id();
+		_html(`<li>${_escape(void 0 !== $label ? $label : x)}${_el_resume($scope2_id, "a")}</li>`);
+		writeScope($scope2_id, {
+			d: $label,
+			_: _scope_with_id($scope0_id)
+		});
+	}, 0, $scope0_id, "c", 1, 0, 0, 0, 1);
+	_html(`</ul><button id=x>x</button>${_el_resume($scope0_id, "d")}<button id=y>y</button>${_el_resume($scope0_id, "e")}`);
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, {
+		f: x,
+		g: y,
+		h: $x__closures,
+		i: $y__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/render.debug.md
@@ -1,0 +1,125 @@
+# Render
+```html
+<div
+  id="known"
+>
+  one:10
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:101
+</div>
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+
+# Update
+```js
+container.querySelector("#x").click();
+```
+```html
+<div
+  id="known"
+>
+  one:20
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:101
+</div>
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+## Change
+```
+UPDATE: #known::text@4 "10" => "20"
+UPDATE: ul > li:nth-of-type(1)::text "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("#y").click();
+```
+```html
+<div
+  id="known"
+>
+  one:20
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:102
+</div>
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+## Change
+```
+UPDATE: #local::text@2 "101" => "102"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/render.md
@@ -1,0 +1,125 @@
+# Render
+```html
+<div
+  id="known"
+>
+  one:10
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:101
+</div>
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+
+# Update
+```js
+container.querySelector("#x").click();
+```
+```html
+<div
+  id="known"
+>
+  one:20
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:101
+</div>
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+## Change
+```
+UPDATE: #known::text@4 "10" => "20"
+UPDATE: ul > li:nth-of-type(1)::text "1" => "2"
+```
+
+# Update
+```js
+container.querySelector("#y").click();
+```
+```html
+<div
+  id="known"
+>
+  one:20
+</div>
+<div
+  id="known"
+>
+  two:0
+</div>
+<div
+  id="local"
+>
+  L:102
+</div>
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    a
+  </li>
+</ul>
+<button
+  id="x"
+>
+  x
+</button>
+<button
+  id="y"
+>
+  y
+</button>
+```
+## Change
+```
+UPDATE: #local::text@2 "101" => "102"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/writes.debug.html
@@ -1,0 +1,33 @@
+<div id=known>one:<!>10<!--M_*3 #text/1--></div>
+<div id=known>two:<!>0<!--M_*4 #text/1--></div>
+<div id=local>L:<!>101<!--M_*5 #text/1--></div>
+<ul>
+  <li>1<!--M_*6 #text/0--></li>
+  <li>a<!--M_*7 #text/0--></li>
+</ul><button id=x>x</button><!--M_*1 #button/3--><button
+  id=y>y</button><!--M_*1 #button/4-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "BranchScopes:#ul/2": [_(6), _(7)],
+      x: 1,
+      y: 1,
+      "ClosureScopes:x": new Set([_(3), _(4)]),
+      "ClosureScopes:y": new Set([_(5)])
+    }, 1, {
+      _: _(1)
+    }, {
+      $b: 0,
+      _: _(1)
+    }, {
+      _: _(1)
+    }, {
+      _: _(1)
+    }, {
+      $label: "a",
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/__snapshots__/writes.html
@@ -1,0 +1,30 @@
+<div id=known>one:<!>10<!--M_*3 b--></div>
+<div id=known>two:<!>0<!--M_*4 b--></div>
+<div id=local>L:<!>101<!--M_*5 b--></div>
+<ul>
+  <li>1<!--M_*6 a--></li>
+  <li>a<!--M_*7 a--></li>
+</ul><button id=x>x</button><!--M_*1 d--><button id=y>y</button><!--M_*1 e-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ac: [_(6), _(7)],
+    f: 1,
+    g: 1,
+    h: new Set([_(3), _(4)]),
+    i: new Set([_(5)])
+  }, 1, {
+    _: _(1)
+  }, {
+    e: 0,
+    _: _(1)
+  }, {
+    _: _(1)
+  }, {
+    _: _(1)
+  }, {
+    d: "a",
+    _: _(1)
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2700,
-      "brotli": 1362
+      "min": 3611,
+      "brotli": 1764
     }
   },
   "html": {
-    "min": 442,
-    "brotli": 285
+    "min": 676,
+    "brotli": 373
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/tags/child.marko
@@ -1,0 +1,2 @@
+<${input.content}("one")/>
+<${input.content}("two", 0)/>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/template.marko
@@ -1,0 +1,20 @@
+<let/x=1/>
+<let/y=1/>
+
+<child|a, b = x * 10|>
+  <div id="known">${a}:${b}</div>
+</child>
+
+<define/Local|a, b = y + 100|>
+  <div id="local">${a}:${b}</div>
+</define>
+<Local("L")/>
+
+<ul>
+  <for|{ label = x }| of=[{}, { label: "a" }]>
+    <li>${label}</li>
+  </for>
+</ul>
+
+<button id="x" onClick() { x++ }>x</button>
+<button id="y" onClick() { y++ }>y</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-top-level-default/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickX(container: Element) {
+  (container.querySelector("#x") as HTMLButtonElement).click();
+}
+
+function clickY(container: Element) {
+  (container.querySelector("#y") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickX, clickY],
+};

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -37,6 +37,7 @@ import {
   replaceNullishAndEmptyFunctionsWith0,
   writeHTMLResumeStatements,
 } from "../util/signals";
+import { stripDefaultValuesFromParams } from "../util/strip-default-values";
 import { toFirstExpressionOrBlock } from "../util/to-first-expression-or-block";
 import { translateByTarget } from "../util/visitors";
 import * as walks from "../util/walks";
@@ -147,6 +148,14 @@ export default {
         const bodySection = getSectionForBody(tagBody);
         writer.flushInto(tag);
         writeHTMLResumeStatements(tagBody);
+
+        const defaultStatements: t.Statement[] = [];
+        stripDefaultValuesFromParams(node.body.params, defaultStatements);
+        if (defaultStatements.length) {
+          (node.body.body as unknown as t.Statement[]).unshift(
+            ...defaultStatements,
+          );
+        }
 
         tag
           .replaceWith(

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -54,6 +54,7 @@ import {
   setSectionOwnerResumedByMarker,
   writeHTMLResumeStatements,
 } from "../util/signals";
+import { stripDefaultValuesFromParams } from "../util/strip-default-values";
 import { getMemberExpressionPropString } from "../util/to-property-name";
 import { translateByTarget } from "../util/visitors";
 import * as walks from "../util/walks";
@@ -225,6 +226,11 @@ export default {
         const params = node.body.params;
         const statements: t.Statement[] = [];
         const bodyStatements = node.body.body as t.Statement[];
+        const paramDefaultStatements: t.Statement[] = [];
+        stripDefaultValuesFromParams(params, paramDefaultStatements);
+        if (paramDefaultStatements.length) {
+          bodyStatements.unshift(...paramDefaultStatements);
+        }
         const singleChild =
           bodySection.content?.singleChild &&
           bodySection.content.startType !== ContentType.Text;

--- a/packages/runtime-tags/src/translator/index.ts
+++ b/packages/runtime-tags/src/translator/index.ts
@@ -3,6 +3,7 @@ import type { Config } from "@marko/compiler";
 import coreTagLib from "./core";
 import runtimeInfo from "./util/runtime-info";
 import { extractVisitors } from "./util/visitors";
+import AssignmentPattern from "./visitors/assignment-pattern";
 import MarkoCDATA from "./visitors/cdata";
 import MarkoComment from "./visitors/comment";
 import MarkoDeclaration from "./visitors/declaration";
@@ -26,6 +27,7 @@ const visitors = extractVisitors({
   Program,
   Function,
   ReferencedIdentifier,
+  AssignmentPattern,
   ImportDeclaration,
   MarkoDocumentType,
   MarkoDeclaration,

--- a/packages/runtime-tags/src/translator/util/get-root.ts
+++ b/packages/runtime-tags/src/translator/util/get-root.ts
@@ -20,10 +20,39 @@ export function getMarkoRoot(path: t.NodePath<t.Node>) {
 export function getExprRoot(path: t.NodePath<t.Node>) {
   let curPath = path;
   while (!isMarko(curPath.parentPath!)) {
+    if (isMarkoBindingDefaultValue(curPath)) break;
     curPath = curPath.parentPath!;
   }
 
   return curPath;
+}
+
+// A Marko binding's default is its own expression root: its references
+// drive that binding's derivation, not the expression the pattern is in.
+function isMarkoBindingDefaultValue(path: t.NodePath<t.Node>) {
+  if (path.key !== "right" || path.parentPath!.type !== "AssignmentPattern") {
+    return false;
+  }
+
+  let curPath = path.parentPath!;
+  while (true) {
+    const { parentPath } = curPath;
+    switch (parentPath?.type) {
+      case "ObjectProperty":
+      case "ObjectPattern":
+      case "ArrayPattern":
+      case "RestElement":
+      case "AssignmentPattern":
+        curPath = parentPath;
+        break;
+      case "MarkoTagBody":
+        return curPath.listKey === "params";
+      case "MarkoTag":
+        return curPath.key === "var";
+      default:
+        return false;
+    }
+  }
 }
 
 export function getFnRoot(path: t.NodePath<t.Node>) {

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -860,7 +860,7 @@ function writeParamsToSignals(
         addStatement(
           "render",
           info.tagSection,
-          arg.extra?.referencedBindings, // TODO: pretty sure content needs to have the reference group of it's param defaults.
+          arg.extra?.referencedBindings,
           t.expressionStatement(
             t.callExpression(argExportIdentifier, [
               createScopeReadExpression(
@@ -880,8 +880,44 @@ function writeParamsToSignals(
   }
 
   const attrPropsTree = propTree.props[i];
-  if (attrPropsTree) {
+  if (
+    attrPropsTree &&
+    (!tag.node.arguments?.length ||
+      tag.node.attributes.length ||
+      tag.node.attributeTags.length ||
+      tag.node.body.body.length)
+  ) {
     writeAttrsToSignals(tag, attrPropsTree, `${importAlias}_input`, info);
+    i++;
+  }
+
+  // Missing args still apply (as undefined) to match the runtime params
+  // applier; otherwise joined signals never settle during initial render.
+  for (const key in propTree.props) {
+    if (+key >= i) {
+      addStatement(
+        "render",
+        info.tagSection,
+        undefined,
+        t.expressionStatement(
+          t.callExpression(
+            info.getBindingIdentifier(
+              propTree.props[key].binding,
+              `${importAlias}_param_${key}`,
+            ),
+            [
+              createScopeReadExpression(
+                info.childScopeBinding,
+                info.tagSection,
+              ),
+              t.unaryExpression("void", t.numericLiteral(0)),
+            ],
+          ),
+        ),
+        undefined,
+        true,
+      );
+    }
   }
 }
 
@@ -1227,7 +1263,9 @@ function writeAttrsToSignals(
         addStatement(
           "render",
           info.tagSection,
-          undefined, // TODO: pretty sure content needs to have the reference group of it's param defaults.
+          // Param defaults derive within the body section, so their
+          // references belong to the body rather than this statement.
+          undefined,
           t.expressionStatement(
             t.callExpression(
               info.getBindingIdentifier(

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -6,6 +6,7 @@ import { decodeAccessor } from "../../common/helpers";
 import { toAccess } from "../../html/serializer";
 import { finalizeFunctionRegistry } from "../visitors/function";
 import { scopeIdentifier } from "../visitors/program";
+import evaluate from "./evaluate";
 import { forEachIdentifierPath } from "./for-each-identifier";
 import { generateUid } from "./generate-uid";
 import { getAccessorPrefix } from "./get-accessor-char";
@@ -60,7 +61,7 @@ import {
   type SerializeReason,
 } from "./serialize-reasons";
 import { finalizeTagDownstreams } from "./set-tag-sections-downstream";
-import { addSetupStatement } from "./setup-statements";
+import { addSetupExpr, addSetupStatement } from "./setup-statements";
 import {
   getBindingGetterIdentifier,
   getSignals,
@@ -112,6 +113,7 @@ export interface Binding {
   noSerialize: boolean;
   noSerializeProperties: Opt<string>;
   upstreamAlias: Binding | undefined;
+  defaultSource: Binding | undefined;
   restOffset: number | undefined;
   scopeOffset: Binding | undefined;
   scopeAccessor: string | undefined;
@@ -230,6 +232,7 @@ export function createBinding(
     getters: new Map(),
     propertyAliases: new Map(),
     upstreamAlias,
+    defaultSource: undefined,
     restOffset: undefined,
     scopeOffset: undefined,
     scopeAccessor: undefined,
@@ -251,7 +254,8 @@ export function createBinding(
       binding.upstreamAlias = propBinding;
       propBinding.aliases.add(binding);
     } else {
-      // TODO: check if default is used, if so an intermediate binding is needed
+      // The alias root holds the raw property value: a defaulted destructure
+      // roots its source binding here, never the derived binding.
       upstreamAlias!.propertyAliases.set(property, binding);
     }
   } else if (upstreamAlias) {
@@ -761,6 +765,59 @@ function createBindingsAndTrackReferences(
       }
       break;
     }
+    // A default is two bindings: the source holds the applied value and
+    // `left` derives from it (see initDefaultedValue / stripDefaultValues).
+    case "AssignmentPattern": {
+      const { left, right } = lVal;
+      const defaultSource = createBinding(
+        generateUid(
+          (left.type === "Identifier" ? left.name : property) || "pattern",
+        ),
+        type,
+        section,
+        upstreamAlias,
+        property,
+        excludeProperties,
+        left.loc,
+        true,
+      );
+      const valueExtra = evaluate(right) as unknown as ReferencedExtra;
+      addRead(valueExtra, {}, defaultSource, section, undefined);
+
+      createBindingsAndTrackReferences(
+        left,
+        BindingType.derived,
+        scope,
+        section,
+        undefined,
+        undefined,
+        undefined,
+      );
+
+      const binding = left.extra?.binding;
+      if (binding) {
+        if (left.type === "Identifier") {
+          const constantViolations = scope.getBinding(
+            left.name,
+          )?.constantViolations;
+          if (constantViolations?.length) {
+            for (const assignment of constantViolations) {
+              if (assignment.type !== "MarkoTag") {
+                throw assignment.buildCodeFrameError(
+                  `${left.name} is readonly and cannot be mutated.`,
+                );
+              }
+            }
+          }
+        }
+
+        binding.defaultSource = defaultSource;
+        (lVal.extra ??= {}).binding = binding;
+        setBindingDownstream(binding, valueExtra);
+        addSetupExpr(section, right);
+      }
+      break;
+    }
   }
 }
 
@@ -913,6 +970,19 @@ export function finalizeReferences() {
   const readsByExpression = getReadsByExpression();
   const fnReadsByExpression = getFunctionReadsByExpression();
   const intersectionsBySection = new Map<Section, Intersection[]>();
+
+  // A pruned defaulted binding drops its fallback's read of the source so
+  // the source can prune too (reverse creation order visits inner defaults first).
+  for (const binding of [...bindings].reverse()) {
+    if (binding.defaultSource && pruneBinding(binding)) {
+      const valueExprs = getBindingValueExprs().get(binding);
+      if (valueExprs && valueExprs !== true) {
+        forEach(valueExprs, (expr) => {
+          if (!expr.merged) dropExtra(expr as ReferencedExtra);
+        });
+      }
+    }
+  }
 
   for (const [expr, reads] of readsByExpression) {
     if (isReferencedExtra(expr)) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -90,6 +90,7 @@ export interface Signal {
   hasSideEffect: boolean;
   forcePersist: boolean;
   inline: { value: t.Expression } | undefined;
+  valueParamDefault: t.Expression | undefined;
   export: boolean;
   extraArgs: t.Expression[] | undefined;
   prependStatements: t.Statement[] | undefined;
@@ -282,6 +283,7 @@ export function getSignal(
         hasDynamicSubscribers: false,
         forcePersist: false,
         inline: undefined,
+        valueParamDefault: undefined,
         extraArgs: undefined,
         prependStatements: undefined,
         buildAssignment: undefined,
@@ -695,7 +697,7 @@ export function getSignalFn(signal: Signal): t.Expression {
   }
 
   if (!signal.hasSideEffect) {
-    if (isValue && signal.render.length === 1) {
+    if (isValue && !signal.valueParamDefault && signal.render.length === 1) {
       const render = signal.render[0];
       if (render.type === "ExpressionStatement") {
         const { expression } = render;
@@ -715,7 +717,15 @@ export function getSignalFn(signal: Signal): t.Expression {
 
     return t.arrowFunctionExpression(
       isValue
-        ? [scopeIdentifier, getSignalValueIdentifier(signal)]
+        ? [
+            scopeIdentifier,
+            signal.valueParamDefault
+              ? t.assignmentPattern(
+                  getSignalValueIdentifier(signal),
+                  signal.valueParamDefault,
+                )
+              : getSignalValueIdentifier(signal),
+          ]
         : [scopeIdentifier],
       toFirstExpressionOrBlock(signal.render),
     );
@@ -953,6 +963,7 @@ export function getResumeRegisterId(
 export function writeSignals(section: Section) {
   const seen = new Set<Signal>();
   const written = new Set<Signal>();
+  collapseDefaultedValues(section);
   writeGetters(section);
 
   for (const signal of getSignals(section).values()) {
@@ -1055,6 +1066,68 @@ export function writeSignals(section: Section) {
   }
 
   return written;
+}
+
+// A defaulted binding's derivation; collapseDefaultedValues may replace
+// the conditional with a parameter default once every signal exists.
+export function initDefaultedValue(binding: Binding, value: t.Expression) {
+  if (!binding.pruned) {
+    const section = binding.section;
+    const source = binding.defaultSource!;
+    addValue(
+      section,
+      value.extra!.referencedBindings,
+      initValue(binding),
+      t.conditionalExpression(
+        t.binaryExpression(
+          "!==",
+          t.unaryExpression("void", t.numericLiteral(0)),
+          createScopeReadExpression(source, section),
+        ),
+        createScopeReadExpression(source, section),
+        value,
+      ),
+    );
+  }
+}
+
+// Moves a defaulted binding's fallback onto a value parameter (preferring
+// the derived signal's own) when the source read would lower to one.
+function collapseDefaultedValues(section: Section) {
+  const signals = getSignals(section);
+  forEach(section.bindings, (binding) => {
+    const source = binding.defaultSource;
+    if (source && !binding.pruned) {
+      const derivedSignal = signals.get(binding);
+      const sourceSignal = signals.get(source);
+      const entry =
+        derivedSignal &&
+        !derivedSignal.inline &&
+        sourceSignal &&
+        canDefaultValueParam(sourceSignal) &&
+        sourceSignal.values.find((value) => value.signal === derivedSignal);
+      if (entry && entry.value.type === "ConditionalExpression") {
+        const target = canDefaultValueParam(derivedSignal)
+          ? derivedSignal
+          : sourceSignal;
+        target.valueParamDefault = entry.value.alternate;
+        entry.value = entry.value.consequent;
+      }
+    }
+  });
+}
+
+function canDefaultValueParam(signal: Signal) {
+  return (
+    !signal.hasSideEffect &&
+    !signal.forcePersist &&
+    !signal.inline &&
+    !signal.valueParamDefault &&
+    !getSerializeReason(
+      signal.section,
+      signal.referencedBindings as ReferencedBindings & Binding,
+    )
+  );
 }
 
 function writeGetters(section: Section) {

--- a/packages/runtime-tags/src/translator/util/strip-default-values.ts
+++ b/packages/runtime-tags/src/translator/util/strip-default-values.ts
@@ -1,0 +1,86 @@
+import { types as t } from "@marko/compiler";
+
+/**
+ * Replaces defaulted patterns with their source variable in HTML output so
+ * the pre default value can serialize for resume; a const derives the rest.
+ */
+export function stripDefaultValues(
+  lVal: t.LVal,
+  statements: t.Statement[],
+): t.LVal {
+  switch (lVal.type) {
+    case "AssignmentPattern": {
+      const source = lVal.extra?.binding?.defaultSource;
+      if (!source) break;
+      const nestedStatements: t.Statement[] = [];
+      const left = stripDefaultValues(lVal.left, nestedStatements);
+      const sourceId = t.identifier(source.name);
+      statements.push(
+        t.variableDeclaration("const", [
+          t.variableDeclarator(
+            left as t.VariableDeclarator["id"],
+            t.conditionalExpression(
+              t.binaryExpression(
+                "!==",
+                t.unaryExpression("void", t.numericLiteral(0)),
+                t.cloneNode(sourceId),
+              ),
+              t.cloneNode(sourceId),
+              lVal.right,
+            ),
+          ),
+        ]),
+        ...nestedStatements,
+      );
+      return sourceId;
+    }
+    case "ObjectPattern":
+      for (const prop of lVal.properties) {
+        if (prop.type === "ObjectProperty") {
+          if (t.isLVal(prop.value)) {
+            const value = stripDefaultValues(prop.value, statements);
+            if (value !== prop.value) {
+              prop.shorthand = false;
+              prop.value = value as t.ObjectProperty["value"];
+            }
+          }
+        } else {
+          stripDefaultValues(prop.argument, statements);
+        }
+      }
+      break;
+    case "ArrayPattern":
+      for (let i = 0; i < lVal.elements.length; i++) {
+        const element = lVal.elements[i];
+        if (element) {
+          if (element.type === "RestElement") {
+            stripDefaultValues(element.argument, statements);
+          } else if (t.isLVal(element)) {
+            const replacement = stripDefaultValues(element, statements);
+            if (replacement !== element) {
+              lVal.elements[i] = replacement as t.PatternLike;
+            }
+          }
+        }
+      }
+      break;
+  }
+
+  return lVal;
+}
+
+export function stripDefaultValuesFromParams(
+  params: t.MarkoTagBody["params"],
+  statements: t.Statement[],
+) {
+  for (let i = 0; i < params.length; i++) {
+    const param = params[i];
+    if (t.isLVal(param)) {
+      const replacement = stripDefaultValues(param, statements);
+      if (replacement !== param) {
+        // A replaced param is always the source identifier.
+        params[i] = replacement as t.Identifier;
+      }
+    }
+  }
+}

--- a/packages/runtime-tags/src/translator/util/translate-attrs.ts
+++ b/packages/runtime-tags/src/translator/util/translate-attrs.ts
@@ -29,6 +29,7 @@ import {
 import { getScopeReasonDeclaration } from "./serialize-guard";
 import { isReasonDynamic } from "./serialize-reasons";
 import { getResumeRegisterId } from "./signals";
+import { stripDefaultValuesFromParams } from "./strip-default-values";
 import { toObjectProperty } from "./to-property-name";
 
 const contentProps = new WeakSet<t.Node>();
@@ -272,6 +273,9 @@ function translateForAttrTag(
 ) {
   const forTag = attrTags[index] as t.NodePath<t.MarkoTag>;
   const bodyStatements: t.Statement[] = [];
+  if (isOutputHTML()) {
+    stripDefaultValuesFromParams(forTag.node.body.params, bodyStatements);
+  }
   addAllAttrTagsAsDynamic(
     forTag,
     attrTagLookup,
@@ -408,6 +412,11 @@ function buildContent(body: t.NodePath<t.MarkoTagBody>) {
   const bodySection = body.node.extra?.section;
   if (bodySection) {
     if (isOutputHTML()) {
+      const defaultStatements: t.Statement[] = [];
+      stripDefaultValuesFromParams(body.node.params, defaultStatements);
+      if (defaultStatements.length) {
+        body.node.body.unshift(...(defaultStatements as any));
+      }
       const serialized = getSectionRegisterReasons(bodySection);
       let dynamicSerializeReason =
         !!bodySection.paramReasonGroups ||

--- a/packages/runtime-tags/src/translator/util/translate-var.ts
+++ b/packages/runtime-tags/src/translator/util/translate-var.ts
@@ -7,6 +7,7 @@ import { toArray } from "./optional";
 import { getCanonicalBinding } from "./references";
 import { getOrCreateSection } from "./sections";
 import { getSerializeReason } from "./serialize-reasons";
+import { stripDefaultValues } from "./strip-default-values";
 import { toPropertyName } from "./to-property-name";
 
 export default function translateVar(
@@ -106,9 +107,17 @@ export default function translateVar(
     }
   });
 
-  tag.insertBefore(
-    t.variableDeclaration(kind, [t.variableDeclarator(tagVar, initialValue)]),
-  );
+  const defaultStatements: t.Statement[] = [];
+  const strippedVar = stripDefaultValues(tagVar, defaultStatements);
+  tag.insertBefore([
+    t.variableDeclaration(kind, [
+      t.variableDeclarator(
+        strippedVar as t.VariableDeclarator["id"],
+        initialValue,
+      ),
+    ]),
+    ...defaultStatements,
+  ]);
 }
 
 function getDestructurePattern(id: t.NodePath<t.Identifier>) {

--- a/packages/runtime-tags/src/translator/visitors/assignment-pattern.ts
+++ b/packages/runtime-tags/src/translator/visitors/assignment-pattern.ts
@@ -1,0 +1,19 @@
+import { types as t } from "@marko/compiler";
+
+import { isOutputDOM } from "../util/marko-config";
+import { initDefaultedValue } from "../util/signals";
+import type { TemplateVisitor } from "../util/visitors";
+
+export default {
+  translate: {
+    enter(pattern) {
+      const { node } = pattern;
+      const binding = node.extra?.binding;
+      // The HTML output instead materializes the defaulted binding where
+      // the pattern is emitted (see strip-default-values.ts).
+      if (binding?.defaultSource && isOutputDOM()) {
+        initDefaultedValue(binding, node.right);
+      }
+    },
+  },
+} satisfies TemplateVisitor<t.AssignmentPattern>;

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -102,24 +102,6 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
   normalizeBody(tag.get("body").get("body"));
   normalizeBody(tag.get("attributeTags"));
 
-  if (node.var) {
-    const insertions = getAssignmentInsertions(node.var);
-    if (insertions) {
-      tag.insertAfter(insertions);
-    }
-  }
-
-  if (node.body.params.length) {
-    let insertions: t.MarkoTag[] | undefined;
-    for (const param of node.body.params) {
-      insertions = getAssignmentInsertions(param, insertions);
-    }
-
-    if (insertions) {
-      node.body.body = [...insertions, ...node.body.body];
-    }
-  }
-
   if (name.type === "StringLiteral") {
     const tagName = name.value;
     if (
@@ -425,74 +407,4 @@ function getLiteralName(node: t.Node) {
     case "StringLiteral":
       return node.value;
   }
-}
-
-function getAssignmentInsertions(
-  node: t.Node,
-  insertions?: t.MarkoTag[] | undefined,
-) {
-  switch (node.type) {
-    case "ObjectPattern":
-      for (const prop of node.properties) {
-        if (prop.type === "ObjectProperty") {
-          if (prop.value.type === "AssignmentPattern") {
-            const { left, right } = prop.value;
-            const sourceName = generateUid(
-              getLiteralName(left) || getLiteralName(prop.key) || "pattern",
-            );
-            prop.shorthand = false;
-            prop.value = t.identifier(sourceName);
-            (insertions ||= []).push(
-              toConstTag(left as any, toFallbackExpr(sourceName, right)),
-            );
-            getAssignmentInsertions(left, insertions);
-          } else {
-            insertions = getAssignmentInsertions(prop.value, insertions);
-          }
-        }
-      }
-      break;
-    case "ArrayPattern":
-      for (let i = 0, len = node.elements.length; i < len; i++) {
-        const el = node.elements[i];
-        if (el != null) {
-          if (el.type === "AssignmentPattern") {
-            const { left, right } = el;
-            const sourceName = generateUid(getLiteralName(left) || "pattern");
-            node.elements[i] = t.identifier(sourceName);
-            (insertions ||= []).push(
-              toConstTag(left as any, toFallbackExpr(sourceName, right)),
-            );
-            getAssignmentInsertions(left, insertions);
-          } else {
-            insertions = getAssignmentInsertions(el, insertions);
-          }
-        }
-      }
-      break;
-  }
-
-  return insertions;
-}
-
-function toFallbackExpr(id: string, fallback: t.Expression) {
-  return t.conditionalExpression(
-    t.binaryExpression("!==", buildUndefined(), t.identifier(id)),
-    t.identifier(id),
-    fallback,
-  );
-}
-
-function toConstTag(id: t.Identifier, expr: t.Expression) {
-  return t.markoTag(
-    t.stringLiteral("const"),
-    [t.markoAttribute("value", expr, null, null, true)],
-    t.markoTagBody(),
-    null,
-    id,
-  );
-}
-
-function buildUndefined() {
-  return t.unaryExpression("void", t.numericLiteral(0));
 }


### PR DESCRIPTION
Default values in tag params and destructured tag variables are modeled directly in the binding graph: a source binding holds the value applied at the pattern's position, and the declared binding is derived from it. The DOM output registers the derivation as a signal value, collapsing it to a native parameter default (`($scope, $x = fallback) =>`) when the fallback needs no state; the HTML output materializes the source variable so it stays serializable for resume. The alias root of a shared property always holds the raw value, so aliased destructures agree regardless of which side has a default. A defaulted binding that is never read prunes together with its fallback and source, so unused defaults leave no trace in the DOM output.