### PR TITLE
fix: keep CSS sourcemaps for `<style>` blocks when the entry output map is skipped

### DIFF
--- a/.changeset/style-virtual-dep-sourcemaps.md
+++ b/.changeset/style-virtual-dep-sourcemaps.md
@@ -1,0 +1,6 @@
+---
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+---
+
+Keep sourcemaps for extracted `<style>` blocks even when the main output map is skipped. The compiler no longer emits a sourcemap for entry outputs (`hydrate`, or a `page`/`load` entry) since the generated wrapper maps back to nothing useful, and the `<style>` extractor now derives its virtual dependency's sourcemap from the configured `sourceMaps` option instead of the (now conditionally disabled) Babel output setting. Together this lets a bundler integration enable `sourceMaps` for entry compiles to preserve CSS sourcemaps without also emitting a meaningless map for the entry wrapper.

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -131,7 +131,9 @@ function getBaseBabelConfig(filename, { babelConfig, ...markoConfig }) {
     ...babelConfig,
     filename,
     sourceType: "module",
-    sourceMaps: markoConfig.sourceMaps,
+    // An entry wrapper's own map is meaningless; the translator still keeps
+    // extracted `<style>` maps off `markoConfig.sourceMaps` regardless.
+    sourceMaps: isEntryOutput(markoConfig) ? false : markoConfig.sourceMaps,
     code: markoConfig.code,
     ast: markoConfig.ast,
     plugins:
@@ -185,4 +187,8 @@ function getFs(config) {
 
 function isTranslatedOutput(output) {
   return output !== "source" && output !== "migrate";
+}
+
+function isEntryOutput({ output, entry }) {
+  return output === "hydrate" || entry != null;
 }

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -359,12 +359,12 @@ function getStyleImportPath(
   node: t.MarkoTag,
   names: string[] | undefined,
 ): string | null | undefined {
-  const { resolveVirtualDependency } = file.markoOpts;
+  const { resolveVirtualDependency, sourceMaps } = file.markoOpts;
   if (!resolveVirtualDependency) {
     return undefined;
   }
 
-  const { filename, sourceMaps } = file.opts;
+  const { filename } = file.opts;
   let ext = STYLE_EXT_REG.exec(node.rawValue || "")?.[1] || ".css";
 
   if (node.var && !/\.module\./.test(ext)) {


### PR DESCRIPTION
## Description

Entry outputs (`hydrate`, or a `page`/`load` entry) are generated wrappers whose sourcemap points back to nothing useful, so `@marko/compiler` no longer emits one for them. So a bundler can still enable `sourceMaps` on entry compiles to keep the maps of extracted `<style>` blocks, the style extractor now reads `sourceMaps` from `markoOpts` instead of the Babel output setting the compiler disables for entries.

This is the compiler/runtime-tags half of the fix for the spurious `Sourcemap for "<template>.marko-virtual.scss" points to missing source files` dev warning; it pairs with the `@marko/vite` change that stops forcing `sourceMaps: false` on entry configs.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01AF5JjTrZTp37F1DVUUvUoJ)_