### PR TITLE
fix: multiple &lt;style&gt; tags of one flavor no longer clobber each other's CSS

### DIFF
--- a/.changeset/style-tag-virtual-path-collision.md
+++ b/.changeset/style-tag-virtual-path-collision.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix multiple `<style>` tags of the same flavor in one template clobbering each other's CSS. Each block's virtual file now resolves to a distinct path; single-style templates are unchanged.

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/dom.bundle.debug.js
@@ -14,4 +14,7 @@ const $input = ($scope, input) => {
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "  c", $setup, $input);
 
 // v:template.marko.css
-var v_template_marko_default = "\n  .b { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1); }\n";
+var v_template_marko_default = "\n  .a { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0); }\n";
+
+// v:template.marko.1.css
+var v_template_marko_1_default = "\n  .b { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1); }\n";

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,8 @@
 // v:template.marko.css
-var v_template_marko_default = "\n  .b { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1); }\n";
+var v_template_marko_default = "\n  .a { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0); }\n";
+
+// v:template.marko.1.css
+var v_template_marko_1_default = "\n  .b { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1); }\n";
 
 // template.marko
 var template_default = _template("__tests__/template.marko", (input) => {

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -62,6 +62,11 @@ declare module "@marko/compiler/dist/types" {
 }
 
 const STYLE_EXT_REG = /^style((?:\.[a-zA-Z0-9$_-]+)+)?/;
+// Same-extension <style> block count per program, so each block's virtual file path is distinct.
+const programStyleCounts = new WeakMap<
+  t.Program,
+  Partial<Record<string, number>>
+>();
 
 export default {
   analyze(tag) {
@@ -366,6 +371,12 @@ function getStyleImportPath(
     ext = ".module" + ext;
   }
 
+  const program = getProgram().node;
+  let counts = programStyleCounts.get(program);
+  if (!counts) programStyleCounts.set(program, (counts = {}));
+  const index = counts[ext] || 0;
+  counts[ext] = index + 1;
+
   const magicString = sourceMaps
     ? new MagicString(file.code, { filename })
     : undefined;
@@ -420,7 +431,7 @@ function getStyleImportPath(
   }
 
   return resolveVirtualDependency(filename, {
-    virtualPath: `./${path.basename(filename) + ext}`,
+    virtualPath: `./${path.basename(filename)}${index ? `.${index}` : ""}${ext}`,
     code,
     map,
   });


### PR DESCRIPTION
## Description

Two same-flavor `<style>` blocks in one template resolved to the same virtual file path (`./template.marko.css`), so the second registration overwrote the first and that block's static CSS silently vanished. Later blocks now get an index suffix per extension (`./template.marko.1.css`); the first block's path — and every single-style template — is byte-identical to before.

Includes a changeset (`@marko/runtime-tags` patch) and updated `style-tag-dynamic-two-tags` snapshots, which previously pinned the loss (only the second block's rule survived).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_017Az6N2kEKaqNeRU7F2cjh6)_