### PR TITLE
fix(runtime-tags): resume a partially-consumed sync generator as a sync generator

### DIFF
--- a/.changeset/serializer-touched-generator.md
+++ b/.changeset/serializer-touched-generator.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a partially-consumed sync generator resuming as an async generator, which broke client-side `for..of`/spread over the resumed value (no `Symbol.iterator`).

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -912,6 +912,20 @@ describe("serializer", () => {
       })();
       assertStringify(gen, `(function*(){yield 1;yield;yield 2;yield})()`);
     });
+
+    it("partially consumed resumes as an exhausted sync generator", () => {
+      const gen = (function* () {
+        yield 1;
+        yield 2;
+      })();
+      gen.next();
+      const [result] = assertSerializer().assertStringify(
+        gen,
+        `(function*(){}())`,
+      ) as [Generator];
+      assert.equal(typeof result[Symbol.iterator], "function");
+      assert.deepEqual([...result], []);
+    });
   });
 
   describe("errors", () => {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1443,7 +1443,7 @@ function writeReadableStream(
 
 function writeGenerator(state: State, iter: Generator, ref: Reference) {
   if ((iter as any)[kTouchedIterator]) {
-    state.buf.push("(async function*(){}())");
+    state.buf.push("(function*(){}())");
     return true;
   }
 


### PR DESCRIPTION
## Description

The "touched" branch of `writeGenerator` emitted `(async function*(){}())` for a sync generator that had `next()` called — copy-pasted from `writeAsyncGenerator`. The resumed value had no `Symbol.iterator`, so `for..of`/spread that worked server-side threw client-side. It now emits the exhausted sync form.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_