### PR TITLE
Remove resolved dynamic-style-in-loop feedback entry

### DIFF
--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -1,20 +1,3 @@
 # Unclear Code & Docs
 
 Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).
-
-## Dynamic style values inside `<for>`/`<if>` are undocumented but load-bearing
-
-`src/translator/core/style.ts:113` | 2026-07-09 | impact:low | effort:low
-
-A `<style>` with `${...}` interpolations placed inside a `<for>` body gives
-each iteration its own values (the emitted `<style class=sN>.sN~*{--x:v}`
-shell precedes that iteration's siblings, and the latest preceding stylesheet
-wins the tie), which is exactly what per-item styling wants — verified live
-with 24 loop iterations resolving 24 distinct values. Nothing in the styling
-docs says the feature composes with control flow, and two real traps sit next
-to it: the emitted style ELEMENTS interleave with the loop's content, so
-`nth-child` selectors over the siblings silently skip half their targets (use
-`nth-of-type`), and any higher-specificity rule using the `animation:`
-shorthand resets an interpolated `animation-delay` because the shorthand
-implicitly sets delay to `0s`. A docs example of a dynamic style in a loop,
-plus a note about element interleaving, would have saved the debugging session.


### PR DESCRIPTION
## Description

Removes the resolved `agent-feedback/unclear.md` entry about dynamic `<style>` values inside `<for>` being undocumented. The behavior and its `:nth-child` interleaving gotcha are now documented in the website styling guide (marko-js/website#175).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjEDUVBkt1gR5JNa6pwYFj)_