### PR TITLE
Expose cheatsheet.md through the package exports map

### DIFF
--- a/.changeset/export-cheatsheet.md
+++ b/.changeset/export-cheatsheet.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Expose `cheatsheet.md` through the package `exports` map so module resolvers can locate it as `marko/cheatsheet.md`.

--- a/packages/runtime-tags/package.json
+++ b/packages/runtime-tags/package.json
@@ -20,6 +20,7 @@
     ".": {
       "types": "./index.d.ts"
     },
+    "./cheatsheet.md": "./cheatsheet.md",
     "./translator": "./src/translator/index.ts",
     "./tags/*": "./tags/*",
     "./debug/*": "./src/*.ts",
@@ -53,6 +54,7 @@
     ".": {
       "types": "./index.d.ts"
     },
+    "./cheatsheet.md": "./cheatsheet.md",
     "./package.json": "./package.json",
     "./translator": "./dist/translator/index.js",
     "./tags/*": "./tags/*",


### PR DESCRIPTION
## Description

Adds `"./cheatsheet.md": "./cheatsheet.md"` to `@marko/runtime-tags`' exports (both the development map and the publish `exports:override`), so module resolvers can locate the LLM syntax reference from #3392 as `marko/cheatsheet.md` instead of guessing a file path inside the package.

Companion to marko-js/resolve-sync#10 (which fixes exports-map subpath resolution + `silent`) and marko-js/vite#283 (which resolves the sheet to point coding agents at it from compile errors).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys

---
_Generated by [Claude Code](https://claude.ai/code/session_01KZUGLZL3YoBToFLSEv2Nys)_