### PR TITLE
fix(runtime-tags): resolve reorder markers stranded by an errored try body

### DIFF
--- a/.changeset/resolve-aborted-reorders.md
+++ b/.changeset/resolve-aborted-reorders.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix hydration never completing when an `<await>` inside streamed content is dropped by a `<try>` catch. Reorder markers whose content can no longer render now flush as empty reorders so client counters settle.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -41,3 +41,38 @@ therefore relied upon for correctness. A real fix needs `isSupersetSources` to
 use a strict/proper-superset test (equal sources must not prune each other)
 _and_ the corrected arithmetic, then a full snapshot audit — out of scope for a
 one-line change.
+
+## CSR: rejected `<await>` under an ancestor `@placeholder` never dismisses the placeholder
+
+`packages/runtime-tags/src/dom/control-flow.ts:376` | 2026-07-10 | impact:med | effort:med
+
+In a pure client render of `<try @placeholder><await>…<try @catch><await=rejecting>…`,
+when the inner await rejects, `_await_promise`'s reject handler zeroes the
+ancestor placeholder's counter (`awaitCounter.i = 0`) without running the
+counter's completion, and `renderCatch` only unwinds a `PlaceholderBranch` on
+the try that owns the `@catch`. When the placeholder lives on an _ancestor_
+try (the nearest-placeholder lookup in `_await_promise` attaches the counter
+there), the detached content is never re-inserted and the page shows the
+placeholder forever; the catch content renders only into the detached tree.
+Observed in the `catch-reject-nested-in-await` fixture's `render-csr` snapshot
+(final state stays `loading outer...`; SSR of the same template shows
+`caught: ERROR!` plus the sibling `<div>`). A fix needs the reject path to
+complete (not zero) the pending counter so `dismissPlaceholder`/pending
+effects run, while keeping the forced-zero semantics for resumed reorder
+records — those `c()` implementations do stream-node surgery that must not run
+on rejection.
+
+## Inline reorder runtime holds only one pending `onNextSibling` callback
+
+`packages/runtime-tags/src/html/inlined-runtimes.debug.ts:37` | 2026-07-10 | impact:low | effort:med
+
+`runtime.x` keeps a single `nextSibling`/`onNextSibling` pair. A `<t hidden>`
+swap callback pending at the element's next sibling is overwritten if, while
+walking the `<t>`'s children, a placeholder-end comment (`!id`) matches the
+"content arrived before its end marker" branch and re-assigns the pair — the
+outer swap then never fires. Tracing current server emission orders suggests
+this is unreachable today (catch/content `<t>`s and their end markers always
+stream in an order where the earlier callback fires before the overwrite),
+but it is one flush-ordering change away from a silent hydration freeze. A
+queue (or firing the pending callback before re-assigning) would make the
+inline runtime robust; weigh against inline-runtime byte cost.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -26,6 +26,12 @@ The dependency upgrade took everything to latest except two majors that are true
 
 Bare `npm audit` shows 3 advisories (`serialize-javascript` high, `js-yaml`/mocha moderate, `diff` low), all transitively under `mocha` and `@changesets/cli` — dev tooling that never ships. They can't be resolved by version bumps: the fixes live in higher majors than mocha's ranges allow (`serialize-javascript ^6`→fix in 7.x, `diff ^7`→8.x, `js-yaml ^4`→5.x), mocha 11.7.6 is the newest stable, and the latest `@changesets/parse` still pins `js-yaml ^4.1.1`. Rather than pin them via `overrides`, the repo audits production deps only: **`npm run audit`** (`npm audit --omit=dev`) is the gate and returns 0 — that's what consumers of the published packages actually receive. Revisit and drop the distinction once mocha/changesets update their transitive deps upstream.
 
+## `test:parallel` summary reports "0 failing" while workers have failures
+
+`scripts/test-parallel.js:146` | 2026-07-10 | impact:med | effort:low
+
+The aggregate line parses worker output with `/(\d+) failing/`, but the snapshot harness prints failures as `N unexpectedly failing`, which the regex does not match — a run with failing snapshots prints `… 0 failing across N workers` while still exiting 1. Anyone reading the summary (or piping it, which masks the exit code) concludes the suite is green; this shipped a stale-snapshot commit to `main` that CI then caught. Match `unexpectedly failing` too, or derive the failure count from the worker exit codes.
+
 ## Fixture `sizes.json` rewrites are unconditional, so `--grep`-scoped runs leave other fixtures stale
 
 `packages/runtime-tags/src/__tests__/main.test.ts:322` | 2026-07-10 | impact:low | effort:low

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -37,3 +37,19 @@ The aggregate line parses worker output with `/(\d+) failing/`, but the snapshot
 `packages/runtime-tags/src/__tests__/main.test.ts:322` | 2026-07-10 | impact:low | effort:low
 
 The `after()` hook writes each fixture's `sizes.json` on every optimized test run, not just under `UPDATE_EXPECTATIONS=1`. A runtime helper change validated with `npm run test:update -- --grep <name>` therefore captures new sizes only for grep-matched fixtures; any other fixture bundling the same helper keeps stale numbers that a later unrelated full run silently rewrites into the working tree (e.g. a `_lifecycle` change also resizes `for-resume-owns-branch-cleanup` and `if-resume-owns-branch-cleanup`, whose names do not match "lifecycle"). Either gate the write on `UPDATE_EXPECTATIONS` and fail on drift otherwise, or document that runtime `src/dom`/`src/html` changes require a full-suite pass before committing so all affected `sizes.json` land in the same diff.
+
+## Shared-promise test util corrupts `wait()` when a stream ends with unconsumed promises
+
+`packages/runtime-tags/src/__tests__/utils/resolve.ts:106` | 2026-07-10 | impact:med | effort:low
+
+If an SSR fixture's stream completes while a registered `resolveAfter(_, id)`
+promise is still pending (e.g. a `@catch` fires and the boundary stops waiting
+on a sibling await), the abandoned `tick()` timer chain later runs
+`r(++state.lastId)` against the state that `resetResolveState()` just reset.
+The steps' first `wait()` then sees `state.lastId` ahead of
+`state.promises.size` and its `while (id !== nextId)` loop never converges —
+the ssr test times out at 10s and mocha hangs afterwards on the leaked timers.
+Workaround used by `catch-reject-sibling-pending-await`: model
+never-consumed awaits with `new Promise(() => {})` instead of the shared
+counter. A robust fix could stamp each state object (capture `state` in
+`tick()` and drop stray resolutions after reset).

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+_enable_catch();
+const $placeholder_content2 = _content_resume("__tests__/template.marko_6_content", "loading inner...", "b");
+const $placeholder_content = _content_resume("__tests__/template.marko_5_content", "loading outer...", "b");
+const $await_content2__changes = /*@__PURE__*/ _closure_get("changes", ($scope) => _text($scope["#text/1"], $scope._._._._.changes), ($scope) => $scope._._._._, "__tests__/template.marko_4_changes/pending");
+const $await_content2__setup__script = _script("__tests__/template.marko_4", ($scope) => _on($scope["#div/0"], "change", function() {
+	$changes($scope._._._._, $scope._._._._.changes + 1);
+}));
+const $await_content2__setup = ($scope) => {
+	$await_content2__changes($scope);
+	$await_content2__setup__script($scope);
+};
+const $await_content2 = /*@__PURE__*/ _await_content("#text/0", "<div>changes: <!></div>", " Db%l", $await_content2__setup);
+const $try_content2__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content2__setup = ($scope) => {
+	$await_content2($scope);
+	$try_content2__await_promise($scope, resolveAfter("inner", 2));
+};
+const $await_content__try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content2__setup);
+const $await_content__setup = ($scope) => $await_content__try($scope, { placeholder: attrTag({ content: $placeholder_content2($scope) }) });
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<!><!><!>", "b%c", $await_content__setup);
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("outer", 1));
+};
+const $changes__closure = /*@__PURE__*/ _closure($await_content2__changes);
+const $changes = /*@__PURE__*/ _let("changes/1", $changes__closure);
+const $try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$changes($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+_enable_catch();
+const $placeholder_content2 = _content_resume("a2", "loading inner...", "b");
+const $placeholder_content = _content_resume("a4", "loading outer...", "b");
+const $await_content2__changes = /*@__PURE__*/ _closure_get(2, ($scope) => _text($scope.b, $scope._._._._.b), ($scope) => $scope._._._._, "a0");
+const $await_content2__setup__script = _script("a1", ($scope) => _on($scope.a, "change", function() {
+	$changes($scope._._._._, $scope._._._._.b + 1);
+}));
+const $changes = /*@__PURE__*/ _let(1, /* @__PURE__ */ _closure($await_content2__changes));

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = new Set();
+	let changes = 0;
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_try($scope2_id, "#text/0", _content_resume("__tests__/template.marko_3_content", () => {
+				const $scope3_id = _scope_id();
+				_scope_reason();
+				_await($scope3_id, "#text/0", resolveAfter("inner", 2), () => {
+					const $scope4_id = _scope_id();
+					_script($scope4_id, "__tests__/template.marko_4_changes/pending");
+					_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope4_id, "#text/1")}</div>${_el_resume($scope4_id, "#div/0")}`);
+					_script($scope4_id, "__tests__/template.marko_4");
+					writeScope($scope4_id, { _: _scope_with_id($scope3_id) }, "__tests__/template.marko", "9:8");
+					_resume_branch($scope4_id);
+				});
+				writeScope($scope3_id, { _: _scope_with_id($scope2_id) }, "__tests__/template.marko", "7:6");
+			}, $scope2_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_6_content", () => {
+				_scope_reason();
+				const $scope6_id = _scope_id();
+				_html("loading inner...");
+			}, $scope2_id) }) });
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "6:4");
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:2");
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_5_content", () => {
+		_scope_reason();
+		const $scope5_id = _scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		changes,
+		"ClosureScopes:changes": $changes__closures
+	}, "__tests__/template.marko", 0, { changes: "3:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = /* @__PURE__ */ new Set();
+	let changes = 0;
+	_try($scope0_id, "a", _content_resume("a5", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_try($scope2_id, "a", _content_resume("a3", () => {
+				const $scope3_id = _scope_id();
+				_scope_reason();
+				_await($scope3_id, "a", resolveAfter("inner", 2), () => {
+					const $scope4_id = _scope_id();
+					_script($scope4_id, "a0");
+					_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope4_id, "b")}</div>${_el_resume($scope4_id, "a")}`);
+					_script($scope4_id, "a1");
+					writeScope($scope4_id, { _: _scope_with_id($scope3_id) });
+					_resume_branch($scope4_id);
+				});
+				writeScope($scope3_id, { _: _scope_with_id($scope2_id) });
+			}, $scope2_id), { placeholder: attrTag({ content: _content_resume("a2", () => {
+				_scope_reason();
+				_scope_id();
+				_html("loading inner...");
+			}, $scope2_id) }) });
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a4", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		b: changes,
+		c: $changes__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-csr.debug.md
@@ -1,0 +1,56 @@
+# Render
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+```
+
+# Update
+## Change
+```
+REMOVE: ::text("loading outer...")
+```
+
+# Update
+```html
+loading inner...
+```
+## Change
+```
+INSERT: ::text("loading inner...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div
+REMOVE: div + ::text("loading inner...")
+UPDATE: div::text@9 "" => "0"
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,46 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading inner...
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: ::text("loading inner...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div::text("changes: ")
+INSERT: div::text@0 + ::text("0")
+REMOVE: ::text("loading inner...")
+INSERT: div
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/render-ssr.md
@@ -1,0 +1,46 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading inner...
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: ::text("loading inner...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div::text("changes: ")
+INSERT: div::text@0 + ::text("0")
+REMOVE: ::text("loading inner...")
+INSERT: div
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/writes.debug.html
@@ -1,0 +1,53 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 #text/0 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    changes: 0,
+    "ClosureScopes:changes": new Set
+  }, {
+    _: _(1),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko_5_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b><!--M_[--><!--M_[--><!--M_!^5-->loading
+  inner...<!--M_!5--><!--M_]4 #text/0 5--><!--M_]2 #text/0 4--></t>
+<t hidden M_=5><!--M_#c--></t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    _: _(4),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(4,
+      "packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko_6_content"
+      )
+  }]);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=c><!--M_[-->
+  <div>changes: <!>0<!--M_*7 #text/1--></div>
+  <!--M_*7 #div/0--><!--M_]5 #text/0 7-->
+</t>
+<script>
+  M._.r.push(_ => [7, {
+    _: _(5)
+  }]);
+  M._.j.c = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko_4_changes/pending 7 packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko_4 7"
+      )
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/__snapshots__/writes.html
@@ -1,0 +1,46 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 a 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    c: new Set
+  }, {
+    _: _(1),
+    C: "a",
+    Q: _(1, "a4")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b><!--M_[--><!--M_[--><!--M_!^5-->loading
+  inner...<!--M_!5--><!--M_]4 a 5--><!--M_]2 a 4--></t>
+<t hidden M_=5><!--M_#c--></t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    _: _(4),
+    C: "a",
+    Q: _(4, "a2")
+  }]);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=c><!--M_[-->
+  <div>changes: <!>0<!--M_*7 b--></div><!--M_*7 a--><!--M_]5 a 7-->
+</t>
+<script>
+  M._.r.push(_ => [7, {
+    _: _(5)
+  }]);
+  M._.j.c = _ => {
+    _.push("a0 7 a1 7")
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7734,
+      "brotli": 3386
+    }
+  },
+  "html": {
+    "min": 1287,
+    "brotli": 662
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/template.marko
@@ -1,0 +1,14 @@
+import { resolveAfter } from "../../utils/resolve";
+
+<let/changes = 0/>
+<try>
+  <@placeholder>loading outer...</@placeholder>
+  <await=resolveAfter("outer", 1)>
+    <try>
+      <@placeholder>loading inner...</@placeholder>
+      <await=resolveAfter("inner", 2)>
+        <div onChange() { changes++ }>changes: ${changes}</div>
+      </await>
+    </try>
+  </await>
+</try>

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+function change(container: Element) {
+  const div = container.querySelector("div")!;
+  const window = div.ownerDocument.defaultView!;
+  div.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, flush, wait, change],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10048,
-      "brotli": 3948
+      "min": 10057,
+      "brotli": 3952
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,48 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const never = new Promise(() => {});
+_enable_catch();
+const $catch_content2 = _content_resume("__tests__/template.marko_7_content", "inner caught", "b");
+const $await_content2 = /*@__PURE__*/ _await_content("#text/0", "never inner", "b");
+const $try_content3__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content3__setup = ($scope) => {
+	$await_content2($scope);
+	$try_content3__await_promise($scope, never);
+};
+const $catch_content__err_message = ($scope, err_message) => _text($scope["#text/0"], err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("__tests__/template.marko_5_content", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $try_content2__try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content3__setup);
+const $await_content3 = /*@__PURE__*/ _await_content("#text/1", "never outer", "b");
+const $try_content2__await_promise = /*@__PURE__*/ _await_promise("#text/1");
+const $try_content2__setup = ($scope) => {
+	$await_content3($scope);
+	$try_content2__try($scope, { catch: attrTag({ content: $catch_content2($scope) }) });
+	$try_content2__await_promise($scope, rejectAfter(new Error("ERROR!"), 2));
+};
+const $placeholder_content = _content_resume("__tests__/template.marko_3_content", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get("changes", ($scope) => _text($scope["#text/2"], $scope._._.changes), ($scope) => $scope._._, "__tests__/template.marko_2_changes/pending");
+const $await_content__try = /*@__PURE__*/ _try("#text/0", "<!><!><!><!>", "b%b%c", $try_content2__setup);
+const $await_content__setup__script = _script("__tests__/template.marko_2", ($scope) => _on($scope["#div/1"], "change", function() {
+	$changes($scope._._, $scope._._.changes + 1);
+}));
+const $await_content__setup = ($scope) => {
+	$await_content__changes($scope);
+	$await_content__try($scope, { catch: attrTag({ content: $catch_content($scope) }) });
+	$await_content__setup__script($scope);
+};
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<!><!><div>changes: <!></div>", "b%b Db%l", $await_content__setup);
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("outer", 1));
+};
+const $changes__closure = /*@__PURE__*/ _closure($await_content__changes);
+const $changes = /*@__PURE__*/ _let("changes/1", $changes__closure);
+const $try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$changes($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const never = new Promise(() => {});
+_enable_catch();
+const $catch_content2 = _content_resume("a0", "inner caught", "b");
+const $catch_content__err_message = ($scope, err_message) => _text($scope.a, err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("a2", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $placeholder_content = _content_resume("a6", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get(2, ($scope) => _text($scope.c, $scope._._.b), ($scope) => $scope._._, "a4");
+const $await_content__setup__script = _script("a5", ($scope) => _on($scope.b, "change", function() {
+	$changes($scope._._, $scope._._.b + 1);
+}));
+const $changes = /*@__PURE__*/ _let(1, /* @__PURE__ */ _closure($await_content__changes));

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,55 @@
+// template.marko
+const never = new Promise(() => {});
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = new Set();
+	let changes = 0;
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "__tests__/template.marko_2_changes/pending");
+			_try($scope2_id, "#text/0", _content_resume("__tests__/template.marko_4_content", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_try($scope4_id, "#text/0", _content_resume("__tests__/template.marko_6_content", () => {
+					const $scope6_id = _scope_id();
+					_scope_reason();
+					_await($scope6_id, "#text/0", never, () => {
+						const $scope8_id = _scope_id();
+						_html("never inner");
+					}, 0);
+				}, $scope4_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_7_content", () => {
+					_scope_reason();
+					const $scope7_id = _scope_id();
+					_html("inner caught");
+				}, $scope4_id) }) });
+				_await($scope4_id, "#text/1", rejectAfter(new Error("ERROR!"), 2), () => {
+					const $scope9_id = _scope_id();
+					_html("never outer");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_5_content", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "#text/0", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {}, "__tests__/template.marko", "21:8");
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "#text/2")}</div>${_el_resume($scope2_id, "#div/1")}`);
+			_script($scope2_id, "__tests__/template.marko_2");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "10:4");
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "8:2");
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_3_content", () => {
+		_scope_reason();
+		const $scope3_id = _scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		changes,
+		"ClosureScopes:changes": $changes__closures
+	}, "__tests__/template.marko", 0, { changes: "7:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/html.bundle.js
@@ -1,0 +1,55 @@
+// template.marko
+const never = new Promise(() => {});
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = /* @__PURE__ */ new Set();
+	let changes = 0;
+	_try($scope0_id, "a", _content_resume("a7", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "a4");
+			_try($scope2_id, "a", _content_resume("a3", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_try($scope4_id, "a", _content_resume("a1", () => {
+					const $scope6_id = _scope_id();
+					_scope_reason();
+					_await($scope6_id, "a", never, () => {
+						_scope_id();
+						_html("never inner");
+					}, 0);
+				}, $scope4_id), { catch: attrTag({ content: _content_resume("a0", () => {
+					_scope_reason();
+					_scope_id();
+					_html("inner caught");
+				}, $scope4_id) }) });
+				_await($scope4_id, "b", rejectAfter(/* @__PURE__ */ new Error("ERROR!"), 2), () => {
+					_scope_id();
+					_html("never outer");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("a2", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "a", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {});
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "c")}</div>${_el_resume($scope2_id, "b")}`);
+			_script($scope2_id, "a5");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a6", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		b: changes,
+		c: $changes__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-csr.debug.md
@@ -1,0 +1,43 @@
+# Render
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div
+REMOVE: div + ::text("loading outer...")
+UPDATE: div::text@9 "" => "0"
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+REMOVE: ::text + div
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/render-ssr.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/writes.debug.html
@@ -1,0 +1,55 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 #text/0 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    changes: 0,
+    "ClosureScopes:changes": new Set
+  }, {
+    _: _(1),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko_3_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^d--><!--M_[--><!--M_!^c--><!--M_#e--><!--M_!c--><!--M_]5 #text/0 6--><!--M_#f--><!--M_!d--><!--M_]4 #text/0 5-->
+  <div>changes: <!>0<!--M_*4 #text/2--></div>
+  <!--M_*4 #div/1--><!--M_]2 #text/0 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    "#BranchAccessor": "#text/0",
+    "#CatchContent": _(4,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko_5_content"
+      )
+  }, {
+    "#BranchAccessor": "#text/0",
+    "#CatchContent": _(5,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko_7_content"
+      )
+  }]);
+  M._.j.b = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko_2_changes/pending 4 packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko_2 4"
+      )
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=e></t>
+<t hidden M_=f></t>
+<t hidden M_=d>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/__snapshots__/writes.html
@@ -1,0 +1,46 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 a 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    c: new Set
+  }, {
+    _: _(1),
+    C: "a",
+    Q: _(1, "a6")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^d--><!--M_[--><!--M_!^c--><!--M_#e--><!--M_!c--><!--M_]5 a 6--><!--M_#f--><!--M_!d--><!--M_]4 a 5-->
+  <div>changes: <!>0<!--M_*4 c--></div><!--M_*4 b--><!--M_]2 a 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    C: "a",
+    E: _(4, "a2")
+  }, {
+    C: "a",
+    E: _(5, "a0")
+  }]);
+  M._.j.b = _ => {
+    _.push("a4 4 a5 4")
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=e></t>
+<t hidden M_=f></t>
+<t hidden M_=d>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7818,
+      "brotli": 3446
+    }
+  },
+  "html": {
+    "min": 1323,
+    "brotli": 676
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/template.marko
@@ -1,0 +1,25 @@
+import { rejectAfter, resolveAfter } from "../../utils/resolve";
+
+// A promise that outlives the stream: its `<await>` is wrapped in its own
+// `<try>` (so its boundary never aborts) while the enclosing `<try>` catches.
+static const never = new Promise(() => {});
+
+<let/changes = 0/>
+<try>
+  <@placeholder>loading outer...</@placeholder>
+  <await=resolveAfter("outer", 1)>
+    <try>
+      <try>
+        <await=never>
+          never inner
+        </await>
+        <@catch>inner caught</@catch>
+      </try>
+      <await=rejectAfter(new Error("ERROR!"), 2)>
+        never outer
+      </await>
+      <@catch|err|>caught: ${err.message}</@catch>
+    </try>
+    <div onChange() { changes++ }>changes: ${changes}</div>
+  </await>
+</try>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+function change(container: Element) {
+  const div = container.querySelector("div");
+  if (!div) return;
+  const window = div.ownerDocument.defaultView!;
+  div.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, flush, wait, flush, wait, change],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope["#text/0"], err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("__tests__/template.marko_5_content", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $await_content2 = /*@__PURE__*/ _await_content("#text/0", "never", "b");
+const $try_content2__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content2__setup = ($scope) => {
+	$await_content2($scope);
+	$try_content2__await_promise($scope, rejectAfter(new Error("ERROR!"), 1));
+};
+const $placeholder_content = _content_resume("__tests__/template.marko_3_content", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get("changes", ($scope) => _text($scope["#text/2"], $scope._._.changes), ($scope) => $scope._._, "__tests__/template.marko_2_changes/pending");
+const $await_content__try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content2__setup);
+const $await_content__setup__script = _script("__tests__/template.marko_2", ($scope) => _on($scope["#div/1"], "change", function() {
+	$changes($scope._._, $scope._._.changes + 1);
+}));
+const $await_content__setup = ($scope) => {
+	$await_content__changes($scope);
+	$await_content__try($scope, { catch: attrTag({ content: $catch_content($scope) }) });
+	$await_content__setup__script($scope);
+};
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<!><!><div>changes: <!></div>", "b%b Db%l", $await_content__setup);
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("outer", 1));
+};
+const $changes__closure = /*@__PURE__*/ _closure($await_content__changes);
+const $changes = /*@__PURE__*/ _let("changes/1", $changes__closure);
+const $try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$changes($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope.a, err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("a0", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $placeholder_content = _content_resume("a4", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get(2, ($scope) => _text($scope.c, $scope._._.b), ($scope) => $scope._._, "a2");
+const $await_content__setup__script = _script("a3", ($scope) => _on($scope.b, "change", function() {
+	$changes($scope._._, $scope._._.b + 1);
+}));
+const $changes = /*@__PURE__*/ _let(1, /* @__PURE__ */ _closure($await_content__changes));

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = new Set();
+	let changes = 0;
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "__tests__/template.marko_2_changes/pending");
+			_try($scope2_id, "#text/0", _content_resume("__tests__/template.marko_4_content", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "#text/0", rejectAfter(new Error("ERROR!"), 1), () => {
+					const $scope6_id = _scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_5_content", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "#text/0", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {}, "__tests__/template.marko", "11:8");
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "#text/2")}</div>${_el_resume($scope2_id, "#div/1")}`);
+			_script($scope2_id, "__tests__/template.marko_2");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "6:4");
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:2");
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_3_content", () => {
+		_scope_reason();
+		const $scope3_id = _scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		changes,
+		"ClosureScopes:changes": $changes__closures
+	}, "__tests__/template.marko", 0, { changes: "3:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/html.bundle.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = /* @__PURE__ */ new Set();
+	let changes = 0;
+	_try($scope0_id, "a", _content_resume("a5", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "a2");
+			_try($scope2_id, "a", _content_resume("a1", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "a", rejectAfter(/* @__PURE__ */ new Error("ERROR!"), 1), () => {
+					_scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "a", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {});
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "c")}</div>${_el_resume($scope2_id, "b")}`);
+			_script($scope2_id, "a3");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a4", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		b: changes,
+		c: $changes__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-csr.debug.md
@@ -1,0 +1,36 @@
+# Render
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div
+REMOVE: div + ::text("loading outer...")
+UPDATE: div::text@9 "" => "0"
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: ::text("caught: "), ::text("ERROR!")
+UPDATE: ::text@8 "" => "ERROR!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div::text("changes: ")
+INSERT: div::text@0 + ::text("0")
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/render-ssr.md
@@ -1,0 +1,20 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div::text("changes: ")
+INSERT: div::text@0 + ::text("0")
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/writes.debug.html
@@ -1,0 +1,41 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 #text/0 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    changes: 0,
+    "ClosureScopes:changes": new Set
+  }, {
+    _: _(1),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko_3_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b><!--M_[--><!--M_[--><!--M_!^c--><!--M_!c--><!--M_]4 #text/0 5-->
+  <div>changes: <!>0<!--M_*4 #text/2--></div>
+  <!--M_*4 #div/1--><!--M_]2 #text/0 4-->
+</t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    "#BranchAccessor": "#text/0",
+    "#CatchContent": _(4,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko_5_content"
+      )
+  }]);
+  M._.j.b = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko_2_changes/pending 4 packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko_2 4"
+      )
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/__snapshots__/writes.html
@@ -1,0 +1,34 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 a 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    c: new Set
+  }, {
+    _: _(1),
+    C: "a",
+    Q: _(1, "a4")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b><!--M_[--><!--M_[--><!--M_!^c--><!--M_!c--><!--M_]4 a 5-->
+  <div>changes: <!>0<!--M_*4 c--></div><!--M_*4 b--><!--M_]2 a 4-->
+</t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    C: "a",
+    E: _(4, "a0")
+  }]);
+  M._.j.b = _ => {
+    _.push("a2 4 a3 4")
+  };
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7769,
+      "brotli": 3427
+    }
+  },
+  "html": {
+    "min": 1171,
+    "brotli": 652
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/template.marko
@@ -1,0 +1,15 @@
+import { rejectAfter, resolveAfter } from "../../utils/resolve";
+
+<let/changes = 0/>
+<try>
+  <@placeholder>loading outer...</@placeholder>
+  <await=resolveAfter("outer", 1)>
+    <try>
+      <await=rejectAfter(new Error("ERROR!"), 1)>
+        never
+      </await>
+      <@catch|err|>caught: ${err.message}</@catch>
+    </try>
+    <div onChange() { changes++ }>changes: ${changes}</div>
+  </await>
+</try>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, wait, flush, wait],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope["#text/0"], err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("__tests__/template.marko_5_content", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $await_content2 = /*@__PURE__*/ _await_content("#text/0", "never", "b");
+const $try_content2__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content2__setup = ($scope) => {
+	$await_content2($scope);
+	$try_content2__await_promise($scope, rejectAfter(new Error("ERROR!"), 2));
+};
+const $placeholder_content = _content_resume("__tests__/template.marko_3_content", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get("changes", ($scope) => _text($scope["#text/2"], $scope._._.changes), ($scope) => $scope._._, "__tests__/template.marko_2_changes/pending");
+const $await_content__try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content2__setup);
+const $await_content__setup__script = _script("__tests__/template.marko_2", ($scope) => _on($scope["#div/1"], "change", function() {
+	$changes($scope._._, $scope._._.changes + 1);
+}));
+const $await_content__setup = ($scope) => {
+	$await_content__changes($scope);
+	$await_content__try($scope, { catch: attrTag({ content: $catch_content($scope) }) });
+	$await_content__setup__script($scope);
+};
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<!><!><div>changes: <!></div>", "b%b Db%l", $await_content__setup);
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("outer", 1));
+};
+const $changes__closure = /*@__PURE__*/ _closure($await_content__changes);
+const $changes = /*@__PURE__*/ _let("changes/1", $changes__closure);
+const $try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$changes($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope.a, err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("a0", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $placeholder_content = _content_resume("a4", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get(2, ($scope) => _text($scope.c, $scope._._.b), ($scope) => $scope._._, "a2");
+const $await_content__setup__script = _script("a3", ($scope) => _on($scope.b, "change", function() {
+	$changes($scope._._, $scope._._.b + 1);
+}));
+const $changes = /*@__PURE__*/ _let(1, /* @__PURE__ */ _closure($await_content__changes));

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = new Set();
+	let changes = 0;
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "__tests__/template.marko_2_changes/pending");
+			_try($scope2_id, "#text/0", _content_resume("__tests__/template.marko_4_content", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "#text/0", rejectAfter(new Error("ERROR!"), 2), () => {
+					const $scope6_id = _scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_5_content", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "#text/0", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {}, "__tests__/template.marko", "11:8");
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "#text/2")}</div>${_el_resume($scope2_id, "#div/1")}`);
+			_script($scope2_id, "__tests__/template.marko_2");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "6:4");
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:2");
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_3_content", () => {
+		_scope_reason();
+		const $scope3_id = _scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		changes,
+		"ClosureScopes:changes": $changes__closures
+	}, "__tests__/template.marko", 0, { changes: "3:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/html.bundle.js
@@ -1,0 +1,42 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = /* @__PURE__ */ new Set();
+	let changes = 0;
+	_try($scope0_id, "a", _content_resume("a5", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "a2");
+			_try($scope2_id, "a", _content_resume("a1", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "a", rejectAfter(/* @__PURE__ */ new Error("ERROR!"), 2), () => {
+					_scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "a", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {});
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "c")}</div>${_el_resume($scope2_id, "b")}`);
+			_script($scope2_id, "a3");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a4", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		b: changes,
+		c: $changes__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-csr.debug.md
@@ -1,0 +1,43 @@
+# Render
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div
+REMOVE: div + ::text("loading outer...")
+UPDATE: div::text@9 "" => "0"
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+REMOVE: ::text + div
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/render-ssr.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/writes.debug.html
@@ -1,0 +1,49 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 #text/0 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    changes: 0,
+    "ClosureScopes:changes": new Set
+  }, {
+    _: _(1),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko_3_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^c--><!--M_#d--><!--M_!c--><!--M_]4 #text/0 5-->
+  <div>changes: <!>0<!--M_*4 #text/2--></div>
+  <!--M_*4 #div/1--><!--M_]2 #text/0 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    "#BranchAccessor": "#text/0",
+    "#CatchContent": _(4,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko_5_content"
+      )
+  }]);
+  M._.j.b = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko_2_changes/pending 4 packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko_2 4"
+      )
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=d></t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/__snapshots__/writes.html
@@ -1,0 +1,42 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 a 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    c: new Set
+  }, {
+    _: _(1),
+    C: "a",
+    Q: _(1, "a4")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^c--><!--M_#d--><!--M_!c--><!--M_]4 a 5-->
+  <div>changes: <!>0<!--M_*4 c--></div><!--M_*4 b--><!--M_]2 a 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    C: "a",
+    E: _(4, "a0")
+  }]);
+  M._.j.b = _ => {
+    _.push("a2 4 a3 4")
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=d></t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7769,
+      "brotli": 3427
+    }
+  },
+  "html": {
+    "min": 1225,
+    "brotli": 659
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/template.marko
@@ -1,0 +1,15 @@
+import { rejectAfter, resolveAfter } from "../../utils/resolve";
+
+<let/changes = 0/>
+<try>
+  <@placeholder>loading outer...</@placeholder>
+  <await=resolveAfter("outer", 1)>
+    <try>
+      <await=rejectAfter(new Error("ERROR!"), 2)>
+        never
+      </await>
+      <@catch|err|>caught: ${err.message}</@catch>
+    </try>
+    <div onChange() { changes++ }>changes: ${changes}</div>
+  </await>
+</try>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+function change(container: Element) {
+  const div = container.querySelector("div");
+  if (!div) return;
+  const window = div.ownerDocument.defaultView!;
+  div.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, flush, wait, flush, wait, change],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,43 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const never = new Promise(() => {});
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope["#text/0"], err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("__tests__/template.marko_5_content", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $await_content2 = /*@__PURE__*/ _await_content("#text/0", "slow sibling", "b");
+const $try_content2__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $await_content3 = /*@__PURE__*/ _await_content("#text/1", "never", "b");
+const $try_content2__await_promise2 = /*@__PURE__*/ _await_promise("#text/1");
+const $try_content2__setup = ($scope) => {
+	$await_content2($scope);
+	$await_content3($scope);
+	$try_content2__await_promise($scope, never);
+	$try_content2__await_promise2($scope, rejectAfter(new Error("ERROR!"), 2));
+};
+const $placeholder_content = _content_resume("__tests__/template.marko_3_content", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get("changes", ($scope) => _text($scope["#text/2"], $scope._._.changes), ($scope) => $scope._._, "__tests__/template.marko_2_changes/pending");
+const $await_content__try = /*@__PURE__*/ _try("#text/0", "<!><!><!><!>", "b%b%c", $try_content2__setup);
+const $await_content__setup__script = _script("__tests__/template.marko_2", ($scope) => _on($scope["#div/1"], "change", function() {
+	$changes($scope._._, $scope._._.changes + 1);
+}));
+const $await_content__setup = ($scope) => {
+	$await_content__changes($scope);
+	$await_content__try($scope, { catch: attrTag({ content: $catch_content($scope) }) });
+	$await_content__setup__script($scope);
+};
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<!><!><div>changes: <!></div>", "b%b Db%l", $await_content__setup);
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0");
+const $try_content__setup = ($scope) => {
+	$await_content($scope);
+	$try_content__await_promise($scope, resolveAfter("outer", 1));
+};
+const $changes__closure = /*@__PURE__*/ _closure($await_content__changes);
+const $changes = /*@__PURE__*/ _let("changes/1", $changes__closure);
+const $try = /*@__PURE__*/ _try("#text/0", "<!><!><!>", "b%c", $try_content__setup);
+function $setup($scope) {
+	$changes($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const never = new Promise(() => {});
+_enable_catch();
+const $catch_content__err_message = ($scope, err_message) => _text($scope.a, err_message);
+const $catch_content__$params = ($scope, $params2) => $catch_content__err_message($scope, $params2[0]?.message);
+const $catch_content = _content_resume("a0", "caught: <!>", "b%b", 0, $catch_content__$params);
+const $placeholder_content = _content_resume("a4", "loading outer...", "b");
+const $await_content__changes = /*@__PURE__*/ _closure_get(2, ($scope) => _text($scope.c, $scope._._.b), ($scope) => $scope._._, "a2");
+const $await_content__setup__script = _script("a3", ($scope) => _on($scope.b, "change", function() {
+	$changes($scope._._, $scope._._.b + 1);
+}));
+const $changes = /*@__PURE__*/ _let(1, /* @__PURE__ */ _closure($await_content__changes));

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,47 @@
+// template.marko
+const never = new Promise(() => {});
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = new Set();
+	let changes = 0;
+	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "#text/0", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "__tests__/template.marko_2_changes/pending");
+			_try($scope2_id, "#text/0", _content_resume("__tests__/template.marko_4_content", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "#text/0", never, () => {
+					const $scope6_id = _scope_id();
+					_html("slow sibling");
+				}, 0);
+				_await($scope4_id, "#text/1", rejectAfter(new Error("ERROR!"), 2), () => {
+					const $scope7_id = _scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_5_content", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "#text/0", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {}, "__tests__/template.marko", "18:8");
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "#text/2")}</div>${_el_resume($scope2_id, "#div/1")}`);
+			_script($scope2_id, "__tests__/template.marko_2");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "10:4");
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "8:2");
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_3_content", () => {
+		_scope_reason();
+		const $scope3_id = _scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		changes,
+		"ClosureScopes:changes": $changes__closures
+	}, "__tests__/template.marko", 0, { changes: "7:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/html.bundle.js
@@ -1,0 +1,47 @@
+// template.marko
+const never = new Promise(() => {});
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $changes__closures = /* @__PURE__ */ new Set();
+	let changes = 0;
+	_try($scope0_id, "a", _content_resume("a5", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_await($scope1_id, "a", resolveAfter("outer", 1), () => {
+			const $scope2_id = _scope_id();
+			_script($scope2_id, "a2");
+			_try($scope2_id, "a", _content_resume("a1", () => {
+				const $scope4_id = _scope_id();
+				_scope_reason();
+				_await($scope4_id, "a", never, () => {
+					_scope_id();
+					_html("slow sibling");
+				}, 0);
+				_await($scope4_id, "b", rejectAfter(/* @__PURE__ */ new Error("ERROR!"), 2), () => {
+					_scope_id();
+					_html("never");
+				}, 0);
+			}, $scope2_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
+				const $scope5_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope5_reason, 0);
+				const $scope5_id = _scope_id();
+				_html(`caught: ${_sep($sg__err_message)}${_escape(err.message)}${_el_resume($scope5_id, "a", $sg__err_message)}`);
+				_serialize_if($scope5_reason, 0) && writeScope($scope5_id, {});
+			}, $scope2_id) }) });
+			_html(`<div>changes: <!>${_escape(changes)}${_el_resume($scope2_id, "c")}</div>${_el_resume($scope2_id, "b")}`);
+			_script($scope2_id, "a3");
+			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
+			_resume_branch($scope2_id);
+		});
+		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a4", () => {
+		_scope_reason();
+		_scope_id();
+		_html("loading outer...");
+	}, $scope0_id) }) });
+	writeScope($scope0_id, {
+		b: changes,
+		c: $changes__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-csr.debug.md
@@ -1,0 +1,43 @@
+# Render
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+```
+
+# Update
+```html
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+INSERT: div
+REMOVE: div + ::text("loading outer...")
+UPDATE: div::text@9 "" => "0"
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: ::text("loading outer...")
+REMOVE: ::text + div
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/render-ssr.md
@@ -1,0 +1,48 @@
+# Render
+```html
+loading outer...
+```
+
+# Update
+```html
+loading outer...
+```
+## Change
+```
+INSERT: t > div::text("changes: ")
+INSERT: t > div::text@0 + ::text("0")
+```
+
+# Update
+```html
+caught: ERROR!
+<div>
+  changes: 0
+</div>
+```
+## Change
+```
+REMOVE: ::text("loading outer...")
+INSERT: div
+INSERT: ::text("caught: ERROR!")
+```
+
+# Update
+```js
+const div = container.querySelector("div");
+if (!div) return;
+const window = div.ownerDocument.defaultView;
+div.dispatchEvent(new window.Event("change", {
+  bubbles: true
+}));
+```
+```html
+caught: ERROR!
+<div>
+  changes: 1
+</div>
+```
+## Change
+```
+UPDATE: div::text@9 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/writes.debug.html
@@ -1,0 +1,50 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 #text/0 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    changes: 0,
+    "ClosureScopes:changes": new Set
+  }, {
+    _: _(1),
+    "#BranchAccessor": "#text/0",
+    "#PlaceholderContent": _(1,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko_3_content"
+      )
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^c--><!--M_#d--><!--M_#e--><!--M_!c--><!--M_]4 #text/0 5-->
+  <div>changes: <!>0<!--M_*4 #text/2--></div>
+  <!--M_*4 #div/1--><!--M_]2 #text/0 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    "#BranchAccessor": "#text/0",
+    "#CatchContent": _(4,
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko_5_content"
+      )
+  }]);
+  M._.j.b = _ => {
+    _.push(
+      "packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko_2_changes/pending 4 packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko_2 4"
+      )
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=d></t>
+<t hidden M_=e></t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/__snapshots__/writes.html
@@ -1,0 +1,43 @@
+<!--M_[--><!--M_!^2-->loading outer...<!--M_!2--><!--M_]1 a 2-->
+<t hidden M_=2><!--M_#b--></t>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    c: new Set
+  }, {
+    _: _(1),
+    C: "a",
+    Q: _(1, "a4")
+  }]];
+  REORDER_RUNTIME(M._);
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=b>
+  <!--M_[--><!--M_[--><!--M_!^c--><!--M_#d--><!--M_#e--><!--M_!c--><!--M_]4 a 5-->
+  <div>changes: <!>0<!--M_*4 c--></div><!--M_*4 b--><!--M_]2 a 4-->
+</t>
+<script>
+  M._.r.push(_ => [4, {
+    _: _(2)
+  }, {
+    C: "a",
+    E: _(4, "a0")
+  }]);
+  M._.j.b = _ => {
+    _.push("a2 4 a3 4")
+  };
+  M._.w()
+</script>
+
+<!-- FLUSH -->
+
+<t hidden M_=d></t>
+<t hidden M_=e></t>
+<t hidden M_=c>caught: ERROR!</t>
+<script>
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7789,
+      "brotli": 3434
+    }
+  },
+  "html": {
+    "min": 1255,
+    "brotli": 665
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/template.marko
@@ -1,0 +1,22 @@
+import { rejectAfter, resolveAfter } from "../../utils/resolve";
+
+// A promise that outlives the stream: the sibling `<await>`'s content never
+// renders because the shared `<try>` catches first.
+static const never = new Promise(() => {});
+
+<let/changes = 0/>
+<try>
+  <@placeholder>loading outer...</@placeholder>
+  <await=resolveAfter("outer", 1)>
+    <try>
+      <await=never>
+        slow sibling
+      </await>
+      <await=rejectAfter(new Error("ERROR!"), 2)>
+        never
+      </await>
+      <@catch|err|>caught: ${err.message}</@catch>
+    </try>
+    <div onChange() { changes++ }>changes: ${changes}</div>
+  </await>
+</try>

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+import { flush, wait } from "../../utils/resolve";
+
+function change(container: Element) {
+  const div = container.querySelector("div");
+  if (!div) return;
+  const window = div.ownerDocument.defaultView!;
+  div.dispatchEvent(new window.Event("change", { bubbles: true }));
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, flush, flush, wait, flush, wait, change],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.debug.js
@@ -19,11 +19,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $childScope = _peek_scope_id();
 	let divName = parent_el_default({});
 	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_divName/var");
-	_html(`${_escape(divName)}${_el_resume($scope0_id, "#text/2")}</div><span>`);
+	_html(`<!>${_escape(divName)}${_el_resume($scope0_id, "#text/2")}</div><span>`);
 	const $childScope2 = _peek_scope_id();
 	let spanName = parent_el_default({});
 	_var($scope0_id, "#scopeOffset/4", $childScope2, "__tests__/template.marko_0_spanName/var");
-	_html(`${_escape(spanName)}${_el_resume($scope0_id, "#text/5")}</span>`);
+	_html(`<!>${_escape(spanName)}${_el_resume($scope0_id, "#text/5")}</span>`);
 	writeScope($scope0_id, {
 		"#childScope/0": _existing_scope($childScope),
 		"#childScope/3": _existing_scope($childScope2)

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.js
@@ -16,11 +16,11 @@ var template_default = _template("a", (input) => {
 	const $childScope = _peek_scope_id();
 	let divName = parent_el_default({});
 	_var($scope0_id, "b", $childScope, "a0");
-	_html(`${_escape(divName)}${_el_resume($scope0_id, "c")}</div><span>`);
+	_html(`<!>${_escape(divName)}${_el_resume($scope0_id, "c")}</div><span>`);
 	const $childScope2 = _peek_scope_id();
 	let spanName = parent_el_default({});
 	_var($scope0_id, "e", $childScope2, "a1");
-	_html(`${_escape(spanName)}${_el_resume($scope0_id, "f")}</span>`);
+	_html(`<!>${_escape(spanName)}${_el_resume($scope0_id, "f")}</span>`);
 	writeScope($scope0_id, {
 		a: _existing_scope($childScope),
 		d: _existing_scope($childScope2)

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/render-ssr.debug.md
@@ -12,15 +12,15 @@
 ```html
 <div>
   <!--Body Text-->
-  <!--DIV-->
+  DIV
 </div>
 <span>
   <!--Body Text-->
-  <!--SPAN-->
+  SPAN
 </span>
 ```
 ## Change
 ```
-UPDATE: div > #comment:nth-of-type(2) "M_*2 #comment/0" => "DIV"
-UPDATE: span > #comment:nth-of-type(2) "M_*4 #comment/0" => "SPAN"
+UPDATE: div::text "" => "DIV"
+UPDATE: span::text "" => "SPAN"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/render-ssr.md
@@ -12,15 +12,15 @@
 ```html
 <div>
   <!--Body Text-->
-  <!--DIV-->
+  DIV
 </div>
 <span>
   <!--Body Text-->
-  <!--SPAN-->
+  SPAN
 </span>
 ```
 ## Change
 ```
-UPDATE: div > #comment:nth-of-type(2) "M_*2 a" => "DIV"
-UPDATE: span > #comment:nth-of-type(2) "M_*4 a" => "SPAN"
+UPDATE: div::text "" => "DIV"
+UPDATE: span::text "" => "SPAN"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/writes.debug.html
@@ -1,5 +1,8 @@
-<div><!--Body Text--><!--M_*2 #comment/0--><!--M_*1 #text/2--></div>
-<span><!--Body Text--><!--M_*4 #comment/0--><!--M_*1 #text/5--></span>
+<div><!--Body Text--><!--M_*2 #comment/0-->
+  <!><!--M_*1 #text/2-->
+</div><span><!--Body Text--><!--M_*4 #comment/0-->
+  <!><!--M_*1 #text/5-->
+</span>
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/writes.html
@@ -1,5 +1,8 @@
-<div><!--Body Text--><!--M_*2 a--><!--M_*1 c--></div>
-<span><!--Body Text--><!--M_*4 a--><!--M_*1 f--></span>
+<div><!--Body Text--><!--M_*2 a-->
+  <!><!--M_*1 c-->
+</div><span><!--Body Text--><!--M_*4 a-->
+  <!><!--M_*1 f-->
+</span>
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9765,
-      "brotli": 3849
+      "min": 9774,
+      "brotli": 3853
     }
   },
   "html": {

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -818,7 +818,7 @@ export function _await<T>(
               withIsAsync(content, value);
             }
           });
-          boundary.endAsync(chunk);
+          boundary.endAsync();
         }
       }
     },
@@ -896,7 +896,7 @@ function tryCatch(content: () => void, catchContent: (err: unknown) => void) {
   const chunk = $chunk;
   const { boundary } = chunk;
   const { state } = boundary;
-  const catchBoundary = new Boundary(state);
+  const catchBoundary = new Boundary(state, undefined, boundary);
   const body = chunk.fork(catchBoundary, null);
   const bodyEnd = body.render(content);
 
@@ -1064,7 +1064,8 @@ export class Boundary extends AbortController {
   public count = 0;
   constructor(
     public state: State,
-    parent?: AbortSignal,
+    signal?: AbortSignal,
+    public parent?: Boundary,
   ) {
     super();
     this.signal.addEventListener("abort", () => {
@@ -1073,12 +1074,12 @@ export class Boundary extends AbortController {
       this.onNext();
     });
 
-    if (parent) {
-      if (parent.aborted) {
-        this.abort(parent.reason);
+    if (signal) {
+      if (signal.aborted) {
+        this.abort(signal.reason);
       } else {
-        parent.addEventListener("abort", () => {
-          this.abort(parent.reason);
+        signal.addEventListener("abort", () => {
+          this.abort(signal.reason);
         });
       }
     }
@@ -1102,14 +1103,9 @@ export class Boundary extends AbortController {
     }
   }
 
-  endAsync(chunk?: Chunk) {
+  endAsync() {
     if (!this.signal.aborted && this.count) {
       this.count--;
-
-      if (chunk?.reorderId) {
-        this.state.reorder(chunk);
-      }
-
       this.onNext();
     }
   }
@@ -1394,17 +1390,35 @@ export class Chunk {
     }
 
     if (state.writeReorders) {
-      needsWalk = true;
-
-      if (!state.hasReorderRuntime) {
-        state.hasReorderRuntime = true;
-        scripts = concatScripts(
-          scripts,
-          REORDER_RUNTIME_CODE + "(" + runtimePrefix + ")",
-        );
-      }
+      let carried: Chunk[] | null = null;
 
       for (const reorderedChunk of state.writeReorders) {
+        // A chunk requeued when its reorder marker streamed delivers once
+        // settled, or as an empty reorder once an aborted boundary strands it.
+        if (reorderedChunk.async && reorderedChunk.consumed) {
+          let aborted: Boundary | undefined = reorderedChunk.boundary;
+          while (aborted && !aborted.signal.aborted) {
+            aborted = aborted.parent;
+          }
+
+          if (!aborted) {
+            (carried ||= []).push(reorderedChunk);
+            continue;
+          }
+
+          reorderedChunk.async = false;
+        }
+
+        needsWalk = true;
+
+        if (!state.hasReorderRuntime) {
+          state.hasReorderRuntime = true;
+          scripts = concatScripts(
+            scripts,
+            REORDER_RUNTIME_CODE + "(" + runtimePrefix + ")",
+          );
+        }
+
         const { reorderId } = reorderedChunk;
         const readyReservations: string[] = [];
         let reorderHTML = "";
@@ -1435,6 +1449,7 @@ export class Chunk {
               Mark.ReorderMarker,
               (cur.reorderId = state.nextReorderId()),
             );
+            state.reorder(cur);
             cur.html = cur.effects = cur.scripts = cur.lastEffect = "";
             cur.next = null;
           }
@@ -1486,7 +1501,7 @@ export class Chunk {
           "</t>";
       }
 
-      state.writeReorders = null;
+      state.writeReorders = carried;
     }
 
     if (needsWalk) {


### PR DESCRIPTION
## Description

An `<await>` whose reorder marker (`<!--#id-->`) had streamed never delivered its `<t hidden>` chunk once a `<try>` catch dropped its content. Nested markers all gate the outermost pending placeholder client side, so one stranded marker froze hydration: the placeholder was never dismissed and event handlers were never wired (investigated for #3174).

Async chunks now enter `writeReorders` when their marker streams, and the reorder loop is the single owner of delivery — carrying a chunk until it settles, or emitting it as an empty reorder once its boundary chain aborts.

Covered by three new fixtures: a reject nested in streamed content, a never-settling sibling await in the same catch body, and a never-settling await wrapped in its own `<try>` (transitive strand).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xpd3sRDAUpXhBuwssQgQkL

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xpd3sRDAUpXhBuwssQgQkL)_