### PR TITLE
fix(runtime-tags): preserve -0 through serialization

### DIFF
--- a/.changeset/serializer-negative-zero.md
+++ b/.changeset/serializer-negative-zero.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix serialized `-0` resuming as `+0` (the serializer otherwise preserves non-JSON numerics like `NaN` and `±Infinity`). Float typed array elements shared the same stringification and are also fixed.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -72,6 +72,7 @@ describe("serializer", () => {
 
     describe("number", () => {
       it("zero", () => assertStringify(0, `0`));
+      it("negative zero", () => assertStringify(-0, `-0`));
       it("positive", () => assertStringify(1, `1`));
       it("negative", () => assertStringify(-1, `-1`));
       it("decimal", () => assertStringify(0.1, `0.1`));
@@ -629,6 +630,10 @@ describe("serializer", () => {
         new Float64Array([1, 2, 3]),
         `new Float64Array([1,2,3])`,
       ));
+    it("Float64Array with negative zero", () =>
+      assertStringify(new Float64Array([-0, 1]), `new Float64Array([-0,1])`));
+    it("Float64Array with only negative zero", () =>
+      assertStringify(new Float64Array([-0, 0]), `new Float64Array([-0,0])`));
 
     it("shared buffer, multiple views", () => {
       const buffer = new ArrayBuffer(32);

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -747,7 +747,7 @@ function writeString(
 }
 
 function writeNumber(state: State, val: number) {
-  state.buf.push(val + "");
+  state.buf.push(isNegativeZero(val) ? "-0" : val + "");
   return true;
 }
 
@@ -1885,7 +1885,7 @@ function typedArrayToInitString(view: TypedArray) {
   let result = "[";
   let sep = "";
   for (let i = 0; i < view.length; i++) {
-    result += sep + view[i];
+    result += sep + (isNegativeZero(view[i]) ? "-0" : view[i]);
     sep = ",";
   }
 
@@ -1895,10 +1895,14 @@ function typedArrayToInitString(view: TypedArray) {
 
 function hasOnlyZeros(typedArray: TypedArray) {
   for (let i = 0; i < typedArray.length; i++) {
-    if (typedArray[i] !== 0) return false;
+    if (typedArray[i] !== 0 || isNegativeZero(typedArray[i])) return false;
   }
 
   return true;
+}
+
+function isNegativeZero(val: number) {
+  return val === 0 && 1 / val < 0;
 }
 
 function isWordOrDigit(char: string) {


### PR DESCRIPTION
## Description

`writeNumber` stringified with `val + ""`, so `-0` resumed as `+0` even though the serializer otherwise preserves non-JSON numerics (NaN, ±Infinity). Float typed array elements shared the same stringification, including the all-zeros `new Float64Array(n)` shorthand which also lost the sign.

Zero-with-negative-sign now emits `-0` in `writeNumber`, `typedArrayToInitString`, and disqualifies the length-only `hasOnlyZeros` shorthand. Non-zero values keep the single `=== 0` comparison on the hot path.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_