### PR TITLE
test: parallelize and trim the coverage report (~3x faster)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
           cache: npm
       - name: Install dependencies
         run: npm ci
-      # Coverage collection + the c8 report add ~45% to the job (the report
-      # alone is ~1 min of single-threaded remapping), so only the newest node
-      # version pays for it — coverage is version-independent for this suite.
+      # Coverage collection + the report still add to the job (the v8->istanbul
+      # remap is now fanned across cores by scripts/coverage-report.js), so only
+      # the newest node version pays for it — coverage is version-independent.
       - name: Run tests
         if: ${{ matrix.node != 26 }}
         run: npm run @ci:test:fast

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "@ci:lint": "eslint --format unix . && prettier . --check --with-node-modules --log-level=warn",
     "@ci:release": "npm run build && node scripts/pkg-override && changeset publish && npm run @ci:release-alias && node scripts/pkg-override && npm ci",
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.ts",
-    "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 c8 npm run test:parallel",
+    "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 NODE_V8_COVERAGE=coverage/tmp npm run test:parallel && node scripts/coverage-report.js",
     "@ci:test:fast": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 npm run test:parallel",
     "@ci:version": "npm run build && npm run format && changeset version && npm i --package-lock-only",
     "audit": "npm audit --omit=dev",

--- a/scripts/c8-shard.js
+++ b/scripts/c8-shard.js
@@ -1,0 +1,44 @@
+// Preload (`node --require`) for the parallel coverage report
+// (scripts/coverage-report.js). It wraps c8's Report factory so each
+// `c8 report` process does less of the expensive v8->istanbul remap while
+// producing output identical to a single `c8 report`:
+//
+//   1. Skip third-party `node_modules` scripts. Coverage only counts
+//      `packages/*/src`, and a dependency's coverage can never map back to marko
+//      src (only the workspace-symlinked `@marko`/`marko` packages can, so those
+//      are kept) — so remapping chai/jsdom/babel/rolldown/etc. is pure waste
+//      that c8's after-remap exclude discards anyway. It's ~half the scripts.
+//   2. Remap only this shard's `1/total` slice of the survivors
+//      (C8_SHARD="<id>:<total>"), fanning the rest across cores.
+//
+// Both filters run on c8's own fully-merged V8 ranges, so the shards' istanbul
+// maps are disjoint and merge back to exactly the single-process result.
+const path = require("node:path");
+
+const [id, total] = (process.env.C8_SHARD || "0:1").split(":").map(Number);
+const THIRD_PARTY = /[/\\]node_modules[/\\]/;
+const MARKO_PACKAGE = /[/\\]node_modules[/\\](@marko[/\\]|marko[/\\])/;
+
+const reportPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "c8",
+  "lib",
+  "report.js",
+);
+const factory = require(reportPath);
+// Swap c8's Report factory in the module cache so commands/report.js picks up
+// our wrapper; each instance keeps c8's real merge/config/exclude logic.
+require.cache[reportPath].exports = function shardedReport(opts) {
+  const instance = factory(opts);
+  const merge = instance._getMergedProcessCov.bind(instance);
+  instance._getMergedProcessCov = () => {
+    const cov = merge();
+    cov.result = cov.result
+      .filter((s) => !THIRD_PARTY.test(s.url) || MARKO_PACKAGE.test(s.url))
+      .filter((_, i) => i % total === id);
+    return cov;
+  };
+  return instance;
+};

--- a/scripts/coverage-report.js
+++ b/scripts/coverage-report.js
@@ -1,0 +1,106 @@
+// Parallel coverage report for the `test:parallel` run.
+//
+// `c8 report`'s cost is v8->istanbul remapping (applying source maps to turn V8
+// byte-range coverage into istanbul line/branch coverage) — single-threaded
+// over every executed script, ~90s of the CI coverage job. Here we run N
+// `c8 report --reporter=json` shards in parallel: each reuses c8's real merge
+// (so every shard sees the same fully-merged V8 ranges) but, via the
+// `scripts/c8-shard.js` preload, (a) skips third-party node_modules scripts
+// (~half of them, and they can't map to marko src) and (b) remaps only its 1/N
+// slice of the survivors. The slices are disjoint, so merging the shards'
+// istanbul maps is identical to a single `c8 report` — branches and all — just
+// spread across cores and skipping the waste (measured ~3x: 90s -> 30s).
+//
+// Plain CommonJS, no `~ts` hook (this is the c8-adjacent process; loading a
+// require hook here has historically broken c8's istanbul report step).
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const libCoverage = require("istanbul-lib-coverage");
+const libReport = require("istanbul-lib-report");
+const reports = require("istanbul-reports");
+
+const ROOT = path.resolve(__dirname, "..");
+const COVERAGE = path.join(ROOT, "coverage");
+const TMP = path.join(COVERAGE, "tmp");
+const C8_BIN = path.join(ROOT, "node_modules", "c8", "bin", "c8.js");
+const SHARD_PRELOAD = path.join(__dirname, "c8-shard.js");
+// Match `.c8rc.json`'s reporters for the merged output.
+const FINAL_REPORTERS = ["lcov", "text-summary"];
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+async function main() {
+  const dumps = fs.existsSync(TMP)
+    ? fs.readdirSync(TMP).filter((f) => f.endsWith(".json"))
+    : [];
+  if (!dumps.length) {
+    console.error(
+      `No V8 coverage dumps in ${path.relative(ROOT, TMP)}. ` +
+        `Was the suite run with NODE_V8_COVERAGE=${path.relative(ROOT, TMP)}?`,
+    );
+    process.exit(1);
+  }
+
+  // More shards keep remapping busy but each re-merges the dumps, so returns
+  // diminish past the core count; cap there.
+  const shards = Math.max(1, os.availableParallelism());
+  const started = Date.now();
+
+  const shardDirs = Array.from({ length: shards }, (_, i) =>
+    path.join(COVERAGE, `.shard-${i}`),
+  );
+  await Promise.all(shardDirs.map((dir, i) => runShard(i, shards, dir)));
+
+  // Merge the disjoint shard maps into one, then emit the final reporters once.
+  const map = libCoverage.createCoverageMap({});
+  for (const dir of shardDirs) {
+    const file = path.join(dir, "coverage-final.json");
+    if (fs.existsSync(file)) {
+      map.merge(JSON.parse(fs.readFileSync(file, "utf8")));
+    }
+  }
+  const context = libReport.createContext({ dir: COVERAGE, coverageMap: map });
+  for (const name of FINAL_REPORTERS) {
+    reports.create(name, {}).execute(context);
+  }
+
+  for (const dir of shardDirs) fs.rmSync(dir, { recursive: true, force: true });
+  const secs = ((Date.now() - started) / 1000).toFixed(1);
+  console.log(`\ncoverage: ${shards}-way parallel remap + merge in ${secs}s`);
+}
+
+// Run `c8 report` over all dumps but, via the C8_SHARD preload, remap only this
+// shard's scripts, emitting the istanbul json map.
+function runShard(id, total, reportDir) {
+  return new Promise((resolve, reject) => {
+    const args = [
+      "--require",
+      SHARD_PRELOAD,
+      C8_BIN,
+      "report",
+      "--temp-directory",
+      TMP,
+      "--reports-dir",
+      reportDir,
+      "--reporter",
+      "json",
+    ];
+    const child = spawn(process.execPath, args, {
+      cwd: ROOT,
+      env: { ...process.env, C8_SHARD: `${id}:${total}` },
+      stdio: ["ignore", "ignore", "inherit"],
+    });
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolve()
+        : reject(new Error(`coverage shard ${id} failed (exit ${code})`)),
+    );
+  });
+}

--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -16,6 +16,7 @@
 // Usage: node scripts/test-parallel.js [extra mocha args...]
 //        MARKO_TEST_WORKERS=8 node scripts/test-parallel.js
 const { spawn } = require("node:child_process");
+const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
 
@@ -62,6 +63,13 @@ main(process.argv.slice(2)).catch((err) => {
 });
 
 async function main(mochaArgs) {
+  // Under coverage (`NODE_V8_COVERAGE` set by @ci:test) the workers write V8
+  // dumps into this shared dir; clear any stale dumps first so a previous run's
+  // coverage can't leak into this one. `scripts/coverage-report.js` remaps them.
+  if (process.env.NODE_V8_COVERAGE) {
+    fs.rmSync(process.env.NODE_V8_COVERAGE, { recursive: true, force: true });
+    fs.mkdirSync(process.env.NODE_V8_COVERAGE, { recursive: true });
+  }
   const files = (
     await glob(SPEC_GLOB, { cwd: ROOT, absolute: true, filesOnly: true })
   ).filter((f) => !f.includes("node_modules"));


### PR DESCRIPTION
## Description

The CI coverage job's `c8 report` runs `v8-to-istanbul` remapping **single-threaded over every executed script** (~90s on 4 cores). This replaces that step with `scripts/coverage-report.js`, which reuses c8's own merge/config/exclude logic but, per shard (via the `scripts/c8-shard.js` `--require` preload):

- **skips third-party `node_modules` scripts** — coverage only counts `packages/*/src`, and a dependency's coverage can never map back to marko src (the workspace-symlinked `@marko`/`marko` packages *are* kept), so remapping chai/jsdom/babel/rolldown/etc. is pure waste that c8's after-remap exclude discards anyway (~half the scripts); and
- **remaps only its `1/N` slice** of the survivors, fanning the rest across cores.

The shards' slices are disjoint over c8's fully-merged V8 ranges, so merging their istanbul maps is identical to a single `c8 report`. `@ci:test` now collects V8 coverage directly via `NODE_V8_COVERAGE` and runs the parallel report.

**Measured on the full suite (4 cores): 90s → 29s (~3x), with byte-identical `lcov.info` and coverage summary** (statements/branches/functions/lines all unchanged).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes. <!-- N/A: CI tooling; validated by comparing lcov output before/after -->


---
_Generated by [Claude Code](https://claude.ai/code/session_01KkX3jvp7Xh2Um1782p3EUm)_