### PR TITLE
fix(runtime-tags): report readonly compile error for &lt;id&gt;/&lt;define&gt; tag variable assignments

### DIFF
--- a/.changeset/readonly-tag-var-assignment.md
+++ b/.changeset/readonly-tag-var-assignment.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix assignments to `<id>` and `<define>` tag variables compiling to silent no-ops (the assignment was replaced with its bare right-hand side). They now report the same "readonly and cannot be mutated" compile error as `<const>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko:2:21
+      1 | <define/greeting value="hello"/>
+    > 2 | <button onClick() { greeting = { value: "hi" } }>${greeting.value}</button>
+        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ greeting is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko:2:21
+      1 | <define/greeting value="hello"/>
+    > 2 | <button onClick() { greeting = { value: "hi" } }>${greeting.value}</button>
+        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ greeting is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko:2:21
+      1 | <define/greeting value="hello"/>
+    > 2 | <button onClick() { greeting = { value: "hi" } }>${greeting.value}</button>
+        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ greeting is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko:2:21
+      1 | <define/greeting value="hello"/>
+    > 2 | <button onClick() { greeting = { value: "hi" } }>${greeting.value}</button>
+        |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^ greeting is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/template.marko
@@ -1,0 +1,2 @@
+<define/greeting value="hello"/>
+<button onClick() { greeting = { value: "hi" } }>${greeting.value}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-define-var/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko:2:21
+      1 | <id/uid/>
+    > 2 | <button onClick() { uid = "changed" }>${uid}</button>
+        |                     ^^^^^^^^^^^^^^^ uid is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko:2:21
+      1 | <id/uid/>
+    > 2 | <button onClick() { uid = "changed" }>${uid}</button>
+        |                     ^^^^^^^^^^^^^^^ uid is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko:2:21
+      1 | <id/uid/>
+    > 2 | <button onClick() { uid = "changed" }>${uid}</button>
+        |                     ^^^^^^^^^^^^^^^ uid is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko:2:21
+      1 | <id/uid/>
+    > 2 | <button onClick() { uid = "changed" }>${uid}</button>
+        |                     ^^^^^^^^^^^^^^^ uid is readonly and cannot be mutated.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/template.marko
@@ -1,0 +1,2 @@
+<id/uid/>
+<button onClick() { uid = "changed" }>${uid}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-id-var/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/const.ts
+++ b/packages/runtime-tags/src/translator/core/const.ts
@@ -5,7 +5,7 @@ import {
   type Tag,
 } from "@marko/compiler/babel-utils";
 
-import { assertNoBodyContent } from "../util/assert";
+import { assertNoBodyContent, assertNoTagVarMutation } from "../util/assert";
 import evaluate from "../util/evaluate";
 import { isOutputDOM } from "../util/marko-config";
 import {
@@ -68,21 +68,7 @@ export default {
     const binding = trackVarReferences(tag, BindingType.derived, upstreamAlias);
 
     if (binding) {
-      if (node.var!.type === "Identifier") {
-        const constantViolations = tag.scope.getBinding(
-          node.var.name,
-        )?.constantViolations;
-        if (constantViolations?.length) {
-          for (const assignment of constantViolations) {
-            if (assignment.type !== "MarkoTag") {
-              // Ignore duplicate declaration violations.
-              throw assignment.buildCodeFrameError(
-                `${node.var.name} is readonly and cannot be mutated.`,
-              );
-            }
-          }
-        }
-      }
+      assertNoTagVarMutation(tag);
       if (!valueExtra.nullable) binding.nullable = false;
       if (!upstreamAlias) {
         setBindingDownstream(binding, valueExtra);

--- a/packages/runtime-tags/src/translator/core/define.ts
+++ b/packages/runtime-tags/src/translator/core/define.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import { assertNoArgs, type Tag } from "@marko/compiler/babel-utils";
 
+import { assertNoTagVarMutation } from "../util/assert";
 import { isOutputHTML } from "../util/marko-config";
 import { analyzeAttributeTags } from "../util/nested-attribute-tags";
 import {
@@ -54,6 +55,8 @@ export default {
       dropNodes(getAllTagReferenceNodes(tag.node));
       return;
     }
+
+    assertNoTagVarMutation(tag);
 
     const paramsBinding = trackParamsReferences(tagBody, BindingType.param);
     setTagDownstream(tag, varBinding);

--- a/packages/runtime-tags/src/translator/core/id.ts
+++ b/packages/runtime-tags/src/translator/core/id.ts
@@ -6,7 +6,7 @@ import {
   type Tag,
 } from "@marko/compiler/babel-utils";
 
-import { assertNoBodyContent } from "../util/assert";
+import { assertNoBodyContent, assertNoTagVarMutation } from "../util/assert";
 import evaluate from "../util/evaluate";
 import { isOutputHTML } from "../util/marko-config";
 import {
@@ -62,6 +62,7 @@ export default {
 
     const binding = trackVarReferences(tag, BindingType.derived);
     if (binding) {
+      assertNoTagVarMutation(tag);
       setBindingDownstream(binding, !!valueAttr && evaluate(valueAttr.value));
     }
 

--- a/packages/runtime-tags/src/translator/util/assert.ts
+++ b/packages/runtime-tags/src/translator/util/assert.ts
@@ -11,6 +11,25 @@ export function assertNoSpreadAttrs(tag: t.NodePath<t.MarkoTag>) {
   }
 }
 
+export function assertNoTagVarMutation(tag: t.NodePath<t.MarkoTag>) {
+  const tagVar = tag.node.var;
+  if (tagVar?.type === "Identifier") {
+    const constantViolations = tag.scope.getBinding(
+      tagVar.name,
+    )?.constantViolations;
+    if (constantViolations?.length) {
+      for (const assignment of constantViolations) {
+        // Ignore duplicate declaration violations.
+        if (assignment.type !== "MarkoTag") {
+          throw assignment.buildCodeFrameError(
+            `${tagVar.name} is readonly and cannot be mutated.`,
+          );
+        }
+      }
+    }
+  }
+}
+
 export function assertNoBodyContent(tag: t.NodePath<t.MarkoTag>) {
   if (tag.node.body.body.length) {
     const tagName = tag.get("name");


### PR DESCRIPTION
## Description

`<const>` validates tag-variable mutations, but `<id>`/`<define>` vars fell through to the signal codegen path that replaces the assignment with its bare right-hand side: `onClick() { x = "changed" }` against `<id/x/>` emitted the literal statement `"changed";` — the assignment was discarded with no compile or runtime error while sibling updates in the same handler proceeded.

The `<const>` readonly check is extracted into a shared `assertNoTagVarMutation` and applied to `<id>` and `<define>` (identifier vars; destructured `<define>` vars keep the property/change-handler machinery), producing the same "readonly and cannot be mutated" code-frame error.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_