### PR TITLE
fix(runtime-tags): hoist serialized generator values out of the lazy body so reference dedup works

### DIFF
--- a/.changeset/serializer-generator-dedup.md
+++ b/.changeset/serializer-generator-dedup.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix values yielded/returned by a serialized sync generator registering for reference dedup at positions inside the generator's lazy body. Reusing such a value in the same flush resumed it as `undefined` (the binding assignment only ran if the generator was iterated), and reuse in a later flush emitted invalid JS that killed that flush's resume script. Values are now hoisted into eagerly evaluated arguments, matching the `Symbol.iterator` serialization strategy.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -882,7 +882,7 @@ describe("serializer", () => {
         (function* () {
           yield 1;
         })(),
-        `(function*(){yield 1})()`,
+        `(function*(a){yield*a})([1])`,
       ));
     it("multiple", () =>
       assertStringify(
@@ -891,7 +891,7 @@ describe("serializer", () => {
           yield 2;
           yield 3;
         })(),
-        `(function*(){yield 1;yield 2;yield 3})()`,
+        `(function*(a){yield*a})([1,2,3])`,
       ));
     it("nested", () =>
       assertStringify(
@@ -900,7 +900,7 @@ describe("serializer", () => {
             yield 1;
           })();
         })(),
-        `(function*(){yield 1})()`,
+        `(function*(a){yield*a})([1])`,
       ));
 
     it("yield undefined", () => {
@@ -910,7 +910,59 @@ describe("serializer", () => {
         yield 2;
         yield undefined;
       })();
-      assertStringify(gen, `(function*(){yield 1;yield;yield 2;yield})()`);
+      assertStringify(gen, `(function*(a){yield*a})([1,$,2,$])`);
+    });
+
+    it("replays yields and return on resume", async () => {
+      const gen = (function* () {
+        yield 1;
+        yield 2;
+        return 3;
+      })();
+      const [result] = assertSerializer().assertStringify(
+        gen,
+        `(function*(a,r){yield*a;return r})([1,2],3)`,
+      ) as [Generator];
+      assert.deepEqual(await consumeIterator(result), {
+        yielded: [1, 2],
+        returned: 3,
+        errored: undefined,
+      });
+    });
+
+    it("dedupes a yielded value reused in the same flush", () => {
+      const shared = { x: 1 };
+      const gen = (function* () {
+        yield shared;
+      })();
+      assertStringify(
+        { gen, shared },
+        `{gen:(function*(a){yield*a})(_.a=[_.b={x:1}]),shared:_.b}`,
+      );
+    });
+
+    it("dedupes a yielded value reused across flushes", () => {
+      const serializer = assertSerializer();
+      const shared = { x: 1 };
+      const gen = (function* () {
+        yield shared;
+      })();
+      serializer.assertStringify(gen, `(function*(a){yield*a})(_.a=[{x:1}])`);
+      serializer.assertStringify({ c: shared }, `{c:_.b=_.a[0]}`);
+    });
+
+    it("dedupes a returned value reused across flushes", () => {
+      const serializer = assertSerializer();
+      const shared = { x: 1 };
+      // eslint-disable-next-line require-yield
+      const gen = (function* () {
+        return shared;
+      })();
+      serializer.assertStringify(
+        gen,
+        `(function*(a,r){yield*a;return r})([],_.a={x:1})`,
+      );
+      serializer.assertStringify({ c: shared }, `{c:_.a}`);
     });
 
     it("partially consumed resumes as an exhausted sync generator", () => {
@@ -1961,7 +2013,9 @@ function assertEqualAtAccessor<T>(
   assert.deepEqual(a, b, `${inspect(a)} !== ${inspect(b)} at ${accessor}`);
 }
 
-async function consumeIterator(iter: AsyncIterator<unknown>) {
+async function consumeIterator(
+  iter: AsyncIterator<unknown> | Iterator<unknown>,
+) {
   const yielded: unknown[] = [];
   let errored: unknown = undefined;
   let returned: unknown = undefined;

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1456,29 +1456,71 @@ function writeGenerator(state: State, iter: Generator, ref: Reference) {
     return true;
   }
 
-  let sep = "";
-  state.buf.push("(function*(){");
+  const yields: unknown[] = [];
+  let returnValue: unknown;
+  let needsId: undefined | boolean;
 
   while (true) {
     const { value, done } = iter.next();
     if (done) {
-      if (value !== undefined) {
-        state.buf.push(sep + "return ");
-        writeProp(state, value, ref, "");
-      }
+      returnValue = value;
       break;
     }
 
-    if (value === undefined) {
-      state.buf.push(sep + "yield");
-    } else {
-      state.buf.push(sep + "yield ");
-      writeProp(state, value, ref, "");
-    }
-    sep = ";";
+    needsId ||= isDedupedMember(value);
+    yields.push(value);
   }
 
-  state.buf.push("})()");
+  if (returnValue === undefined && !yields.length) {
+    state.buf.push("(function*(){})()");
+    return true;
+  }
+
+  // Yield/return values live in eagerly evaluated arguments — the body only
+  // runs when iterated, so values written there would break reference dedup.
+  state.buf.push(
+    returnValue === undefined
+      ? "(function*(a){yield*a})("
+      : "(function*(a,r){yield*a;return r})(",
+  );
+  if (needsId) {
+    const arrayRef = new Reference(
+      ref,
+      null,
+      state.flush,
+      null,
+      nextRefAccess(state),
+    );
+    state.buf.push(arrayRef.id + "=");
+    writeArray(state, yields, arrayRef);
+  } else {
+    writeArray(
+      state,
+      yields,
+      new Reference(ref, null, state.flush, state.buf.length),
+    );
+  }
+
+  if (returnValue !== undefined) {
+    const sepIndex = state.buf.push(",") - 1;
+    if (
+      writeProp(state, returnValue, ref, "") &&
+      isDedupedMember(returnValue)
+    ) {
+      // The return value has no accessor path from the generator, so a
+      // later reuse can only reach it through an eagerly claimed binding.
+      const retRef =
+        typeof returnValue === "string"
+          ? state.strs.get(returnValue)
+          : state.refs.get(returnValue as WeakKey);
+      if (retRef && !retRef.id && retRef.scopeId === undefined) {
+        retRef.id = nextRefAccess(state);
+        state.buf[sepIndex] = "," + retRef.id + "=";
+      }
+    }
+  }
+
+  state.buf.push(")");
   return true;
 }
 


### PR DESCRIPTION
## Description

Unlike the `Symbol.iterator` path (whose backing values live in a bound array precisely because "members cannot be written there without breaking reference dedup"), `writeGenerator` wrote yield/return values directly inside the emitted `(function*(){...})()` body while dedup still recorded those buffer positions. Same-flush reuse (`{gen, shared}` where `gen` yields `shared`) resumed `shared` as `undefined` — the binding assignment only ran if the generator was iterated — and cross-flush reuse emitted `_(1).gen.`, a SyntaxError that killed that flush's resume script.

Yields are now hoisted into an eagerly evaluated argument array (`(function*(a){yield*a})([...])`, with the same `needsId` logic as Map/Set backing arrays), and a return value becomes a second argument (`(function*(a,r){yield*a;return r})([...], v)`) with an eagerly claimed binding when it's a dedupable value, since no accessor path exists from the generator to reach it later.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_