### PR TITLE
perf(runtime-tags): gate tag-variable resume registration on child-scope serialization

### DIFF
--- a/.changeset/tag-var-resume-gate.md
+++ b/.changeset/tag-var-resume-gate.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Custom tag variables whose child scope is never serialized now emit a plain, tree-shakeable signal instead of an impure `_var_resume` registration, shrinking client bundles.

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,7 @@ const $child_content__setHtml__script = _script("__tests__/template.marko_1_setH
 const $child_content__setHtml = /*@__PURE__*/ _closure_get("setHtml", $child_content__setHtml__script);
 const $child_content__setup = $child_content__setHtml;
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1_content", 0, 0, $child_content__setup);
-const $setHtml = _var_resume("__tests__/template.marko_0_setHtml/var", /*@__PURE__*/ _const("setHtml"));
+const $setHtml = /*@__PURE__*/ _const("setHtml");
 function $setup($scope) {
 	_var($scope, "#childScope/0", $setHtml);
 	$setup$1($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/__snapshots__/dom.bundle.js
@@ -6,4 +6,3 @@ _resume("b0", $_return);
 
 // template.marko
 const $child_content = /*@__PURE__*/ _content("a1", 0, 0, /* @__PURE__ */ _closure_get(3, _script("a0", ($scope) => $scope._.c("Hello world"))));
-const $setHtml = _var_resume("a2", /*@__PURE__*/ _const(2));

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1875,
-        "brotli": 988
+        "min": 1685,
+        "brotli": 895
       },
       "files": {
         "tags/child.marko": 146,
-        "template.marko": 245
+        "template.marko": 184
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/error-tag-var-uninitialized/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-tag-var-uninitialized/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $Tag_content__input_content = $Tag_content__dynamicTag;
 const $Tag_content__setup = /*@__PURE__*/ _child_setup(($scope) => _return($scope, "A"));
 const $Tag_content__$params = ($scope, $params2) => $Tag_content__input($scope, $params2[0]);
 const $Tag_content__input = ($scope, input) => $Tag_content__input_content($scope, input.content);
-const $name = _var_resume("__tests__/template.marko_0_name/var", /*@__PURE__*/ _const("name"));
+const $name = /*@__PURE__*/ _const("name");
 function $setup($scope) {
 	_var($scope, "#childScope/0", $name);
 	$Tag_content__setup._($scope["#childScope/0"], $scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -24,7 +24,7 @@ var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $templ
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml/hoist", "setHtml", "ClosureScopes:1");
-const $what_content__setHtml = _var_resume("__tests__/template.marko_1_setHtml/var", /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml)));
+const $what_content__setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
 const $what_content__setup = ($scope) => {
 	_var($scope, "#childScope/0", $what_content__setHtml);
 	$setup$2($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.js
@@ -6,7 +6,6 @@ _resume("b0", $_return);
 
 // template.marko
 const $setHtml_getter = _hoist_resume("a0", 2, "B1");
-const $what_content__setHtml = _var_resume("a3", /*@__PURE__*/ _const(2));
 const $setup__script = _script("a2", ($scope) => {
 	for (const fn of $setHtml_getter($scope)) fn("Hoist from custom tag");
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2268,
-        "brotli": 1148
+        "min": 2132,
+        "brotli": 1087
       },
       "files": {
         "tags/child.marko": 146,
-        "template.marko": 294
+        "template.marko": 219
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
@@ -27,14 +27,14 @@ var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $templ
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!><!><!>`)($template$2);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&%b%c`)($walks$2);
 const $setHtml3_getter = /*@__PURE__*/ _hoist("setHtml3", "ClosureScopes:4");
-const $inputshowsectionnull_content__setHtml = _var_resume("__tests__/template.marko_4_setHtml3/var", /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3)));
+const $inputshowsectionnull_content__setHtml = /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3));
 const $inputshowsectionnull_content__setup = ($scope) => {
 	_var($scope, "#childScope/0", $inputshowsectionnull_content__setHtml);
 	$setup$1($scope["#childScope/0"]);
 };
 const $inputshowsectionnull_content = _content_resume("__tests__/template.marko_4_content", $template$1, /*@__PURE__*/ ((_w0) => `0${_w0}&`)(" b"), $inputshowsectionnull_content__setup, 0, "ClosureScopes:4");
 const $setHtml2_getter = /*@__PURE__*/ _hoist("setHtml2", "ClosureScopes:3", "ClosureScopes:2");
-const $thing_content2__setHtml = _var_resume("__tests__/template.marko_3_setHtml2/var", /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2)));
+const $thing_content2__setHtml = /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2));
 const $thing_content2__setup = ($scope) => {
 	_var($scope, "#childScope/0", $thing_content2__setHtml);
 	$setup$1($scope["#childScope/0"]);
@@ -46,7 +46,7 @@ const $inputshowThingnull_content__setup = ($scope) => {
 };
 const $inputshowThingnull_content = _content_resume("__tests__/template.marko_2_content", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$2), $inputshowThingnull_content__setup, 0, "ClosureScopes:2");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml/hoist", "setHtml", "ClosureScopes:1");
-const $thing_content__setHtml = _var_resume("__tests__/template.marko_1_setHtml/var", /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml)));
+const $thing_content__setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
 const $thing_content__setup = ($scope) => {
 	_var($scope, "#childScope/0", $thing_content__setHtml);
 	$setup$1($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.js
@@ -21,14 +21,14 @@ _resume("b0", $_return);
 
 // template.marko
 const $setHtml3_getter = /*@__PURE__*/ _hoist(2, "B4");
-const $inputshowsectionnull_content__setHtml = _var_resume("a6", /*@__PURE__*/ _const(2));
+const $inputshowsectionnull_content__setHtml = /*@__PURE__*/ _const(2);
 const $inputshowsectionnull_content__setup = ($scope) => {
 	_var($scope, 0, $inputshowsectionnull_content__setHtml);
 	$setup($scope.a);
 };
 const $inputshowsectionnull_content = _content_resume("a4", $template, /*@__PURE__*/ ((_w0) => `0${_w0}&`)(" b"), $inputshowsectionnull_content__setup, 0, "B4");
 const $setHtml2_getter = /*@__PURE__*/ _hoist(2, "B3", "B2");
-const $thing_content2__setHtml = _var_resume("a7", /*@__PURE__*/ _const(2));
+const $thing_content2__setHtml = /*@__PURE__*/ _const(2);
 const $thing_content2__setup = ($scope) => {
 	_var($scope, 0, $thing_content2__setHtml);
 	$setup($scope.a);
@@ -40,7 +40,6 @@ const $inputshowThingnull_content__setup = ($scope) => {
 };
 const $inputshowThingnull_content = _content_resume("a3", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks), $inputshowThingnull_content__setup, 0, "B2");
 const $setHtml_getter = _hoist_resume("a0", 2, "B1");
-const $thing_content__setHtml = _var_resume("a8", /*@__PURE__*/ _const(2));
 const $setup__script = _script("a5", ($scope) => {
 	for (const fn of $setHtml_getter($scope)) fn("Hoist from custom tag");
 	$setHtml2_getter($scope)()("Hoist from dynamic tag");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13905,
-        "brotli": 5299
+        "min": 13829,
+        "brotli": 5270
       },
       "files": {
         "tags/thing.marko": 360,
         "tags/child.marko": 243,
-        "template.marko": 1598
+        "template.marko": 1484
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $templ
 const $template = "<!><!><hr><!><hr><!><!>";
 const $walks = "b%c%c%c";
 const $setHtml3_getter = _hoist_resume("__tests__/template.marko_0_setHtml3/hoist", "setHtml3", "BranchScopes:#ul/0", "BranchScopes:#text/2");
-const $for_content4__setHtml = _var_resume("__tests__/template.marko_4_setHtml3/var", /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3)));
+const $for_content4__setHtml = /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3));
 const $for_content4__setup = ($scope) => {
 	_var($scope, "#childScope/0", $for_content4__setHtml);
 	$setup$1($scope["#childScope/0"]);
@@ -26,13 +26,13 @@ const $for_content3__setup = ($scope) => $for_content3__for($scope, [
 	1
 ]);
 const $setHtml2_getter = /*@__PURE__*/ _hoist("setHtml2", "BranchScopes:#text/1");
-const $for_content2__setHtml = _var_resume("__tests__/template.marko_2_setHtml2/var", /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2)));
+const $for_content2__setHtml = /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2));
 const $for_content2__setup = ($scope) => {
 	_var($scope, "#childScope/0", $for_content2__setHtml);
 	$setup$1($scope["#childScope/0"]);
 };
 const $setHtml_getter = /*@__PURE__*/ _hoist("setHtml", "BranchScopes:#text/0");
-const $for_content__setHtml = _var_resume("__tests__/template.marko_1_setHtml/var", /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml)));
+const $for_content__setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
 const $for_content__setup = ($scope) => {
 	_var($scope, "#childScope/0", $for_content__setHtml);
 	$setup$1($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/dom.bundle.js
@@ -6,11 +6,8 @@ _resume("b0", $_return);
 
 // template.marko
 const $setHtml3_getter = _hoist_resume("a0", 2, "Aa", "Ac");
-const $for_content4__setHtml = _var_resume("a2", /*@__PURE__*/ _const(2));
 const $setHtml2_getter = /*@__PURE__*/ _hoist(2, "Ab");
-const $for_content2__setHtml = _var_resume("a3", /*@__PURE__*/ _const(2));
 const $setHtml_getter = /*@__PURE__*/ _hoist(2, "Aa");
-const $for_content__setHtml = _var_resume("a4", /*@__PURE__*/ _const(2));
 const $setup__script = _script("a1", ($scope) => {
 	$setHtml_getter($scope)()("First Only");
 	$setHtml2_getter($scope)()("First Only");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2378,
-        "brotli": 1190
+        "min": 2204,
+        "brotli": 1120
       },
       "files": {
         "tags/child.marko": 146,
-        "template.marko": 658
+        "template.marko": 434
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,7 @@ const $for_content2__setup = ($scope) => {
 	$input_value($scope["#childScope/0"], `${$scope._["#LoopKey"]},${$scope["#LoopKey"]}`);
 	$for_content2__setup__script($scope);
 };
-const $for_content2__ref = _var_resume("__tests__/template.marko_2_ref/var", /*@__PURE__*/ _const("ref", ($scope) => _assert_hoist($scope.ref)));
+const $for_content2__ref = /*@__PURE__*/ _const("ref", ($scope) => _assert_hoist($scope.ref));
 const $for_content__for = /*@__PURE__*/ _for_to("#text/0", "", /*@__PURE__*/ ((_w0) => `0${_w0}&`)(""), $for_content2__setup);
 const $for_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _el_read($scope._["#pre/1"]).innerHTML += `${[...$for_content__ref_getter($scope)].length}; ${$for_content__ref_getter($scope)()}\n\t`);
 const $for_content__setup = ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.js
@@ -9,6 +9,5 @@ const $ref_getter = _hoist_resume("a0", 3, "Aa", "Ad");
 const $for_content__ref_getter = _hoist_resume("a1", 3, "Aa");
 const $for_content2__ref_getter = _hoist_resume("a2", 3);
 const $for_content2__setup__script = _script("a3", ($scope) => $scope._._.c.innerHTML += `${[...$for_content2__ref_getter($scope)].length}; ${$for_content2__ref_getter($scope)()}\n\t`);
-const $for_content2__ref = _var_resume("a6", /*@__PURE__*/ _const(3));
 const $for_content__setup__script = _script("a4", ($scope) => $scope._.b.innerHTML += `${[...$for_content__ref_getter($scope)].length}; ${$for_content__ref_getter($scope)()}\n\t`);
 const $setup__script = _script("a5", ($scope) => $scope.a.innerHTML += `${[...$ref_getter($scope)].length}; ${$ref_getter($scope)()}\n\t`);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2424,
-        "brotli": 1189
+        "min": 2288,
+        "brotli": 1125
       },
       "files": {
         "tags/child.marko": 119,
-        "template.marko": 793
+        "template.marko": 722
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -36,7 +36,7 @@ function $setup($scope) {
 	$setup$1($scope["#childScope/1"]);
 	$setup__script($scope);
 }
-const $api = _var_resume("__tests__/template.marko_0_api/var", /*@__PURE__*/ _const("api", ($scope) => _assert_hoist($scope.api)));
+const $api = /*@__PURE__*/ _const("api", ($scope) => _assert_hoist($scope.api));
 function $action($scope) {
 	return function() {
 		$api_getter($scope)().addClass("child");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.js
@@ -17,7 +17,6 @@ _resume("c0", $_return);
 // template.marko
 const $api_getter = /*@__PURE__*/ _hoist(3);
 const $setup__script = _script("a1", ($scope) => $api_getter($scope)().setHtml("works"));
-const $api = _var_resume("a2", /*@__PURE__*/ _const(3));
 function $action($scope) {
 	return function() {
 		$api_getter($scope)().addClass("child");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2335,
-        "brotli": 1182
+        "min": 2199,
+        "brotli": 1114
       },
       "files": {
         "tags/child.marko": 109,
         "tags/source.marko": 231,
-        "template.marko": 351
+        "template.marko": 294
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -28,5 +28,5 @@ function $setup($scope) {
 	_var($scope, "#childScope/1", $setHtml);
 	$setup$1($scope["#childScope/1"]);
 }
-const $setHtml = _var_resume("__tests__/template.marko_0_setHtml/var", /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml)));
+const $setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.js
@@ -9,4 +9,3 @@ _resume("b0", $_return);
 
 // template.marko
 const $setHtml_getter = _hoist_resume("a0", 3);
-const $setHtml = _var_resume("a1", /*@__PURE__*/ _const(3));

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2212,
-        "brotli": 1114
+        "min": 2076,
+        "brotli": 1058
       },
       "files": {
         "tags/thing.marko": 106,
         "tags/child.marko": 146,
-        "template.marko": 147
+        "template.marko": 86
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
@@ -25,19 +25,19 @@ const $walks = /*@__PURE__*/ ((_w0) => `b%b/${_w0}&%b%b%c`)("");
 const $if_content5__setup__script = _script("__tests__/template.marko_5", ($scope) => $setHtml3_getter($scope._)()("Hello world"));
 const $if_content5__setup = $if_content5__setup__script;
 const $setHtml3_getter = /*@__PURE__*/ _hoist("setHtml3", "BranchScopes:#text/3");
-const $if_content4__setHtml = _var_resume("__tests__/template.marko_4_setHtml3/var", /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3)));
+const $if_content4__setHtml = /*@__PURE__*/ _const("setHtml3", ($scope) => _assert_hoist($scope.setHtml3));
 const $if_content4__setup = ($scope) => {
 	_var($scope, "#childScope/0", $if_content4__setHtml);
 	$setup$2($scope["#childScope/0"]);
 };
 const $setHtml2_getter = /*@__PURE__*/ _hoist("setHtml2", "BranchScopes:#text/2");
-const $if_content3__setHtml = _var_resume("__tests__/template.marko_3_setHtml2/var", /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2)));
+const $if_content3__setHtml = /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2));
 const $if_content3__setup = ($scope) => {
 	_var($scope, "#childScope/0", $if_content3__setHtml);
 	$setup$2($scope["#childScope/0"]);
 };
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml/hoist", "setHtml", "BranchScopes:#text/0", "BranchScopes:#text/0");
-const $if_content2__setHtml = _var_resume("__tests__/template.marko_2_setHtml/var", /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml)));
+const $if_content2__setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
 const $if_content2__setup = ($scope) => {
 	_var($scope, "#childScope/0", $if_content2__setHtml);
 	$setup$2($scope["#childScope/0"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.js
@@ -10,11 +10,8 @@ const $input_value__script = _script("c0", ($scope) => $scope.c);
 // template.marko
 const $if_content5__setup = _script("a1", ($scope) => $setHtml3_getter($scope._)()("Hello world"));
 const $setHtml3_getter = /*@__PURE__*/ _hoist(2, "Ad");
-const $if_content4__setHtml = _var_resume("a3", /*@__PURE__*/ _const(2));
 const $setHtml2_getter = /*@__PURE__*/ _hoist(2, "Ac");
-const $if_content3__setHtml = _var_resume("a4", /*@__PURE__*/ _const(2));
 const $setHtml_getter = _hoist_resume("a0", 2, "Aa", "Aa");
-const $if_content2__setHtml = _var_resume("a5", /*@__PURE__*/ _const(2));
 const $setup__script = _script("a2", ($scope) => {
 	$setHtml_getter($scope)()("Hello world");
 	$setHtml2_getter($scope)()("Hello world");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2384,
-        "brotli": 1182
+        "min": 2210,
+        "brotli": 1119
       },
       "files": {
         "tags/child.marko": 146,
         "tags/thing.marko": 106,
-        "template.marko": 674
+        "template.marko": 452
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
@@ -27,5 +27,5 @@ function $setup($scope) {
 	_var($scope, "#childScope/1", $x);
 	$setup$1($scope["#childScope/1"]);
 }
-const $x = _var_resume("__tests__/template.marko_0_x/var", /*@__PURE__*/ _const("x", ($scope) => _assert_hoist($scope.x)));
+const $x = /*@__PURE__*/ _const("x", ($scope) => _assert_hoist($scope.x));
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.js
@@ -9,4 +9,3 @@ _resume("c0", $_return);
 
 // template.marko
 const $x_getter = _hoist_resume("a0", 3);
-const $x = _var_resume("a1", /*@__PURE__*/ _const(3));

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2209,
-        "brotli": 1115
+        "min": 2073,
+        "brotli": 1057
       },
       "files": {
         "tags/child.marko": 125,
         "tags/source.marko": 101,
-        "template.marko": 135
+        "template.marko": 80
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,7 @@ const $Tag_content__input_content = $Tag_content__dynamicTag;
 const $Tag_content__setup = /*@__PURE__*/ _child_setup(($scope) => _return($scope, "A"));
 const $Tag_content__$params = ($scope, $params2) => $Tag_content__input($scope, $params2[0]);
 const $Tag_content__input = ($scope, input) => $Tag_content__input_content($scope, input.content);
-const $name = _var_resume("__tests__/template.marko_0_name/var", /*@__PURE__*/ _const("name"));
+const $name = /*@__PURE__*/ _const("name");
 function $setup($scope) {
 	_var($scope, "#childScope/0", $name);
 	$Tag_content__setup._($scope["#childScope/0"], $scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/__snapshots__/dom.bundle.js
@@ -1,3 +1,2 @@
 // template.marko
 const $Tag_content2 = /*@__PURE__*/ _content("a2", 0, 0, /* @__PURE__ */ _closure_get(3, _script("a1", ($scope) => console.log($scope._.c))));
-const $name = _var_resume("a3", /*@__PURE__*/ _const(2));

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1820,
-      "brotli": 966
+      "min": 1630,
+      "brotli": 868
     }
   },
   "html": {

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -70,6 +70,7 @@ import {
   getResumeRegisterId,
   initValue,
   setBindingSerializedValue,
+  signalHasStatements,
   writeHTMLResumeStatements,
 } from "./signals";
 import { createSectionState } from "./state";
@@ -347,7 +348,11 @@ export function knownTagTranslateDOM(
   if (node.var) {
     const varBinding = node.var.extra!.binding!;
     const source = initValue(varBinding);
-    source.register = true;
+    // Register for resume only when the child scope serializes (mirrors the HTML
+    // `_var` gate); keep it for empty signals so their `_var` decl isn't elided.
+    source.register =
+      !!getSerializeReason(tagSection, childScopeBinding) ||
+      !signalHasStatements(source);
     source.buildAssignment = (valueSection, value) => {
       const changeArgs = [
         createScopeReadExpression(childScopeBinding, valueSection),


### PR DESCRIPTION
## Description

A custom tag variable was always registered for resume via the impure, non-tree-shakeable `_var_resume`, even when the tag's child scope is never serialized (the HTML side already skips writing the register id in that case). This gates the DOM registration on the same child-scope serialize reason, so a statically-returned tag variable compiles to a plain, shakeable signal:

```js
// before
const $setHtml = _var_resume("…_setHtml/var", /*@__PURE__*/ _const("setHtml"));
// after
const $setHtml = /*@__PURE__*/ _const("setHtml");
```

A dynamic (state/param) reason still registers, and an empty/unread var keeps its registration so its `_var` declaration isn't elided. 11 fixtures shrink; only `dom.bundle*.js`/`sizes.json` change and the full suite (incl. resume) is green.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.
