### PR TITLE
fix(runtime-tags): serialize values by prototype so an own constructor property cannot corrupt them

### DIFF
--- a/.changeset/serializer-proto-dispatch.md
+++ b/.changeset/serializer-proto-dispatch.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix serialization dispatching on `val.constructor`, which let an own `constructor` property (e.g. in parsed JSON data) silently corrupt or drop the value. Values are now classified by their prototype's constructor.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -484,6 +484,23 @@ describe("serializer", () => {
       assertStringify(obj, `{y:{z:2}}`);
     });
 
+    describe("own constructor property", () => {
+      it("plain object", () =>
+        assertStringify({ constructor: 1, x: 2 }, `{constructor:1,x:2}`));
+      it("known function value", () =>
+        assertStringify({ constructor: Date, x: 2 }, `{constructor:Date,x:2}`));
+      it("parsed JSON", () =>
+        assertStringify(
+          JSON.parse('{"constructor":{"x":1}}'),
+          `{constructor:{x:1}}`,
+        ));
+      it("array", () => {
+        const arr: any = [1, 2];
+        arr.constructor = Map;
+        assertStringify(arr, `[1,2]`);
+      });
+    });
+
     it("Symbol.iterator inline", () => {
       const obj = {
         x: 1,
@@ -1833,9 +1850,13 @@ function assertIsDeepSubset(
   if (seen.has(subset)) return;
   seen.add(subset);
 
-  const aConstructor = subset.constructor?.name || "Null Prototype";
+  // Classified by prototype so an own `constructor` property on either
+  // side cannot change the comparison.
+  const aConstructor =
+    Object.getPrototypeOf(subset)?.constructor?.name || "Null Prototype";
   const bConstructor =
-    (superset as object).constructor?.name || "Null Prototype";
+    Object.getPrototypeOf(superset as object)?.constructor?.name ||
+    "Null Prototype";
   assert.equal(
     aConstructor,
     bConstructor,

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -831,7 +831,9 @@ function writeObject(
 }
 
 function writeUnknownObject(state: State, val: object, ref: Reference) {
-  switch (val.constructor) {
+  // The constructor is read from the prototype so an own `constructor`
+  // property (e.g. parsed JSON data) cannot change how a value is written.
+  switch (Object.getPrototypeOf(val)?.constructor) {
     case undefined:
       return writeNullObject(state, val, ref);
     case Object:


### PR DESCRIPTION
## Description

`writeUnknownObject` switched on `val.constructor`, an own-property lookup, so JSON-shaped data with a `constructor` key misbehaved silently: `{constructor: 1, x: 2}` dropped the whole value, `{constructor: Date}` serialized as `new Date(NaN)`, and an array with an own `constructor` property became `{}`.

Dispatch now reads the constructor from `Object.getPrototypeOf(val)`, so own properties can't affect classification while all supported types (including generators, whose constructor is inherited through the intrinsic generator prototype) resolve exactly as before. The test helper's type comparison is aligned to the same prototype-based classification.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_