### PR TITLE
Stop escape-script-case fixture leaking window.foo into shared jsdom

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -1,18 +1,3 @@
 # Cleanup
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
-
-## `render` suite: `escape-script-case` fixture leaks `window.foo` into the shared jsdom browser
-
-`packages/runtime-class/test/render/fixtures/escape-script-case/template.marko:2` | 2026-07-11 | impact:low | effort:low
-
-The `render` suite renders every vdom fixture into one module-level jsdom
-browser, and this fixture's inline `<script>var foo = ...</script>` executes
-there, defining `window.foo` for every later fixture. Three `syntax-*`
-fixtures silently depended on that leak (fixed to read `window.foo`
-defensively when `scripts/test-parallel` began slicing the suite across
-workers); any future fixture referencing a bare `foo` in an executed script
-would repeat the trap, and only off the happy path (`--grep`, slicing). Either
-rename the variable to something obviously fixture-scoped, drop the executed
-script in favor of a non-executing `type="text/template"`, or reset leaked
-globals between fixtures in `create-marko-jsdom-module`.

--- a/packages/runtime-class/test/render/fixtures/escape-script-case/expected.html
+++ b/packages/runtime-class/test/render/fixtures/escape-script-case/expected.html
@@ -1,3 +1,5 @@
 <script>
-    var foo = {"name":"Evil \x3C/script>"};
+    (function () {
+        var foo = {"name":"Evil \x3C/script>"};
+    })();
 </script><pre>{"name":"Evil &lt;/SCRIPT>"}</pre>

--- a/packages/runtime-class/test/render/fixtures/escape-script-case/template.marko
+++ b/packages/runtime-class/test/render/fixtures/escape-script-case/template.marko
@@ -1,4 +1,6 @@
 <script>
-    var foo = ${JSON.stringify(input.foo)};
+    (function () {
+        var foo = ${JSON.stringify(input.foo)};
+    })();
 </script>
 <pre>${JSON.stringify(input.foo)}</pre>

--- a/packages/runtime-class/test/render/fixtures/escape-script-case/vdom-expected.html
+++ b/packages/runtime-class/test/render/fixtures/escape-script-case/vdom-expected.html
@@ -1,4 +1,4 @@
 <SCRIPT>
-  "\n    var foo = {\"name\":\"Evil </SCRIPT>\"};\n"
+  "\n    (function () {\n        var foo = {\"name\":\"Evil </SCRIPT>\"};\n    })();\n"
 <PRE>
   "{\"name\":\"Evil </SCRIPT>\"}"


### PR DESCRIPTION
## Description

The render suite runs every fixture in one shared jsdom, and the `escape-script-case` fixture's inline `var foo = …` script executed there, defining `window.foo` for every later fixture. Three `syntax-*` fixtures silently depended on that leak (they read `window.foo` defensively), and any future fixture using a bare `foo` in an executed script would hit the same trap, only off the happy path (`--grep`, slicing).

Wrapping the assignment in an IIFE stops the leak while keeping it a real `<script>`, so the script-escaping coverage is unchanged (the escaped value in the snapshot is byte-identical). Test-fixture only; no shipped code changes.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEDUVBkt1gR5JNa6pwYFj)_