### PR TITLE
fix: import tags from installed packages by their resolved name

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": minor
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Import tags from installed packages by the name their taglib was resolved through, instead of by a realpath which for a virtual store (eg pnpm) is not importable.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9536,9 +9536,9 @@
       }
     },
     "node_modules/relative-import-path": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.0.tgz",
-      "integrity": "sha512-ZvbtoduKQmD4PZeJPfH6Ql21qUWhaMxiHkIsH+FUnZqKDwNIXBtGg5zRZyHWomiGYk8n5+KMBPK7Mi4D0XWfNg==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/relative-import-path/-/relative-import-path-1.0.1.tgz",
+      "integrity": "sha512-mLABwLdOB694B3BW3bNlLOJsWCDhFRBn4BW+gkhILZXJFaymkQWDZom+3qOGYFpbN9K8eeQx8lsy2N+SX/qncQ==",
       "license": "MIT"
     },
     "node_modules/require-directory": {
@@ -11280,7 +11280,7 @@
         "lasso-package-root": "^1.0.1",
         "raptor-regexp": "^1.0.1",
         "raptor-util": "^3.2.0",
-        "relative-import-path": "^1.0.0",
+        "relative-import-path": "^1.0.1",
         "resolve-from": "^5.0.0",
         "self-closing-tags": "^1.0.1",
         "source-map-support": "^0.5.21"

--- a/packages/compiler/babel-utils.d.ts
+++ b/packages/compiler/babel-utils.d.ts
@@ -54,6 +54,10 @@ export interface TagDefinition {
   isRepeated?: boolean;
   targetProperty?: string;
   taglibId: string;
+  /** Set when the taglib was discovered by resolving an installed package. */
+  packageName?: string;
+  /** The root directory of `packageName`, which contains all files for this tag. */
+  packageRoot?: string;
   types?: string;
   template?: string;
   renderer?: string;
@@ -303,7 +307,11 @@ export function parseTemplateLiteral(
   sourceEnd?: null | number,
 ): t.TemplateLiteral;
 
-export function resolveRelativePath(file: t.BabelFile, request: string): string;
+export function resolveRelativePath(
+  file: t.BabelFile,
+  request: string,
+  tagDef?: TagDefinition,
+): string;
 export function importDefault(
   file: t.BabelFile,
   request: string,

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -76,7 +76,7 @@
     "lasso-package-root": "^1.0.1",
     "raptor-regexp": "^1.0.1",
     "raptor-util": "^3.2.0",
-    "relative-import-path": "^1.0.0",
+    "relative-import-path": "^1.0.1",
     "resolve-from": "^5.0.0",
     "self-closing-tags": "^1.0.1",
     "source-map-support": "^0.5.21"

--- a/packages/compiler/src/babel-utils/imports.js
+++ b/packages/compiler/src/babel-utils/imports.js
@@ -5,10 +5,13 @@ import { relativeImportPath } from "relative-import-path";
 
 const IMPORTS_KEY = Symbol();
 const FS_START = path.sep === "/" ? path.sep : /^(.*?:)/.exec(cwd)[1];
+const REG_NODE_MODULES = /[\\/]node_modules[\\/]/;
 
-export function resolveRelativePath(file, request) {
+export function resolveRelativePath(file, request, tagDef) {
   if (request.startsWith(FS_START)) {
-    request = relativeImportPath(file.opts.filename, request);
+    request =
+      packageImportPath(file.opts.filename, tagDef, request) ||
+      relativeImportPath(file.opts.filename, request);
   }
 
   if (file.markoOpts.optimize) {
@@ -19,6 +22,34 @@ export function resolveRelativePath(file, request) {
   }
 
   return request;
+}
+
+/**
+ * A tag installed into `node_modules` is imported through the name its package was
+ * resolved by, since its path is a realpath which may not be importable at all.
+ */
+function packageImportPath(from, tagDef, request) {
+  if (!tagDef?.packageName || !REG_NODE_MODULES.test(request)) return;
+
+  const { packageRoot } = tagDef;
+  // Within the package we stay relative, both because it always resolves and
+  // because a self reference would only work if the package exports the tag.
+  if (!isWithin(packageRoot, request) || isWithin(packageRoot, from)) return;
+
+  const subPath = path.relative(packageRoot, request);
+  return `${tagDef.packageName}/${subPath.split(path.sep).join("/")}`;
+}
+
+function isWithin(dir, filename) {
+  const rel = path.relative(dir, filename);
+  // `path.relative` walks out of the dir with `..`, or returns an absolute path
+  // when it cannot relate the two at all, eg across windows drives.
+  return (
+    !!rel &&
+    rel !== ".." &&
+    !rel.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rel)
+  );
 }
 
 export function importDefault(file, request, nameHint) {

--- a/packages/compiler/src/babel-utils/tags.js
+++ b/packages/compiler/src/babel-utils/tags.js
@@ -347,7 +347,8 @@ export function resolveTagImport(path, request) {
     const tagName = request.slice(1, -1);
     const tagDef = getTagDefForTagName(file, tagName);
     const tagEntry = tagDef && (tagDef.renderer || tagDef.template);
-    const relativePath = tagEntry && resolveRelativePath(file, tagEntry);
+    const relativePath =
+      tagEntry && resolveRelativePath(file, tagEntry, tagDef);
 
     if (!relativePath) {
       throw path.buildCodeFrameError(

--- a/packages/compiler/src/taglib/finder/index.js
+++ b/packages/compiler/src/taglib/finder/index.js
@@ -124,7 +124,9 @@ function find(dirname, registeredTaglibs, tagDiscoveryDirs) {
           rootPkg.__dirname,
         );
         if (taglibPath) {
-          var taglib = taglibLoader.loadTaglibFromFile(taglibPath, true);
+          // Resolving realpaths the taglib, which for a virtual store (eg pnpm) bears
+          // no relation to how it is imported, so hold onto the name it resolved by.
+          var taglib = taglibLoader.loadTaglibFromFile(taglibPath, true, name);
           addTaglib(taglib);
         }
       }

--- a/packages/compiler/src/taglib/loader/Taglib.js
+++ b/packages/compiler/src/taglib/loader/Taglib.js
@@ -26,11 +26,12 @@ function handleImport(taglib, importedTaglib) {
 }
 
 class Taglib {
-  constructor(filePath, isFromPackageJson) {
+  constructor(filePath, isFromPackageJson, packageName) {
     ok(filePath, '"filePath" expected');
     this.filePath = this.path /* deprecated */ = this.id = filePath;
     this.isFromPackageJson = isFromPackageJson === true;
     this.dirname = path.dirname(this.filePath);
+    this.packageName = packageName;
     this.scriptLang = undefined;
     this.tags = {};
     this.migrators = [];
@@ -72,6 +73,23 @@ class Taglib {
     }
     this.tags[tag.name] = tag;
     tag.taglibId = this.id || this.path;
+    this.setTagPackage(tag);
+  }
+
+  setPackageName(packageName) {
+    this.packageName = packageName;
+    for (var name in this.tags) {
+      if (hasOwnProperty.call(this.tags, name)) {
+        this.setTagPackage(this.tags[name]);
+      }
+    }
+  }
+
+  setTagPackage(tag) {
+    if (this.packageName) {
+      tag.packageName = this.packageName;
+      tag.packageRoot = this.dirname;
+    }
   }
 
   addImport(path) {

--- a/packages/compiler/src/taglib/loader/index.js
+++ b/packages/compiler/src/taglib/loader/index.js
@@ -8,8 +8,8 @@ function loadTaglibFromProps(taglib, taglibProps) {
   return loaders.loadTaglibFromProps(taglib, taglibProps);
 }
 
-function loadTaglibFromFile(filePath, isFromPackageJson) {
-  return loaders.loadTaglibFromFile(filePath, isFromPackageJson);
+function loadTaglibFromFile(filePath, isFromPackageJson, packageName) {
+  return loaders.loadTaglibFromFile(filePath, isFromPackageJson, packageName);
 }
 
 function loadTaglibFromDir(filePath, tagDiscoveryDir) {

--- a/packages/compiler/src/taglib/loader/loadTaglibFromFile.js
+++ b/packages/compiler/src/taglib/loader/loadTaglibFromFile.js
@@ -4,7 +4,7 @@ var jsonFileReader = require("./json-file-reader");
 var loaders = require("./loaders");
 var types = require("./types");
 
-function loadFromFile(filePath, isFromPackageJson) {
+function loadFromFile(filePath, isFromPackageJson, packageName) {
   ok(filePath, '"filePath" is required');
 
   var taglib = cache.get(filePath);
@@ -12,11 +12,15 @@ function loadFromFile(filePath, isFromPackageJson) {
   // Only load a taglib once by caching the loaded taglibs using the file
   // system file path as the key
   if (!taglib) {
-    taglib = new types.Taglib(filePath, isFromPackageJson);
+    taglib = new types.Taglib(filePath, isFromPackageJson, packageName);
     cache.put(filePath, taglib);
 
     var taglibProps = jsonFileReader.readFileSync(filePath);
     loaders.loadTaglibFromProps(taglib, taglibProps);
+  } else if (packageName && !taglib.packageName) {
+    // The taglib may have first been loaded by walking up from a file within the
+    // package itself, in which case we did not yet know the name it is installed as.
+    taglib.setPackageName(packageName);
   }
 
   return taglib;

--- a/packages/runtime-class/src/translator/tag/custom-tag.js
+++ b/packages/runtime-class/src/translator/tag/custom-tag.js
@@ -49,7 +49,7 @@ export default function (path, isNullable) {
         // Normally new tags should not be added in the translate stage.
         // We make an exception here for core tags, init-components & _preserve being the primary culprits.
         // TODO: in the future refactor so this is not needed.
-        relativePath = resolveRelativePath(file, tagDef.renderer);
+        relativePath = resolveRelativePath(file, tagDef.renderer, tagDef);
       }
     }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -348,10 +348,11 @@ export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
   let relativePath: string | undefined;
 
   if (t.isStringLiteral(node.name)) {
+    const tagDef = getTagDef(tag);
     const template =
-      (node.extra?.featureType === "class" && getTagDef(tag)?.renderer) ||
+      (node.extra?.featureType === "class" && tagDef?.renderer) ||
       getTagTemplate(tag);
-    relativePath = template && resolveRelativePath(file, template);
+    relativePath = template && resolveRelativePath(file, template, tagDef);
   } else if (node.extra?.tagNameImported) {
     relativePath = node.extra.tagNameImported;
   }


### PR DESCRIPTION
Taglibs are discovered by resolving `<name>/marko.json`, which realpaths the result. For a package manager with a virtual store (eg pnpm) that realpath is not importable, so a tag from an installed package emitted `import ".pnpm/<id>/node_modules/<pkg>/tag.marko"`, which resolves to nothing.

Tag definitions now carry the name their taglib was resolved by, which is used to import them. The name cannot be recovered from the path alone — an aliased dependency (`"my-alias": "npm:real-pkg"`) stores under the real name but is only importable as the alias.

Anything reachable as a path is untouched: a linked/workspace package, and a package importing its own tags, both stay relative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)