### PR TITLE
fix(runtime-tags): reject &lt;textarea&gt; with both a value attribute and body content

### DIFF
--- a/.changeset/textarea-value-and-body.md
+++ b/.changeset/textarea-value-and-body.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `<textarea value=x>body</textarea>` silently dropping the author's `value` attribute (the body was appended as a second, last-wins `value`). Combining both is now a compile error.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko:1:11
+    > 1 | <textarea value=input.v>fallback</textarea>
+        |           ^^^^^^^^^^^^^ A textarea cannot have both a value attribute and body content.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko:1:11
+    > 1 | <textarea value=input.v>fallback</textarea>
+        |           ^^^^^^^^^^^^^ A textarea cannot have both a value attribute and body content.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko:1:11
+    > 1 | <textarea value=input.v>fallback</textarea>
+        |           ^^^^^^^^^^^^^ A textarea cannot have both a value attribute and body content.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko:1:11
+    > 1 | <textarea value=input.v>fallback</textarea>
+        |           ^^^^^^^^^^^^^ A textarea cannot have both a value attribute and body content.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/template.marko
@@ -1,0 +1,1 @@
+<textarea value=input.v>fallback</textarea>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-textarea-value-and-body/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/textarea.ts
+++ b/packages/runtime-tags/src/translator/core/textarea.ts
@@ -23,6 +23,17 @@ export function preAnalyze(tag: t.NodePath<t.MarkoTag>) {
 
     const textValue = normalizeStringExpression(parts);
     if (textValue) {
+      const valueAttr = tag.node.attributes.find(
+        (attr) => t.isMarkoAttribute(attr) && attr.name === "value",
+      );
+      if (valueAttr) {
+        throw tag.hub.file.hub.buildError(
+          valueAttr,
+          "A textarea cannot have both a value attribute and body content.",
+          SyntaxError,
+        );
+      }
+
       tag.node.attributes.push(t.markoAttribute("value", textValue));
     }
 


### PR DESCRIPTION
## Description

`preAnalyze` converts a `<textarea>` body into a `value` attribute and appended it without checking for an existing one; since the last attribute wins, `<textarea value=input.v>fallback</textarea>` silently discarded `value=input.v` from both output targets with no diagnostic. It is now a compile error pointing at the `value` attribute, mirroring `<script>`'s duplicate-value check.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_