### PR TITLE
fix(runtime-tags): reject duplicate value attributes on &lt;let&gt;

### DIFF
--- a/.changeset/let-duplicate-value.md
+++ b/.changeset/let-duplicate-value.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a duplicate `value` attribute on `<let>` (e.g. `<let/x=input.a value=input.b/>`) wiring reactivity to one attribute while generating code for the other, which threw a `ReferenceError` on the client. It is now a compile error, matching `<script>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko:1:16
+    > 1 | <let/x=input.a value=input.b/>
+        |                ^^^^^^^^^^^^^ Invalid duplicate value attribute.
+      2 | <div>${x}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko:1:16
+    > 1 | <let/x=input.a value=input.b/>
+        |                ^^^^^^^^^^^^^ Invalid duplicate value attribute.
+      2 | <div>${x}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko:1:16
+    > 1 | <let/x=input.a value=input.b/>
+        |                ^^^^^^^^^^^^^ Invalid duplicate value attribute.
+      2 | <div>${x}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko:1:16
+    > 1 | <let/x=input.a value=input.b/>
+        |                ^^^^^^^^^^^^^ Invalid duplicate value attribute.
+      2 | <div>${x}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/template.marko
@@ -1,0 +1,2 @@
+<let/x=input.a value=input.b/>
+<div>${x}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-duplicate-value/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -42,8 +42,20 @@ export default {
     for (const attr of node.attributes) {
       if (t.isMarkoAttribute(attr)) {
         if (attr.name === "value") {
+          if (valueAttr) {
+            throw tag.hub.buildError(
+              attr,
+              "Invalid duplicate value attribute.",
+            );
+          }
           valueAttr = attr;
         } else if (attr.name === "valueChange") {
+          if (valueChangeAttr) {
+            throw tag.hub.buildError(
+              attr,
+              "Invalid duplicate valueChange attribute.",
+            );
+          }
           valueChangeAttr = attr;
         } else {
           const start = attr.loc?.start;


### PR DESCRIPTION
## Description

Analyze tracked references from the *last* `value` attribute while translate emitted the *first*: `<let/x=input.a value=input.b/>` wired reactivity to `input.b` but generated code calling `$input_a(...)`, which was never declared — CSR mount threw `ReferenceError: $input_a is not defined` (SSR passed). `<script>` already rejects this shape; `<let>` now does too (for `valueChange` as well), with the same "Invalid duplicate value attribute." error.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_