### PR TITLE
Make common syntax errors self-guiding

### DIFF
--- a/.changeset/guided-error-hints.md
+++ b/.changeset/guided-error-hints.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+---
+
+Make common syntax errors self-guiding. Call-style control flow (`<if(cond)>`, `<await(x) p>`, `<show(x)>`) now says how to write the condition/value as an attribute; bare JS declarations at the template root (`let count = 0;`) and slashless `<let count=0>`/`<const x=1>` point at the tag-variable form and `static`; unknown tags from other frameworks get curated pointers (`<slot>` → `<${input.content}/>`, `<state>` → `<let>`) before falling back to nearest-name suggestions; JSX-style brace-wrapped attribute values (`onClick={handler}` and values that only parse once unwrapped) explain that attribute values are plain JavaScript expressions; attribute tags on `<await>` point at `<try>` with `<@placeholder>`/`<@catch>`. Also fixes a typo in the nested-attribute-tags assertion message ("Tag not support" → "Tag does not support").

--- a/packages/compiler/babel-utils.d.ts
+++ b/packages/compiler/babel-utils.d.ts
@@ -178,11 +178,14 @@ export function assertAllowedAttributes(
   path: t.NodePath<t.MarkoTag>,
   allowed: string[],
 ): void;
-export function assertNoArgs(path: t.NodePath<t.MarkoTag>): void;
+export function assertNoArgs(path: t.NodePath<t.MarkoTag>, hint?: string): void;
 export function assertNoVar(path: t.NodePath<t.MarkoTag>): void;
 export function assertNoAttributes(path: t.NodePath<t.MarkoTag>): void;
 export function assertNoParams(path: t.NodePath<t.MarkoTag>): void;
-export function assertNoAttributeTags(path: t.NodePath<t.MarkoTag>): void;
+export function assertNoAttributeTags(
+  path: t.NodePath<t.MarkoTag>,
+  hint?: string,
+): void;
 export function assertAttributesOrArgs(path: t.NodePath<t.MarkoTag>): void;
 export function assertAttributesOrSingleArg(path: t.NodePath<t.MarkoTag>): void;
 

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -16,6 +16,22 @@ import { buildCodeFrameError } from "../util/build-code-frame";
 import throwAggregateError from "../util/merge-errors";
 
 const noop = () => {};
+const jsxStyleAttrValueReg = /^\{[\s\S]*\}$/;
+// A brace wrapped attribute value that only parses once unwrapped is almost
+// certainly a JSX/Svelte style value (eg `onClick={handler}`); say so instead
+// of surfacing the bare expression parse error.
+const withWrappedAttrValueHint = (file, part, rawValue, node) => {
+  const trimmed = rawValue.trim();
+  if (
+    node.type === "MarkoParseError" &&
+    jsxStyleAttrValueReg.test(trimmed) &&
+    parseExpression(file, trimmed.slice(1, -1), part.value.start).type !==
+      "MarkoParseError"
+  ) {
+    node.label += `${node.label.endsWith(".") ? "" : "."} Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping \`{ }\`.`;
+  }
+  return node;
+};
 const emptyRange = (part) => part.start === part.end;
 const isAttrTag = (tag) => tag.name.value?.[0] === "@";
 const isStatementTag = (tag) => tag.tagDef?.parseOptions?.statement;
@@ -412,10 +428,12 @@ export function parseMarko(file) {
     onAttrValue(part) {
       currentAttr.end = part.end;
       currentAttr.bound = part.bound;
-      currentAttr.value = parseExpression(
+      const rawAttrValue = parser.read(part.value);
+      currentAttr.value = withWrappedAttrValueHint(
         file,
-        parser.read(part.value),
-        part.value.start,
+        part,
+        rawAttrValue,
+        parseExpression(file, rawAttrValue, part.value.start),
       );
     },
 

--- a/packages/compiler/src/babel-utils/assert.js
+++ b/packages/compiler/src/babel-utils/assert.js
@@ -41,23 +41,23 @@ export function assertNoParams(path) {
   }
 }
 
-export function assertNoAttributeTags(path) {
+export function assertNoAttributeTags(path, hint) {
   if (path.node.attributeTags.length) {
     throw path.hub.buildError(
       path.node.attributeTags[0],
-      "Tag not support nested attribute tags.",
+      `Tag does not support nested attribute tags.${hint ? ` ${hint}` : ""}`,
     );
   }
 }
 
-export function assertNoArgs(path) {
+export function assertNoArgs(path, hint) {
   const args = path.node.arguments;
   if (args && args.length) {
     const start = args[0].loc.start;
     const end = args[args.length - 1].loc.end;
     throw path.hub.buildError(
       { loc: { start, end } },
-      "Tag does not support arguments.",
+      `Tag does not support arguments.${hint ? ` ${hint}` : ""}`,
     );
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko:1:18
+    > 1 | <button onClick={() => input.onPress()}>Click</button>
+        |                  ^ Unexpected token. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko:1:18
+    > 1 | <button onClick={() => input.onPress()}>Click</button>
+        |                  ^ Unexpected token. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko:1:18
+    > 1 | <button onClick={() => input.onPress()}>Click</button>
+        |                  ^ Unexpected token. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko:1:18
+    > 1 | <button onClick={() => input.onPress()}>Click</button>
+        |                  ^ Unexpected token. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/template.marko
@@ -1,0 +1,1 @@
+<button onClick={() => input.onPress()}>Click</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-attr-value-jsx-braces/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko:3:3
+      1 | <await|user|=input.userPromise>
+      2 |   ${user.name}
+    > 3 |   <@catch|err|>${err.message}</@catch>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Tag does not support nested attribute tags. For pending and error UI, wrap the `<await>` in a [`<try>` tag](https://markojs.com/docs/reference/core-tag#try) with `<@placeholder>` and `<@catch|err|>` attribute tags.
+      4 | </await>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko:3:3
+      1 | <await|user|=input.userPromise>
+      2 |   ${user.name}
+    > 3 |   <@catch|err|>${err.message}</@catch>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Tag does not support nested attribute tags. For pending and error UI, wrap the `<await>` in a [`<try>` tag](https://markojs.com/docs/reference/core-tag#try) with `<@placeholder>` and `<@catch|err|>` attribute tags.
+      4 | </await>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko:3:3
+      1 | <await|user|=input.userPromise>
+      2 |   ${user.name}
+    > 3 |   <@catch|err|>${err.message}</@catch>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Tag does not support nested attribute tags. For pending and error UI, wrap the `<await>` in a [`<try>` tag](https://markojs.com/docs/reference/core-tag#try) with `<@placeholder>` and `<@catch|err|>` attribute tags.
+      4 | </await>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko:3:3
+      1 | <await|user|=input.userPromise>
+      2 |   ${user.name}
+    > 3 |   <@catch|err|>${err.message}</@catch>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Tag does not support nested attribute tags. For pending and error UI, wrap the `<await>` in a [`<try>` tag](https://markojs.com/docs/reference/core-tag#try) with `<@placeholder>` and `<@catch|err|>` attribute tags.
+      4 | </await>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/template.marko
@@ -1,0 +1,4 @@
+<await|user|=input.userPromise>
+  ${user.name}
+  <@catch|err|>${err.message}</@catch>
+</await>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-await-attr-tags/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<const/doubled=count * 2>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<const/doubled=count * 2>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<const/doubled=count * 2>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-const-no-tag-var/template.marko:1:2
     > 1 | <const="Hello"/>
-        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^^^ The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<const/doubled=count * 2>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-dom.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-args/template.marko:2:7
       1 | <if=false>Skipped</if>
     > 2 | <else(input.show)>Hello World</else>
-        |       ^^^^^^^^^^ Tag does not support arguments.
+        |       ^^^^^^^^^^ Tag does not support arguments. Write the condition as an attribute instead: `<else if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-dom.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-args/template.marko:2:7
       1 | <if=false>Skipped</if>
     > 2 | <else(input.show)>Hello World</else>
-        |       ^^^^^^^^^^ Tag does not support arguments.
+        |       ^^^^^^^^^^ Tag does not support arguments. Write the condition as an attribute instead: `<else if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-html.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-args/template.marko:2:7
       1 | <if=false>Skipped</if>
     > 2 | <else(input.show)>Hello World</else>
-        |       ^^^^^^^^^^ Tag does not support arguments.
+        |       ^^^^^^^^^^ Tag does not support arguments. Write the condition as an attribute instead: `<else if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-else-args/__snapshots__/error-compile-html.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-else-args/template.marko:2:7
       1 | <if=false>Skipped</if>
     > 2 | <else(input.show)>Hello World</else>
-        |       ^^^^^^^^^^ Tag does not support arguments.
+        |       ^^^^^^^^^^ Tag does not support arguments. Write the condition as an attribute instead: `<else if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-dom.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/template.marko:2:10
       1 | <if=false>Skipped</if>
     > 2 | <else-if(input.show)>Hello World</else-if>
-        |          ^^^^^^^^^^ Tag does not support arguments.
+        |          ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<else-if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-dom.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/template.marko:2:10
       1 | <if=false>Skipped</if>
     > 2 | <else-if(input.show)>Hello World</else-if>
-        |          ^^^^^^^^^^ Tag does not support arguments.
+        |          ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<else-if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-html.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/template.marko:2:10
       1 | <if=false>Skipped</if>
     > 2 | <else-if(input.show)>Hello World</else-if>
-        |          ^^^^^^^^^^ Tag does not support arguments.
+        |          ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<else-if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/__snapshots__/error-compile-html.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-elseif-args/template.marko:2:10
       1 | <if=false>Skipped</if>
     > 2 | <else-if(input.show)>Hello World</else-if>
-        |          ^^^^^^^^^^ Tag does not support arguments.
+        |          ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<else-if=condition>`.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko:3:17
+      1 | static function handleClick() {}
+      2 |
+    > 3 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko:3:17
+      1 | static function handleClick() {}
+      2 |
+    > 3 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko:3:17
+      1 | static function handleClick() {}
+      2 |
+    > 3 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko:3:17
+      1 | static function handleClick() {}
+      2 |
+    > 3 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/template.marko
@@ -1,0 +1,3 @@
+static function handleClick() {}
+
+<button onClick={handleClick}>Click</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-handler-object-value/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-args/template.marko:1:5
     > 1 | <if(input.show)>Hello World</if>
-        |     ^^^^^^^^^^ Tag does not support arguments.
+        |     ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-args/template.marko:1:5
     > 1 | <if(input.show)>Hello World</if>
-        |     ^^^^^^^^^^ Tag does not support arguments.
+        |     ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-args/template.marko:1:5
     > 1 | <if(input.show)>Hello World</if>
-        |     ^^^^^^^^^^ Tag does not support arguments.
+        |     ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-args/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-if-args/template.marko:1:5
     > 1 | <if(input.show)>Hello World</if>
-        |     ^^^^^^^^^^ Tag does not support arguments.
+        |     ^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<let/count=0>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<let/count=0>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<let/count=0>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-let-no-tag-var/template.marko:1:2
     > 1 | <let=0/>
-        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).
+        |  ^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<let/count=0>`.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko:1:7
+    > 1 | <show(input.visible)>Hello</show>
+        |       ^^^^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko:1:7
+    > 1 | <show(input.visible)>Hello</show>
+        |       ^^^^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko:1:7
+    > 1 | <show(input.visible)>Hello</show>
+        |       ^^^^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko:1:7
+    > 1 | <show(input.visible)>Hello</show>
+        |       ^^^^^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/template.marko
@@ -1,0 +1,1 @@
+<show(input.visible)>Hello</show>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-args/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-args/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko:1:5
+    > 1 | let count = 0;
+        |     ^^^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko:1:5
+    > 1 | let count = 0;
+        |     ^^^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko:1:5
+    > 1 | let count = 0;
+        |     ^^^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko:1:5
+    > 1 | let count = 0;
+        |     ^^^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <div>${count}</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/template.marko
@@ -1,0 +1,3 @@
+let count = 0;
+
+<div>${count}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-let/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko:1:8
+    > 1 | <main><slot/></main>
+        |        ^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<slot>`. To render content passed to this tag, use a [dynamic tag](https://markojs.com/docs/reference/language#dynamic-tags): `<${input.content}/>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko:1:8
+    > 1 | <main><slot/></main>
+        |        ^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<slot>`. To render content passed to this tag, use a [dynamic tag](https://markojs.com/docs/reference/language#dynamic-tags): `<${input.content}/>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko:1:8
+    > 1 | <main><slot/></main>
+        |        ^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<slot>`. To render content passed to this tag, use a [dynamic tag](https://markojs.com/docs/reference/language#dynamic-tags): `<${input.content}/>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko:1:8
+    > 1 | <main><slot/></main>
+        |        ^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<slot>`. To render content passed to this tag, use a [dynamic tag](https://markojs.com/docs/reference/language#dynamic-tags): `<${input.content}/>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/template.marko
@@ -1,0 +1,1 @@
+<main><slot/></main>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-alias-slot/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -54,9 +54,15 @@ declare module "@marko/compiler/dist/types" {
 export default {
   analyze(tag: t.NodePath<t.MarkoTag>) {
     assertNoVar(tag);
-    assertNoArgs(tag);
+    assertNoArgs(
+      tag,
+      "Write the promise as a value attribute and receive the result as a tag parameter instead: `<await|result|=promise>`.",
+    );
     assertNoSpreadAttrs(tag);
-    assertNoAttributeTags(tag);
+    assertNoAttributeTags(
+      tag,
+      "For pending and error UI, wrap the `<await>` in a [`<try>` tag](https://markojs.com/docs/reference/core-tag#try) with `<@placeholder>` and `<@catch|err|>` attribute tags.",
+    );
     const { node } = tag;
     const tagBody = tag.get("body");
     const section = getOrCreateSection(tag);

--- a/packages/runtime-tags/src/translator/core/const.ts
+++ b/packages/runtime-tags/src/translator/core/const.ts
@@ -29,10 +29,22 @@ export default {
     const [valueAttr] = node.attributes;
 
     if (!node.var) {
+      const looksLikeDeclaration =
+        !node.attributes.some(
+          (attr) =>
+            t.isMarkoAttribute(attr) && (attr.default || attr.name === "value"),
+        ) &&
+        node.attributes.length === 1 &&
+        t.isMarkoAttribute(node.attributes[0]) &&
+        /^[A-Za-z_$][\w$]*$/.test(node.attributes[0].name);
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The [`<const>` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).",
+          `The [\`<const>\` tag](https://markojs.com/docs/reference/core-tag#const) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables)${
+            looksLikeDeclaration
+              ? `; the variable goes after a slash: \`<const/${(node.attributes[0] as t.MarkoAttribute).name}=...>\`. For a one time module level value, prefix a plain JavaScript statement with \`static\`.`
+              : ", e.g. `<const/doubled=count * 2>`."
+          }`,
         );
     }
 

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -482,8 +482,14 @@ export function flattenTextOnlyConditional(rootTag: t.NodePath<t.MarkoTag>) {
 }
 
 function assertValidCondition(tag: t.NodePath<t.MarkoTag>) {
+  const conditionTagName = getTagName(tag);
   assertNoVar(tag);
-  assertNoArgs(tag);
+  assertNoArgs(
+    tag,
+    conditionTagName === "else"
+      ? "Write the condition as an attribute instead: `<else if=condition>`."
+      : `Write the condition as a value attribute instead: \`<${conditionTagName}=condition>\`.`,
+  );
   assertNoParams(tag);
   assertHasBody(tag);
   assertNoSpreadAttrs(tag);

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -60,8 +60,12 @@ export default {
         } else {
           const start = attr.loc?.start;
           const end = attr.loc?.end;
-          const msg =
+          let msg =
             "The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler.";
+          if (!tagVar && /^[A-Za-z_$][\w$]*$/.test(attr.name)) {
+            // Written like a JS declaration (`let count = 0;` or `<let count=0>`).
+            msg += ` To declare reactive state, the variable goes after a slash: \`<let/${attr.name}=...>\`. For a one time module level value, prefix a plain JavaScript statement with \`static\`.`;
+          }
 
           if (start == null || end == null) {
             throw tag.get("name").buildCodeFrameError(msg);
@@ -85,7 +89,7 @@ export default {
       throw tag
         .get("name")
         .buildCodeFrameError(
-          "The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables).",
+          "The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) requires a [tag variable](https://markojs.com/docs/reference/language#tag-variables), e.g. `<let/count=0>`.",
         );
     }
 

--- a/packages/runtime-tags/src/translator/core/show.ts
+++ b/packages/runtime-tags/src/translator/core/show.ts
@@ -328,7 +328,10 @@ function isLiteral(expr: t.Expression) {
 
 function assertValidShow(tag: t.NodePath<t.MarkoTag>) {
   assertNoVar(tag);
-  assertNoArgs(tag);
+  assertNoArgs(
+    tag,
+    "Write the condition as a value attribute instead: `<show=condition>`.",
+  );
   assertNoParams(tag);
   assertNoSpreadAttrs(tag);
   assertHasBody(tag);

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -361,6 +361,23 @@ export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
   return relativePath;
 }
 
+// Tags from other frameworks (or older Marko versions) that deserve a curated
+// pointer instead of a nearest-name suggestion.
+const knownWrongTags = new Map([
+  [
+    "slot",
+    "To render content passed to this tag, use a [dynamic tag](https://markojs.com/docs/reference/language#dynamic-tags): `<${input.content}/>`.",
+  ],
+  [
+    "state",
+    "Reactive state is declared with the [`<let>` tag](https://markojs.com/docs/reference/core-tag#let): `<let/name=initialValue>`.",
+  ],
+  [
+    "fragment",
+    "Marko templates and tag bodies may have multiple root nodes; no fragment wrapper is needed.",
+  ],
+]);
+
 function tagNotFoundError(tag: t.NodePath<t.MarkoTag>) {
   const tagName = getTagName(tag);
   if (tagName && tag.scope.hasBinding(tagName)) {
@@ -371,7 +388,10 @@ function tagNotFoundError(tag: t.NodePath<t.MarkoTag>) {
       );
   }
   let didYouMean = "";
-  if (tagName) {
+  const knownWrongTagHint = tagName && knownWrongTags.get(tagName);
+  if (knownWrongTagHint) {
+    didYouMean = ` ${knownWrongTagHint}`;
+  } else if (tagName) {
     const closestTag = closest(
       tagName,
       Object.keys((getTaglibLookup(tag.hub.file) as any).merged.tags),

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -1253,6 +1253,15 @@ function assertNativeHandlerAttr(
   tag: t.NodePath<t.MarkoTag>,
   attr: t.MarkoAttribute,
 ) {
+  if (t.isObjectExpression(attr.value)) {
+    throw tag.hub.buildError(
+      attr.value,
+      `The \`${attr.name}\` ${
+        isEventHandler(attr.name) ? "event handler" : "change handler"
+      } on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping \`{ }\` (e.g. \`${attr.name}=myHandler\` or \`${attr.name}() { ... }\`).`,
+      Error,
+    );
+  }
   if (computeNode(attr.value)?.value) {
     throw tag.hub.buildError(
       attr.value,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Common wrong-dialect mistakes (JSX braces, Svelte/Marko 4/5 habits, args-form control flow) previously died with generic errors. The frequent shapes now say what to write instead:

- `<if(cond)>` / `<await(x) p>` / `<show(x)>` append their value-attribute forms (`<if=condition>`, `<await|result|=promise>`, …); `assertNoArgs`/`assertNoAttributeTags` accept an optional hint (and the latter's message typo is fixed).
- Bare JS declarations at the template root (`let count = 0;`) and slashless `<let count=0>`/`const x = 1;` point at the tag-variable form (`<let/count=…>`) and `static`.
- Unknown tags consult a curated cross-framework alias table before the nearest-name suggestion: `slot` → `<${input.content}/>`, `state` → `<let>`, `fragment` → multiple roots are fine.
- Brace-wrapped attribute values (`onClick={() => …}`) get "plain JavaScript expressions, not JSX; remove the wrapping `{ }`" on both failure paths (parse error and object-literal handler values).
- `@placeholder`/`@catch` on `<await>` point at wrapping `<try>`.

Each hint states the correct general form only (no task-specific content). Covered by new error-snapshot fixtures.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys)_