### PR TITLE
fix(runtime-tags): claim dedup bindings for long strings settled through async values

### DIFF
--- a/.changeset/serializer-mutation-string-dedup.md
+++ b/.changeset/serializer-mutation-string-dedup.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix an SSR crash (`TypeError: Cannot read properties of null (reading 'id')`) when a long string first serialized as a promise/stream/async-generator settled value was reused in a later flush. Such strings now claim their dedup binding eagerly, matching how object values on that path already behave.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -1258,6 +1258,18 @@ describe("serializer", () => {
       assert.deepEqual(serializer.get("a"), error);
       await assert.rejects(result, error);
     });
+
+    it("dedupes a settled long string reused in a later flush", async () => {
+      const serializer = assertSerializer();
+      const msg = "this string is long enough to dedup";
+      const [result] = await serializer.assertStringify(
+        Promise.resolve(msg),
+        `(p=>p=new Promise((f,r)=>_.a={f,r(e){p.catch(_=>0);r(e)}}))()`,
+        `_.a.f(_.a="${msg}")`,
+      );
+      assert.equal(await result, msg);
+      serializer.assertStringify({ msg }, `{msg:_.a}`);
+    });
   });
 
   describe("async generator", () => {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -519,7 +519,13 @@ function writeAssigned(state: State) {
       if (mutation.value === undefined) {
         // Settling with undefined writes no argument (`_.x.f()`).
       } else if (writeProp(state, mutation.value, null, "")) {
-        const valueRef = state.refs.get(mutation.value as object);
+        // Mutation values have no parent accessor path, so a later reuse can
+        // only reach them through an eagerly claimed binding (strings dedup
+        // through `strs` and would otherwise crash resolving cross flush).
+        const valueRef =
+          typeof mutation.value === "string"
+            ? state.strs.get(mutation.value)
+            : state.refs.get(mutation.value as object);
         // Scopes never claim a binding (`_(N)` is self-resolving).
         if (valueRef && !valueRef.id && valueRef.scopeId === undefined) {
           valueRef.id = mutation.valueId || nextRefAccess(state);


### PR DESCRIPTION
## Description

Strings above the dedup length written through the mutation path (promise/ReadableStream/async-generator settle values) registered in `state.strs` with `parent: null` and, unlike objects on that path, got no eager binding. When a later flush reused the string, `assignId`'s cross-flush branch dereferenced `cur.parent!.id` and threw `TypeError: Cannot read properties of null (reading 'id')` from `stringifyScopes`, crashing the render. Repro: `Promise.resolve(longString)` in flush 1, `{msg: longString}` in flush 2.

The value-binding block in `writeAssigned` now looks strings up in `state.strs` (objects keep using `state.refs`) so they claim their binding eagerly. For promise settlements the binding reuses the already-allocated handle id (`_.a.f(_.a="...")`), so the common case costs no extra bytes.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_