### PR TITLE
Improve compiler diagnostics for common mistakes

### DIFF
--- a/.changeset/spicy-errors-suggest.md
+++ b/.changeset/spicy-errors-suggest.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Improve compiler diagnostics for common mistakes: `<for key=>` suggests `by=`, a bare line of root-level text suggests the text syntax, and camelCase `style=` object keys warn to use kebab-case.

--- a/packages/runtime-tags/cheatsheet.md
+++ b/packages/runtime-tags/cheatsheet.md
@@ -14,7 +14,8 @@ Marko 6 = HTML superset. NOT JSX, NOT old Marko 4/5. `.marko` files are componen
    - object: `user = { ...user, name }`
 5. Events: method shorthand `onClick() { ... }` or `onClick=fn`. Handler gets the DOM event: `onSubmit(e) { e.preventDefault(); save() }`. Don't sync input values through `onInput`/`onChange` listeners — that's what change handlers (next rule) are for, and they make the data's owner explicit.
 6. Native inputs are UNCONTROLLED by default: `value=` only sets the initial value. Adding the matching `*Change` handler is what makes them controlled — `valueChange` on `<input>`/`<textarea>`/`<select>`, `checkedChange` on checkboxes/radios, `openChange` on `<details>`/`<dialog>`. `value:=text` is the shorthand for `value=text valueChange(v) { text = v }`. (`<textarea value:=text/>` — value attribute, not body.)
-7. Write the change handler yourself when updates need transforming — number inputs give STRINGS: `<input type="number" value=n valueChange(v) { n = +v }>`.
+7. Transform in the handler when needed — number inputs give STRINGS: `<input type="number" value=n valueChange(v) { n = +v }>`, or `value:parseFloat:=n`.
+8. Radio/checkbox groups: `checkedValue:=picked` on each input (shared var, distinct `value=`) — the match is checked; array var for multi-checkbox. Dropdown: `<select value:=picked>`.
 
 ## Canonical component (copy this shape)
 
@@ -109,7 +110,8 @@ Don't fetch while rendering: start data loads early, pass the PROMISE through th
 
 - Repeated attr tags (many `<@tab ...>`) arrive as the SINGULAR prop `input.tab`, which is iterable but NOT an array: `input.tab[i]` and `input.tab.length` are undefined. To index or count, spread first: `<const/tabs=[...input.tab ?? []]>` then `tabs[active]`/`tabs.length`. Looping directly is fine: `<for|tab| of=input.tab>`.
 - Conditional attrs: `false`/`null` attrs are omitted from HTML. `aria-selected` etc. want strings: `aria-selected=(i === active && "true")`.
-- `class=` / `style=` accept strings, objects, arrays: `class=["btn", { active }]`, `style={ color }` (single braces).
+- `class=` / `style=` accept strings, objects, arrays: `class=["btn", { active }]`, `style={ color }` (single braces). `style=` keys are kebab-case CSS names (`{ "background-color": c }`), not camelCase.
+- `<id/x>` mints a collision-free id for label/input wiring (`<label for=x>`/`<input id=x>`) — don't hardcode ids in reusable tags; `<id/x=input.id>` reuses a caller's.
 
 ## Client-side effects (rare — prefer state/const)
 
@@ -124,6 +126,26 @@ Don't fetch while rendering: start data loads early, pass the PROMISE through th
 ```
 
 `<style>` = real CSS, extracted & global. `<script>` = reactive effect, NOT an HTML script tag.
+
+Imperative libs (charts, maps) needing mount/update/destroy: use `<lifecycle>`, not a hand-wired `<script>`. `this` persists across all three; return an object from `onMount` to stash the instance:
+
+```marko
+<canvas/canvas/>
+<lifecycle
+  onMount() { return { chart: new Chart(canvas(), data) } }
+  onUpdate() { this.chart.setData(data) }         // re-runs when `data` changes
+  onDestroy() { this.chart.destroy() }
+/>
+```
+
+## Lazy loading
+
+Defer a tag's JS into its own bundle until a trigger fires: `render`, `visible#sel`, `idle`, `media(...)`, `on-click#sel` (combine with `|`). Server HTML renders immediately; `<try>` shows a `@placeholder` while loading. Don't hand-roll an `IntersectionObserver`.
+
+```marko
+import PriceChart from "<price-chart>" with { load: "visible#chart" }
+<div#chart><PriceChart symbol=input.symbol/></div>
+```
 
 ## DON'T (these are errors or silently wrong)
 
@@ -144,3 +166,9 @@ Don't fetch while rendering: start data loads early, pass the PROMISE through th
 | `by=item` using the loop variable                           | `by="propName"` or `by=(item) => key` — `by=` is evaluated outside the loop          |
 | `onInput(e) { q = e.target.value }` to sync an input        | `value:=q` — the change handler owns the value                                       |
 | fetching inside the component that renders the data         | start the promise early (route handler / top of template), pass it down to `<await>` |
+| `style={ backgroundColor: c }` (camelCase keys)             | `style={ "background-color": c }` (kebab-case)                                       |
+| `this.querySelector` / `this.getRootNode()` in `<script>`   | element ref getter: `<div/el>` then `el()` (there is no `this`)                      |
+| `<div/my-el>` / `<input/card-input>` (hyphen in tag var)    | valid JS identifier: `<div/myEl>`                                                    |
+| hand-rolled radios `checked=x checkedChange(v){…}`          | `checkedValue:=picked` on each radio (shared var, distinct `value=`)                 |
+| hand-rolled `IntersectionObserver` to defer a widget's JS   | `import W from "<w>" with { load: "visible#sel" }`                                   |
+| imperative lib wired through `<script>` mount + cleanup     | `<lifecycle onMount/onUpdate/onDestroy>` (keeps `this` across all three)             |

--- a/packages/runtime-tags/src/__tests__/common-helpers.test.ts
+++ b/packages/runtime-tags/src/__tests__/common-helpers.test.ts
@@ -93,4 +93,42 @@ describe("runtime-tags/common/helpers", () => {
       }
     });
   });
+
+  describe("camelCase style key warning", () => {
+    const captureWarns = (fn: () => void) => {
+      const calls: string[] = [];
+      const original = console.warn;
+      console.warn = (msg: string) => calls.push(msg);
+      try {
+        fn();
+      } finally {
+        console.warn = original;
+      }
+      return calls;
+    };
+
+    it("warns once and suggests kebab-case for a camelCase key", () => {
+      const calls = captureWarns(() => {
+        styleValue({ paddingTop: "4px" });
+        styleValue({ paddingTop: "8px" });
+      });
+      assert.equal(calls.length, 1);
+      assert.match(calls[0], /`paddingTop` is not a CSS property name/);
+      assert.match(calls[0], /`padding-top`/);
+    });
+
+    it("adds the leading dash for the lowercase ms prefix", () => {
+      const calls = captureWarns(() => styleValue({ msFlexAlign: "center" }));
+      assert.match(calls[0], /`-ms-flex-align`/);
+    });
+
+    it("does not warn for kebab keys, custom properties, or plain names", () => {
+      const calls = captureWarns(() => {
+        styleValue({ "background-color": "red" });
+        styleValue({ "--fooBar": "1px" });
+        styleValue({ color: "red" });
+      });
+      assert.equal(calls.length, 0);
+    });
+  });
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko:2:29
+      1 | <ul>
+    > 2 |   <for|item| of=input.items key=item.id>
+        |                             ^^^^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) keys items with the `by=` attribute, not `key=`. Use `by="propName"` or `by=(item, index) => key`.
+      3 |     <li>${item.name}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko:2:29
+      1 | <ul>
+    > 2 |   <for|item| of=input.items key=item.id>
+        |                             ^^^^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) keys items with the `by=` attribute, not `key=`. Use `by="propName"` or `by=(item, index) => key`.
+      3 |     <li>${item.name}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko:2:29
+      1 | <ul>
+    > 2 |   <for|item| of=input.items key=item.id>
+        |                             ^^^^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) keys items with the `by=` attribute, not `key=`. Use `by="propName"` or `by=(item, index) => key`.
+      3 |     <li>${item.name}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko:2:29
+      1 | <ul>
+    > 2 |   <for|item| of=input.items key=item.id>
+        |                             ^^^^^^^^^^^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) keys items with the `by=` attribute, not `key=`. Use `by="propName"` or `by=(item, index) => key`.
+      3 |     <li>${item.name}</li>
+      4 |   </for>
+      5 | </ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/template.marko
@@ -1,0 +1,5 @@
+<ul>
+  <for|item| of=input.items key=item.id>
+    <li>${item.name}</li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-key-attribute/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko:1:1
+    > 1 | Welcome to the dashboard
+        | ^^^^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<Welcome>`. If this line is meant to be text, prefix it with `--` (e.g. `-- Welcome to the dashboard`) or wrap it in an element such as `<p>Welcome to the dashboard</p>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko:1:1
+    > 1 | Welcome to the dashboard
+        | ^^^^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<Welcome>`. If this line is meant to be text, prefix it with `--` (e.g. `-- Welcome to the dashboard`) or wrap it in an element such as `<p>Welcome to the dashboard</p>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko:1:1
+    > 1 | Welcome to the dashboard
+        | ^^^^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<Welcome>`. If this line is meant to be text, prefix it with `--` (e.g. `-- Welcome to the dashboard`) or wrap it in an element such as `<p>Welcome to the dashboard</p>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko:1:1
+    > 1 | Welcome to the dashboard
+        | ^^^^^^^ Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) `<Welcome>`. If this line is meant to be text, prefix it with `--` (e.g. `-- Welcome to the dashboard`) or wrap it in an element such as `<p>Welcome to the dashboard</p>`.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/template.marko
@@ -1,0 +1,1 @@
+Welcome to the dashboard

--- a/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-root-text-as-tag/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/translator-api.test.ts
+++ b/packages/runtime-tags/src/__tests__/translator-api.test.ts
@@ -219,4 +219,100 @@ describe("runtime-tags/translator-api", () => {
       assert.equal(isEmbed(compileHTML(page, false)), false);
     });
   });
+
+  describe("camelCase style key warning", () => {
+    const warnings = (src: string) =>
+      (
+        compiler.compileSync(src, path.join(__dirname, "tmp.marko"), {
+          ...baseConfig,
+          cache: new Map(),
+          output: "html",
+        }).meta.diagnostics ?? []
+      )
+        .filter((d) => d.type === "warning")
+        .map((d) => d.label);
+
+    it("warns on a camelCased style object key and suggests kebab-case", () => {
+      const [label, ...rest] = warnings(
+        '<div style={ backgroundColor: "red" }>Hi</div>',
+      );
+      assert.equal(rest.length, 0);
+      assert.match(label, /`backgroundColor` is not a CSS property name/);
+      assert.match(label, /`background-color`/);
+    });
+
+    it("warns for camelCase keys inside a style array and vendor prefixes", () => {
+      assert.match(
+        warnings(
+          '<div style=["display:block", { marginRight: 16 }]>Hi</div>',
+        )[0],
+        /`margin-right`/,
+      );
+      assert.match(
+        warnings('<div style={ WebkitTransform: "scale(2)" }>Hi</div>')[0],
+        /`-webkit-transform`/,
+      );
+      // The Microsoft `ms` prefix is lowercase, so it needs the leading dash added.
+      assert.match(
+        warnings('<div style={ msFlexAlign: "center" }>Hi</div>')[0],
+        /`-ms-flex-align`/,
+      );
+    });
+
+    it("does not warn on kebab-case keys, custom properties, or computed keys", () => {
+      assert.equal(
+        warnings('<div style={ "background-color": "red" }>Hi</div>').length,
+        0,
+      );
+      assert.equal(
+        warnings('<div style={ "--fooBar": "1px" }>Hi</div>').length,
+        0,
+      );
+      assert.equal(warnings('<div style={ color: "red" }>Hi</div>').length, 0);
+      assert.equal(
+        warnings('<let/k="color"><div style={ [k]: "red" }>Hi</div>').length,
+        0,
+      );
+      assert.equal(
+        warnings('<div style="background-color: red">Hi</div>').length,
+        0,
+      );
+      assert.equal(warnings('<div style={ 0: "1px" }>Hi</div>').length, 0);
+    });
+  });
+
+  describe("diagnostic branch coverage", () => {
+    const compileError = (src: string) => {
+      try {
+        compiler.compileSync(src, path.join(__dirname, "tmp.marko"), {
+          ...baseConfig,
+          cache: new Map(),
+          output: "html",
+        });
+      } catch (err) {
+        return (err as Error).message;
+      }
+      return "";
+    };
+
+    it("tailors the `<for key=>` suggestion to the loop type", () => {
+      assert.match(
+        compileError("<for|k, v| in={ a: 1 } key=k>${k}</for>"),
+        /keys items with the `by=` attribute.*`by=\(key, value\) => key`/s,
+      );
+      assert.match(
+        compileError("<for|i| to=3 key=i>${i}</for>"),
+        /keys items with the `by=` attribute.*`by=\(num\) => key`/s,
+      );
+    });
+
+    it("only hints text syntax for concise-mode prose, not real tags", () => {
+      // Angle-bracket tag with boolean attrs: no prose hint.
+      const html = compileError("<Modal open/>");
+      assert.match(html, /Unable to find entry point/);
+      assert.doesNotMatch(html, /meant to be text/);
+      // Concise word tag with a valued attribute: also not prose.
+      assert.doesNotMatch(compileError("Foo bar=1"), /meant to be text/);
+    });
+  });
 });

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -57,7 +57,22 @@ export function stringifyClassObject(name: string, value: unknown) {
   return value ? name : "";
 }
 
+const warnedStyleKeys = MARKO_DEBUG ? new Set<string>() : undefined;
 export function stringifyStyleObject(name: string, value: unknown) {
+  if (
+    MARKO_DEBUG &&
+    /[A-Z]/.test(name) &&
+    !name.includes("-") &&
+    !warnedStyleKeys!.has(name)
+  ) {
+    // Runtime counterpart to the compile-time check, for dynamic style objects.
+    warnedStyleKeys!.add(name);
+    console.warn(
+      `\`${name}\` is not a CSS property name; \`style\` object keys are written verbatim, so it renders as invalid CSS. Use \`${name
+        .replace(/[A-Z]/g, (m) => "-" + m.toLowerCase())
+        .replace(/^ms-/, "-ms-")}\`.`,
+    );
+  }
   return value || value === 0 ? name + ":" + value : "";
 }
 

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -102,6 +102,23 @@ export default {
       allowAttrs.push("by");
     }
 
+    // Redirect the React/Vue `key=` habit to `by=` before the generic error.
+    const keyAttr = tag.node.attributes.find(
+      (attr) => attr.type === "MarkoAttribute" && attr.name === "key",
+    );
+    if (keyAttr) {
+      throw tag.hub.buildError(
+        keyAttr,
+        `The [\`<for>\` tag](https://markojs.com/docs/reference/core-tag#for) keys items with the \`by=\` attribute, not \`key=\`. ${
+          forType === "of"
+            ? 'Use `by="propName"` or `by=(item, index) => key`'
+            : forType === "in"
+              ? "Use `by=(key, value) => key`"
+              : "Use `by=(num) => key`"
+        }.`,
+      );
+    }
+
     assertAllowedAttributes(tag, allowAttrs);
 
     if (isAttrTag) return;

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -390,8 +390,12 @@ function tagNotFoundError(tag: t.NodePath<t.MarkoTag>) {
   }
   let didYouMean = "";
   const knownWrongTagHint = tagName && knownWrongTags.get(tagName);
+  const proseText = tagName && getProseText(tag);
   if (knownWrongTagHint) {
     didYouMean = ` ${knownWrongTagHint}`;
+  } else if (proseText) {
+    // A bare line of words parses as a tag; the author likely meant text.
+    didYouMean = ` If this line is meant to be text, prefix it with \`--\` (e.g. \`-- ${proseText}\`) or wrap it in an element such as \`<p>${proseText}</p>\`.`;
   } else if (tagName) {
     const closestTag = closest(
       tagName,
@@ -406,6 +410,55 @@ function tagNotFoundError(tag: t.NodePath<t.MarkoTag>) {
     .buildCodeFrameError(
       `Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) \`<${tagName}>\`.${didYouMean}`,
     );
+}
+
+// A concise-mode word tag with only boolean word-attributes and no var/params/
+// body is likely stray prose; returns the reconstructed sentence, else undefined.
+const wordReg = /^[A-Za-z]+$/;
+function getProseText(tag: t.NodePath<t.MarkoTag>) {
+  const { node } = tag;
+  const tagName = getTagName(tag);
+  if (
+    !tagName ||
+    !wordReg.test(tagName) ||
+    node.var ||
+    node.body.params.length ||
+    node.body.body.length ||
+    !node.attributes.length ||
+    // An explicit `<Modal open/>` is a deliberate tag, not prose.
+    !isConciseModeTag(node)
+  ) {
+    return;
+  }
+  return collectProseWords(node, tagName);
+}
+
+// HTML mode: `loc` starts on `<`, before the name. Concise mode: they align.
+function isConciseModeTag(node: t.MarkoTag) {
+  const tagLoc = node.loc;
+  const nameLoc = node.name.loc;
+  if (!tagLoc || !nameLoc) return false;
+  return (
+    tagLoc.start.line === nameLoc.start.line &&
+    tagLoc.start.column === nameLoc.start.column
+  );
+}
+
+function collectProseWords(node: t.MarkoTag, tagName: string) {
+  let text = tagName;
+  for (const attr of node.attributes) {
+    if (
+      attr.type !== "MarkoAttribute" ||
+      attr.default ||
+      !wordReg.test(attr.name) ||
+      attr.value.type !== "BooleanLiteral" ||
+      attr.value.value !== true
+    ) {
+      return;
+    }
+    text += " " + attr.name;
+  }
+  return text;
 }
 
 function importOrSelfReferenceName(

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -4,6 +4,7 @@ import {
   assertNoAttributeTags,
   assertNoParams,
   computeNode,
+  diagnosticWarn,
   getProgram,
   getTagDef,
 } from "@marko/compiler/babel-utils";
@@ -139,6 +140,7 @@ export default {
           seen[attr.name] = attr;
           assertValidNativeAttrName(tag, attr);
           assertNativeAttrValueType(tag, attr);
+          if (attr.name === "style") warnCamelCaseStyleKeys(tag, attr);
 
           if (injectNonce && attr.name === "nonce") {
             injectNonce = false;
@@ -1246,6 +1248,51 @@ function assertNativeAttrValueType(
       `The \`${name}\` attribute cannot be a plain object (it would render as \`[object Object]\`).`,
       Error,
     );
+  }
+}
+
+// `style=` keys are written verbatim, so a camelCased DOM name like
+// `backgroundColor` becomes invalid CSS. Warn with the kebab-case equivalent.
+function warnCamelCaseStyleKeys(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute,
+) {
+  const { value } = attr;
+  const objects =
+    value.type === "ObjectExpression"
+      ? [value]
+      : value.type === "ArrayExpression"
+        ? value.elements.filter(
+            (el): el is t.ObjectExpression => el?.type === "ObjectExpression",
+          )
+        : [];
+
+  for (const object of objects) {
+    for (const prop of object.properties) {
+      if (prop.type !== "ObjectProperty" || prop.computed) continue;
+      const { key } = prop;
+      const name =
+        key.type === "Identifier"
+          ? key.name
+          : key.type === "StringLiteral"
+            ? key.value
+            : undefined;
+      if (
+        name &&
+        !name.startsWith("--") &&
+        !name.includes("-") &&
+        /[A-Z]/.test(name)
+      ) {
+        const kebab = name
+          .replace(/[A-Z]/g, (m) => "-" + m.toLowerCase())
+          // The lowercase `ms` prefix needs a leading dash: `-ms-…`.
+          .replace(/^ms-/, "-ms-");
+        diagnosticWarn(tag, {
+          label: `\`${name}\` is not a CSS property name; the [\`style=\` object](https://markojs.com/docs/reference/native-tag#style) writes keys out verbatim (unlike the camelCased DOM style API), so this renders as invalid CSS the browser ignores. Use the kebab-case name \`${kebab}\`.`,
+          loc: key.loc ?? undefined,
+        });
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Point three common mistakes at their fix instead of a generic/confusing message:

- `<for key=>` suggests `by=` instead of "does not support the `key` attribute".
- A bare line of root-level text (`Welcome aboard`) suggests the `--`/element text syntax instead of "custom tag not found" (concise mode only, so `<Modal open/>` is unaffected).
- camelCase `style=` object keys (`{ backgroundColor }`) warn to use the kebab-case CSS name (browsers otherwise silently ignore the output).

Cheatsheet updated with the same guidance plus a few adjacent gaps (`checkedValue`, `<id>`, `<lifecycle>`, lazy `load`).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01G7aE9sX2FWJ9cMKCxBnfgQ)_