### PR TITLE
Remove dead AccessorPrefix.Getter; document pureDOMFunctions purity

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,12 +2,6 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
-## Remove the unused `AccessorPrefix.Getter` member
-
-`packages/runtime-tags/src/common/accessor.ts:11` | 2026-07-10 | impact:low | effort:low
-
-`AccessorPrefix.Getter` (`"J"`, debug `"Getter:"`) has no references anywhere in `src` — no translator emit site and no runtime read (the `Getter` interface in `translator/util/references.ts:142` is the unrelated hoisted-getter concept). Remove it from both accessor enums, or wire it up if getter state was meant to live on scope keys.
-
 ## `render` suite: `escape-script-case` fixture leaks `window.foo` into the shared jsdom browser
 
 `packages/runtime-class/test/render/fixtures/escape-script-case/template.marko:2` | 2026-07-11 | impact:low | effort:low

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -2,12 +2,6 @@
 
 Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).
 
-## Document why side-effecting runtime factories are safely marked pure
-
-`packages/runtime-tags/src/translator/util/runtime.ts:21` | 2026-07-02 | impact:low | effort:low
-
-`pureDOMFunctions` includes `_template`, `_await_promise`, `_await_content`, `_load_template`, and `_load_setup`, yet those factories have observable side effects at call time: `_template` calls `_resume(id, renderer)` (`packages/runtime-tags/src/dom/template.ts:42`) and the await/load factories call `_enable_catch()`/`enableBranches()` latches. The annotations are sound only because of a non-obvious invariant: registration is needed exactly when the value can be referenced by a serialized register id, which requires the value to be reachable in the client module graph anyway, and the enable latches are re-triggered by whichever construct survives tree-shaking. Two independent reviews flagged these as possibly-unsound; a comment on `pureDOMFunctions` stating the invariant would prevent repeated re-derivation.
-
 ## Dynamic style values inside `<for>`/`<if>` are undocumented but load-bearing
 
 `src/translator/core/style.ts:113` | 2026-07-09 | impact:low | effort:low

--- a/packages/runtime-tags/src/common/accessor.debug.ts
+++ b/packages/runtime-tags/src/common/accessor.debug.ts
@@ -8,7 +8,6 @@ export enum AccessorPrefix {
   ControlledValue = "ControlledValue:",
   DynamicHTMLLastChild = "DynamicHTMLLastChild:",
   EventAttributes = "EventAttributes:",
-  Getter = "Getter:",
   KeyedScopes = "KeyedScopes:",
   Lifecycle = "Lifecycle:",
   Promise = "Promise:",

--- a/packages/runtime-tags/src/common/accessor.ts
+++ b/packages/runtime-tags/src/common/accessor.ts
@@ -8,7 +8,6 @@ export enum AccessorPrefix {
   ControlledValue = "G",
   DynamicHTMLLastChild = "H",
   EventAttributes = "I",
-  Getter = "J",
   KeyedScopes = "O",
   Lifecycle = "K",
   Promise = "L",

--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -18,6 +18,12 @@ import runtimeInfo from "./runtime-info";
 export type DOMRuntimeHelpers = keyof typeof import("../../dom");
 export type HTMLRuntimeHelpers = keyof typeof import("../../html");
 
+// Marked `@__PURE__` (see callRuntime) so a bundler may drop a call whose
+// result is unused, despite call-time side effects: `_resume` registration
+// (`_template`, `_dynamic_tag`) and the `_enable_catch()`/`enableBranches()`
+// latches. This is sound because registration only matters when the value is
+// referenced by a serialized register id (which keeps it in the module graph),
+// and the latches are re-triggered by whichever construct survives shaking.
 const pureDOMFunctions = new Set<string>([
   "_await_promise",
   "_await_content",


### PR DESCRIPTION
Two small cleanups from the agent-feedback backlog.

- **Remove `AccessorPrefix.Getter`** — the `"J"` / debug `"Getter:"` member had no emit site or runtime read (the only other `Getter` is the unrelated hoisted-getter interface in `translator/util/references.ts`). Dropped from both accessor enums; it was never serialized, so output is unchanged (representative fixtures produce no snapshot/sizes churn).
- **Document `pureDOMFunctions`** — added a comment explaining why factories with call-time side effects (`_resume` registration, the `_enable_catch()`/`enableBranches()` latches) are soundly annotated `@__PURE__`.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEDUVBkt1gR5JNa6pwYFj)_