### PR TITLE
fix(runtime-tags): restrict runtime imports to the translate stage

### DIFF
--- a/.changeset/restrict-runtime-imports-to-translate.md
+++ b/.changeset/restrict-runtime-imports-to-translate.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix the text-only `<if>` optimization importing the output-specific `_to_text` helper during the cached pre-analyze phase, which could leak the server (HTML) runtime — including the serializer — into the client bundle. Runtime helper imports are now restricted to the translate phase.

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template = "<button> </button><div> </div>";
 const $walks = " D l D l";
 const $count = /*@__PURE__*/ _let("count/4", ($scope) => {
 	_text($scope["#text/1"], $scope.count);
-	_text($scope["#text/3"], true ? `${_to_text$1($scope.count)}` : "");
+	_text($scope["#text/3"], true ? $scope.count : "");
 });
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	_on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/dom.bundle.js
@@ -1,9 +1,9 @@
 // template.marko
 const $count = /*@__PURE__*/ _let(4, ($scope) => {
 	_text($scope.b, $scope.e);
-	_text($scope.d, `${_to_text($scope.e)}`);
+	_text($scope.d, $scope.e);
 });
-const $setup__script = _script$1("a0", ($scope) => {
+const $setup__script = _script("a0", ($scope) => {
 	_on($scope.a, "click", function() {
 		$count($scope, $scope.e + 1);
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}<div>${true ? _escape(`${_to_text(count)}`) : ""}${_el_resume($scope0_id, "#text/3")}</div>${_el_resume($scope0_id, "#div/2")}`);
+	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}<div>${true ? _escape(count) : ""}${_el_resume($scope0_id, "#text/3")}</div>${_el_resume($scope0_id, "#div/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}<div>${_escape(`${_to_text(count)}`)}${_el_resume($scope0_id, "d")}</div>${_el_resume($scope0_id, "c")}`);
+	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}<div>${_escape(count)}${_el_resume($scope0_id, "d")}</div>${_el_resume($scope0_id, "c")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { e: count });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10057,
-      "brotli": 3952
+      "min": 2647,
+      "brotli": 1330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/dom.bundle.debug.js
@@ -1,9 +1,9 @@
 // template.marko
 const $template = "<!><!><!>";
 const $walks = "b%c";
-const $for_content__item = ($scope, item) => _text($scope["#text/0"], item ? `${_to_text(item)}` : "");
+const $for_content__item = ($scope, item) => _text($scope["#text/0"], item ? item : "");
 const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
-const $for = /*@__PURE__*/ _for_of$1("#text/0", "<div> </div>", "D l", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<div> </div>", "D l", 0, $for_content__$params);
 function $setup($scope) {
 	$for($scope, [[
 		"a",
@@ -11,4 +11,4 @@ function $setup($scope) {
 		"c"
 	]]);
 }
-var template_default = /*@__PURE__*/ _template$1("__tests__/template.marko", $template, "b%c", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/html.bundle.debug.js
@@ -8,6 +8,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		"c"
 	], (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<div>${item ? _escape(`${_to_text(item)}`) : ""}</div>`);
+		_html(`<div>${item ? _escape(item) : ""}</div>`);
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/__snapshots__/html.bundle.js
@@ -8,6 +8,6 @@ var template_default = _template("a", (input) => {
 		"c"
 	], (item) => {
 		_scope_id();
-		_html(`<div>${item ? _escape(`${_to_text(item)}`) : ""}</div>`);
+		_html(`<div>${item ? _escape(item) : ""}</div>`);
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,7 @@
 // template.marko
 const $template = "<div> </div>";
 const $walks = "D l";
-const $mounted = /*@__PURE__*/ _let("mounted/1", ($scope) => _text($scope["#text/0"], $scope.mounted ? `${_to_text$1("A")}B${_to_text$1($scope.mounted && "C")}D` : ""));
+const $mounted = /*@__PURE__*/ _let("mounted/1", ($scope) => _text($scope["#text/0"], $scope.mounted ? `${_to_text("A")}B${_to_text($scope.mounted && "C")}D` : ""));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => $mounted($scope, true));
 function $setup($scope) {
 	$mounted($scope, undefined);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/__snapshots__/dom.bundle.js
@@ -1,3 +1,3 @@
 // template.marko
 const $mounted = /*@__PURE__*/ _let(1, ($scope) => _text($scope.a, $scope.b ? `${_to_text("A")}B${_to_text($scope.b && "C")}D` : ""));
-const $setup__script = _script$1("a0", ($scope) => $mounted($scope, true));
+const $setup__script = _script("a0", ($scope) => $mounted($scope, true));

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9774,
-      "brotli": 3853
+      "min": 2379,
+      "brotli": 1221
     }
   },
   "html": {

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -8,7 +8,7 @@ import {
 
 import { WalkCode } from "../../common/types";
 import { assertNoSpreadAttrs } from "../util/assert";
-import { bodyToTextLiteral } from "../util/body-to-text-literal";
+import { bodyToRawTextLiteral, kRawText } from "../util/body-to-text-literal";
 import { getAccessorPrefix } from "../util/get-accessor-char";
 import { getParentTag } from "../util/get-parent-tag";
 import { getTagName } from "../util/get-tag-name";
@@ -468,9 +468,13 @@ export function flattenTextOnlyConditional(rootTag: t.NodePath<t.MarkoTag>) {
   }
 
   let expr: t.Expression = t.stringLiteral("");
+  let rawText = false;
   for (let i = branches.length; i--;) {
     const branchTag = branches[i];
-    const text = bodyToTextLiteral(branchTag.node.body);
+    const text = bodyToRawTextLiteral(branchTag.node.body);
+    // A template literal means static text concatenated with a raw
+    // interpolation, which translate must still coerce.
+    rawText ||= t.isTemplateLiteral(text);
     expr = isCoreTagName(branchTag, "else")
       ? text
       : t.conditionalExpression(branchTag.node.attributes[0].value, text, expr);
@@ -479,7 +483,11 @@ export function flattenTextOnlyConditional(rootTag: t.NodePath<t.MarkoTag>) {
   for (let i = branches.length; i-- > 1;) {
     branches[i].remove();
   }
-  rootTag.replaceWith(t.markoPlaceholder(expr, true));
+  const placeholder = t.markoPlaceholder(expr, true);
+  if (rawText) {
+    (placeholder.extra ??= {})[kRawText] = true;
+  }
+  rootTag.replaceWith(placeholder);
 }
 
 function assertValidCondition(tag: t.NodePath<t.MarkoTag>) {

--- a/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
+++ b/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
@@ -3,7 +3,54 @@ import { types as t } from "@marko/compiler";
 import { escapeTemplateRaw } from "./normalize-string-expression";
 import { callRuntime } from "./runtime";
 
+// Marks a flattened `<if>` whose value still holds raw interpolations
+// concatenated with static text, so translate runs `injectTextCoercion`.
+export const kRawText = Symbol("raw text placeholder");
+declare module "@marko/compiler/dist/types" {
+  export interface MarkoPlaceholderExtra {
+    [kRawText]?: true;
+  }
+}
+
+// Translate: a text-only body as a JS string, each interpolation coerced with
+// `_to_text`. Used by text-only native tags and html comments.
 export function bodyToTextLiteral(body: t.MarkoTagBody) {
+  return buildTextLiteral(body, toText, false);
+}
+
+// Pre-analyze: same, but interpolations stay raw (the output-specific `_to_text`
+// import can't precede translate) and a lone interpolation stays bare so the
+// placeholder coerces it directly; `injectTextCoercion` finishes the rest.
+export function bodyToRawTextLiteral(body: t.MarkoTagBody) {
+  return buildTextLiteral(body, (value) => value, true);
+}
+
+// Translate: wrap each raw interpolation from `bodyToRawTextLiteral` in
+// `_to_text`, in place so analyze bindings survive. Recurse the conditional;
+// stop at each template literal (its expressions are the values themselves).
+export function injectTextCoercion(expr: t.Expression) {
+  switch (expr.type) {
+    case "ConditionalExpression":
+      injectTextCoercion(expr.consequent);
+      injectTextCoercion(expr.alternate);
+      break;
+    case "TemplateLiteral":
+      expr.expressions = expr.expressions.map((child) =>
+        toText(child as t.Expression),
+      );
+      break;
+  }
+}
+
+function toText(value: t.Expression) {
+  return callRuntime("_to_text", value);
+}
+
+function buildTextLiteral(
+  body: t.MarkoTagBody,
+  coerce: (value: t.Expression) => t.Expression,
+  bareSingle: boolean,
+) {
   const templateQuasis: t.TemplateElement[] = [];
   const templateExpressions: t.Expression[] = [];
   let currentQuasi = "";
@@ -14,11 +61,19 @@ export function bodyToTextLiteral(body: t.MarkoTagBody) {
     } else if (t.isMarkoPlaceholder(child)) {
       placeholderExtra ||= child.value.extra;
       templateQuasis.push(templateElement(currentQuasi, false));
-      templateExpressions.push(callRuntime("_to_text", child.value));
+      templateExpressions.push(coerce(child.value));
       currentQuasi = "";
     }
   }
   if (templateExpressions.length) {
+    if (
+      bareSingle &&
+      templateExpressions.length === 1 &&
+      !currentQuasi &&
+      !templateQuasis[0].value.cooked
+    ) {
+      return templateExpressions[0];
+    }
     templateQuasis.push(templateElement(currentQuasi, true));
     const literal = t.templateLiteral(templateQuasis, templateExpressions);
     literal.extra = placeholderExtra;

--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -12,6 +12,7 @@ import {
   _escape_style,
   _unescaped,
 } from "../../html";
+import { isTranslate } from "./get-compile-stage";
 import { getMarkoOpts, isOutputDOM, isOutputHTML } from "./marko-config";
 import runtimeInfo from "./runtime-info";
 
@@ -61,6 +62,13 @@ const pureDOMFunctions = new Set<string>([
 ] satisfies DOMRuntimeHelpers[]);
 
 export function importRuntime(name: DOMRuntimeHelpers | HTMLRuntimeHelpers) {
+  // The `dom`/`html` import path is only known at translate; emitting it into
+  // the cached, output-shared earlier AST leaks one runtime into the other.
+  if (!isTranslate()) {
+    throw new Error(
+      `\`importRuntime(${JSON.stringify(name)})\` may only be called during the translate stage.`,
+    );
+  }
   const { output } = getMarkoOpts();
   return importNamed(getFile(), getRuntimePath(output), name);
 }

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -2,6 +2,7 @@ import { types as t } from "@marko/compiler";
 
 import { isVoid } from "../../common/helpers";
 import { WalkCode } from "../../common/types";
+import { injectTextCoercion, kRawText } from "../util/body-to-text-literal";
 import evaluate from "../util/evaluate";
 import { isCoreTagName } from "../util/is-core-tag";
 import { isNonHTMLText } from "../util/is-non-html-text";
@@ -94,6 +95,10 @@ export default {
 
       const { node } = placeholder;
       const { value } = node;
+      // Restore `_to_text` on a flattened `<if>` now that the output is known.
+      if (node.extra?.[kRawText]) {
+        injectTextCoercion(value);
+      }
       const valueExtra = evaluate(value);
       const { confident, computed } = valueExtra;
 


### PR DESCRIPTION
## Description

Runtime helpers resolve to an output-specific `dom`/`html` import path, so emitting one before the output is known — during the cached, output-shared pre-analyze phase — bakes that path into an AST that a compile cache shares across outputs. The text-only `<if>` flattening did this via `_to_text`, so a shared-cache compile could pull the server (HTML) runtime, serializer included, into the client bundle.

`importRuntime` now throws when called outside the translate stage (guarding against regressions), and the flattening emits raw Marko text during pre-analyze with `_to_text` injected at translate once the output is known. Generated output is unchanged; the affected fixtures' client bundles drop ~7.4 KB min each as the leaked runtime is removed.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_014J9CPshEXi11wbwJsMmcrd)_