### PR TITLE
fix(runtime-tags): detect exclusive controllable attrs by presence

### DIFF
--- a/.changeset/exclusive-attrs-falsy-presence.md
+++ b/.changeset/exclusive-attrs-falsy-presence.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix the development-only `checkedValue`/`checked` mutual-exclusivity assertion missing the conflict when a spread supplies a falsy controllable value (e.g. `checkedValue={0}` or `checked={false}`). Presence is now tested with `in` instead of truthiness, matching how the runtime detects these attributes elsewhere.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -88,12 +88,6 @@ inline runtime robust; weigh against inline-runtime byte cost.
 
 In `_attr_select_value`'s `MutationObserver` (fired when `<option>`s are added/removed), the decision to run `onChange` is `value.length !== el.selectedOptions.length || value.some((v, i) => v != el.selectedOptions[i].value)` (lines 352–353). `value` is `scope[ControlledValue]` in app-supplied order, while `el.selectedOptions` is always document order and selection is applied set-wise (`opt.selected = value.includes(opt.value)` in `setSelectValue`). So a set-equal but reordered controlled array (e.g. `value=["b","a"]` with options rendered `a,b`, both selected) flags a false mismatch on any option add/remove and fires `valueChange(getSelectValue(...))`, silently reordering the app model to document order with no user interaction. Native multi-select never preserves order (any real user change already document-orders the model), so impact is low — the only novel effect is a spurious change side-effect on unrelated option mutations, which stabilizes after one fire. Fix: compare as sets (length plus `every(v => selectedValues.has(v))`).
 
-## `assertExclusiveAttrs` uses truthiness, missing conflicts when a controllable value attribute is falsy
-
-`packages/runtime-tags/src/common/errors.ts:127` | 2026-07-14 | impact:low | effort:low
-
-`assertExclusiveAttrs` detects the presence of the `checkedValue` and `checked` value-attributes by truthiness (`if (attrs.checkedValue)` line 127, `if (attrs.checked)` lines 130/135). Mutual exclusivity is a property of an attribute being present, not of its value, so a legitimate falsy value — a radio `checkedValue={0}` / `checkedValue=""`, or a controlled `checked={false}` — makes the branch skip, the conflicting `checked` is never pushed, and the "…are mutually exclusive" error is silently not thrown. The runtime treats these as presence elsewhere (`"checkedValue" in nextAttrs`, `dom/dom.ts:209`), confirming presence is the intended test. Only these two are affected: the sibling `checkedChange`/`checkedValueChange`/`valueChange` are handlers where a falsy value legitimately means absent (consistent with `assertHandlerIsFunction`), so those correctly stay truthiness checks. `MARKO_DEBUG`-only, so a missed dev/test assertion rather than a production fault. Fix: `"checkedValue" in attrs` and `"checked" in attrs`.
-
 ## `createProgramState` cache guard uses truthiness, would recompute a falsy stored value
 
 `packages/runtime-tags/src/translator/util/state.ts:11` | 2026-07-14 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The attributes checkedValue and checked are mutually exclusive.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+const $template = "<input>";
+const $walks = " b";
+const $setup = () => {};
+const $input_attrs__script = _script("__tests__/template.marko_0_input_attrs", ($scope) => _attrs_script($scope, "#input/0"));
+const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
+	_attrs($scope, "#input/0", $scope.input_attrs);
+	$input_attrs__script($scope);
+});
+const $input = ($scope, input) => $input_attrs($scope, input.attrs);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attrs(input.attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_input_attrs");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+The attributes checkedValue and checked are mutually exclusive.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/template.marko
@@ -1,0 +1,1 @@
+<input ...input.attrs>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  skip_optimize: true,
+  error_html: true,
+  error_dom: true,
+  steps: [{ attrs: { checkedValue: 0, checked: false } }],
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -124,15 +124,15 @@ export function assertExclusiveAttrs(
       (exclusiveAttrs ||= []).push("checkedChange");
     }
 
-    if (attrs.checkedValue) {
+    if ("checkedValue" in attrs) {
       (exclusiveAttrs ||= []).push("checkedValue");
 
-      if (attrs.checked) {
+      if ("checked" in attrs) {
         exclusiveAttrs.push("checked");
       }
     } else if (attrs.checkedValueChange) {
       (exclusiveAttrs ||= []).push("checkedValueChange");
-      if (attrs.checked) {
+      if ("checked" in attrs) {
         exclusiveAttrs.push("checked");
       }
     }


### PR DESCRIPTION
## Description

`assertExclusiveAttrs` (the `MARKO_DEBUG` check that `checkedValue` and `checked` aren't both set on one input) detected those two value-attributes by **truthiness**. Mutual exclusivity is about an attribute being *present*, not its value, so a spread supplying a falsy controllable value skipped the branch and never threw:

```marko
<input ...{ checkedValue: 0, checked: false }>
```

Both attributes are present and conflict, yet no error fired. (Statically-written attributes were unaffected — the compile-time caller passes attribute nodes, which are always truthy.)

Presence is now tested with `in`, matching how the runtime already detects these attributes elsewhere (`"checkedValue" in nextAttrs`). The sibling **handler** attributes (`checkedChange`/`checkedValueChange`/`valueChange`) stay truthiness checks, since a falsy handler legitimately means absent.

Added the `error-exclusive-checked-value-spread` fixture (debug-only, since the assertion is stripped in production builds).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_