### PR TITLE
Guided compile error for `by=` keyed by the loop's own parameter

### DIFF
--- a/.changeset/by-param-guided-error.md
+++ b/.changeset/by-param-guided-error.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Keying a `<for>` by its own loop parameter (`<for|city| of=cities by=city>`) is now a guided compile error suggesting the property-string and function forms (`by="id"` / `by=(city) => key`), instead of dying at render time with a bare undefined-variable error — the `by=` expression is evaluated before the loop runs, so the loop parameter is not in scope there.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko:2:33
+      1 | <ul>
+    > 2 |   <for|city| of=input.cities by=city>
+        |                                 ^^^^ The `by=` attribute is evaluated before the loop runs, so `city` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(city) => key`).
+      3 |     <li>${city}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko:2:33
+      1 | <ul>
+    > 2 |   <for|city| of=input.cities by=city>
+        |                                 ^^^^ The `by=` attribute is evaluated before the loop runs, so `city` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(city) => key`).
+      3 |     <li>${city}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko:2:33
+      1 | <ul>
+    > 2 |   <for|city| of=input.cities by=city>
+        |                                 ^^^^ The `by=` attribute is evaluated before the loop runs, so `city` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(city) => key`).
+      3 |     <li>${city}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko:2:33
+      1 | <ul>
+    > 2 |   <for|city| of=input.cities by=city>
+        |                                 ^^^^ The `by=` attribute is evaluated before the loop runs, so `city` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(city) => key`).
+      3 |     <li>${city}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/template.marko
@@ -1,0 +1,5 @@
+<ul>
+  <for|city| of=input.cities by=city>
+    <li>${city}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-dom.debug.txt
@@ -1,7 +1,7 @@
 
-    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:30
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:33
     > 1 | <for|key, value| in={ a: 1 } by="key">
-        |                              ^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
+        |                                 ^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
       2 |   <div>${key}: ${value}</div>
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-dom.txt
@@ -1,7 +1,7 @@
 
-    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:30
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:33
     > 1 | <for|key, value| in={ a: 1 } by="key">
-        |                              ^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
+        |                                 ^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
       2 |   <div>${key}: ${value}</div>
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-html.debug.txt
@@ -1,7 +1,7 @@
 
-    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:30
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:33
     > 1 | <for|key, value| in={ a: 1 } by="key">
-        |                              ^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
+        |                                 ^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
       2 |   <div>${key}: ${value}</div>
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/__snapshots__/error-compile-html.txt
@@ -1,7 +1,7 @@
 
-    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:30
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-in-string-by/template.marko:1:33
     > 1 | <for|key, value| in={ a: 1 } by="key">
-        |                              ^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
+        |                                 ^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string `by` key with `of`; use a `by=(key, value) => ...` function for `<for in>`.
       2 |   <div>${key}: ${value}</div>
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -106,24 +106,34 @@ export default {
 
     if (isAttrTag) return;
 
+    const byAttr = getKnownAttrValues(tag.node).by;
+
     // Only `<for of>` accepts a string `by` (a property-name key shorthand); the
     // `in`/`to`/`until` runtimes invoke `by` as a function, so a string would
     // throw at render. Reject it at compile time with a helpful message.
-    if (forType !== "of") {
-      const byAttr = getKnownAttrValues(tag.node).by;
-      if (byAttr?.type === "StringLiteral") {
-        throw (
-          tag
-            .get("attributes")
-            .find(
-              (attr) => attr.isMarkoAttribute() && attr.node.name === "by",
-            ) || tag
-        ).buildCodeFrameError(
-          `The [\`<for>\` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string \`by\` key with \`of\`; use a \`by=(${
-            forType === "in" ? "key, value" : "index"
-          }) => ...\` function for \`<for ${forType}>\`.`,
-        );
-      }
+    if (forType !== "of" && byAttr?.type === "StringLiteral") {
+      throw tag.hub.buildError(
+        byAttr,
+        `The [\`<for>\` tag](https://markojs.com/docs/reference/core-tag#for) only supports a string \`by\` key with \`of\`; use a \`by=(${
+          forType === "in" ? "key, value" : "index"
+        }) => ...\` function for \`<for ${forType}>\`.`,
+      );
+    }
+
+    // `by=` is evaluated once, before the loop runs, so the loop parameters
+    // are not in scope there. Keying a loop by its own parameter otherwise
+    // dies at render time with a bare undefined-variable error.
+    if (
+      byAttr?.type === "Identifier" &&
+      !tag.scope.getBinding(byAttr.name) &&
+      tag.node.body.params.some((param) =>
+        Object.hasOwn(t.getBindingIdentifiers(param), byAttr.name),
+      )
+    ) {
+      throw tag.hub.buildError(
+        byAttr,
+        `The \`by=\` attribute is evaluated before the loop runs, so \`${byAttr.name}\` is not in scope. Key with a property name string (\`by="id"\`) or a function (\`by=(${byAttr.name}) => key\`).`,
+      );
     }
 
     const bodySection = startSection(tagBody);


### PR DESCRIPTION
## Description

`<for|city| of=input.cities by=city>` — keying a loop with its own parameter — previously compiled fine and then died at render with a bare `city is not defined`. The `by=` expression is evaluated once, before the loop runs, so a loop parameter can never be in scope there, but the mistake reads naturally and nothing said so at compile time.

It is now a compile error pointing at the out-of-scope identifier and naming both correct forms:

> The `by=` attribute is evaluated before the loop runs, so `city` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(city) => key`).

The check only fires when the `by=` value is a bare identifier that matches one of the tag's parameters and resolves to nothing in scope, so every legitimate `by=` shape (property-name string, function, identifier from an outer scope) compiles exactly as before. Covered by a new error fixture.

Both `by=` errors in `<for>` now report through `tag.hub.buildError` anchored at the attribute value, replacing the previous attribute-path lookup (the existing string-`by` fixture snapshots update accordingly).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys