### PR TITLE
fix(runtime-tags): quote serialized numeric object keys that cannot round-trip through ToNumber

### DIFF
--- a/.changeset/serializer-numeric-keys.md
+++ b/.changeset/serializer-numeric-keys.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix serialized object keys made of digits beyond 2**53 (e.g. 64-bit/snowflake ids) resuming as a different key. Bare numeric keys are canonicalized through `ToString(ToNumber(...))`, so digit runs that do not survive that round trip are now quoted.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -298,6 +298,25 @@ describe("serializer", () => {
     it("dashed-keys", () => assertStringify({ "a-b": 1 }, `{"a-b":1}`));
     it("invalid-keys", () =>
       assertStringify({ "0": 1, "a:": 2, "[": 3 }, `{0:1,"a:":2,"[":3}`));
+    // Bare numeric keys are canonicalized through ToString(ToNumber(...)):
+    // `{9007199254740993:1}` would resume with key "9007199254740992".
+    it("numeric keys beyond 2**53", () =>
+      assertStringify(
+        { "9007199254740991": 1, "9007199254740993": 2, "1e+21": 3 },
+        `{9007199254740991:1,"9007199254740993":2,"1e+21":3}`,
+      ));
+    it("numeric key accessor beyond 2**53 across flushes", () => {
+      const serializer = assertSerializer();
+      const nested = { b: 1 };
+      serializer.assertStringify(
+        { "9007199254740993": nested },
+        `{"9007199254740993":{b:1}}`,
+      );
+      serializer.assertStringify(
+        { c: nested },
+        `{c:_.a=_(1).value["9007199254740993"]}`,
+      );
+    });
     // An own `__proto__` data property (e.g. from `JSON.parse`) must serialize
     // as a computed key so it round-trips as a normal property rather than
     // mutating the prototype (`assertStringify` also deserializes + compares).

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1787,6 +1787,12 @@ export function toObjectKey(name: string) {
           return quote(name, i);
         }
       }
+
+      // A bare digit key round-trips through ToString(ToNumber(...)); only 16+
+      // digit runs can break that (precision loss or 1e21 form) and need quoting.
+      if (len > 15 && "" + +name !== name) {
+        return quote(name, 0);
+      }
     }
   } else if (
     (c0 >= Char.LowerA && c0 <= Char.LowerZ) ||


### PR DESCRIPTION
## Description

`toObjectKey` emits digit-run keys bare, but bare numeric literal keys are canonicalized by `ToString(ToNumber(...))`: `{9007199254740993:"v"}` resumes with key `"9007199254740992"` and `{999999999999999999999:"v"}` as `"1e+21"` — silent key corruption for 64-bit/snowflake ids used as object keys. The shared digit path also feeds `toAccess`, so cross-flush accessor chains (`_(1).value[9007199254740993]`) dereferenced the wrong property.

Digit-run keys now stay bare only when they survive the numeric round trip (`"" + +name === name`) and are quoted otherwise, fixing both the literal key and the accessor path.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_