### PR TITLE
fix(marko): resolve page entry load-tag helper for production builds

### DIFF
--- a/.changeset/fix-page-entry-load-tag-resolve.md
+++ b/.changeset/fix-page-entry-load-tag-resolve.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix `TypeError: assetFlush is not a function` when using lazy-loaded components (`import ... with { load }`) in an optimized/production build. The generated page entry now resolves the `load-tag.js` helper through the same src→dist rewrite as every other runtime import, so the page and lazy-load wrappers share a single module instance.

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -309,7 +309,12 @@ export const translate = {
                 t.identifier("withPageAssets"),
               ),
             ],
-            t.stringLiteral("marko/src/runtime/helpers/load-tag.js"),
+            t.stringLiteral(
+              resolveRelativePath(
+                file,
+                "marko/src/runtime/helpers/load-tag.js",
+              ),
+            ),
           ),
           t.exportAllDeclaration(t.stringLiteral(relPath)),
           t.exportDefaultDeclaration(


### PR DESCRIPTION
## Description

The generated page entry hardcoded its `withPageAssets` import as `marko/src/runtime/helpers/load-tag.js` instead of routing it through `resolveRelativePath` like every other runtime helper import. In an optimized build, all other imports (including the lazy-load `withLoadAssets` wrapper) get rewritten `marko/src/` → `marko/dist/`, but the page entry did not — loading two copies of `load-tag.js`. Since `assetFlush` is module-level state set by `withPageAssets`, the page and lazy-load wrappers ended up in separate module instances, so `flush` in the `dist` copy saw `assetFlush` undefined:

```
TypeError: assetFlush is not a function
    at flush (.../marko/dist/runtime/helpers/load-tag.js:110:15)
```

Routing the import through `resolveRelativePath` makes both wrappers resolve to the same module in production (and still `src` in dev, so no change there).

Fixes #3341.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HYsKQAWcfQb56u2gFVCLh8)_