### PR TITLE
perf(runtime-tags): make server render toReadable() lazy and flush pipe()

### DIFF
--- a/.changeset/lazy-server-render-toreadable.md
+++ b/.changeset/lazy-server-render-toreadable.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Make a server render's `toReadable()` lazy (it renders on first read, not on creation) and flush `pipe()` after each chunk so it streams through buffering transforms like `compression`.

--- a/packages/runtime-tags/src/html/template.ts
+++ b/packages/runtime-tags/src/html/template.ts
@@ -186,7 +186,9 @@ class ServerRendered implements RenderedTemplate {
   }) {
     this.#read(
       (html) => {
+        // Flush per chunk so buffering transforms (eg. compression) stream.
         stream.write(html);
+        stream.flush?.();
       },
       (err) => {
         const socket = ("socket" in stream && stream.socket) as
@@ -207,31 +209,40 @@ class ServerRendered implements RenderedTemplate {
 
   toReadable() {
     let cancelled = false;
+    let started = false;
     let boundary: Boundary | undefined;
     const encoder = new TextEncoder();
-    return new ReadableStream({
-      start: (ctrl) => {
-        boundary = this.#read(
-          (html) => {
-            ctrl.enqueue(encoder.encode(html));
-          },
-          (err) => {
-            boundary = undefined;
-            if (!cancelled) {
-              ctrl.error(err);
-            }
-          },
-          () => {
-            boundary = undefined;
-            ctrl.close();
-          },
-        );
+    return new ReadableStream(
+      {
+        // Deferred to the first `pull` so wrapping this in a `Response` does
+        // not start consuming the render until it is actually read.
+        pull: (ctrl) => {
+          if (started) return;
+          started = true;
+          boundary = this.#read(
+            (html) => {
+              ctrl.enqueue(encoder.encode(html));
+            },
+            (err) => {
+              boundary = undefined;
+              if (!cancelled) {
+                ctrl.error(err);
+              }
+            },
+            () => {
+              boundary = undefined;
+              ctrl.close();
+            },
+          );
+        },
+        cancel: (reason) => {
+          cancelled = true;
+          boundary?.abort(reason);
+        },
       },
-      cancel: (reason) => {
-        cancelled = true;
-        boundary?.abort(reason);
-      },
-    });
+      // highWaterMark 0 avoids an eager pre-fill pull, preserving the deferral.
+      { highWaterMark: 0 },
+    );
   }
 
   then<TResult1 = string, TResult2 = never>(


### PR DESCRIPTION
## Description

Two small server-render streaming improvements:

- **`toReadable()` is now lazy** — it starts rendering on the first read (`pull`, with `highWaterMark: 0`) instead of eagerly when the stream is created. Wrapping a render in a `Response` no longer begins consuming it, and no work happens if the stream is never read.
- **`pipe()` now flushes after each chunk.** The public `pipe` type already advertised `flush?()`, but the implementation never called it, so piping a streamed render through a buffering transform (e.g. the `compression` middleware) buffered everything until the end. Verified against real `compression`: chunks now arrive incrementally instead of in one lump at the end.

Behavior is otherwise unchanged; the full runtime-tags suite passes and bundle sizes are unaffected.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CajfEqE4SjN7rTdpj4bx4y)_