### PR TITLE
fix(runtime-class): compile `with { load }` as eager imports under hot reload

### DIFF
--- a/.changeset/load-facade-hot-reload-recursion.md
+++ b/.changeset/load-facade-hot-reload-recursion.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix an infinite recursion in dev mode (`hot: true`) when using `with { load }` imports, where the lazy facade collided with the real template in the hot-reload cache and recursed on render. Since dev loads every module eagerly, these imports now compile as normal eager imports under hot reload; production builds are unchanged.

--- a/packages/runtime-class/src/translator/util/load-import.js
+++ b/packages/runtime-class/src/translator/util/load-import.js
@@ -11,17 +11,27 @@ const loadTagsByFile = new WeakMap();
 export function analyzeLoadImport(importDecl, tagEntry) {
   if (!importDecl.node.attributes?.length) return;
 
-  const loadAttrValuePath = importDecl
+  const loadAttrPath = importDecl
     .get("attributes")
     .find(
       (p) =>
         (p.node.key.type === "Identifier"
           ? p.node.key.name
           : p.node.key.value) === "load",
-    )
-    ?.get("value");
+    );
 
-  if (!loadAttrValuePath) return;
+  if (!loadAttrPath) return;
+
+  // Under hot reload every module is already eagerly loaded, so the lazy facade
+  // buys nothing and its HMR-cached template collides with the real template's
+  // `_` slot, recursing on render (see load-tag-browser.js). Drop the attribute
+  // so the import compiles as a normal eager tag import in dev.
+  if (importDecl.hub.file.markoOpts.hot) {
+    loadAttrPath.remove();
+    return;
+  }
+
+  const loadAttrValuePath = loadAttrPath.get("value");
 
   if (!tagEntry) {
     throw importDecl.buildCodeFrameError(

--- a/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/components/counter.marko
+++ b/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/components/counter.marko
@@ -1,0 +1,6 @@
+class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+}
+<button onClick() { this.state.count++ }>Count: ${this.state.count}</button>

--- a/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/template.marko
+++ b/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/template.marko
@@ -1,0 +1,2 @@
+import Counter from "./components/counter.marko" with { load: "render" };
+<Counter/>

--- a/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/test.js
+++ b/packages/runtime-class/test/api-compiler/fixtures/hot-load-eager/test.js
@@ -1,0 +1,54 @@
+"use strict";
+
+// Regression test for https://github.com/marko-js/marko/issues/3386.
+//
+// Under hot reload the lazy `with { load }` facade was created through the HMR
+// `createTemplate`, which caches by type id. The facade therefore shared the
+// real component's cached template object and `_` accessor, and rendering it
+// recursed between the HMR `proxyRenderer` and the facade's `loadRenderer`
+// until the stack overflowed. Dev already loads every module eagerly, so hot
+// mode now compiles `with { load }` imports as normal eager tag imports and
+// never emits the facade.
+
+var path = require("path");
+var compiler = require("@marko/compiler");
+
+var templatePath = path.join(__dirname, "template.marko");
+var linkAssets = { runtime: "marko/dist/vite/runtime.js", onAsset: function () {} };
+
+function compile(output, hot) {
+  // The compiler caches analysis per file within a process; clear it so each
+  // option set recompiles from scratch.
+  compiler._clearDefaults();
+  return compiler.compileFileSync(templatePath, {
+    output: output,
+    hot: hot,
+    linkAssets: linkAssets,
+    writeVersionComment: false,
+  }).code;
+}
+
+exports.check = function (marko, markoCompiler, expect, snapshot, done) {
+  try {
+    // Dev (hot): no lazy facade, no dynamic import, `load` attribute stripped.
+    ["dom", "html"].forEach(function (output) {
+      var code = compile(output, true);
+      expect(code, output + " hot output").to.not.match(
+        /load-tag-browser|withLoadAssets|import\(/,
+      );
+      expect(code, output + " hot output").to.not.contain("with { load");
+    });
+
+    // Production (non-hot): lazy loading is unchanged.
+    expect(compile("dom", false), "dom production output").to.contain(
+      "load-tag-browser",
+    );
+    expect(compile("html", false), "html production output").to.contain(
+      "withLoadAssets",
+    );
+
+    done();
+  } catch (err) {
+    done(err);
+  }
+};


### PR DESCRIPTION
## Description

Under hot reload (`hot: true`), `with { load }` imports created a lazy facade through the HMR `createTemplate`, which caches templates by type id. The facade shared the real component's cached template object and its `_` accessor, so rendering recursed between the HMR `proxyRenderer` and the facade's `loadRenderer` until the stack overflowed, breaking client hydration.

Dev already loads every module eagerly, so the lazy facade buys nothing there. Hot mode now strips the `load` attribute and compiles the tag as a normal eager import. Production builds keep lazy loading unchanged.

Fixes #3386

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KhY6NbKV4ZMSduxCCUfoJ3)_