### PR TITLE
fix(runtime-tags): report a compile error for assignments to positional tag parameters

### DIFF
--- a/.changeset/positional-param-assignment.md
+++ b/.changeset/positional-param-assignment.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix assignments to a positional tag parameter (e.g. `<for|item|>` + `item = x` in a handler) generating code that referenced an undeclared binding, throwing `ReferenceError: $Change is not defined` during SSR. This is now a compile error pointing at the assignment, since a positional parameter has no object to carry a change handler.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko:2:23
+      1 | <await|data|=input.promise>
+    > 2 |   <button onClick() { data = 1 }>${data}</button>
+        |                       ^^^^ `data` is a tag parameter and cannot be assigned to.
+      3 | </await>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko:2:23
+      1 | <await|data|=input.promise>
+    > 2 |   <button onClick() { data = 1 }>${data}</button>
+        |                       ^^^^ `data` is a tag parameter and cannot be assigned to.
+      3 | </await>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko:2:23
+      1 | <await|data|=input.promise>
+    > 2 |   <button onClick() { data = 1 }>${data}</button>
+        |                       ^^^^ `data` is a tag parameter and cannot be assigned to.
+      3 | </await>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko:2:23
+      1 | <await|data|=input.promise>
+    > 2 |   <button onClick() { data = 1 }>${data}</button>
+        |                       ^^^^ `data` is a tag parameter and cannot be assigned to.
+      3 | </await>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/template.marko
@@ -1,0 +1,3 @@
+<await|data|=input.promise>
+  <button onClick() { data = 1 }>${data}</button>
+</await>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-await-param/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko:2:23
+      1 | <for|item| of=input.list>
+    > 2 |   <button onClick() { item = "changed" }>${item}</button>
+        |                       ^^^^ `item` is a tag parameter and cannot be assigned to.
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko:2:23
+      1 | <for|item| of=input.list>
+    > 2 |   <button onClick() { item = "changed" }>${item}</button>
+        |                       ^^^^ `item` is a tag parameter and cannot be assigned to.
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko:2:23
+      1 | <for|item| of=input.list>
+    > 2 |   <button onClick() { item = "changed" }>${item}</button>
+        |                       ^^^^ `item` is a tag parameter and cannot be assigned to.
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko:2:23
+      1 | <for|item| of=input.list>
+    > 2 |   <button onClick() { item = "changed" }>${item}</button>
+        |                       ^^^^ `item` is a tag parameter and cannot be assigned to.
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/template.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.list>
+  <button onClick() { item = "changed" }>${item}</button>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-for-param/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -577,6 +577,14 @@ function trackAssignment(
       }
 
       if (binding.upstreamAlias && binding.property !== undefined) {
+        // A positional parameter (`<for|item|>`) has no object that could
+        // carry a change handler, so the assignment can never write back.
+        if (binding.upstreamAlias === binding.section.params) {
+          throw assignment.buildCodeFrameError(
+            `\`${binding.name}\` is a tag parameter and cannot be assigned to.`,
+          );
+        }
+
         const changePropName = binding.property + "Change";
         const changeBinding =
           binding.upstreamAlias.propertyAliases.get(changePropName) ||


### PR DESCRIPTION
## Description

`trackAssignment` synthesizes a `<property>Change` binding for any binding with `upstreamAlias` + `property` — the destructured-object controllable machinery — but a positional param's property is `"0"`, yielding a `"0Change"` lookup that can never exist. `<for|item| of=list>` + `item = x` in a handler made the HTML translator emit `writeScope(..., { $Change }, ...)` with `$Change` a free identifier: SSR threw `ReferenceError: $Change is not defined` on first render (the DOM handler threw on click).

Assignments whose upstream alias is the section's params root (positional `<for>`/`<await>` params, and the template's `input` itself) are now a compile error with a code frame — there is no object to carry a change handler, so the assignment could never write back. Object-destructured properties keep the change-binding behavior.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_