### PR TITLE
fix(runtime-tags): error in debug when a function attribute value would render as source

### DIFF
--- a/.changeset/attr-function-value-warning.md
+++ b/.changeset/attr-function-value-warning.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix the debug attribute-value assertion whitelisting any `on*`/`*Change`-named attribute, which let function values render as literal attribute source with no warning (e.g. a spread `{checked, valueChange}` on a plain input wrote `valueChange="(v) => ..."` into the DOM). Handlers the runtime actually consumes never reach the attribute writers, so any function value there now errors in debug, with a hint for unapplied change handlers.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `valueChange` attribute cannot be a function. A change handler is only used when its matching controllable attribute combination applies.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+const $template = "<input>";
+const $walks = " b";
+const $setup = () => {};
+const $input_attrs__script = _script("__tests__/template.marko_0_input_attrs", ($scope) => _attrs_script($scope, "#input/0"));
+const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
+	_attrs($scope, "#input/0", $scope.input_attrs);
+	$input_attrs__script($scope);
+});
+const $input = ($scope, input) => $input_attrs($scope, input.attrs);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attrs(input.attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_input_attrs");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Unable to serialize "\"ControlledHandler:#input/0\"" in packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/template.marko
@@ -1,0 +1,1 @@
+<input ...input.attrs>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ attrs: { checked: true, valueChange: () => {} } }],
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -14,10 +14,16 @@ export function assertValidAttrValue(name: string, value: unknown) {
   }
 
   if (typeof value === "function") {
-    if (name === "content" || /^on/i.test(name) || /Change$/.test(name)) {
-      return;
-    }
-    throw new Error(`The \`${name}\` attribute cannot be a function.`);
+    // Consumed handlers (events, applied controllable change handlers,
+    // content) never reach the attribute writers, so a function here would
+    // render as its source code.
+    throw new Error(
+      `The \`${name}\` attribute cannot be a function.${
+        /Change$/.test(name)
+          ? " A change handler is only used when its matching controllable attribute combination applies."
+          : ""
+      }`,
+    );
   }
 
   const unrenderable = describeUnrenderable(value);


### PR DESCRIPTION
## Description

`assertValidAttrValue` whitelisted any attr name matching `/^on/i` or `/Change$/`, so a spread like `{checked, valueChange}` on a plain input (a non-controllable combination — the DOM spread takes the `checked` branch whose skip regex doesn't cover `valueChange`) set a literal `valueChange="(v) => ..."` DOM attribute containing function source, with no debug warning. Mixed-case names like `ONCLICK` fell through the same hole.

Handlers the runtime actually consumes (events, applied controllable change handlers, `content`) are extracted before the attribute writers ever run, so the whitelist is removed entirely: any function value reaching a writer now errors in debug, with an extra hint when the name looks like an unapplied change handler. The full fixture suite passes with the whitelist gone, confirming no consumed path hits the assertion.

Noted while testing (pre-existing, not changed here): SSR's `_attrs` and the DOM spread pick different controllable branches for `{checked, valueChange}` — SSR keys off `data.checkedChange` truthiness, CSR off `"checked" in nextAttrs` — so this combo diverges between modes; the new debug errors now surface it loudly in both.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_