### PR TITLE
fix(runtime-tags): stringify RegExp attribute values consistently on server and client

### DIFF
--- a/.changeset/regexp-attr-csr.md
+++ b/.changeset/regexp-attr-csr.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix RegExp attribute values rendering differently on the client than on the server. SSR special-cased `RegExp` to write its `.source` while the DOM runtime stringified the whole expression, so the first post-hydration update corrupted an SSR-rendered attribute. The special case is removed: both targets now stringify RegExp values the same way (`pattern="/^a+$/"`).

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9831,
-      "brotli": 3873
+      "min": 9765,
+      "brotli": 3849
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<input><button>strict</button>";
+const $walks = " b b";
+const $pattern = ($scope, pattern) => _attr($scope["#input/0"], "pattern", pattern);
+const $source = /*@__PURE__*/ _let("source/2", ($scope) => $pattern($scope, new RegExp($scope.source)));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$source($scope, "^b+$");
+}));
+function $setup($scope) {
+	$source($scope, "^a+$");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $pattern = ($scope, pattern) => _attr($scope.a, "pattern", pattern);
+const $source = /*@__PURE__*/ _let(2, ($scope) => $pattern($scope, new RegExp($scope.c)));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$source($scope, "^b+$");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let source = "^a+$";
+	const pattern = new RegExp(source);
+	_html(`<input${_attr("pattern", pattern)}>${_el_resume($scope0_id, "#input/0")}<button>strict</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/html.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attr("pattern", /* @__PURE__ */ new RegExp("^a+$"))}>${_el_resume($scope0_id, "a")}<button>strict</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<input
+  pattern="/^a+$/"
+/>
+<button>
+  strict
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<input
+  pattern="/^b+$/"
+/>
+<button>
+  strict
+</button>
+```
+## Change
+```
+UPDATE: input[pattern] "/^a+$/" => "/^b+$/"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<input
+  pattern="/^a+$/"
+/>
+<button>
+  strict
+</button>
+```
+
+# Update
+```js
+container.querySelector("button").click();
+```
+```html
+<input
+  pattern="/^b+$/"
+/>
+<button>
+  strict
+</button>
+```
+## Change
+```
+UPDATE: input[pattern] "/^a+$/" => "/^b+$/"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/writes.debug.html
@@ -1,0 +1,9 @@
+<input
+  pattern="/^a+$/"><!--M_*1 #input/0--><button>strict</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures/regexp-attr/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/__snapshots__/writes.html
@@ -1,0 +1,6 @@
+<input pattern="/^a+$/"><!--M_*1 a--><button>strict</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = ["a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10048,
-      "brotli": 3948
+      "min": 2760,
+      "brotli": 1386
     }
   },
   "html": {
-    "min": 390,
+    "min": 368,
     "brotli": 255
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/template.marko
@@ -1,0 +1,4 @@
+<let/source="^a+$"/>
+<const/pattern = new RegExp(source)/>
+<input pattern=pattern/>
+<button onClick() { source = "^b+$" }>strict</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(container: Element) {
+  container.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/html-attrs.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-attrs.test.ts
@@ -48,9 +48,8 @@ describe("runtime-tags/html/attrs", () => {
       );
     });
 
-    it("should return the source when passed a regexp", () => {
-      const regexp = /foo/;
-      assert.equal(helpers._attr("foo", regexp), ` foo=${regexp.source}`);
+    it("should stringify a regexp like any other object", () => {
+      assert.equal(helpers._attr("foo", /foo/), ` foo="/foo/"`);
     });
   });
 

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -450,11 +450,6 @@ function nonVoidAttr(name: string, value: unknown) {
       return " " + name;
     case "number":
       return " " + name + "=" + value;
-    case "object":
-      if (value instanceof RegExp) {
-        return " " + name + attrAssignment(value.source);
-      }
-      break;
   }
 
   return " " + name + attrAssignment(value + "");


### PR DESCRIPTION
## Description

SSR's `nonVoidAttr` special-cased `RegExp` and wrote `.source` (`pattern="^a+$"`), but the DOM runtime stringified the whole expression (`pattern="/^a+$/"`), so the first post-hydration update corrupted an SSR-rendered attribute: `UPDATE: input[pattern] "^a+$" => "/^b+$/"`.

Per review direction, this now goes the other way: the RegExp special case is removed from SSR entirely, so both targets stringify RegExp values identically (`pattern="/^a+$/"`) with no per-type branching in either runtime. The `regexp-attr` fixture runs in equivalent mode asserting SSR/CSR render identically, and the post-click update stays consistent (`"/^a+$/" => "/^b+$/"`).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.