### PR TITLE
Report all analyze errors in a template at once

### DIFF
--- a/.changeset/multi-error-reporting.md
+++ b/.changeset/multi-error-reporting.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+---
+
+Report every analyze-stage error in a template at once instead of stopping at the first. Analyze failures are now recorded through the compiler's diagnostics channel (`diagnosticError`), and the compiler mirrors the parse layer by throwing all error diagnostics together at the end of the analyze stage (duplicates deduped, capped at 8) — or, when compiling with `errorRecovery`, keeping them as recoverable diagnostics for editors instead of throwing. The tags translator reports tag-level analysis failures this way, skipping the failed tag's subtree to avoid cascading follow-on errors. Templates with a single error produce byte-identical output.

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -5,7 +5,7 @@ import {
 } from "@marko/compiler/internal/babel";
 import path from "path";
 
-import { diagnosticError } from "../babel-utils/diagnostics";
+import { diagnosticError, DiagnosticType } from "../babel-utils/diagnostics";
 import { getFileInternal, setFileInternal } from "../babel-utils/get-file";
 import { getTemplateId } from "../babel-utils/tags";
 import { buildLookup } from "../taglib";
@@ -323,6 +323,29 @@ function getMarkoFile(code, fileOpts, markoOpts) {
       try {
         file.___compileStage = "analyze";
         traverseAll(file, translator.analyze);
+
+        if (!markoOpts.errorRecovery) {
+          // Analyze failures are recorded as error diagnostics so the whole
+          // template reports at once (and editors compiling with
+          // `errorRecovery` keep them as recoverable diagnostics); mirror
+          // the parse layer by throwing them together at the stage's end.
+          const seen = new Set();
+          const errors = [];
+          for (const diag of meta.diagnostics) {
+            if (diag.type !== DiagnosticType.Error) continue;
+            const key = `${
+              diag.loc ? `${diag.loc.start.line}:${diag.loc.start.column}` : ""
+            }:${diag.label}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            errors.push(
+              buildCodeFrameError(filename, file.code, diag.loc, diag.label),
+            );
+            if (errors.length === 8) break;
+          }
+
+          throwAggregateError(errors);
+        }
       } catch (e) {
         compileCache.delete(id);
         throw e;

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.debug.txt
@@ -7,3 +7,11 @@
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
+      1 | <button onClick() {
+    > 2 |   lastClickCount = clickCount;
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+      3 |   clickCount++;
+      4 | }>+</button>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.txt
@@ -7,3 +7,11 @@
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
+      1 | <button onClick() {
+    > 2 |   lastClickCount = clickCount;
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+      3 |   clickCount++;
+      4 | }>+</button>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.debug.txt
@@ -7,3 +7,11 @@
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
+      1 | <button onClick() {
+    > 2 |   lastClickCount = clickCount;
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+      3 |   clickCount++;
+      4 | }>+</button>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.txt
@@ -7,3 +7,11 @@
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
+      1 | <button onClick() {
+    > 2 |   lastClickCount = clickCount;
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+      3 |   clickCount++;
+      4 | }>+</button>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,14 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:1:5
+    > 1 | <if(input.a)>a</if>
+        |     ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      2 | <else if=input.b>b</else>
+      3 |
+      4 | <show(input.c)>c</show>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:4:7
+      2 | <else if=input.b>b</else>
+      3 |
+    > 4 | <show(input.c)>c</show>
+        |       ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,14 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:1:5
+    > 1 | <if(input.a)>a</if>
+        |     ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      2 | <else if=input.b>b</else>
+      3 |
+      4 | <show(input.c)>c</show>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:4:7
+      2 | <else if=input.b>b</else>
+      3 |
+    > 4 | <show(input.c)>c</show>
+        |       ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,14 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:1:5
+    > 1 | <if(input.a)>a</if>
+        |     ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      2 | <else if=input.b>b</else>
+      3 |
+      4 | <show(input.c)>c</show>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:4:7
+      2 | <else if=input.b>b</else>
+      3 |
+    > 4 | <show(input.c)>c</show>
+        |       ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/__snapshots__/error-compile-html.txt
@@ -1,0 +1,14 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:1:5
+    > 1 | <if(input.a)>a</if>
+        |     ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      2 | <else if=input.b>b</else>
+      3 |
+      4 | <show(input.c)>c</show>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko:4:7
+      2 | <else if=input.b>b</else>
+      3 |
+    > 4 | <show(input.c)>c</show>
+        |       ^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<show=condition>`.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/template.marko
@@ -1,0 +1,4 @@
+<if(input.a)>a</if>
+<else if=input.b>b</else>
+
+<show(input.c)>c</show>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze-else-chain/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,23 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:1:6
+    > 1 | <let count=0>
+        |      ^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <if(count > 1)>big</if>
+      4 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:3:5
+      1 | <let count=0>
+      2 |
+    > 3 | <if(count > 1)>big</if>
+        |     ^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      4 |
+      5 | <button onClick={handleClick}>Click</button>
+      6 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:5:17
+      3 | <if(count > 1)>big</if>
+      4 |
+    > 5 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,23 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:1:6
+    > 1 | <let count=0>
+        |      ^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <if(count > 1)>big</if>
+      4 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:3:5
+      1 | <let count=0>
+      2 |
+    > 3 | <if(count > 1)>big</if>
+        |     ^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      4 |
+      5 | <button onClick={handleClick}>Click</button>
+      6 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:5:17
+      3 | <if(count > 1)>big</if>
+      4 |
+    > 5 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,23 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:1:6
+    > 1 | <let count=0>
+        |      ^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <if(count > 1)>big</if>
+      4 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:3:5
+      1 | <let count=0>
+      2 |
+    > 3 | <if(count > 1)>big</if>
+        |     ^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      4 |
+      5 | <button onClick={handleClick}>Click</button>
+      6 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:5:17
+      3 | <if(count > 1)>big</if>
+      4 |
+    > 5 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/__snapshots__/error-compile-html.txt
@@ -1,0 +1,23 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:1:6
+    > 1 | <let count=0>
+        |      ^^^^^^^ The [`<let>` tag](https://markojs.com/docs/reference/core-tag#let) only supports the [`value=` attribute](https://markojs.com/docs/reference/language#shorthand-value) and its change handler. To declare reactive state, the variable goes after a slash: `<let/count=...>`. For a one time module level value, prefix a plain JavaScript statement with `static`.
+      2 |
+      3 | <if(count > 1)>big</if>
+      4 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:3:5
+      1 | <let count=0>
+      2 |
+    > 3 | <if(count > 1)>big</if>
+        |     ^^^^^^^^^ Tag does not support arguments. Write the condition as a value attribute instead: `<if=condition>`.
+      4 |
+      5 | <button onClick={handleClick}>Click</button>
+      6 |
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko:5:17
+      3 | <if(count > 1)>big</if>
+      4 |
+    > 5 | <button onClick={handleClick}>Click</button>
+        |                 ^^^^^^^^^^^^^ The `onClick` event handler on a [native tag](https://markojs.com/docs/reference/native-tag) must be a function. Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping `{ }` (e.g. `onClick=myHandler` or `onClick() { ... }`).
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/template.marko
@@ -1,0 +1,5 @@
+<let count=0>
+
+<if(count > 1)>big</if>
+
+<button onClick={handleClick}>Click</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multiple-analyze/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-dom.debug.txt
@@ -6,3 +6,10 @@
       3 | </if>
       4 | <else>
       5 |   <return=2/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:5:4
+      3 | </if>
+      4 | <else>
+    > 5 |   <return=2/>
+        |    ^^^^^^ The [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) can not be used under the `<"else">` tag.
+      6 | </else>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-dom.txt
@@ -6,3 +6,10 @@
       3 | </if>
       4 | <else>
       5 |   <return=2/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:5:4
+      3 | </if>
+      4 | <else>
+    > 5 |   <return=2/>
+        |    ^^^^^^ The [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) can not be used under the `<"else">` tag.
+      6 | </else>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-html.debug.txt
@@ -6,3 +6,10 @@
       3 | </if>
       4 | <else>
       5 |   <return=2/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:5:4
+      3 | </if>
+      4 | <else>
+    > 5 |   <return=2/>
+        |    ^^^^^^ The [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) can not be used under the `<"else">` tag.
+      6 | </else>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/__snapshots__/error-compile-html.txt
@@ -6,3 +6,10 @@
       3 | </if>
       4 | <else>
       5 |   <return=2/>
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-return-if-else/template.marko:5:4
+      3 | </if>
+      4 | <else>
+    > 5 |   <return=2/>
+        |    ^^^^^^ The [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) can not be used under the `<"else">` tag.
+      6 | </else>

--- a/packages/runtime-tags/src/translator/util/analyze-errors.ts
+++ b/packages/runtime-tags/src/translator/util/analyze-errors.ts
@@ -1,0 +1,32 @@
+import type { types as t } from "@marko/compiler";
+import { diagnosticError } from "@marko/compiler/babel-utils";
+
+import { createProgramState } from "./state";
+
+// Analyze failures are recorded as error diagnostics so one compile reports
+// every mistake in the template (the compiler throws them together at the
+// end of the analyze stage, and editors compiling with `errorRecovery` keep
+// them as recoverable diagnostics instead of a thrown error). Code-frame
+// errors built by the compiler carry their original `label`/`loc`, so
+// nothing is lost converting a caught error into a diagnostic.
+
+const [getHasAnalyzeErrors, setHasAnalyzeErrors] = createProgramState(
+  () => false,
+);
+
+export function reportAnalyzeError(
+  path: t.NodePath<t.Node>,
+  error: unknown,
+): void {
+  if (!(error instanceof Error)) throw error;
+  const { label = error.message, loc } = error as Error & {
+    label?: string;
+    loc?: t.SourceLocation;
+  };
+  setHasAnalyzeErrors(true);
+  diagnosticError(path, { label, loc: loc ?? path.node.loc ?? undefined });
+}
+
+export function hasAnalyzeErrors(): boolean {
+  return getHasAnalyzeErrors();
+}

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -5,6 +5,7 @@ import {
   resolveRelativePath,
 } from "@marko/compiler/babel-utils";
 
+import { hasAnalyzeErrors } from "../../util/analyze-errors";
 import { addAssetImport } from "../../util/asset-imports";
 import {
   type BindingPropTree,
@@ -92,6 +93,10 @@ export default {
     },
 
     exit(program) {
+      // Analyze failures were reported as diagnostics (the compiler throws
+      // them together right after this stage); failed tags were skipped, so
+      // skip finalization work that assumes an error-free template.
+      if (hasAnalyzeErrors()) return;
       finalizeReferences();
       const programExtra = program.node.extra!;
       const paramsBinding = programExtra.binding;

--- a/packages/runtime-tags/src/translator/visitors/scriptlet.ts
+++ b/packages/runtime-tags/src/translator/visitors/scriptlet.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import { getProgram } from "@marko/compiler/babel-utils";
 
+import { reportAnalyzeError } from "../util/analyze-errors";
 import { isOutputHTML } from "../util/marko-config";
 import { mergeReferences } from "../util/references";
 import { getOrCreateSection } from "../util/sections";
@@ -11,9 +12,14 @@ import type { TemplateVisitor } from "../util/visitors";
 export default {
   analyze(scriptlet) {
     if (!scriptlet.node.static) {
-      throw scriptlet.buildCodeFrameError(
-        "Scriptlets are not supported when using the tags api.",
+      reportAnalyzeError(
+        scriptlet,
+        scriptlet.buildCodeFrameError(
+          "Scriptlets are not supported when using the tags api.",
+        ),
       );
+      scriptlet.skip();
+      return;
     }
     mergeReferences(
       getOrCreateSection(scriptlet),

--- a/packages/runtime-tags/src/translator/visitors/tag/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/index.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import { getTagDef, type Plugin } from "@marko/compiler/babel-utils";
 
+import { reportAnalyzeError } from "../../util/analyze-errors";
 import * as hooks from "../../util/plugin-hooks";
 import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
 import type { TemplateVisitor } from "../../util/visitors";
@@ -9,40 +10,63 @@ import CustomTag from "./custom-tag";
 import DynamicTag from "./dynamic-tag";
 import NativeTag from "./native-tag";
 
+declare module "@marko/compiler/dist/types" {
+  export interface MarkoTagExtra {
+    analyzeFailed?: boolean;
+  }
+}
+
 export default {
   analyze: {
     enter(tag) {
-      const tagDef = getTagDef(tag);
-      const type = analyzeTagNameType(tag);
-      const hook = tagDef?.analyzer?.hook as Plugin;
+      // Analyze failures become error diagnostics (instead of aborting on
+      // the first) so a template with several mistakes reports them all
+      // together; the compiler throws them at the end of the stage. A failed
+      // tag's subtree is skipped to limit cascading follow-on errors.
+      try {
+        const tagDef = getTagDef(tag);
+        const type = analyzeTagNameType(tag);
+        const hook = tagDef?.analyzer?.hook as Plugin;
 
-      if (hook) {
-        hooks.enter(hook, tag);
-        return;
-      }
+        if (hook) {
+          hooks.enter(hook, tag);
+          return;
+        }
 
-      if (type === TagNameType.NativeTag) {
-        NativeTag.analyze.enter(tag);
-        return;
-      }
+        if (type === TagNameType.NativeTag) {
+          NativeTag.analyze.enter(tag);
+          return;
+        }
 
-      switch (type) {
-        case TagNameType.CustomTag:
-          CustomTag.analyze.enter(tag);
-          break;
-        case TagNameType.AttributeTag:
-          AttributeTag.analyze.enter(tag);
-          break;
-        case TagNameType.DynamicTag:
-          DynamicTag.analyze.enter(tag);
-          break;
+        switch (type) {
+          case TagNameType.CustomTag:
+            CustomTag.analyze.enter(tag);
+            break;
+          case TagNameType.AttributeTag:
+            AttributeTag.analyze.enter(tag);
+            break;
+          case TagNameType.DynamicTag:
+            DynamicTag.analyze.enter(tag);
+            break;
+        }
+      } catch (err) {
+        (tag.node.extra ??= {}).analyzeFailed = true;
+        reportAnalyzeError(tag, err);
+        tag.skip();
       }
     },
     exit(tag) {
-      const hook = getTagDef(tag)?.analyzer?.hook as Plugin;
+      if (tag.node.extra?.analyzeFailed) return;
+      try {
+        const hook = getTagDef(tag)?.analyzer?.hook as Plugin;
 
-      if (hook) {
-        hooks.exit(hook, tag);
+        if (hook) {
+          hooks.exit(hook, tag);
+          return;
+        }
+      } catch (err) {
+        (tag.node.extra ??= {}).analyzeFailed = true;
+        reportAnalyzeError(tag, err);
         return;
       }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The analyze stage previously threw on the first error, so a template with several mistakes took one compile round-trip per mistake (the parse layer already aggregates its errors).

Analyze failures are now recorded through the compiler's existing diagnostics channel (`diagnosticError`) — code-frame errors carry their original `label`/`loc`, so a caught error converts losslessly — and the compiler mirrors the parse layer by throwing all error diagnostics together at the end of the analyze stage (duplicates deduped, capped at 8). When compiling with `errorRecovery`, they stay recorded as recoverable diagnostics for editors instead of throwing.

The tags translator reports tag-level analysis failures this way (skipping the failed tag's subtree to limit cascading follow-on errors) and skips reference finalization when the template is known broken. No new public API; templates with a single error produce byte-identical output.

New multi-error fixtures, plus two existing fixtures (`error-return-if-else`, `assignment-before-tag-var`) now correctly report their second latent error.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys