### PR TITLE
feat: error on `<if>` conditions truncated by an unenclosed `>`

### DIFF
--- a/.changeset/if-condition-unenclosed-operator.md
+++ b/.changeset/if-condition-unenclosed-operator.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Add a compiler diagnostic for `<if>`/`<else-if>`/`<else if>` conditions that are silently truncated by an unenclosed `>` (e.g. `<if=count > 0>`, where the `>` closes the tag and the rest leaks into the body). The error points at the condition and suggests parenthesizing it: `<if=(count > 0)>`.

--- a/packages/runtime-tags/cheatsheet.md
+++ b/packages/runtime-tags/cheatsheet.md
@@ -157,6 +157,7 @@ import PriceChart from "<price-chart>" with { load: "visible#chart" }
 | `$ const y = x * 2;` (scriptlets are removed)               | `<const/y=x * 2>`                                                                    |
 | `<let x=0>`                                                 | `<let/x=0>`                                                                          |
 | `<if(cond)>`                                                | `<if=cond>`                                                                          |
+| `<if=count > 0>` (unenclosed `>` ends the tag)              | `<if=(count > 0)>` — parenthesize a condition containing `>`                         |
 | `items.push(x)`                                             | `items = items.concat(x)`                                                            |
 | `input.renderBody`                                          | `input.content`                                                                      |
 | `<await>` with `@placeholder`/`@catch`                      | wrap in `<try>`                                                                      |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko:1:5
+    > 1 | <if=foo.length > 0>
+        |     ^^^^^^^^^^ A `>` in this unenclosed [`<if>` condition](https://markojs.com/docs/reference/core-tag#if--else) closes the tag, so the condition is only `foo.length` and the rest becomes body text. Wrap a comparison in parentheses, e.g. `<if=(foo.length > …)>` — or remove the space before `>` if you meant to close the tag.
+      2 |   <span>positive</span>
+      3 | </if>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko:1:5
+    > 1 | <if=foo.length > 0>
+        |     ^^^^^^^^^^ A `>` in this unenclosed [`<if>` condition](https://markojs.com/docs/reference/core-tag#if--else) closes the tag, so the condition is only `foo.length` and the rest becomes body text. Wrap a comparison in parentheses, e.g. `<if=(foo.length > …)>` — or remove the space before `>` if you meant to close the tag.
+      2 |   <span>positive</span>
+      3 | </if>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko:1:5
+    > 1 | <if=foo.length > 0>
+        |     ^^^^^^^^^^ A `>` in this unenclosed [`<if>` condition](https://markojs.com/docs/reference/core-tag#if--else) closes the tag, so the condition is only `foo.length` and the rest becomes body text. Wrap a comparison in parentheses, e.g. `<if=(foo.length > …)>` — or remove the space before `>` if you meant to close the tag.
+      2 |   <span>positive</span>
+      3 | </if>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko:1:5
+    > 1 | <if=foo.length > 0>
+        |     ^^^^^^^^^^ A `>` in this unenclosed [`<if>` condition](https://markojs.com/docs/reference/core-tag#if--else) closes the tag, so the condition is only `foo.length` and the rest becomes body text. Wrap a comparison in parentheses, e.g. `<if=(foo.length > …)>` — or remove the space before `>` if you meant to close the tag.
+      2 |   <span>positive</span>
+      3 | </if>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/template.marko
@@ -1,0 +1,3 @@
+<if=foo.length > 0>
+  <span>positive</span>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-if-condition-closed-by-operator/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -506,16 +506,49 @@ function assertValidCondition(tag: t.NodePath<t.MarkoTag>) {
   switch (getTagName(tag)) {
     case "if":
       assertHasValueAttribute(tag);
+      assertConditionNotClosedByOperator(tag, tag.node.attributes[0]);
       break;
     case "else-if":
       assertHasValueAttribute(tag);
+      assertConditionNotClosedByOperator(tag, tag.node.attributes[0]);
       assertHasPrecedingCondition(tag);
       break;
     case "else":
       assertOptionalIfAttribute(tag);
+      assertConditionNotClosedByOperator(tag, tag.node.attributes[0]);
       assertHasPrecedingCondition(tag);
       break;
   }
+}
+
+// A top-level `>` inside an *unenclosed* attribute value closes the tag, so
+// `<if=foo.length > 0>` is parsed as `<if=(foo.length)>` with ` 0>` leaking into
+// the body as text, with no error. Detect the tell: the condition
+// expression is immediately followed by whitespace and then the `>` that closed
+// the tag, with more (truncated right-hand-side) content after it on the same
+// line. `<` never closes a tag, so only `>` (and `>=`/`>>`/`>>>`) is ambiguous;
+// an enclosed value ends with a `)`/`]` before the `>`, so it is never flagged.
+// The spaceless `<if=a>0>` form is intentionally not flagged: it is
+// indistinguishable from the legitimate inline `<if=cond>text</if>`.
+function assertConditionNotClosedByOperator(
+  tag: t.NodePath<t.MarkoTag>,
+  attr: t.MarkoAttribute | t.MarkoSpreadAttribute | undefined,
+) {
+  if (!attr || !t.isMarkoAttribute(attr)) return;
+  const { value } = attr;
+  if (value.start == null || value.end == null) return;
+
+  const { code } = tag.hub.file;
+  const truncated = /^\s+>([^\n]*)/.exec(code.slice(value.end));
+  if (!truncated || !/\S/.test(truncated[1])) return;
+
+  const tagName = getTagName(tag);
+  const conditionSource = code.slice(value.start, value.end);
+  throw tag.hub.buildError(
+    value,
+    `A \`>\` in this unenclosed [\`<${tagName}>\` condition](https://markojs.com/docs/reference/core-tag#if--else) closes the tag, so the condition is only \`${conditionSource}\` and the rest becomes body text. Wrap a comparison in parentheses, e.g. \`<${tagName}=(${conditionSource} > …)>\` — or remove the space before \`>\` if you meant to close the tag.`,
+    Error,
+  );
 }
 
 function assertHasPrecedingCondition(tag: t.NodePath<t.MarkoTag>) {


### PR DESCRIPTION
## Description

`<if=foo.length > 0>` is a silent footgun: a top-level `>` in an *unenclosed* attribute value closes the tag, so this parses as `<if=(foo.length)>` (a truthiness check) with ` 0>` leaking into the body as text — no error today. It compiles to `foo.length ? " 0>…" : ""`.

This adds a compile-time diagnostic in the `<if>` / `<else-if>` / `<else if>` validation (`assertValidCondition` in `core/if.ts`, which also covers the text-only-flatten fast path). When the condition expression is immediately followed by whitespace, then the `>` that closed the tag, then more content on the same line, it throws a code-frame error pointing at the condition:

```
> 1 | <if=foo.length > 0>
    |     ^^^^^^^^^^ A `>` in this unenclosed `<if>` condition closes the tag, so the
    |     condition is only `foo.length` and the rest becomes body text. Wrap a comparison
    |     in parentheses, e.g. `<if=(foo.length > …)>` — or remove the space before `>`.
```

Why it's high-precision:

- `<` never closes a tag, so only `>` (and `>=`/`>>`) is ambiguous.
- A legit inline `<if=cond>text</if>` is written tight (`cond>`); the footgun has whitespace before the `>` (JS operator spacing). An enclosed value ends with `)`/`]` before the `>`, so it's never flagged. Requiring same-line content after the `>` means a normal multi-line body containing `>` is not flagged.

Known limits (documented in the code comment):

- The spaceless `<if=foo.length>0>` is intentionally **not** flagged — it's indistinguishable from legit inline `<if=cond>text</if>`. Agents essentially always write spaces around `>`.
- A deliberate `<if=cond >text</if>` (space before an intended close, with same-line body) is flagged; the message's second clause tells you how to resolve it either way.

Also adds a row to the cheat sheet's DON'T table so coding agents avoid it in the first place.

Verified: the conditional / branch / show fixture families pass (463 tests), and a new `error-if-condition-closed-by-operator` fixture snapshots the diagnostic.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxuphmsnds4oRGs9CBjM2V)_