### PR TITLE
Record interop bug-bash findings in agent-feedback

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -160,3 +160,102 @@ In `_attr_select_value`'s `MutationObserver` (fired when `<option>`s are added/r
 `packages/runtime-tags/src/translator/util/state.ts:11` | 2026-07-14 | impact:low | effort:low
 
 `createProgramState`'s getter caches with `let state = map.get(getProgram()); if (!state) { map.set(getProgram(), (state = init())); }`. The `if (!state)` truthiness test treats any falsy stored value (`0`, `""`, `false`, `0n`, `NaN`) as absent, so the next read re-runs `init()` and overwrites the caller's value with the init default. Its sibling `createSectionState` (same file) correctly uses `??=` (nullish) for exactly this reason. Latent: the only two falsy-valued program states coincidentally never observe it — `getNextBindingId` (init `() => 0`, `references.ts:197`) is always set to `id + 1 >= 1` before the next read, and `getHasAnalyzeErrors` (init `() => false`, `analyze-errors.ts:13`) only ever stores `true`. A future `createProgramState` whose setter stores a falsy value differing from init would silently recompute. Fix: a `map.has(getProgram())` presence check, or align with `createSectionState`'s nullish pattern.
+
+## Inert Class parent drops client resume for a stateful Tags-API descendant
+
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts:293` | 2026-07-13 | impact:high | effort:high
+
+A Tags-API page that renders an inert Class-API component (no class block /
+component-browser) which itself renders a stateful Tags-API grandchild produces
+a dead (non-resuming) grandchild after SSR: clicking a `<button onClick>` in the
+grandchild does nothing, in **both** debug and optimize. In optimize the class
+boundary is additionally removed outright by the inert-child optimization here
+(`!classHydration && !tagsSerializeReason` → `tag.remove()`), because
+`getClassHydrationMode` (`packages/runtime-class/src/translator/index.js:714`)
+only detects interactivity via `meta.component` and never inspects a Tags-API
+child's `isInteractive` (which lives on `program.node.extra`, not
+`metadata.marko`). But disabling that removal does **not** fix the dead button,
+so the root cause is a deeper resume gap for stateful-tags-inside-inert-class,
+not just the optimization. Repro (CSR works, SSR-resume dead): tags page
+`// use tags` + `<class-wrapper/>`; `class-wrapper.marko` =
+`<div><tags-counter/></div>` (no class block); `tags-counter.marko` =
+`<let/n=0/><button onClick(){n++}>${n}</button>`. A fix likely needs the tags
+translator to surface interactivity on `metadata.marko`, `getClassHydrationMode`
+to return DESCENDANT for interactive tags children, and the boundary to actually
+resume.
+
+## `StringWriter.merge` reads a non-existent `this._writer`
+
+`packages/runtime-class/src/runtime/html/StringWriter.js:42` | 2026-07-13 | impact:low | effort:low
+
+In `merge`, when `otherWriter._data` holds a key absent from `this._data`, the
+else-branch does `this._data[key] = this._writer[key]` — but `StringWriter` has
+no `_writer` property (only `_content`/`_scripts`/`_data`), so `this._writer` is
+`undefined` and the access throws `TypeError`. It should be
+`otherWriter._data[key]`. Currently latent: `_data` effectively only ever holds
+the single `componentDefs` key, so both writers share that key and the
+`.push.apply` branch (line 40) is always taken; the bug surfaces the moment two
+merged writers carry divergent `_data` keys. This sits on the compat/init-
+components data path (`tags-compat/runtime-html.js` `___addComponentsFromContext`).
+
+## Interop feature-detection omits current Tags-only core tags
+
+`packages/runtime-tags/src/translator/interop/feature-detection.ts:176` | 2026-07-13 | impact:med | effort:low
+
+`getFeatureTypeFromCoreTagName` forces Tags for `const/debug/define/id/let/
+lifecycle/log/return/try` but omits three current, non-deprecated Tags-only core
+tags — `<show>`, `<html-script>`, `<html-style>` (`translator/core/index.ts:42-53`;
+none exist in the Class core taglib). In a mixed project (`tagDiscoveryDirs` not
+exclusively `tags`), a Marko 6 file whose only distinguishing feature is one of
+these (e.g. a repo-root global-style component using only `<html-style>`, no
+`<!-- use tags -->`) falls through to the default at lines 48-50 and is
+classified Class; every merged visitor then dispatches to the (nonexistent)
+Class handler (`isTagsAPI() ? enter6 : enter5` → `enter5` undefined) and the tag
+is left untranslated → compile error or wrong output. Also a maintenance hazard:
+each new Tags-only core tag must be hand-synced into this switch. Fix: add the
+missing names and a test asserting every core tag classifies.
+
+## Compat `___deserialize` override dereferences a possibly-undefined scope
+
+`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js:73` | 2026-07-13 | impact:low | effort:low
+
+The compat `ComponentDef.___deserialize` override does
+`o[2] = domCompat.getScope(global, o[2]).m5i` with no null guard, but
+`compat.getScope` returns `getRenderScopes($global)?.[scopeId]`, which is
+legitimately `undefined` when the tags scope carrying `m5i` has not been resumed
+yet. Every other consumer uses optional chaining; the sibling comment at line 38
+even notes "a split parent may not be hydrated yet when the child resumes."
+Under the normal init6-before-init5 ordering the tags scope is registered first,
+so this is not hit today, but any streaming/out-of-order resume of a
+class-in-tags child before its `writeSetScopeForComponent` scope would throw
+`TypeError`. Defensive fix: `getScope(global, o[2])?.m5i`.
+
+## `COMPAT_REGISTRY` caches `[id, scopeId]` for the module lifetime
+
+`packages/runtime-tags/src/html/compat.ts:69` | 2026-07-13 | impact:med | effort:med
+
+`toJSON`'s `COMPAT_REGISTRY` is a module-global `WeakMap` keyed by the registered
+function, and the `_script(scopeId, SET_SCOPE_REGISTER_ID)` side-effect (line 79)
+runs only on the first `toJSON()` for that function object, ever. For any
+registered function reused across renders (a module-level/hoisted `renderBody`,
+or a memoized handler), render #2 returns render #1's cached `scopeId` (per-render
+scope counters reset via `new State`) and never re-emits the `SET_SCOPE`
+registration, so its serialized reference points at a stale scope id and the
+client `getRenderScopes(...)[id]` lookup misses → broken hydration / dead bridged
+handler. Server-side the WeakMap persists across requests, so this is a
+cross-request hazard. Fix: key the cache per-render/per-`State` rather than
+module-globally.
+
+## class→tags bridged render builds its head `Chunk` with null context
+
+`packages/runtime-tags/src/html/compat.ts:116` | 2026-07-13 | impact:med | effort:med
+
+`compat.render` builds the bridged tags child's head `Chunk` with `context: null`
+(the flagged TODO). With null context, inside the bridged subtree
+`isInResumedBranch()` is false and `$chunk.context?.[kBranchId]`/`[kIsAsync]` are
+undefined, so `_script` never calls `_resume_branch` and
+`AccessorProp.ClosestBranchId` is never written. A Class component embedded under
+an async/lazy Tags region (`tags(async) → class → tags(effect)`) then resumes its
+effect with no closest-branch association, attaching it to the wrong branch or
+none → hydration mismatch. Fix: thread the enclosing chunk's context into the
+bridged head chunk.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -109,3 +109,46 @@ The HTML `enter` guards with `if (!getSectionForBody(tag.get("body")))` (line 90
 `packages/runtime-tags/src/translator/util/to-first-expression-or-block.ts:5` | 2026-07-13 | impact:low | effort:low
 
 The switch (lines 5–15) returns `toParenthesizedExpressionIfNeeded(expression)` for Object/Assignment expressions and `expression` otherwise — exactly what `toParenthesizedExpressionIfNeeded` (defined just below at line 17) already does for every input. Replace the whole block with a single `return toParenthesizedExpressionIfNeeded(...)` applied to the first statement's `.expression`.
+
+## Interop `preserveBoundary` / `"preserve"` registration arg is inert (dead code)
+
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts:318` | 2026-07-13 | impact:low | effort:med
+
+The tags translator carefully computes `preserveBoundary` and conditionally
+appends `t.stringLiteral("preserve")` to the compat `s(id, renderer[, mode])`
+registration, but the runtime `register` (`tags-compat/runtime-html.js:240`) does
+`boundaryModeByRenderer.set(renderer, boundaryMode || true)` and only ever reads
+the value as a truthy `forceBoundary`. The `PRESERVE_BOUNDARY = "preserve"`
+constant (`runtime-html.js:11`) is defined but never referenced anywhere. So the
+translator's `preserveBoundary` branch produces no behavioral difference, and
+because `register` coerces to `true`, any `s(id, renderer)` forces the boundary
+for that renderer's inert uses in other templates (over-serialization), since
+`boundaryModeByRenderer` is keyed by the shared renderer object. Strongly
+suggests an intended `boundaryMode === PRESERVE_BOUNDARY` runtime branch that was
+never wired up — either implement it or drop the dead constant + arg.
+
+## Compat re-render writes scope nodes onto a DOM node instead of the branch scope
+
+`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js:179` | 2026-07-13 | impact:low | effort:low
+
+In `renderAndMorph`, after `host = rootNode.startNode`, the call
+`domCompat.setScopeNodes(host, rootNode.startNode, rootNode.endNode)` writes
+`#StartNode`/`#EndNode` onto the fragment's DOM marker node (a self-assign plus
+an unused end ref) rather than onto the tags branch **scope** — the argument was
+almost certainly meant to be `scope`. Consequence: the `host.fragment` fast-path
+at line 158 can never fire for a resumed child, so every re-render falls through
+to the `___componentLookup` / `___marko5Component.___rootNode` lookup. Correctness
+is unaffected (later renders reuse `___marko5Component.___rootNode`), so this is a
+dead optimization + a confusing stale-node invariant; verify destroy/move
+semantics before changing to `scope`.
+
+## Interop emits a duplicate registration scriptlet per class-tag occurrence
+
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts:326` | 2026-07-13 | impact:low | effort:low
+
+Each Class-API custom-tag occurrence pushes its own registration statement to
+`program.body` with no dedup by class-file id: three `<class-display/>` uses emit
+three identical `_resume("…",_classDisplay)` (DOM) / `_s("…",_classDisplay)`
+(HTML) statements (the `??=` non-template branch at lines 360-377 duplicates the
+same way). Idempotent, so not incorrect, but N× redundant given "bundle size is a
+feature" — one registration per unique class file would suffice.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -175,3 +175,47 @@ Invoke-only propagation skips same-program `<define>` props because reads are in
 `packages/runtime-tags/src/translator/core/style.ts:154` | 2026-07-14 | impact:low | effort:low
 
 `dynamicStyleNameOffset` runs `t.traverseFast(getProgram().node, ...)` over the entire program AST for every dynamic `<style>` tag, summing `node.extra.dynamicStyle.names.length` for tags whose `node.start` precedes the current one. Because analyze is a depth-first traversal in ascending source position and the current tag's `dynamicStyle` extra is set only afterward, the offset is simply the running total of all previously-analyzed dynamic styles' name counts — maintainable with an O(1) program-scoped counter, exactly the `programStyleCounts` WeakMap idiom already used ~20 lines below in `getStyleImportPath`. As written it is O(K·N) (K dynamic-style tags × N program nodes), walking the whole tree K times. Impact is low because K is tiny in realistic templates. A replacement must keep disjoint, deterministic per-tag ranges; the current code keys on `node.start`, so an incremental counter relies on the normal source-order visit invariant.
+
+## Interop bridges a Class parent's `on-x` handler as a fresh closure each render
+
+`packages/runtime-class/src/runtime/helpers/dynamic-tag.js:191` | 2026-07-13 | impact:low | effort:low
+
+`addTagsEvents` calls `bindTagsEventHandler(component, handler, extraArgs)` to
+fold a Class parent's `on-x("method")` binding into the Tags child's `onX` input,
+allocating a **new** function every render (client path). The Tags child's input
+signal (`_const("input_onX", …)`) dirty-checks by identity, so every Class-parent
+re-render re-runs the child's event-attach signal (`_on(...)`) even though the
+target method is unchanged. `_on` is delegation-based so the re-attach itself is
+cheap, but the wasted signal re-execution is avoidable: cache the bound handler
+per `(component, methodName, extraArgs)` (string-method handlers are the common
+case and cache trivially) so the child sees a stable `onX` identity across
+renders.
+
+## `getClassHydrationMode` never memoizes its "no hydration" result
+
+`packages/runtime-class/src/translator/index.js:714` | 2026-07-13 | impact:low | effort:low
+
+`getClassHydrationMode` caches `meta.classHydration` only when it returns a
+truthy mode (SELF/DESCENDANT); the `undefined` (no-hydration) result is never
+stored, so `Object.hasOwn(meta, "classHydration")` stays false and every parent
+that references a shared inert child re-runs the full recursive descent over that
+child's subtree. In a wide/deep component graph this is repeated O(subtree) work
+per referencing parent. Memoizing the negative result (`meta.classHydration =
+undefined` with a presence sentinel, or a separate `visited`-scoped cache) makes
+it single-pass per file.
+
+## Compat resume runs the event resolver over every key of every boundary scope
+
+`packages/runtime-tags/src/dom/compat.ts:52` | 2026-07-13 | impact:low | effort:low
+
+The `SET_SCOPE_REGISTER_ID` resume iterates **all** enumerable keys of every
+compat boundary scope (including `$global`, `m5c`, `#Id`, `#StartNode`, …) and
+calls `classEventResolver` on each, even when the app has no bridged Class→Tags
+events. Related: `Component.prototype.___setCustomEvents` is patched on the
+prototype for **all** Class components (`tags-compat/runtime-dom.js:59`), so every
+component with custom events pays an extra `for…of` + `resolveRegistered` per
+event regardless of interop, and `compat.onFlush` permanently patches
+`Chunk.prototype.flushHTML` process-wide (`html/compat.ts:57`), taxing every pure
+Marko 6 chunk flush with a `writersByGlobal.get` miss once the class-compat
+module is loaded. Each is minor individually; worth gating the resolver loop on a
+"has bridged events" flag and scoping the patches.


### PR DESCRIPTION
Notes from a bug-bash of the Class↔Tags interop layer, recorded under `agent-feedback/`:

- **bugs.md** — 6 findings (incl. a HIGH inert-class-parent resume gap)
- **perf.md** — 3 inefficiencies
- **cleanup.md** — 3 dead-code / dedup opportunities

Documentation only — no runtime or translator changes.