### PR TITLE
fix(runtime-tags): escape ampersands that begin any parseable character reference in attributes

### DIFF
--- a/.changeset/attr-charref-escaping.md
+++ b/.changeset/attr-charref-escaping.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix attribute escaping only handling fully-formed, semicolon-terminated character references. HTML parsers also decode semicolon-less numeric references (`&#38x` parses as `&x`) and, in attribute values, legacy named references when the next character is not `=` or alphanumeric (`x &amp y` parses as `x & y`), so several authored values round-tripped to different strings. `&` is now escaped whenever it starts anything that could parse as a reference (`&#` or `&` + ASCII letter); a bare `&` still passes through raw.

--- a/packages/runtime-tags/src/__tests__/html-attrs.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-attrs.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert/strict";
+import { JSDOM } from "jsdom";
 
 import * as helpers from "../html/attrs";
 
@@ -26,7 +27,9 @@ describe("runtime-tags/html/attrs", () => {
       assert.equal(helpers._attr("foo", "bar/baz"), " foo=bar/baz"); // only escape slash at end.
       assert.equal(helpers._attr("foo", "bar/"), ' foo="bar/"');
       assert.equal(helpers._attr("foo", 'bar"baz'), " foo='bar\"baz'");
-      assert.equal(helpers._attr("foo", "bar&baz"), " foo=bar&baz"); // only escape entity like ranges.
+      assert.equal(helpers._attr("foo", "bar&baz"), ' foo="bar&amp;baz"');
+      assert.equal(helpers._attr("foo", "a && b"), ' foo="a && b"'); // a bare `&` never decodes.
+      assert.equal(helpers._attr("foo", "1&2"), " foo=1&2");
       assert.equal(
         helpers._attr("foo", "bar&quot;baz"),
         ' foo="bar&amp;quot;baz"',
@@ -50,6 +53,29 @@ describe("runtime-tags/html/attrs", () => {
 
     it("should stringify a regexp like any other object", () => {
       assert.equal(helpers._attr("foo", /foo/), ` foo="/foo/"`);
+    });
+
+    it("round-trips values containing reference-like sequences", () => {
+      // Parsers also decode semicolon-less numeric and legacy named
+      // references, so these historically parsed back differently.
+      for (const value of [
+        "x &amp y",
+        "AT&amp",
+        "&#38x",
+        "&#x26end",
+        "?q=a&sect=1",
+        "a && b",
+        "tom & jerry",
+        "&bogus name",
+      ]) {
+        const html = `<div${helpers._attr("data-x", value)}></div>`;
+        const dom = new JSDOM(html);
+        assert.equal(
+          dom.window.document.querySelector("div")!.getAttribute("data-x"),
+          value,
+          html,
+        );
+      }
     });
   });
 

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -455,9 +455,12 @@ function nonVoidAttr(name: string, value: unknown) {
   return " " + name + attrAssignment(value + "");
 }
 
-const singleQuoteAttrReplacements = /'|&(?=#?\w+;)/g;
-const doubleQuoteAttrReplacements = /"|&(?=#?\w+;)/g;
-const needsQuotedAttr = /["'>\s]|&#?\w+;|\/$/g;
+// Every character reference starts `&#` or `&` + an ASCII letter — and
+// parsers also decode semicolon-less numeric and legacy named references —
+// so any such `&` must be escaped to round-trip (a bare `&` never decodes).
+const singleQuoteAttrReplacements = /'|&(?=[#a-zA-Z])/g;
+const doubleQuoteAttrReplacements = /"|&(?=[#a-zA-Z])/g;
+const needsQuotedAttr = /["'>\s]|&[#a-zA-Z]|\/$/g;
 export function attrAssignment(value: string) {
   return value
     ? needsQuotedAttr.test(value)


### PR DESCRIPTION
## Description

The attribute value escapers only escaped `&` when followed by a fully-formed, semicolon-terminated reference (`&#?\w+;`). But HTML parsers also decode semicolon-less numeric references (`&#38x` → `&x`) and, in attribute values, legacy named references when the next char is not `=` or alphanumeric (`x &amp y` → `x & y`, trailing `AT&amp` → `AT&`) — so SSR output and a CSR `setAttribute` of the same value disagreed for a range of authored strings.

Every character reference starts `&#` or `&` + ASCII letter, so `&` is now escaped in exactly those cases (correct by construction without shipping the ~106-entry legacy name table; this is server-only code so the byte cost is in output, ~4 bytes per such `&`). A bare `&` (before space, digit, another `&`, etc.) never decodes and still passes through raw. A jsdom round-trip test covers the previously-corrupting shapes, including `?q=a&sect=1`-style URLs (`&sect` is a legacy reference).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_