### PR TITLE
test(runtime-class): fix flaky flush-here-and-after fixtures (timer race)

### DIFF
--- a/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-after/test.js
+++ b/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-after/test.js
@@ -1,5 +1,9 @@
+const { promiseProvider } = require("../../../__util__/async-helpers");
+
+// Order flushes by setImmediate ticks (the queue BufferedWriter flushes on)
+// rather than wall-clock timers, so the interleaving can't collapse under load.
 exports.templateData = {
-  wait: (timeout) => new Promise((resolve) => setTimeout(resolve, timeout)),
+  wait: (delay) => promiseProvider((delay / 10) * 3),
 };
 
 exports.skip_vdom = true;

--- a/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-before/test.js
+++ b/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-before/test.js
@@ -1,5 +1,9 @@
+const { promiseProvider } = require("../../../__util__/async-helpers");
+
+// Order flushes by setImmediate ticks (the queue BufferedWriter flushes on)
+// rather than wall-clock timers, so the interleaving can't collapse under load.
 exports.templateData = {
-  wait: (timeout) => new Promise((resolve) => setTimeout(resolve, timeout)),
+  wait: (delay) => promiseProvider((delay / 10) * 3),
 };
 
 exports.skip_vdom = true;

--- a/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-reverse/test.js
+++ b/packages/runtime-class/test/render/fixtures/flush-here-and-after-async-reverse/test.js
@@ -1,5 +1,9 @@
+const { promiseProvider } = require("../../../__util__/async-helpers");
+
+// Order flushes by setImmediate ticks (the queue BufferedWriter flushes on)
+// rather than wall-clock timers, so the interleaving can't collapse under load.
 exports.templateData = {
-  wait: (timeout) => new Promise((resolve) => setTimeout(resolve, timeout)),
+  wait: (delay) => promiseProvider((delay / 10) * 3),
 };
 
 exports.skip_vdom = true;

--- a/packages/runtime-class/test/render/fixtures/flush-here-and-after-with-body/test.js
+++ b/packages/runtime-class/test/render/fixtures/flush-here-and-after-with-body/test.js
@@ -1,5 +1,9 @@
+const { promiseProvider } = require("../../../__util__/async-helpers");
+
+// Order flushes by setImmediate ticks (the queue BufferedWriter flushes on)
+// rather than wall-clock timers, so the interleaving can't collapse under load.
 exports.templateData = {
-  wait: (timeout) => new Promise((resolve) => setTimeout(resolve, timeout)),
+  wait: (delay) => promiseProvider((delay / 10) * 3),
 };
 
 exports.skip_vdom = true;


### PR DESCRIPTION
## Description

Fixes an intermittent snapshot failure in the `flush-here-and-after-*` render fixtures (`runtime-class`). Seen most recently on `test: node@22` while `node@24`/`node@26` passed on the same commit — a timing race, not a real regression.

**Root cause.** These fixtures order their async resolutions with wall-clock `setTimeout` delays (`wait: (t) => new Promise(r => setTimeout(r, t))`). `BufferedWriter` batches writes and flushes them on a `setImmediate` (`src/runtime/html/BufferedWriter.js`), and it only schedules one flush at a time. Under CI load, two awaits whose delays are close (e.g. `20ms`/`40ms`) can become overdue and fire within the **same** event-loop turn, so both write into the buffer before the single scheduled flush runs. Their output then collapses into one flush cycle — reordering the emitted chunks (`Flush 3Flush 2`) and merging the two children's `$MC` asset scripts into a single `<script>` — which no longer matches the recorded `html` snapshot.

**Fix.** Switch these fixtures from `setTimeout` to `promiseProvider` (the existing `test/__util__/async-helpers` primitive already used by `await-ordering`), which advances by `setImmediate` ticks — the *same* queue `BufferedWriter` flushes on. Ordering is therefore independent of CPU load. Each `10ms` of the original delay maps to 3 ticks, preserving the relative ordering each fixture encodes while guaranteeing one flush fully drains before the next await resolves.

- Output is **byte-identical** to the existing snapshots — no snapshot churn; only the four `test.js` files change.
- `await-timeout` is intentionally left on real timers (it exercises the timeout feature itself).

**Verification.** A congestion repro that blocks the event loop past both delays: the old `setTimeout` waits collapse on **20/20** runs, while the new `promiseProvider` waits produce the correct interleaving (`Flush 1 Flush 2 Flush 4 Flush 3`, two separate `$MC` scripts) on **20/20**. The full async-render fixture neighborhood (278 tests) passes unchanged.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes. <!-- N/A: test-only -->
- [x] I have added tests to cover my changes. <!-- makes existing async-flush fixtures deterministic -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01N8mHmGLPY3iWof2oxpEJFS)_