### PR TITLE
feat: guide coding agents to the marko cheat sheet on compile errors

### DIFF
--- a/.changeset/compiler-agent-cheatsheet.md
+++ b/.changeset/compiler-agent-cheatsheet.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+---
+
+Guide coding agents to the marko cheat sheet on compile errors.

--- a/cspell.json
+++ b/cspell.json
@@ -60,6 +60,7 @@
     "prebundling",
     "subcomponents",
     "cheatsheet",
+    "CLAUDECODE",
     "unkeyed",
     "Autokeyed",
     "autokeys",

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -13,10 +13,11 @@ Translator-agnostic compiler: parses `.marko` into a Babel AST (custom node type
 
 ## Translator contract
 
-A translator module exports: `translate` (required visitor), `taglibs` (required, `[[id, props]]`), optional `transform` / `analyze` visitors, `tagDiscoveryDirs`, `optionalTaglibs`, `preferAPI` (`"tags"` | `"class"`), and `getRuntimeEntryFiles(output, optimize)`. Loading is resolved from `config.translator` or auto-detected from the app's dependencies (`util/try-load-translator.js`, default logic in `config.js`).
+A translator module exports: `translate` (required visitor), `taglibs` (required, `[[id, props]]`), optional `transform` / `analyze` visitors, `tagDiscoveryDirs`, `optionalTaglibs`, `preferAPI` (`"tags"` | `"class"`), `getRuntimeEntryFiles(output, optimize)`, and optionally `cheatsheet` (a module-relative path to an LLM syntax reference; `tryLoadTranslator` resolves it to a cwd-relative path and `util/agent-fix-guide.js` points coding agents at it on compile errors). Loading is resolved from `config.translator` or auto-detected from the app's dependencies (`util/try-load-translator.js`, default logic in `config.js`).
 
 ## Notes
 
 - `output: "source"` / `"migrate"` re-print `.marko` source (tooling/codemods) — no translator codegen.
 - Bumping any `@babel/*` version requires regenerating the corresponding patch in root `patches/` (patch-package); the custom AST types and generated `dist/types.d.ts` (`npm run build-babel-types -w @marko/compiler`) depend on them.
 - Adding a core tag in a translator shows up in taglib-lookup expectations here and in `packages/runtime-class/test/taglib-lookup/`.
+- `util/agent-fix-guide.js` — when a terminal coding agent is detected (env markers) and the loaded translator declares a `cheatsheet`, thrown compile errors get a one-line pointer to it (relative to `cwd`) appended at the `compile[Sync]` boundary. No-op for humans, for runtimes without a cheat sheet, and for inline translator objects (so error snapshots, which compile with an inline translator object, are unaffected).

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -13,6 +13,7 @@ import path from "path";
 import corePlugin from "./babel-plugin";
 import defaultConfig from "./config";
 import * as taglib from "./taglib";
+import appendAgentFixGuide from "./util/agent-fix-guide";
 import { buildCodeFrameError } from "./util/build-code-frame";
 import throwAggregateError from "./util/merge-errors";
 import shouldOptimize from "./util/should-optimize";
@@ -32,16 +33,24 @@ export function configure(newConfig) {
 
 export async function compile(src, filename, config) {
   const markoConfig = loadMarkoConfig(config);
-  const babelConfig = await loadBabelConfig(filename, markoConfig);
-  const babelResult = await transformAsync(src, babelConfig);
-  return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
+  try {
+    const babelConfig = await loadBabelConfig(filename, markoConfig);
+    const babelResult = await transformAsync(src, babelConfig);
+    return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
+  } catch (err) {
+    throw appendAgentFixGuide(err, markoConfig.translator);
+  }
 }
 
 export function compileSync(src, filename, config) {
   const markoConfig = loadMarkoConfig(config);
-  const babelConfig = loadBabelConfigSync(filename, markoConfig);
-  const babelResult = transformSync(src, babelConfig);
-  return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
+  try {
+    const babelConfig = loadBabelConfigSync(filename, markoConfig);
+    const babelResult = transformSync(src, babelConfig);
+    return buildResult(src, filename, markoConfig.errorRecovery, babelResult);
+  } catch (err) {
+    throw appendAgentFixGuide(err, markoConfig.translator);
+  }
 }
 
 export async function compileFile(filename, config) {

--- a/packages/compiler/src/util/agent-fix-guide.js
+++ b/packages/compiler/src/util/agent-fix-guide.js
@@ -1,0 +1,51 @@
+import tryLoadTranslator from "./try-load-translator";
+
+const applied = Symbol("markoAgentFixGuide");
+
+export default function appendAgentFixGuide(error, translator) {
+  if (error instanceof Error && !error[applied] && isCodingAgent()) {
+    const guide = fixGuide(translator);
+    if (guide) {
+      // `message` is locked against Babel mutations, so redefine rather than assign.
+      error[applied] = true;
+      Object.defineProperty(error, "message", {
+        value: error.message + guide,
+        enumerable: true,
+        writable: true,
+        configurable: true,
+      });
+    }
+  }
+
+  return error;
+}
+
+// Env markers terminal coding agents set.
+function isCodingAgent() {
+  return (
+    typeof process === "object" &&
+    (process.env.CLAUDECODE ||
+      process.env.CLAUDE_CODE ||
+      process.env.CURSOR_AGENT ||
+      process.env.GEMINI_CLI ||
+      process.env.CODEX_SANDBOX ||
+      process.env.CODEX_THREAD_ID ||
+      process.env.AI_AGENT)
+  );
+}
+
+function fixGuide(translator) {
+  // Only resolved specifiers expose a cheat sheet; inline objects (tests,
+  // embedders) opt out.
+  if (typeof translator !== "string") return undefined;
+
+  try {
+    const cheatsheet = tryLoadTranslator(translator)?.cheatsheet;
+    return cheatsheet
+      ? `\n\nFix guide: READ ${cheatsheet} before writing a fix.`
+      : undefined;
+  } catch {
+    // Leave the real compile error untouched if the translator can't load.
+    return undefined;
+  }
+}

--- a/packages/compiler/src/util/try-load-translator.js
+++ b/packages/compiler/src/util/try-load-translator.js
@@ -1,14 +1,26 @@
 import markoModules from "@marko/compiler/modules";
+import path from "path";
 
 import config from "../config";
 const cache = {};
 
 export default function (requested = config.translator) {
   if (typeof requested === "string") {
-    return (
-      cache[requested] ||
-      (cache[requested] = markoModules.require(markoModules.resolve(requested)))
-    );
+    let translator = cache[requested];
+    if (!translator) {
+      const file = markoModules.resolve(requested);
+      translator = markoModules.require(file);
+      // The translator declares its LLM cheat sheet relative to its own module;
+      // resolve it to a cwd-relative path an agent can read directly.
+      if (typeof translator.cheatsheet === "string") {
+        translator.cheatsheet = path.relative(
+          markoModules.cwd,
+          path.resolve(path.dirname(file), translator.cheatsheet),
+        );
+      }
+      cache[requested] = translator;
+    }
+    return translator;
   }
 
   return requested;

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko:2:16
+      1 | <let/count=0>
+    > 2 | Welcome aboard ${count}
+        |                ^^^^^^^^ Invalid attribute name.
+      3 |
+
+Fix guide: READ packages/runtime-tags/cheatsheet.md before writing a fix.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko:2:16
+      1 | <let/count=0>
+    > 2 | Welcome aboard ${count}
+        |                ^^^^^^^^ Invalid attribute name.
+      3 |
+
+Fix guide: READ packages/runtime-tags/cheatsheet.md before writing a fix.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko:2:16
+      1 | <let/count=0>
+    > 2 | Welcome aboard ${count}
+        |                ^^^^^^^^ Invalid attribute name.
+      3 |
+
+Fix guide: READ packages/runtime-tags/cheatsheet.md before writing a fix.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko:2:16
+      1 | <let/count=0>
+    > 2 | Welcome aboard ${count}
+        |                ^^^^^^^^ Invalid attribute name.
+      3 |
+
+Fix guide: READ packages/runtime-tags/cheatsheet.md before writing a fix.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/template.marko
@@ -1,0 +1,2 @@
+<let/count=0>
+Welcome aboard ${count}

--- a/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-agent-fix-guide/test.ts
@@ -1,0 +1,4 @@
+export const config = {
+  error_compiler: true,
+  fix_guide: true,
+};

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -51,6 +51,11 @@ export type TestConfig = {
   skip_csr?: boolean;
   skip_ssr?: boolean;
   error_compiler?: true | string[];
+  /**
+   * Compiles the error fixture as if a coding agent were driving the terminal,
+   * so the snapshot captures the compiler's cheat-sheet fix-guide.
+   */
+  fix_guide?: boolean;
   /** Compiles the fixture with a custom `runtimeId` compiler option. */
   runtime_id?: string;
 };
@@ -66,6 +71,17 @@ const slots = process.env.MARKO_TEST_SLOTS
   : null;
 function inShard(index: number) {
   return slots === null || slots.has(index % slotTotal);
+}
+
+function noop() {}
+
+function forceCodingAgent() {
+  const prev = process.env.CLAUDECODE;
+  process.env.CLAUDECODE = "1";
+  return () => {
+    if (prev === undefined) delete process.env.CLAUDECODE;
+    else process.env.CLAUDECODE = prev;
+  };
 }
 
 describe("runtime-tags/translator", () => {
@@ -199,14 +215,24 @@ function testFixtures(interop?: true) {
             if (config.error_compiler) {
               await snapMode(
                 () => {
-                  for (const f of config.error_compiler === true
-                    ? [templateFile]
-                    : (config.error_compiler as string[]).map(resolve)) {
-                    compiler.compileFileSync(f, {
-                      ...getModeOpts(),
-                      linkAssets: { runtime: "asset-runtime", onAsset() {} },
-                      output,
-                    });
+                  // The fix-guide only fires for an agent-driven terminal and a
+                  // translator resolved from a specifier, so force both here.
+                  const restore = config.fix_guide ? forceCodingAgent() : noop;
+                  try {
+                    for (const f of config.error_compiler === true
+                      ? [templateFile]
+                      : (config.error_compiler as string[]).map(resolve)) {
+                      compiler.compileFileSync(f, {
+                        ...getModeOpts(),
+                        ...(config.fix_guide && {
+                          translator: "@marko/runtime-tags/translator",
+                        }),
+                        linkAssets: { runtime: "asset-runtime", onAsset() {} },
+                        output,
+                      });
+                    }
+                  } finally {
+                    restore();
                   }
                 },
                 `error-compile-${output}.txt`,

--- a/packages/runtime-tags/src/translator/index.ts
+++ b/packages/runtime-tags/src/translator/index.ts
@@ -18,6 +18,10 @@ import MarkoText from "./visitors/text";
 
 export { version } from "../../package.json";
 
+// LLM cheat sheet location, relative to this module. The compiler resolves it
+// against the translator's path and points terminal coding agents here on error.
+export const cheatsheet = "../../cheatsheet.md";
+
 const visitors = extractVisitors({
   Program,
   Function,


### PR DESCRIPTION
## Description

When a coding agent is driving the terminal, thrown compile errors now end with a pointer to the runtime's cheat sheet (`Fix guide: READ …/cheatsheet.md before writing a fix.`). The translator declares where its cheat sheet lives and the compiler resolves it and appends the pointer at the `compile()` boundary — so every build tool benefits, not just `@marko/vite`.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YFHu9UdLb4gSB6YsmvZw8n)_