### PR TITLE
fix(runtime-tags): diagnose a load import with no default specifier

### DIFF
--- a/.changeset/load-import-missing-specifier.md
+++ b/.changeset/load-import-missing-specifier.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Replace the opaque `Cannot destructure property 'local' of undefined` crash with a clear compile-time diagnostic when a `load` import has no default specifier (e.g. `import "./foo.marko" with { load: "render" }` with nothing bound).

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -70,12 +70,6 @@ inline runtime robust; weigh against inline-runtime byte cost.
 
 `getAllKnownPropNames` collects `propTree.props` keys plus `propTree.rest?.props` keys, stopping after one `rest` level, while its siblings `getKnownFromPropTree` and `hasAllKnownProps` (same file) recurse the full `rest` chain. A prop at `rest.rest.props` is thus resolved as "known" by `getKnownFromPropTree` yet absent from the name set `known-tag.ts` builds as `remaining` (`new Set(getAllKnownPropNames(propTree))`, ~lines 494/1025), which tracks known props still to emit — a missing name means that prop is never wired from the spread. Currently unreachable: no fixture builds a 2-level rest chain (instrumenting the whole suite found none), so the fix is byte-identical on every fixture. Fix: `if (propTree.rest) keys.push(...getAllKnownPropNames(propTree.rest));`.
 
-## `load` import with no default specifier crashes translate instead of a diagnostic
-
-`packages/runtime-tags/src/translator/visitors/import-declaration.ts:108` | 2026-07-13 | impact:low | effort:low
-
-The analyze pass validates that any _present_ specifiers are default specifiers (lines 91–97) but never requires one to exist, so a `load` import carrying zero specifiers passes analysis. Translate then does `node.specifiers.find(t.isImportDefaultSpecifier)!` (line 108); `.find` returns `undefined`, the `!`/destructure throws an opaque "Cannot destructure property 'local' of undefined" instead of a `buildCodeFrameError`. Fix: in the analyze block, after the specifier loop, throw a code-frame error when `!node.specifiers.some(t.isImportDefaultSpecifier)`.
-
 ## SSR controlled-form value normalization diverges from DOM for `0n`/`NaN`/`false`, causing a hydration mismatch
 
 `packages/runtime-tags/src/html/attrs.ts:516` | 2026-07-14 | impact:low | effort:low
@@ -179,9 +173,3 @@ bridged head chunk.
 `packages/runtime-tags/src/dom/control-flow.ts:535` | 2026-07-14 | impact:high | effort:med
 
 The dynamic-tag change checks compare `renderer?.[RendererProp.Id] || renderer` (`:535` for `_dynamic_tag`, `:647` for `_dynamic_tag_content`, plus the DOM `_attr_content`). `RendererProp.Id` is the template/section resume id, identical for every _instance_ of one content section — instances differ only by their `RendererProp.Owner` scope. So switching a dynamic tag between two instances of the same content — two `<attrs.content>` from two instances of one provider tag, or the list-detail `<${selected.content}/>` — is a silent no-op: no teardown or re-render, and closures stay subscribed to the old owner's scope. A control with two _distinct_ tag files behaves correctly, pinning the defect to the id-only comparison. Fix: compare `(id, owner)` — content renderer objects are recreated per render so identity alone over-fires, while the owner scope is stable per instance; the resume handshake must serialize a scope-registered renderer as its registered reference so the first post-resume update stays instance-aware.
-
-## An empty-bodied `<html-comment>` resumes as a text node instead of the comment
-
-`packages/runtime-tags/src/dom/resume.ts:402` | 2026-07-14 | impact:med | effort:med
-
-For an `<html-comment>${c}</html-comment>` whose body serializes empty, SSR writes `<!---->` immediately before the resume marker. The node-claim heuristic — `prev && (prev.nodeType < 8 /* COMMENT_NODE */ || (prev as Comment).data) ? prev : insertBefore(new Text())` — exists so an empty `<!>` separator is _not_ claimed (a fresh Text node is created instead), but it cannot distinguish an intentional empty comment: `prev` is a comment (`nodeType === 8`, so `< 8` is false) with empty `data` (falsy), so it builds a Text node as the binding rather than claiming the comment. After hydration, setting `c = "secret"` renders `secret` as visible text where a pure client render produces `<!--secret-->` — an SSR-resume vs CSR divergence. Fix: give the html-comment marker a dedicated resume symbol (e.g. `ResumeSymbol.NodeComment`) that claims the immediately-preceding sibling unconditionally, since the tag always writes its comment right before the marker.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko:1:1
+    > 1 | import "./child.marko" with { load: "render" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko:1:1
+    > 1 | import "./child.marko" with { load: "render" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko:1:1
+    > 1 | import "./child.marko" with { load: "render" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko:1:1
+    > 1 | import "./child.marko" with { load: "render" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/child.marko
@@ -1,0 +1,1 @@
+<div>child</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/template.marko
@@ -1,0 +1,1 @@
+import "./child.marko" with { load: "render" }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-load-import-missing-specifier/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -96,6 +96,12 @@ export default {
           );
         }
       }
+
+      if (!node.specifiers.some(t.isImportDefaultSpecifier)) {
+        throw importDecl.buildCodeFrameError(
+          "Invalid load import, a default specifier is required.",
+        );
+      }
     }
   },
   translate: {


### PR DESCRIPTION
## Description

A `load` import validated that any _present_ specifiers were default specifiers, but never required one to exist. So `import "./child.marko" with { load: "render" }` with nothing bound passed analysis and then crashed `translate` on `node.specifiers.find(t.isImportDefaultSpecifier)!` — surfacing as an opaque `Cannot destructure property 'local' of undefined` TypeError rather than a diagnostic.

`analyze` now requires a default specifier, so the mistake produces a code-frame error:

```
> 1 | import "./child.marko" with { load: "render" }
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
```

Added the `error-load-import-missing-specifier` fixture to cover it.

Also removes two resolved entries from `agent-feedback/bugs.md`: this bug, and the empty-`<html-comment>` resume bug fixed in #3445 (whose entry was never removed when that PR merged).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_