### PR TITLE
fix(runtime-tags): keep serialized errors valid JS when cause/errors cannot be written inline

### DIFF
--- a/.changeset/serializer-error-cause.md
+++ b/.changeset/serializer-error-cause.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix serialized `Error`/`AggregateError` values emitting invalid JS when the `cause`/`errors` value cannot be written inline (e.g. a circular reference back through the error), which aborted the entire resume script.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -935,6 +935,22 @@ describe("serializer", () => {
         ));
       it("absent", () =>
         assertStringify(new Error("test"), `new Error("test")`));
+      it("circular applied as a deferred assignment", () => {
+        const err = new Error("boom") as Error & { cause: unknown };
+        const wrapper = { err };
+        err.cause = wrapper;
+        assertStringify(
+          { wrapper },
+          `{wrapper:_.a={err:_.b=new Error("boom")}},_.b.cause=_.a`,
+        );
+      });
+      it("unserializable dropped but stays valid JS", () => {
+        class Thing {}
+        assertStringify(
+          new Error("test", { cause: new Thing() }),
+          `new Error("test")`,
+        );
+      });
     });
 
     describe("AggregateError", () => {
@@ -962,6 +978,15 @@ describe("serializer", () => {
         assertStringify(
           { errors: agg.errors, agg },
           `{errors:_.a=[new Error("test")],agg:new AggregateError(_.a,"test")}`,
+        );
+      });
+      it("circular errors applied as a deferred assignment", () => {
+        const agg = new AggregateError([], "test");
+        const arr = [agg];
+        agg.errors = arr;
+        assertStringify(
+          arr,
+          `_.a=[_.b=new AggregateError([],"test")],_.b.errors=_.a`,
         );
       });
     });

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1210,9 +1210,14 @@ function writeError(state: State, val: Error, ref: Reference) {
   const result =
     "new " + val.constructor.name + "(" + quote(val.message + "", 0);
   if (val.cause !== undefined) {
-    state.buf.push(result + ",{cause:");
-    writeProp(state, val.cause, ref, "cause");
-    state.buf.push("})");
+    const pos = state.buf.push(result + ",{cause:") - 1;
+    if (writeProp(state, val.cause, ref, "cause")) {
+      state.buf.push("})");
+    } else {
+      // A circular cause is applied through its deferred assignment instead;
+      // slicing preserves any id assignment prefixed onto the chunk.
+      state.buf[pos] = state.buf[pos].slice(0, -",{cause:".length) + ")";
+    }
   } else {
     state.buf.push(result + ")");
   }
@@ -1225,7 +1230,10 @@ function writeAggregateError(
   ref: Reference,
 ) {
   state.buf.push("new AggregateError(");
-  writeProp(state, val.errors, ref, "errors");
+  if (!writeProp(state, val.errors, ref, "errors")) {
+    // Circular errors are applied through their deferred assignment instead.
+    state.buf.push("[]");
+  }
   if (val.message) {
     state.buf.push("," + quote(val.message + "", 0) + ")");
   } else {


### PR DESCRIPTION
## Description

`writeError` pushed `",{cause:"` and ignored `writeProp`'s return value (`writeAggregateError` shared the pattern for `errors`). When the value couldn't be written inline — a circular reference back through the error, or an unserializable instance — the output became `new Error("m",{cause:})`: a SyntaxError that kills the entire inline resume script.

On failure the constructor call now closes without the options bag (a circular cause is still applied through its deferred assignment), and `AggregateError` falls back to `[]` for its required first argument.

Perf note: every success path keeps the exact pre-change allocation/push shape — same single concat and `buf.push` count — so the hot path only gains a branch on a boolean `writeProp` already returned. The extra work (slicing the `,{cause:` suffix off the chunk) happens only on the failure path, which previously produced invalid JS.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.