### PR TITLE
Assert fixture sizes.json on test runs instead of silently rewriting

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -20,12 +20,6 @@ The dependency upgrade took everything to latest except two majors that are true
 
 Bare `npm audit` shows 3 advisories (`serialize-javascript` high, `js-yaml`/mocha moderate, `diff` low), all transitively under `mocha` and `@changesets/cli` — dev tooling that never ships. They can't be resolved by version bumps: the fixes live in higher majors than mocha's ranges allow (`serialize-javascript ^6`→fix in 7.x, `diff ^7`→8.x, `js-yaml ^4`→5.x), mocha 11.7.6 is the newest stable, and the latest `@changesets/parse` still pins `js-yaml ^4.1.1`. Rather than pin them via `overrides`, the repo audits production deps only: **`npm run audit`** (`npm audit --omit=dev`) is the gate and returns 0 — that's what consumers of the published packages actually receive. Revisit and drop the distinction once mocha/changesets update their transitive deps upstream.
 
-## Fixture `sizes.json` rewrites are unconditional, so `--grep`-scoped runs leave other fixtures stale
-
-`packages/runtime-tags/src/__tests__/main.test.ts:322` | 2026-07-10 | impact:low | effort:low
-
-The `after()` hook writes each fixture's `sizes.json` on every optimized test run, not just under `UPDATE_EXPECTATIONS=1`. A runtime helper change validated with `npm run test:update -- --grep <name>` therefore captures new sizes only for grep-matched fixtures; any other fixture bundling the same helper keeps stale numbers that a later unrelated full run silently rewrites into the working tree (e.g. a `_lifecycle` change also resizes `for-resume-owns-branch-cleanup` and `if-resume-owns-branch-cleanup`, whose names do not match "lifecycle"). Either gate the write on `UPDATE_EXPECTATIONS` and fail on drift otherwise, or document that runtime `src/dom`/`src/html` changes require a full-suite pass before committing so all affected `sizes.json` land in the same diff.
-
 ## Further `test:parallel` speedups need CPU cuts, not scheduling
 
 `scripts/test-parallel.js:1` | 2026-07-11 | impact:med | effort:high

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -1,4 +1,5 @@
 import * as compiler from "@marko/compiler";
+import assert from "assert";
 import fs from "fs";
 import { html_beautify } from "js-beautify";
 import path from "path";
@@ -319,10 +320,22 @@ function testFixtures(interop?: true) {
           optimize &&
             !hasCompilerError &&
             after(() => {
-              fs.writeFileSync(
-                path.join(fixtureDir, "sizes.json"),
-                JSON.stringify(stats, null, 2) + "\n",
-              );
+              const sizesFile = path.join(fixtureDir, "sizes.json");
+              const actual = JSON.stringify(stats, null, 2) + "\n";
+              // Assert instead of rewriting: a --grep test:update refreshes only
+              // matched fixtures, so a silent rewrite would bury stale sizes.
+              if (process.env.UPDATE_EXPECTATIONS) {
+                fs.writeFileSync(sizesFile, actual);
+              } else {
+                const expected = fs.existsSync(sizesFile)
+                  ? fs.readFileSync(sizesFile, "utf8")
+                  : "";
+                assert.strictEqual(
+                  actual,
+                  expected,
+                  `sizes.json out of date for "${entry}" — run \`npm run test:update\``,
+                );
+              }
             });
 
           skipSSR ||


### PR DESCRIPTION
## Description

The fixture `sizes.json` `after()` hook rewrote on every optimized run, so a `--grep`-scoped `test:update` refreshed only matched fixtures while a later full run silently overwrote the stale ones into the working tree.

This gates the write on `UPDATE_EXPECTATIONS` and asserts equality otherwise, so drift fails the run like a snapshot and points at `npm run test:update`. Sizes use a build-time `MARKO_DEBUG` define (not the env var), so CI's `MARKO_DEBUG=1` doesn't shift them. Test-infra only; no shipped code changes.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEDUVBkt1gR5JNa6pwYFj)_