### PR TITLE
Record two deferred resume bugs and a comment-style convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,8 @@ npm run change                                           # add a changeset (requ
 
 Organize files top-down (progressive disclosure): public API/exports first, then orchestration, helpers, and low-level detail last — use function-declaration hoisting.
 
+Comments are a last resort and never exceed two lines: prefer self-describing code, and when one is needed it captures intent — never what the code was or what was removed.
+
 Marko language reference: <https://markojs.com/llms.txt> lists every docs page; append `.md` to any docs URL for markdown.
 
 ## Agent feedback

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -259,3 +259,15 @@ an async/lazy Tags region (`tags(async) → class → tags(effect)`) then resume
 effect with no closest-branch association, attaching it to the wrong branch or
 none → hydration mismatch. Fix: thread the enclosing chunk's context into the
 bridged head chunk.
+
+## `_dynamic_tag` compares only the renderer id, conflating instances of the same content
+
+`packages/runtime-tags/src/dom/control-flow.ts:535` | 2026-07-14 | impact:high | effort:med
+
+The dynamic-tag change checks compare `renderer?.[RendererProp.Id] || renderer` (`:535` for `_dynamic_tag`, `:647` for `_dynamic_tag_content`, plus the DOM `_attr_content`). `RendererProp.Id` is the template/section resume id, identical for every _instance_ of one content section — instances differ only by their `RendererProp.Owner` scope. So switching a dynamic tag between two instances of the same content — two `<attrs.content>` from two instances of one provider tag, or the list-detail `<${selected.content}/>` — is a silent no-op: no teardown or re-render, and closures stay subscribed to the old owner's scope. A control with two _distinct_ tag files behaves correctly, pinning the defect to the id-only comparison. Fix: compare `(id, owner)` — content renderer objects are recreated per render so identity alone over-fires, while the owner scope is stable per instance; the resume handshake must serialize a scope-registered renderer as its registered reference so the first post-resume update stays instance-aware.
+
+## An empty-bodied `<html-comment>` resumes as a text node instead of the comment
+
+`packages/runtime-tags/src/dom/resume.ts:402` | 2026-07-14 | impact:med | effort:med
+
+For an `<html-comment>${c}</html-comment>` whose body serializes empty, SSR writes `<!---->` immediately before the resume marker. The node-claim heuristic — `prev && (prev.nodeType < 8 /* COMMENT_NODE */ || (prev as Comment).data) ? prev : insertBefore(new Text())` — exists so an empty `<!>` separator is _not_ claimed (a fresh Text node is created instead), but it cannot distinguish an intentional empty comment: `prev` is a comment (`nodeType === 8`, so `< 8` is false) with empty `data` (falsy), so it builds a Text node as the binding rather than claiming the comment. After hydration, setting `c = "secret"` renders `secret` as visible text where a pure client render produces `<!--secret-->` — an SSR-resume vs CSR divergence. Fix: give the html-comment marker a dedicated resume symbol (e.g. `ResumeSymbol.NodeComment`) that claims the immediately-preceding sibling unconditionally, since the tag always writes its comment right before the marker.


### PR DESCRIPTION
## Description

Documentation only — no runtime or translator changes.

- **`agent-feedback/bugs.md`** — records two suspected resume/hydration bugs whose fixes are being deferred:
  - `_dynamic_tag` compares only the renderer id (`RendererProp.Id`), so switching a dynamic tag between two instances of the same content section (two `<attrs.content>` from two provider instances, or `<${selected.content}/>`) is a silent no-op — no teardown, and closures stay subscribed to the old owner scope.
  - An empty-bodied `<html-comment>` resumes as a text node instead of claiming the `<!---->`, so setting the bound value renders it as visible text after hydration (SSR-resume vs CSR divergence).
- **`AGENTS.md`** — adds a brief comment-style convention: two-line max, prefer self-describing code, capture intent rather than history.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_019LVk6XNQmXKQ7VAvakvnor)_