### PR TITLE
Fix wait() test util desync after a stream reset; stop test helpers inflating fixture sizes

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -26,25 +26,6 @@ Bare `npm audit` shows 3 advisories (`serialize-javascript` high, `js-yaml`/moch
 
 The `after()` hook writes each fixture's `sizes.json` on every optimized test run, not just under `UPDATE_EXPECTATIONS=1`. A runtime helper change validated with `npm run test:update -- --grep <name>` therefore captures new sizes only for grep-matched fixtures; any other fixture bundling the same helper keeps stale numbers that a later unrelated full run silently rewrites into the working tree (e.g. a `_lifecycle` change also resizes `for-resume-owns-branch-cleanup` and `if-resume-owns-branch-cleanup`, whose names do not match "lifecycle"). Either gate the write on `UPDATE_EXPECTATIONS` and fail on drift otherwise, or document that runtime `src/dom`/`src/html` changes require a full-suite pass before committing so all affected `sizes.json` land in the same diff.
 
-## Shared-promise test util corrupts `wait()` when a stream ends with unconsumed promises
-
-`packages/runtime-tags/src/__tests__/utils/resolve.ts:106` | 2026-07-10 | impact:med | effort:low
-
-If an SSR fixture's stream completes while a registered `resolveAfter(_, id)`
-promise is still pending (e.g. a `@catch` fires and the boundary stops waiting
-on a sibling await), the abandoned `tick()` timer chain later runs
-`r(++state.lastId)` against the state that `resetResolveState()` just reset.
-The steps' first `wait()` then sees `state.lastId` ahead of
-`state.promises.size` and its `while (id !== nextId)` loop never converges —
-the ssr test times out at 10s and mocha hangs afterwards on the leaked timers.
-Workaround used by `catch-reject-sibling-pending-await`: model
-never-consumed awaits with `new Promise(() => {})` instead of the shared
-counter. A robust fix could stamp each state object (capture `state` in
-`tick()` and drop stray resolutions after reset). Note `scripts/test-parallel`
-now passes `--exit` to its mocha workers, so leaked timers no longer wedge a
-parallel run — the underlying `wait()` corruption (and the 10s timeout it
-causes) still needs the fix described here.
-
 ## Further `test:parallel` speedups need CPU cuts, not scheduling
 
 `scripts/test-parallel.js:1` | 2026-07-11 | impact:med | effort:high

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8062,
-      "brotli": 3417
+      "min": 7375,
+      "brotli": 3217
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6818,
-      "brotli": 2993
+      "min": 6194,
+      "brotli": 2799
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9525,
-      "brotli": 4006
+      "min": 8838,
+      "brotli": 3815
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4474
+      "min": 10063,
+      "brotli": 4264
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7432,
-      "brotli": 3275
+      "min": 6808,
+      "brotli": 3070
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6843,
-      "brotli": 3031
+      "min": 6219,
+      "brotli": 2845
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7538,
-      "brotli": 3319
+      "min": 6912,
+      "brotli": 3125
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7685,
-      "brotli": 3382
+      "min": 7063,
+      "brotli": 3185
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7734,
-      "brotli": 3386
+      "min": 7112,
+      "brotli": 3195
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8196,
-      "brotli": 3529
+      "min": 7508,
+      "brotli": 3321
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7730,
-      "brotli": 3327
+      "min": 7044,
+      "brotli": 3133
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9665,
-      "brotli": 4041
+      "min": 8981,
+      "brotli": 3852
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3763,
-      "brotli": 1767
+      "min": 3145,
+      "brotli": 1559
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7730,
-      "brotli": 3327
+      "min": 7044,
+      "brotli": 3133
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9513,
-      "brotli": 3989
+      "min": 8825,
+      "brotli": 3795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9515,
-      "brotli": 3990
+      "min": 8827,
+      "brotli": 3798
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7818,
-      "brotli": 3446
+      "min": 7194,
+      "brotli": 3254
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7769,
-      "brotli": 3427
+      "min": 7147,
+      "brotli": 3228
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7769,
-      "brotli": 3427
+      "min": 7147,
+      "brotli": 3228
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7789,
-      "brotli": 3434
+      "min": 7167,
+      "brotli": 3244
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7489,
-      "brotli": 3300
+      "min": 6865,
+      "brotli": 3097
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6745,
-        "brotli": 2991
+        "min": 6121,
+        "brotli": 2810
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "child.mjs": {
-      "min": 817,
-      "brotli": 368
+      "min": 199,
+      "brotli": 143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1680,
-      "brotli": 800
+      "min": 1062,
+      "brotli": 593
     },
     "child.mjs": {
       "min": 223,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "child.mjs": {
-      "min": 416,
-      "brotli": 275
+      "min": 419,
+      "brotli": 280
     },
     "grand-child.mjs": {
-      "min": 211,
-      "brotli": 149
+      "min": 214,
+      "brotli": 153
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 750,
-      "brotli": 331
+      "min": 132,
+      "brotli": 109
     },
     "child.mjs": {
       "min": 143,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2003,
-      "brotli": 953
+      "min": 1324,
+      "brotli": 729
     },
     "child.mjs": {
       "min": 177,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9666,
-      "brotli": 4064
+      "min": 8977,
+      "brotli": 3867
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/utils/bundle.ts
+++ b/packages/runtime-tags/src/__tests__/utils/bundle.ts
@@ -20,6 +20,8 @@ const assetRuntimeId = "\0asset-runtime";
 const assetRuntimeIdRe = /\0asset-runtime$/;
 const virtualFilePrefix = "v:";
 const virtualRe = /(?:^|\/)v:/;
+// Test-only helpers (utils/resolve) are excluded from the measured bundle.
+const testUtilRe = /[\\/]__tests__[\\/]utils[\\/]/;
 
 export async function createServerRunner<T extends Record<string, string>>(
   cwd: string,
@@ -116,6 +118,9 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
       sourcemap: true,
       sourcemapExcludeSources: true,
       chunkFileNames: "[name].mjs",
+      // Split test-only helpers into their own chunk: still imported at runtime
+      // (same realm, so behavior is unchanged) but skipped by buildSnapshot.
+      manualChunks: (id) => (testUtilRe.test(id) ? "test-utils" : undefined),
     },
   });
   const htmlBuilt = build({

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -1,16 +1,20 @@
 declare global {
   var __RESOLVE_STATE__: {
+    generation: number;
     lastId: number;
     promises: Map<number, Promise<number>>;
   };
 }
 
 const state = (globalThis.__RESOLVE_STATE__ ||= {
+  generation: 0,
   lastId: 0,
   promises: new Map(),
 });
 
 export function resetResolveState() {
+  // Bump the generation so still-pending tick() chains are seen as stale.
+  state.generation++;
   state.lastId = 0;
   state.promises = new Map();
 }
@@ -109,17 +113,21 @@ function getSharedPromise(id: number = state.lastId + 1): Promise<number> {
 
   let promise = state.promises.get(id);
   if (!promise) {
-    state.promises.set(id, (promise = getSharedPromise(id - 1).then(tick)));
+    const { generation } = state;
+    promise = getSharedPromise(id - 1).then(() => tick(generation));
+    state.promises.set(id, promise);
   }
   return promise;
 }
 
-function tick() {
+function tick(generation: number) {
   return new Promise<number>((r) => {
     setTimeout(() => {
       setImmediate(() => {
         setTimeout(() => {
-          r(++state.lastId);
+          // A tick still pending from an earlier generation must not advance
+          // lastId, or the next phase's wait() would never converge.
+          r(generation === state.generation ? ++state.lastId : state.lastId);
         });
       });
     });


### PR DESCRIPTION
Two fixes to the async test harness, as two commits.

**`wait()` desync** — a `tick()` timer firing after `resetResolveState()` advanced the shared `lastId`, leaving `wait()` unable to converge (10s ssr timeout). Promises are now generation-stamped; stale-generation ticks drop instead of incrementing.

**Fixture sizes** — `resolve.ts` was inlined into every async fixture's measured bundle (a top-level `globalThis` side effect blocks tree-shaking), so editing it churned ~28 `sizes.json`. Test utils now go in a separate `test-utils` chunk (same realm, so behavior/snapshots are unchanged) that `buildSnapshot` skips — dom sizes drop to shippable-only and stop churning. No runtime change.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.