### PR TITLE
fix: `<script>` top-level return no longer short-circuits sibling effects

### DIFF
--- a/.changeset/script-top-level-return.md
+++ b/.changeset/script-top-level-return.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix a top-level `return` in a `<script>` tag short-circuiting the effects of following sibling `<script>`/`<lifecycle>` tags in the same section (they compile into a single shared effect). A script whose body has a top-level `return` is now kept as an isolated call so the `return` stays local.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -76,12 +76,6 @@ inline runtime robust; weigh against inline-runtime byte cost.
 
 The analyze pass validates that any _present_ specifiers are default specifiers (lines 91–97) but never requires one to exist, so a `load` import carrying zero specifiers passes analysis. Translate then does `node.specifiers.find(t.isImportDefaultSpecifier)!` (line 108); `.find` returns `undefined`, the `!`/destructure throws an opaque "Cannot destructure property 'local' of undefined" instead of a `buildCodeFrameError`. Fix: in the analyze block, after the specifier loop, throw a code-frame error when `!node.specifiers.some(t.isImportDefaultSpecifier)`.
 
-## A top-level `return` in one `<script>` short-circuits sibling `<script>`/`<lifecycle>` effects
-
-`packages/runtime-tags/src/translator/core/script.ts:128` | 2026-07-14 | impact:low | effort:low
-
-The DOM path of `script.ts` `translate.exit` inlines a non-async, block-bodied `<script>` as bare statements (`inlineBody = hasDeclaration ? value.body : value.body.body`, line 128), then `addStatement("effect", section, referencedBindings, inlineBody)` (line 133). `addStatement`/`getSignal` key effect statements by the referenced-binding set identity, so multiple `<script>`/`<lifecycle>` tags in one section that reference nothing, or the same single binding, accumulate into ONE `signal.effect` array, emitted as a single `_script(id, (scope) => { ...all statements... })` arrow. A top-level `return` in an earlier inlined script therefore returns out of the whole shared arrow, silently skipping every following sibling's statements. Verified by compiling `<let/x=0/><script>if(!x) return; a(x)</script><script>b(x)</script>` for DOM: both bodies merge into one arrow where `b(x)` is skipped when `!x`, though the second script has no guard. This is a client-only quirk, not an SSR/CSR divergence (script effects are client-only; resume runs the same merged arrow). Fix: wrap each inlined block body in its own IIFE/arrow, or keep the block as a nested statement so `return` stays local.
-
 ## SSR controlled-form value normalization diverges from DOM for `0n`/`NaN`/`false`, causing a hydration mismatch
 
 `packages/runtime-tags/src/html/attrs.ts:516` | 2026-07-14 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+const $template = "";
+const $walks = "";
+const $x__script = _script("__tests__/template.marko_0_x", ($scope) => {
+	(() => {
+		if ($scope.x) return;
+		console.log("first: " + $scope.x);
+	})();
+	console.log("second: " + $scope.x);
+});
+const $x = /*@__PURE__*/ _let("x/0", $x__script);
+function $setup($scope) {
+	$x($scope, true);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", "", "", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// template.marko
+const $x = /*@__PURE__*/ _let(0, _script("a0", ($scope) => {
+	(() => {
+		if ($scope.a) return;
+		console.log("first: " + $scope.a);
+	})();
+	console.log("second: " + $scope.a);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,9 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = true;
+	_script($scope0_id, "__tests__/template.marko_0_x");
+	writeScope($scope0_id, { x }, "__tests__/template.marko", 0, { x: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/html.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = true;
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { a: x });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/render.debug.md
@@ -1,0 +1,5 @@
+# Render
+## Console
+```
+LOG "second: true"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/render.md
@@ -1,0 +1,5 @@
+# Render
+## Console
+```
+LOG "second: true"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/writes.debug.html
@@ -1,0 +1,9 @@
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      x: !0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/template.marko_0_x 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/__snapshots__/writes.html
@@ -1,0 +1,7 @@
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    a: !0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 1673,
+      "brotli": 885
+    }
+  },
+  "html": {
+    "min": 309,
+    "brotli": 226
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-top-level-return/template.marko
@@ -1,0 +1,3 @@
+<let/x = true/>
+<script>if (x) return; console.log("first: " + x)</script>
+<script>console.log("second: " + x)</script>

--- a/packages/runtime-tags/src/translator/core/script.ts
+++ b/packages/runtime-tags/src/translator/core/script.ts
@@ -116,15 +116,19 @@ export default {
           if (value.async || value.generator) {
             referencesScope = traverseContains(value, isScopeIdentifier);
           } else if (t.isBlockStatement(value.body)) {
-            let hasDeclaration = false;
-            for (const child of value.body.body) {
-              if (t.isDeclaration(child)) {
-                hasDeclaration = true;
-                break;
+            // A top-level `return` must stay local (IIFE fallback below), so only
+            // inline the body's statements when there is none.
+            if (!traverseContains(value.body, isReturnStatement)) {
+              let hasDeclaration = false;
+              for (const child of value.body.body) {
+                if (t.isDeclaration(child)) {
+                  hasDeclaration = true;
+                  break;
+                }
               }
-            }
 
-            inlineBody = hasDeclaration ? value.body : value.body.body;
+              inlineBody = hasDeclaration ? value.body : value.body.body;
+            }
           } else {
             inlineBody = t.expressionStatement(value.body);
           }
@@ -170,6 +174,22 @@ function isAwaitExpression(node: t.Node) {
     case "ClassPrivateMethod":
       return skip;
     case "AwaitExpression":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isReturnStatement(node: t.Node) {
+  switch (node.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+    case "ClassMethod":
+    case "ObjectMethod":
+    case "ClassPrivateMethod":
+      return skip;
+    case "ReturnStatement":
       return true;
     default:
       return false;


### PR DESCRIPTION
## Description

A top-level `return` in a `<script>` tag silently skipped the effects of the following sibling `<script>`/`<lifecycle>` tags in the same section.

Scripts (and lifecycles) that reference the same bindings compile into **one shared `_script` effect arrow**, with each script's body inlined. So a top-level `return` in an earlier script returned out of the *whole* arrow, short-circuiting every following sibling's effect:

```js
// before — one shared arrow; the return skips console.log("second")
_script(id, (scope) => {
  if (scope.x) return;
  console.log("first");
  console.log("second");
});
```

The fix detects a top-level `return` (ignoring returns nested inside inner functions) and keeps that script as an isolated IIFE call so its `return` stays local. Return-free scripts still inline unchanged, so there's no byte cost for the common case:

```js
// after — the first script's return is isolated
_script(id, (scope) => {
  (() => { if (scope.x) return; console.log("first"); })();
  console.log("second");
});
```

Verified end-to-end with the new `script-top-level-return` fixture, which logs `"second"` only because the second script still runs (it fails when the fix is reverted).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_