### PR TITLE
perf: store pending render slots at the signal key

### DIFF
--- a/.changeset/render-slot-keys.md
+++ b/.changeset/render-slot-keys.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Improve render queue speed and memory by storing pending render slots at the signal key; intersection pending counters move to complemented keys so the two cannot collide.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,7 +7,7 @@
     {
       "name": "*",
       "total": {
-        "min": 25866,
+        "min": 25857,
         "brotli": 9518
       }
     },
@@ -18,12 +18,12 @@
         "brotli": 119
       },
       "runtime": {
-        "min": 3912,
-        "brotli": 1727
+        "min": 3904,
+        "brotli": 1732
       },
       "total": {
-        "min": 4073,
-        "brotli": 1846
+        "min": 4065,
+        "brotli": 1851
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 80
       },
       "runtime": {
-        "min": 2471,
-        "brotli": 1246
+        "min": 2463,
+        "brotli": 1239
       },
       "total": {
-        "min": 2551,
-        "brotli": 1326
+        "min": 2543,
+        "brotli": 1319
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 365
       },
       "runtime": {
-        "min": 6453,
-        "brotli": 2833
+        "min": 6443,
+        "brotli": 2822
       },
       "total": {
-        "min": 7099,
-        "brotli": 3198
+        "min": 7089,
+        "brotli": 3187
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 101
       },
       "runtime": {
-        "min": 2676,
-        "brotli": 1317
+        "min": 2668,
+        "brotli": 1309
       },
       "total": {
-        "min": 2791,
-        "brotli": 1418
+        "min": 2783,
+        "brotli": 1410
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6453 (min) 2833 (brotli)
+// size: 6443 (min) 2822 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -72,7 +72,6 @@ let decodeAccessor = (num) =>
   runId = 2,
   pendingEffects = [],
   pendingRenders = [],
-  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length;) effects[i++](effects[i++]);
   },
@@ -508,18 +507,18 @@ function bySecondArg(_item, index) {
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     if (((render.d = value), render.e === runId || catchEnabled)) return;
     render.e = runId;
   } else
     ((render = {
-      a: scopeKey * scopeKeyOffset + signalKey,
+      a: scopeKey * 1e6 + signalKey,
       b: scope,
       c: signal,
       d: value,
       e: runId,
     }),
-      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+      signalKey >= 0 && (scope[signalKey] = render));
   queuePendingRender(render);
 }
 function queuePendingRender(render) {

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2676 (min) 1317 (brotli)
+// size: 2668 (min) 1309 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -13,7 +13,6 @@ let decodeAccessor = (num) =>
   runId = 2,
   pendingEffects = [],
   pendingRenders = [],
-  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length;) effects[i++](effects[i++]);
   },
@@ -213,18 +212,18 @@ function normalizeAttrValue(value) {
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     if (((render.d = value), render.e === runId || catchEnabled)) return;
     render.e = runId;
   } else
     ((render = {
-      a: scopeKey * scopeKeyOffset + signalKey,
+      a: scopeKey * 1e6 + signalKey,
       b: scope,
       c: signal,
       d: value,
       e: runId,
     }),
-      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+      signalKey >= 0 && (scope[signalKey] = render));
   queuePendingRender(render);
 }
 function queuePendingRender(render) {

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 3912 (min) 1727 (brotli)
+// size: 3904 (min) 1732 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -66,7 +66,6 @@ let decodeAccessor = (num) =>
   runId = 2,
   pendingEffects = [],
   pendingRenders = [],
-  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length;) effects[i++](effects[i++]);
   },
@@ -237,18 +236,18 @@ function toInsertNode(startNode, endNode) {
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     if (((render.d = value), render.e === runId || catchEnabled)) return;
     render.e = runId;
   } else
     ((render = {
-      a: scopeKey * scopeKeyOffset + signalKey,
+      a: scopeKey * 1e6 + signalKey,
       b: scope,
       c: signal,
       d: value,
       e: runId,
     }),
-      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+      signalKey >= 0 && (scope[signalKey] = render));
   queuePendingRender(render);
 }
 function queuePendingRender(render) {

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2471 (min) 1246 (brotli)
+// size: 2463 (min) 1239 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -13,7 +13,6 @@ let decodeAccessor = (num) =>
   runId = 2,
   pendingEffects = [],
   pendingRenders = [],
-  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length;) effects[i++](effects[i++]);
   },
@@ -198,18 +197,18 @@ function _text(node, value) {
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     if (((render.d = value), render.e === runId || catchEnabled)) return;
     render.e = runId;
   } else
     ((render = {
-      a: scopeKey * scopeKeyOffset + signalKey,
+      a: scopeKey * 1e6 + signalKey,
       b: scope,
       c: signal,
       d: value,
       e: runId,
     }),
-      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+      signalKey >= 0 && (scope[signalKey] = render));
   queuePendingRender(render);
 }
 function queuePendingRender(render) {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 25866 (min) 9518 (brotli)
+// size: 25857 (min) 9518 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -199,7 +199,6 @@ let empty = [],
   placeholderShown = /* @__PURE__ */ new WeakSet(),
   pendingEffects = [],
   pendingRenders = [],
-  scopeKeyOffset = 1e3,
   runEffects = (effects) => {
     for (let i = 0; i < effects.length;) effects[i++](effects[i++]);
   },
@@ -549,9 +548,9 @@ function _or(id, fn, defaultPending = 1, scopeIdAccessor = "L") {
       (scopeIdAccessor = decodeAccessor(scopeIdAccessor)),
     (scope) => {
       scope.H === runId
-        ? id in scope
-          ? --scope[id] || fn(scope)
-          : (scope[id] = defaultPending)
+        ? (~id) in scope
+          ? --scope[~id] || fn(scope)
+          : (scope[~id] = defaultPending)
         : queueRender(scope, fn, id, 0, scope[scopeIdAccessor]);
     }
   );
@@ -2264,19 +2263,19 @@ function byFirstArg(name) {
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     if (((render.d = value), render.e === runId || (catchEnabled && render.f)))
       return;
     render.e = runId;
   } else
     ((render = {
-      a: scopeKey * scopeKeyOffset + signalKey,
+      a: scopeKey * 1e6 + signalKey,
       b: scope,
       c: signal,
       d: value,
       e: runId,
     }),
-      signalKey >= 0 && (scope[signalKey + scopeKeyOffset] = render));
+      signalKey >= 0 && (scope[signalKey] = render));
   queuePendingRender(render);
 }
 function queuePendingRender(render) {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65847,
-        "brotli": 20208
+        "min": 65829,
+        "brotli": 20230
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67455,
-        "brotli": 20895
+        "min": 67437,
+        "brotli": 20862
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3174,
-        "brotli": 1539
+        "min": 3160,
+        "brotli": 1544
       },
       "files": {
         "template.marko": 236,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65847,
-        "brotli": 20208
+        "min": 65829,
+        "brotli": 20230
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65745,
-        "brotli": 20176
+        "min": 65727,
+        "brotli": 20150
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65786,
-        "brotli": 20187
+        "min": 65768,
+        "brotli": 20180
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67447,
-        "brotli": 20863
+        "min": 67429,
+        "brotli": 20817
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67566,
-        "brotli": 20926
+        "min": 67548,
+        "brotli": 20902
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67755,
-        "brotli": 20966
+        "min": 67737,
+        "brotli": 21009
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67387,
-        "brotli": 20810
+        "min": 67371,
+        "brotli": 20782
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67455,
-        "brotli": 20885
+        "min": 67437,
+        "brotli": 20867
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66152,
-        "brotli": 20390
+        "min": 66134,
+        "brotli": 20307
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65824,
-        "brotli": 20220
+        "min": 65806,
+        "brotli": 20241
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67899,
-        "brotli": 21054
+        "min": 67882,
+        "brotli": 21060
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67397,
-        "brotli": 20823
+        "min": 67379,
+        "brotli": 20851
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67067,
-        "brotli": 20734
+        "min": 67049,
+        "brotli": 20714
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67563,
-        "brotli": 20918
+        "min": 67545,
+        "brotli": 20905
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67170,
-        "brotli": 20707
+        "min": 67152,
+        "brotli": 20719
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66203,
-        "brotli": 20371
+        "min": 66188,
+        "brotli": 20375
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68256,
-        "brotli": 21184
+        "min": 68241,
+        "brotli": 21215
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3164,
-      "brotli": 1546
+      "min": 3150,
+      "brotli": 1540
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2753,
-      "brotli": 1372
+      "min": 2739,
+      "brotli": 1367
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2855,
-      "brotli": 1422
+      "min": 2841,
+      "brotli": 1417
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2558,
-        "brotli": 1300
+        "min": 2544,
+        "brotli": 1290
       },
       "files": {
         "tags/child.marko": 323,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2669,
-      "brotli": 1341
+      "min": 2655,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2647,
-      "brotli": 1338
+      "min": 2633,
+      "brotli": 1331
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2650,
-      "brotli": 1344
+      "min": 2636,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2837,
-      "brotli": 1406
+      "min": 2823,
+      "brotli": 1396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2985,
-      "brotli": 1483
+      "min": 2974,
+      "brotli": 1478
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5951,
-      "brotli": 2724
+      "min": 5935,
+      "brotli": 2714
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2832,
-      "brotli": 1404
+      "min": 2818,
+      "brotli": 1394
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8079,
+      "min": 8062,
       "brotli": 3417
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6834,
-      "brotli": 3014
+      "min": 6818,
+      "brotli": 2993
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9546,
-      "brotli": 4018
+      "min": 9529,
+      "brotli": 4010
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13454,
-        "brotli": 5147
+        "min": 13437,
+        "brotli": 5145
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3235,
-      "brotli": 1617
+      "min": 3224,
+      "brotli": 1618
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2865,
-      "brotli": 1417
+      "min": 2851,
+      "brotli": 1414
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3240,
-      "brotli": 1598
+      "min": 3229,
+      "brotli": 1593
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2750,
-      "brotli": 1374
+      "min": 2736,
+      "brotli": 1367
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10774,
-      "brotli": 4483
+      "min": 10756,
+      "brotli": 4471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7454,
-      "brotli": 3288
+      "min": 7436,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6857,
-      "brotli": 3041
+      "min": 6843,
+      "brotli": 3031
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7554,
-      "brotli": 3322
+      "min": 7538,
+      "brotli": 3319
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7707,
-      "brotli": 3387
+      "min": 7689,
+      "brotli": 3381
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8216,
-      "brotli": 3530
+      "min": 8200,
+      "brotli": 3525
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7748,
-      "brotli": 3333
+      "min": 7730,
+      "brotli": 3327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9684,
-      "brotli": 4053
+      "min": 9665,
+      "brotli": 4041
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7010,
-      "brotli": 3098
+      "min": 6994,
+      "brotli": 3088
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3781,
-      "brotli": 1780
+      "min": 3767,
+      "brotli": 1772
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7748,
-      "brotli": 3333
+      "min": 7730,
+      "brotli": 3327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9535,
-      "brotli": 4003
+      "min": 9517,
+      "brotli": 3988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9537,
-      "brotli": 4005
+      "min": 9519,
+      "brotli": 3989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2671,
-        "brotli": 1343
+        "min": 2657,
+        "brotli": 1334
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2671,
-        "brotli": 1343
+        "min": 2657,
+        "brotli": 1334
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2793,
-        "brotli": 1383
+        "min": 2779,
+        "brotli": 1374
       },
       "files": {
         "tags/my-button.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2698,
-        "brotli": 1349
+        "min": 2684,
+        "brotli": 1347
       },
       "files": {
         "tags/my-button.marko": 280,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2671,
-        "brotli": 1343
+        "min": 2657,
+        "brotli": 1334
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3131,
-        "brotli": 1576
+        "min": 3117,
+        "brotli": 1566
       },
       "files": {
         "tags/my-button.marko": 130,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6244,
-      "brotli": 2840
+      "min": 6228,
+      "brotli": 2838
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6242,
-      "brotli": 2835
+      "min": 6226,
+      "brotli": 2826
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2752,
-      "brotli": 1368
+      "min": 2738,
+      "brotli": 1360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2822,
-      "brotli": 1415
+      "min": 2811,
+      "brotli": 1418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6311,
-      "brotli": 2865
+      "min": 6295,
+      "brotli": 2850
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2637,
-      "brotli": 1333
+      "min": 2623,
+      "brotli": 1330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2614,
-      "brotli": 1319
+      "min": 2600,
+      "brotli": 1316
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2858,
-      "brotli": 1424
+      "min": 2844,
+      "brotli": 1421
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2908,
-      "brotli": 1449
+      "min": 2897,
+      "brotli": 1445
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2864,
-      "brotli": 1438
+      "min": 2850,
+      "brotli": 1432
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2940,
-      "brotli": 1446
+      "min": 2926,
+      "brotli": 1433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7602,
-        "brotli": 3472
+        "min": 7587,
+        "brotli": 3476
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14037,
-        "brotli": 5400
+        "min": 14022,
+        "brotli": 5393
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3110,
-      "brotli": 1562
+      "min": 3096,
+      "brotli": 1549
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4662,
-      "brotli": 2147
+      "min": 4648,
+      "brotli": 2138
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3112,
-      "brotli": 1539
+      "min": 3101,
+      "brotli": 1533
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6327,
-      "brotli": 2887
+      "min": 6311,
+      "brotli": 2878
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7142,
-      "brotli": 3256
+      "min": 7126,
+      "brotli": 3253
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7405,
-      "brotli": 3359
+      "min": 7389,
+      "brotli": 3326
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2629,
-      "brotli": 1331
+      "min": 2615,
+      "brotli": 1328
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6213,
-      "brotli": 2833
+      "min": 6197,
+      "brotli": 2831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2758,
-      "brotli": 1389
+      "min": 2747,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3797,
+        "min": 3786,
         "brotli": 1822
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9280,
-        "brotli": 3521
+        "min": 9264,
+        "brotli": 3518
       },
       "files": {
         "tags/FancyButton.marko": 238,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3694,
-      "brotli": 1750
+      "min": 3680,
+      "brotli": 1748
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1317
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4350,
-      "brotli": 2010
+      "min": 4337,
+      "brotli": 2007
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4229,
-      "brotli": 1958
+      "min": 4218,
+      "brotli": 1959
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4332,
-      "brotli": 1992
+      "min": 4319,
+      "brotli": 1988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10131,
-      "brotli": 3983
+      "min": 10114,
+      "brotli": 3970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7502,
-      "brotli": 3303
+      "min": 7489,
+      "brotli": 3300
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7844,
-        "brotli": 3563
+        "min": 7831,
+        "brotli": 3579
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7622,
-        "brotli": 3358
+        "min": 7608,
+        "brotli": 3357
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6177,
-      "brotli": 2812
+      "min": 6163,
+      "brotli": 2809
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6358,
-        "brotli": 2886
+        "min": 6342,
+        "brotli": 2883
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8308,
-        "brotli": 3726
+        "min": 8294,
+        "brotli": 3746
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7792,
-        "brotli": 3543
+        "min": 7781,
+        "brotli": 3534
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7556,
-        "brotli": 3329
+        "min": 7542,
+        "brotli": 3332
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6159,
-      "brotli": 2801
+      "min": 6145,
+      "brotli": 2803
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6340,
-        "brotli": 2878
+        "min": 6324,
+        "brotli": 2871
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6241,
-      "brotli": 2849
+      "min": 6225,
+      "brotli": 2830
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2742,
-      "brotli": 1379
+      "min": 2731,
+      "brotli": 1378
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2837,
-        "brotli": 1414
+        "min": 2826,
+        "brotli": 1412
       },
       "files": {
         "tags/display-intersection.marko": 225,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2836,
-        "brotli": 1413
+        "min": 2825,
+        "brotli": 1410
       },
       "files": {
         "tags/counter.marko": 324,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15645,
-        "brotli": 6083
+        "min": 15627,
+        "brotli": 6090
       },
       "files": {
         "tags/sections.marko": 736,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2630,
-      "brotli": 1336
+      "min": 2616,
+      "brotli": 1329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5952,
-      "brotli": 2726
+      "min": 5936,
+      "brotli": 2717
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2619,
-      "brotli": 1342
+      "min": 2605,
+      "brotli": 1319
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2682,
-      "brotli": 1354
+      "min": 2668,
+      "brotli": 1346
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2923,
-      "brotli": 1433
+      "min": 2909,
+      "brotli": 1429
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2741,
-      "brotli": 1376
+      "min": 2727,
+      "brotli": 1367
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3149,
-        "brotli": 1574
+        "min": 3135,
+        "brotli": 1563
       },
       "files": {
         "tags/outer.marko": 162,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8523,
-      "brotli": 3765
+      "min": 8509,
+      "brotli": 3780
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8818,
-        "brotli": 3309
+        "min": 8802,
+        "brotli": 3305
       },
       "files": {
         "tags/checkbox.marko": 265,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8876,
-      "brotli": 3345
+      "min": 8863,
+      "brotli": 3339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4231,
-      "brotli": 1926
+      "min": 4217,
+      "brotli": 1922
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4612,
-      "brotli": 2037
+      "min": 4598,
+      "brotli": 2035
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4356,
-      "brotli": 1943
+      "min": 4342,
+      "brotli": 1945
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9072,
-        "brotli": 3381
+        "min": 9059,
+        "brotli": 3371
       },
       "files": {
         "tags/radio.marko": 259,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4365,
-      "brotli": 1974
+      "min": 4354,
+      "brotli": 1963
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9075,
-        "brotli": 3382
+        "min": 9062,
+        "brotli": 3372
       },
       "files": {
         "tags/checkbox.marko": 265,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4365,
-      "brotli": 1974
+      "min": 4354,
+      "brotli": 1963
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3344,
-      "brotli": 1574
+      "min": 3330,
+      "brotli": 1565
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8791,
-        "brotli": 3294
+        "min": 8775,
+        "brotli": 3289
       },
       "files": {
         "tags/my-details.marko": 237,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2792,
-      "brotli": 1391
+      "min": 2778,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10431,
-        "brotli": 3901
+        "min": 10415,
+        "brotli": 3890
       },
       "files": {
         "tags/my-dialog.marko": 244,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2792,
-      "brotli": 1391
+      "min": 2778,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8279,
-      "brotli": 3589
+      "min": 8266,
+      "brotli": 3581
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4129,
-        "brotli": 1911
+        "min": 4118,
+        "brotli": 1902
       },
       "files": {
         "tags/custom-input.marko": 496,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4145,
-        "brotli": 1915
+        "min": 4134,
+        "brotli": 1910
       },
       "files": {
         "tags/my-input.marko": 507,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3862,
-      "brotli": 1802
+      "min": 3848,
+      "brotli": 1795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8797,
-        "brotli": 3298
+        "min": 8781,
+        "brotli": 3293
       },
       "files": {
         "tags/my-input.marko": 235,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3834,
-      "brotli": 1800
+      "min": 3820,
+      "brotli": 1787
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8832,
-      "brotli": 3328
+      "min": 8819,
+      "brotli": 3324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8846,
-      "brotli": 3342
+      "min": 8833,
+      "brotli": 3331
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13673,
-      "brotli": 5213
+      "min": 13658,
+      "brotli": 5207
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5970,
-      "brotli": 2488
+      "min": 5954,
+      "brotli": 2469
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4392,
-      "brotli": 1948
+      "min": 4378,
+      "brotli": 1949
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9294,
-      "brotli": 3980
+      "min": 9277,
+      "brotli": 3973
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11774,
-        "brotli": 4390
+        "min": 11757,
+        "brotli": 4377
       },
       "files": {
         "tags/my-select.marko": 244,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4373,
-      "brotli": 1938
+      "min": 4359,
+      "brotli": 1940
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4164,
-      "brotli": 1847
+      "min": 4150,
+      "brotli": 1838
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8785,
-        "brotli": 3289
+        "min": 8769,
+        "brotli": 3283
       },
       "files": {
         "tags/my-textarea.marko": 238,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3834,
-      "brotli": 1800
+      "min": 3820,
+      "brotli": 1787
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2818,
-      "brotli": 1407
+      "min": 2807,
+      "brotli": 1405
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3345,
-        "brotli": 1651
+        "min": 3331,
+        "brotli": 1638
       },
       "files": {
         "tags/my-let.marko": 241,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2626,
-      "brotli": 1331
+      "min": 2612,
+      "brotli": 1324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2654,
-        "brotli": 1339
+        "min": 2640,
+        "brotli": 1333
       },
       "files": {
         "tags/cell/index.marko": 121,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2720,
-        "brotli": 1363
+        "min": 2706,
+        "brotli": 1364
       },
       "files": {
         "tags/press-button/index.marko": 145,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2667,
-        "brotli": 1342
+        "min": 2653,
+        "brotli": 1340
       },
       "files": {
         "tags/show-result/index.marko": 116,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13587,
-        "brotli": 5206
+        "min": 13572,
+        "brotli": 5195
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13571,
-        "brotli": 5203
+        "min": 13556,
+        "brotli": 5193
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13498,
-        "brotli": 5170
+        "min": 13484,
+        "brotli": 5167
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2953,
-        "brotli": 1438
+        "min": 2939,
+        "brotli": 1427
       },
       "files": {
         "tags/counter.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3260,
-        "brotli": 1582
+        "min": 3249,
+        "brotli": 1580
       },
       "files": {
         "tags/child.marko": 454,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2972,
-        "brotli": 1473
+        "min": 2961,
+        "brotli": 1472
       },
       "files": {
         "tags/child.marko": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2720,
-        "brotli": 1362
+        "min": 2706,
+        "brotli": 1357
       },
       "files": {
         "tags/child.marko": 264,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6426,
-      "brotli": 2916
+      "min": 6410,
+      "brotli": 2911
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13404,
-        "brotli": 5126
+        "min": 13387,
+        "brotli": 5125
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2677,
+      "min": 2663,
       "brotli": 1351
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2649,
-      "brotli": 1333
+      "min": 2635,
+      "brotli": 1329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2649,
-      "brotli": 1333
+      "min": 2635,
+      "brotli": 1330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6692,
-      "brotli": 3042
+      "min": 6676,
+      "brotli": 3031
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6293,
-      "brotli": 2880
+      "min": 6277,
+      "brotli": 2877
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2649,
-      "brotli": 1334
+      "min": 2635,
+      "brotli": 1329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2631,
-      "brotli": 1335
+      "min": 2617,
+      "brotli": 1325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7437,
-        "brotli": 3078
+        "min": 7421,
+        "brotli": 3068
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2861,
-      "brotli": 1421
+      "min": 2847,
+      "brotli": 1418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7434,
-        "brotli": 3376
+        "min": 7418,
+        "brotli": 3365
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6137,
-      "brotli": 2779
+      "min": 6121,
+      "brotli": 2771
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5788,
-      "brotli": 2695
+      "min": 5772,
+      "brotli": 2687
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3124,
-      "brotli": 1565
+      "min": 3110,
+      "brotli": 1555
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5947,
-      "brotli": 2659
+      "min": 5934,
+      "brotli": 2655
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2631,
-      "brotli": 1334
+      "min": 2617,
+      "brotli": 1330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13345,
-      "brotli": 5106
+      "min": 13331,
+      "brotli": 5102
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13237,
-      "brotli": 5063
+      "min": 13220,
+      "brotli": 5044
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14188,
-        "brotli": 5422
+        "min": 14170,
+        "brotli": 5401
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13999,
-        "brotli": 5349
+        "min": 13981,
+        "brotli": 5342
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2907,
-      "brotli": 1436
+      "min": 2893,
+      "brotli": 1429
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6419,
-        "brotli": 2916
+        "min": 6403,
+        "brotli": 2906
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14022,
-        "brotli": 5371
+        "min": 14004,
+        "brotli": 5356
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14251,
-        "brotli": 5436
+        "min": 14236,
+        "brotli": 5419
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13373,
-        "brotli": 5121
+        "min": 13358,
+        "brotli": 5110
       },
       "files": {
         "tags/my-tag.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13898,
-        "brotli": 5332
+        "min": 13880,
+        "brotli": 5321
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14044,
-        "brotli": 5360
+        "min": 14026,
+        "brotli": 5352
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13202,
-      "brotli": 5035
+      "min": 13185,
+      "brotli": 5028
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2823,
-        "brotli": 1399
+        "min": 2809,
+        "brotli": 1393
       },
       "files": {
         "tags/counter.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2914,
-        "brotli": 1438
+        "min": 2900,
+        "brotli": 1430
       },
       "files": {
         "tags/child/index.marko": 312,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4127,
-        "brotli": 1917
+        "min": 4113,
+        "brotli": 1908
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13463,
-        "brotli": 5135
+        "min": 13446,
+        "brotli": 5123
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6696,
-      "brotli": 3028
+      "min": 6680,
+      "brotli": 3011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3332,
-      "brotli": 1636
+      "min": 3318,
+      "brotli": 1633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2745,
-      "brotli": 1392
+      "min": 2731,
+      "brotli": 1373
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2739,
-      "brotli": 1363
+      "min": 2725,
+      "brotli": 1361
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7304,
-      "brotli": 3321
+      "min": 7288,
+      "brotli": 3335
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7937,
-      "brotli": 3585
+      "min": 7921,
+      "brotli": 3583
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8009,
-      "brotli": 3609
+      "min": 7993,
+      "brotli": 3605
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7511,
-      "brotli": 3342
+      "min": 7495,
+      "brotli": 3329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7248,
-      "brotli": 3320
+      "min": 7232,
+      "brotli": 3313
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7050,
-      "brotli": 3239
+      "min": 7034,
+      "brotli": 3228
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7324,
-      "brotli": 3330
+      "min": 7311,
+      "brotli": 3327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8475,
-      "brotli": 3775
+      "min": 8460,
+      "brotli": 3784
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3598,
-      "brotli": 1742
+      "min": 3587,
+      "brotli": 1744
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6639,
-      "brotli": 3000
+      "min": 6626,
+      "brotli": 2992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3222,
-      "brotli": 1576
+      "min": 3211,
+      "brotli": 1574
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3225,
-      "brotli": 1578
+      "min": 3214,
+      "brotli": 1576
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3651,
-      "brotli": 1769
+      "min": 3640,
+      "brotli": 1765
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3796,
-      "brotli": 1805
+      "min": 3785,
+      "brotli": 1800
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8295,
-      "brotli": 3716
+      "min": 8282,
+      "brotli": 3731
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3579,
-      "brotli": 1739
+      "min": 3568,
+      "brotli": 1741
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6986,
-      "brotli": 3201
+      "min": 6970,
+      "brotli": 3205
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7715,
-        "brotli": 3526
+        "min": 7699,
+        "brotli": 3520
       },
       "files": {
         "tags/list.marko": 296,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8061,
-        "brotli": 3659
+        "min": 8045,
+        "brotli": 3676
       },
       "files": {
         "tags/child.marko": 517,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3579,
+      "min": 3568,
       "brotli": 1742
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3469,
-      "brotli": 1695
+      "min": 3455,
+      "brotli": 1692
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3524,
-      "brotli": 1732
+      "min": 3513,
+      "brotli": 1722
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3251,
-      "brotli": 1593
+      "min": 3240,
+      "brotli": 1592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3469,
-      "brotli": 1695
+      "min": 3455,
+      "brotli": 1692
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7068,
-      "brotli": 3203
+      "min": 7052,
+      "brotli": 3191
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7062,
-      "brotli": 3201
+      "min": 7046,
+      "brotli": 3206
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2835,
-      "brotli": 1418
+      "min": 2821,
+      "brotli": 1413
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6843,
-      "brotli": 3154
+      "min": 6827,
+      "brotli": 3127
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7055,
-      "brotli": 3246
+      "min": 7039,
+      "brotli": 3232
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7192,
-      "brotli": 3295
+      "min": 7176,
+      "brotli": 3288
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13923,
-        "brotli": 5308
+        "min": 13905,
+        "brotli": 5299
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14578,
-        "brotli": 5565
+        "min": 14560,
+        "brotli": 5540
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13656,
-        "brotli": 5205
+        "min": 13639,
+        "brotli": 5191
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2667,
-      "brotli": 1339
+      "min": 2653,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2498,
-        "brotli": 1264
+        "min": 2484,
+        "brotli": 1257
       },
       "files": {
         "tags/parent-el.marko": 223,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9031,
-      "brotli": 3765
+      "min": 9015,
+      "brotli": 3754
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2768,
-      "brotli": 1385
+      "min": 2754,
+      "brotli": 1381
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9020,
-      "brotli": 3755
+      "min": 9004,
+      "brotli": 3745
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2669,
-      "brotli": 1351
+      "min": 2655,
+      "brotli": 1348
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2957,
-      "brotli": 1468
+      "min": 2943,
+      "brotli": 1471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5934,
-      "brotli": 2717
+      "min": 5918,
+      "brotli": 2708
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6202,
-      "brotli": 2825
+      "min": 6187,
+      "brotli": 2811
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6071,
-      "brotli": 2761
+      "min": 6055,
+      "brotli": 2760
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6450,
-        "brotli": 2932
+        "min": 6436,
+        "brotli": 2915
       },
       "files": {
         "tags/leaf.marko": 382,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6595,
-        "brotli": 2986
+        "min": 6579,
+        "brotli": 2977
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6566,
-        "brotli": 2978
+        "min": 6550,
+        "brotli": 2961
       },
       "files": {
         "tags/child.marko": 334,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6759,
-        "brotli": 2995
+        "min": 6745,
+        "brotli": 2991
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3305,
-      "brotli": 1636
+      "min": 3291,
+      "brotli": 1632
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3311,
-      "brotli": 1638
+      "min": 3297,
+      "brotli": 1629
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2743,
-      "brotli": 1375
+      "min": 2729,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2743,
-      "brotli": 1375
+      "min": 2729,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8723,
-      "brotli": 3293
+      "min": 8710,
+      "brotli": 3282
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6485,
-      "brotli": 2955
+      "min": 6469,
+      "brotli": 2947
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8807,
-        "brotli": 3302
+        "min": 8791,
+        "brotli": 3291
       },
       "files": {
         "tags/my-input.marko": 350,

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2628,
-      "brotli": 1339
+      "min": 2614,
+      "brotli": 1322
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2646,
-      "brotli": 1336
+      "min": 2632,
+      "brotli": 1328
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2636,
-      "brotli": 1330
+      "min": 2622,
+      "brotli": 1326
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2572,
-      "brotli": 1309
+      "min": 2558,
+      "brotli": 1299
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2750,
-      "brotli": 1373
+      "min": 2736,
+      "brotli": 1367
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2771,
-      "brotli": 1387
+      "min": 2757,
+      "brotli": 1383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2729,
-        "brotli": 1362
+        "min": 2715,
+        "brotli": 1356
       },
       "files": {
         "tags/child.marko": 199,

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2790,
-      "brotli": 1396
+      "min": 2776,
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2791,
-      "brotli": 1392
+      "min": 2777,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6422,
-        "brotli": 2915
+        "min": 6406,
+        "brotli": 2904
       },
       "files": {
         "tags/test.marko": 683,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2999,
-      "brotli": 1507
+      "min": 2985,
+      "brotli": 1498
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2649,
-        "brotli": 1333
+        "min": 2635,
+        "brotli": 1328
       },
       "files": {
         "tags/child/index.marko": 104,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7518,
-        "brotli": 3430
+        "min": 7502,
+        "brotli": 3405
       },
       "files": {
         "tags/inner/index.marko": 1001,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2649,
-        "brotli": 1333
+        "min": 2635,
+        "brotli": 1328
       },
       "files": {
         "tags/child/index.marko": 110,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2773,
-        "brotli": 1396
+        "min": 2759,
+        "brotli": 1387
       },
       "files": {
         "tags/leaf.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2649,
-        "brotli": 1333
+        "min": 2635,
+        "brotli": 1328
       },
       "files": {
         "tags/child-b/index.marko": 112,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2864,
+        "min": 2853,
         "brotli": 1428
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2761,
-      "brotli": 1379
+      "min": 2747,
+      "brotli": 1383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7760,
-        "brotli": 3531
+        "min": 7745,
+        "brotli": 3523
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3055,
-        "brotli": 1502
+        "min": 3044,
+        "brotli": 1499
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3018,
-        "brotli": 1484
+        "min": 3007,
+        "brotli": 1477
       },
       "files": {
         "tags/child.marko": 315,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3289,
-        "brotli": 1624
+        "min": 3278,
+        "brotli": 1618
       },
       "files": {
         "tags/let-global.marko": 572,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3007,
-      "brotli": 1494
+      "min": 2996,
+      "brotli": 1485
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3346,
-        "brotli": 1585
+        "min": 3335,
+        "brotli": 1583
       },
       "files": {
         "tags/child.marko": 1222,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3017,
-      "brotli": 1487
+      "min": 3006,
+      "brotli": 1480
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2969,
-      "brotli": 1466
+      "min": 2958,
+      "brotli": 1459
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2848,
-      "brotli": 1405
+      "min": 2834,
+      "brotli": 1398
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2612,
-      "brotli": 1324
+      "min": 2598,
+      "brotli": 1315
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-set-in-effect/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2402,
+      "min": 2388,
       "brotli": 1229
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2801,
-      "brotli": 1404
+      "min": 2787,
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2778,
-      "brotli": 1382
+      "min": 2764,
+      "brotli": 1372
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-undefined-until-dom/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2373,
-      "brotli": 1218
+      "min": 2359,
+      "brotli": 1205
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2980,
-      "brotli": 1485
+      "min": 2966,
+      "brotli": 1475
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6380,
-        "brotli": 2869
+        "min": 6364,
+        "brotli": 2861
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6609,
-      "brotli": 2936
+      "min": 6593,
+      "brotli": 2926
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2661,
-      "brotli": 1358
+      "min": 2647,
+      "brotli": 1344
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2908,
-      "brotli": 1451
+      "min": 2894,
+      "brotli": 1444
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2921,
-      "brotli": 1434
+      "min": 2907,
+      "brotli": 1429
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2427,
-      "brotli": 1240
+      "min": 2413,
+      "brotli": 1229
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-effect-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2361,
-      "brotli": 1215
+      "min": 2347,
+      "brotli": 1199
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3019,
-      "brotli": 1485
+      "min": 3005,
+      "brotli": 1483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4090,
-      "brotli": 1908
+      "min": 4079,
+      "brotli": 1910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3225,
-        "brotli": 1547
+        "min": 3214,
+        "brotli": 1544
       },
       "files": {
         "tags/2counters.marko": 836,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14012,
-      "brotli": 5342
+      "min": 13997,
+      "brotli": 5338
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2987,
-      "brotli": 1484
+      "min": 2976,
+      "brotli": 1487
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2712,
-      "brotli": 1364
+      "min": 2698,
+      "brotli": 1361
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8930,
-      "brotli": 3357
+      "min": 8914,
+      "brotli": 3349
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2769,
-      "brotli": 1388
+      "min": 2755,
+      "brotli": 1385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-iife/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-iife/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2852,
+      "min": 2841,
       "brotli": 1428
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2676,
-      "brotli": 1354
+      "min": 2662,
+      "brotli": 1337
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-param/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2633,
-      "brotli": 1345
+      "min": 2619,
+      "brotli": 1331
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5446,
-      "brotli": 2299
+      "min": 5430,
+      "brotli": 2294
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2692,
-      "brotli": 1355
+      "min": 2678,
+      "brotli": 1349
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14569,
-      "brotli": 5621
+      "min": 14551,
+      "brotli": 5637
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5401,
-        "brotli": 2278
+        "min": 5387,
+        "brotli": 2270
       },
       "files": {
         "tags/my-box.marko": 207,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6951,
-        "brotli": 2859
+        "min": 6935,
+        "brotli": 2854
       },
       "files": {
         "tags/my-box.marko": 375,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13643,
-        "brotli": 5228
+        "min": 13625,
+        "brotli": 5222
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5381,
-        "brotli": 2269
+        "min": 5367,
+        "brotli": 2261
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8701,
-        "brotli": 3288
+        "min": 8685,
+        "brotli": 3270
       },
       "files": {
         "tags/my-img.marko": 233,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2680,
-      "brotli": 1348
+      "min": 2666,
+      "brotli": 1343
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8023,
-      "brotli": 3619
+      "min": 8008,
+      "brotli": 3611
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3580,
+      "min": 3569,
       "brotli": 1723
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-adjacent-static-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-adjacent-static-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2648,
-      "brotli": 1342
+      "min": 2634,
+      "brotli": 1336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9848,
-      "brotli": 3880
+      "min": 9831,
+      "brotli": 3873
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2636,
-      "brotli": 1331
+      "min": 2622,
+      "brotli": 1328
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2652,
-      "brotli": 1334
+      "min": 2638,
+      "brotli": 1329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2721,
-      "brotli": 1338
+      "min": 2707,
+      "brotli": 1339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7693,
-      "brotli": 3494
+      "min": 7677,
+      "brotli": 3486
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2769,
-        "brotli": 1372
+        "min": 2758,
+        "brotli": 1368
       },
       "files": {
         "tags/setter.marko": 312,

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3345,
-        "brotli": 1651
+        "min": 3331,
+        "brotli": 1638
       },
       "files": {
         "tags/my-let.marko": 241,

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3278,
-      "brotli": 1559
+      "min": 3267,
+      "brotli": 1561
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2714,
-      "brotli": 1366
+      "min": 2700,
+      "brotli": 1357
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2655,
-      "brotli": 1340
+      "min": 2641,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5506,
-      "brotli": 2324
+      "min": 5490,
+      "brotli": 2318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2702,
-      "brotli": 1361
+      "min": 2688,
+      "brotli": 1356
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2879,
-      "brotli": 1423
+      "min": 2865,
+      "brotli": 1417
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2799,
-      "brotli": 1370
+      "min": 2785,
+      "brotli": 1367
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4274,
-      "brotli": 2054
+      "min": 4260,
+      "brotli": 2048
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4274,
-      "brotli": 2056
+      "min": 4260,
+      "brotli": 2045
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4469,
-      "brotli": 2128
+      "min": 4455,
+      "brotli": 2122
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4423,
-      "brotli": 2120
+      "min": 4409,
+      "brotli": 2113
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4341,
-      "brotli": 2084
+      "min": 4327,
+      "brotli": 2074
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4421,
+      "min": 4407,
       "brotli": 2123
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4291,
-      "brotli": 2064
+      "min": 4277,
+      "brotli": 2055
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4274,
-      "brotli": 2056
+      "min": 4260,
+      "brotli": 2045
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4429,
-      "brotli": 2126
+      "min": 4415,
+      "brotli": 2119
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8766,
-      "brotli": 3291
+      "min": 8750,
+      "brotli": 3281
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9084,
-      "brotli": 3408
+      "min": 9071,
+      "brotli": 3399
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14726,
-        "brotli": 5774
+        "min": 14708,
+        "brotli": 5737
       },
       "files": {
         "tags/child.marko": 759,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13549,
-        "brotli": 5182
+        "min": 13531,
+        "brotli": 5172
       },
       "files": {
         "tags/consumer.marko": 510,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
+      "min": 2604,
       "brotli": 1320
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2637,
-      "brotli": 1335
+      "min": 2623,
+      "brotli": 1328
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1321
+      "min": 2604,
+      "brotli": 1318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14428,
-        "brotli": 5503
+        "min": 14410,
+        "brotli": 5482
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13904,
-      "brotli": 5340
+      "min": 13889,
+      "brotli": 5330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2909,
-      "brotli": 1454
+      "min": 2895,
+      "brotli": 1452
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2927,
-      "brotli": 1452
+      "min": 2913,
+      "brotli": 1445
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6134,
-        "brotli": 2793
+        "min": 6118,
+        "brotli": 2782
       },
       "files": {
         "tags/child.marko": 176,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6352,
-        "brotli": 2887
+        "min": 6336,
+        "brotli": 2871
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3434,
-      "brotli": 1667
+      "min": 3420,
+      "brotli": 1652
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2577,
+      "min": 2563,
       "brotli": 1300
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2654,
-      "brotli": 1345
+      "min": 2640,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3146,
-      "brotli": 1570
+      "min": 3132,
+      "brotli": 1557
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3265,
-      "brotli": 1607
+      "min": 3251,
+      "brotli": 1605
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2706,
-      "brotli": 1356
+      "min": 2692,
+      "brotli": 1358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2837,
-      "brotli": 1415
+      "min": 2826,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6938,
-      "brotli": 3088
+      "min": 6924,
+      "brotli": 3089
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6938,
-      "brotli": 3088
+      "min": 6924,
+      "brotli": 3089
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7449,
+      "min": 7435,
       "brotli": 3270
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6597,
-        "brotli": 2979
+        "min": 6581,
+        "brotli": 2975
       },
       "files": {
         "tags/counter.marko": 615,

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2748,
-      "brotli": 1373
+      "min": 2734,
+      "brotli": 1368
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9688,
-      "brotli": 4079
+      "min": 9670,
+      "brotli": 4066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7151,
-      "brotli": 3210
+      "min": 7137,
+      "brotli": 3205
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6033,
-      "brotli": 2719
+      "min": 6017,
+      "brotli": 2708
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2920,
+      "min": 2906,
       "brotli": 1449
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2920,
+      "min": 2906,
       "brotli": 1449
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4273,
-      "brotli": 1949
+      "min": 4259,
+      "brotli": 1939
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3418,
-      "brotli": 1617
+      "min": 3404,
+      "brotli": 1611
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4267,
-      "brotli": 1944
+      "min": 4253,
+      "brotli": 1933
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3923,
-      "brotli": 1836
+      "min": 3909,
+      "brotli": 1826
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4239,
-      "brotli": 1898
+      "min": 4225,
+      "brotli": 1892
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4245,
-      "brotli": 1899
+      "min": 4231,
+      "brotli": 1893
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3965,
-      "brotli": 1847
+      "min": 3951,
+      "brotli": 1842
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13661,
-      "brotli": 5241
+      "min": 13646,
+      "brotli": 5238
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2626,
-      "brotli": 1331
+      "min": 2612,
+      "brotli": 1325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/user-effect-abort-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2520,
-      "brotli": 1289
+      "min": 2506,
+      "brotli": 1278
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2644,
-      "brotli": 1325
+      "min": 2630,
+      "brotli": 1324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -25,7 +25,9 @@ export const placeholderShown = new WeakSet<unknown[]>();
 export let pendingEffects: unknown[] = [];
 let pendingRenders: PendingRender[] = [];
 
-const scopeKeyOffset = 1e3;
+// Orders pending renders across scopes; signal keys are per-section
+// binding ids, so they always fit well below the offset.
+const scopeKeyOffset = 1e6;
 export function queueRender<T, U extends Scope = Scope>(
   scope: U,
   signal: Signal<T, U>,
@@ -34,7 +36,9 @@ export function queueRender<T, U extends Scope = Scope>(
   scopeKey = scope[AccessorProp.Id],
 ) {
   let render: PendingRender | undefined;
-  if (signalKey >= 0 && (render = scope[signalKey + scopeKeyOffset])) {
+  // Slots live at the signal key (small indexes stay fast elements);
+  // accessors are strings and pending counters use complemented keys.
+  if (signalKey >= 0 && (render = scope[signalKey])) {
     render[PendingRenderProp.Value] = value;
     if (
       render[PendingRenderProp.Gen] === runId ||
@@ -51,7 +55,7 @@ export function queueRender<T, U extends Scope = Scope>(
       [PendingRenderProp.Value]: value,
       [PendingRenderProp.Gen]: runId,
     };
-    if (signalKey >= 0) scope[signalKey + scopeKeyOffset] = render;
+    if (signalKey >= 0) scope[signalKey] = render;
   }
   queuePendingRender(render);
 }

--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -105,12 +105,13 @@ export function _or(
 
   return (scope) => {
     if (scope[AccessorProp.Gen] === runId) {
-      if (id in scope) {
-        if (!--scope[id]) {
+      // Complemented keys cannot collide with the render slots at `id`.
+      if ((~id) in scope) {
+        if (!--scope[~id]) {
           fn(scope);
         }
       } else {
-        scope[id] = defaultPending;
+        scope[~id] = defaultPending;
       }
     } else {
       queueRender(scope, fn, id, 0, scope[scopeIdAccessor]);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Pending render slots move from `scope[signalKey + 1e3]` to `scope[signalKey]`. Signal keys are small per-section ids, so slots now live in the scope's fast elements. The `_or` pending counters (the only other integer keys on scopes) move to the bitwise complement (`scope[~id]`) so they cannot collide, and the ordering offset widens `1e3` → `1e6` (same byte count) now that slots no longer depend on it — removing the implicit "signal keys stay below 1000" assumption on both fronts.

Micro-benchmarked on scope-shaped objects (miss+write then repeated dedupe reads, Node 22 / V8):

| slot key | ns/op | heap per scope w/ slots |
|---|---|---|
| `scope[signalKey]` (this PR) | **~20** | ~330 B |
| `scope[signalKey + 1e3]` (before) | ~62 | **~12 KB** |
| `scope[~signalKey]` (negative → named string prop) | ~103 | ~180 B |

The `+1e3` scheme was also quietly expensive on memory: writing index ~1000 to a plain object keeps V8 in *fast holey elements* (index < `kMaxGap`), allocating a ~1000-slot backing store per scope that ever queued a keyed render.

Client bundles shrink **-3724 min / -1564 brotli** bytes across the fixture suite; SSR output unchanged. Covered by the existing fixture suite (snapshots regenerated).

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.