### PR TITLE
Fix `npm run compile` default translator; add `-t` shorthands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ All from repo root. Tests and tooling run directly from TS source (`~ts` Babel r
 npm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run; bail: stops at first failure
 npm run test:parallel                                    # whole suite fanned across CPU cores (~3x faster than a serial npm test)
 npm run test:update -- --grep "..."                      # regenerate snapshots (review the diff!)
-npm run compile -- -t "" -o dom -d foo.marko             # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)
+npm run compile -- -o dom -d foo.marko                   # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)
 npm run build                                            # all packages -> dist/ + .d.ts
 npm run build:sizes                                      # bundle-size table; diffs vs .sizes.json
 npm run lint                                             # eslint + prettier check + cspell
@@ -26,7 +26,7 @@ npm run format                                           # eslint --fix + pretti
 npm run change                                           # add a changeset (required for user-facing changes)
 ```
 
-`npm run compile` is the fastest way to inspect what the translator generates. (`-t ""` works around a broken default for that flag — see `agent-feedback/dx.md`.)
+`npm run compile` is the fastest way to inspect what the translator generates. (Pass `-t class` for the Marko 5 translator; `-t` also accepts a full translator module id.)
 
 ## Repo invariants
 

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -2,12 +2,6 @@
 
 Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
 
-## Fix the broken default translator in `npm run compile`
-
-`scripts/inspect-compiled-output.ts:22` | 2026-07-02 | impact:med | effort:low
-
-The `-t`/`--translator` option defaults to the string `"tags"`, so the fallback at `scripts/inspect-compiled-output.ts:41` (`args.values.translator || "@marko/runtime-tags/translator"`) never fires, and every invocation without an explicit `-t` dies with `Cannot find module 'tags'`. Either default the option to `""` or map shorthand values (`tags` → `@marko/runtime-tags/translator`, `class` → `marko/translator`). The root `AGENTS.md` documents the `-t ""` workaround; update it when fixing.
-
 ## `c8` coverage crashes generating lcov when the wrapped process loads `~ts`
 
 `scripts/test-parallel.js:10` | 2026-07-02 | impact:med | effort:med

--- a/packages/runtime-tags/AGENTS.md
+++ b/packages/runtime-tags/AGENTS.md
@@ -96,7 +96,7 @@ To add a fixture: create the dir + `template.marko` (+ `test.ts` with steps exer
 5. Update `cheatsheet.md` (the LLM syntax reference shipped in the published package) when the change affects user-facing syntax, idioms, or guidance.
 6. Expect broad snapshot/`sizes.json` churn and an update to `packages/runtime-class/test/taglib-lookup/fixtures/getTagsSorted/expected.json` (interop taglib lookup).
 
-**Changing generated output**: iterate with `npm run compile -- -t "" -o dom -d file.marko` (and `-o html`), then `test:update` and audit snapshot diffs — output shape changes ripple through hundreds of fixtures; verify a sample by hand, don't rubber-stamp.
+**Changing generated output**: iterate with `npm run compile -- -o dom -d file.marko` (and `-o html`), then `test:update` and audit snapshot diffs — output shape changes ripple through hundreds of fixtures; verify a sample by hand, don't rubber-stamp.
 
 **Changing runtime behavior**: find the covering fixtures by grepping `__tests__/fixtures` for the runtime helper or syntax; extend `steps` before touching the runtime so the mutation log captures the before/after.
 

--- a/scripts/inspect-compiled-output.ts
+++ b/scripts/inspect-compiled-output.ts
@@ -3,6 +3,13 @@ import fs from "fs";
 import path from "path";
 import { parseArgs } from "util";
 
+// Shorthands for the two in-repo translators; any other -t value (e.g. a full
+// module id) is passed through to the compiler unchanged.
+const TRANSLATORS: Record<string, string> = {
+  tags: "@marko/runtime-tags/translator",
+  class: "marko/translator",
+};
+
 const args = parseArgs({
   allowPositionals: true,
   options: {
@@ -24,6 +31,11 @@ const args = parseArgs({
   },
 });
 
+const translator =
+  TRANSLATORS[args.values.translator] ||
+  args.values.translator ||
+  TRANSLATORS.tags;
+
 for (const entry of args.positionals) {
   const inputFileName = path.resolve(entry);
   const outputFileName = inputFileName + ".js";
@@ -38,7 +50,7 @@ for (const entry of args.positionals) {
       configFile: false,
       browserslistConfigFile: false,
     },
-    translator: args.values.translator || "@marko/runtime-tags/translator",
+    translator,
   });
 
   fs.writeFileSync(outputFileName, code);


### PR DESCRIPTION
## Description

The `-t`/`--translator` option for `npm run compile` (`scripts/inspect-compiled-output.ts`) defaulted to the string `"tags"`. Because that value is truthy, the intended `|| "@marko/runtime-tags/translator"` fallback was dead code, so every invocation without an explicit `-t` died with `Cannot find module 'tags'`.

This resolves `tags`/`class` shorthands to their translator module ids and passes any other value (e.g. a full translator module id) through unchanged:

| Invocation | Result |
| --- | --- |
| `npm run compile` (no `-t`) | tags translator (previously broken) |
| `-t tags` / `-t class` | tags / Marko 5 (`marko/translator`) translator |
| `-t ""` | still resolves to the tags translator (backward compatible with the previously documented workaround) |
| `-t <module-id>` | passed through unchanged |
| `-t bogus` | fails clearly |

The previously documented `-t ""` workaround is removed from `AGENTS.md` and `packages/runtime-tags/AGENTS.md`, and the corresponding `agent-feedback/dx.md` entry is deleted now that it is resolved.

Validated by running each case above end-to-end. This touches only an internal dev script and docs (nothing in a published package), so no changeset is included and there is no test harness for the script to extend.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEDUVBkt1gR5JNa6pwYFj)_