### PR TITLE
fix(runtime-tags): round-trip duplicate headers in the serializer

### DIFF
--- a/.changeset/serialize-duplicate-headers.md
+++ b/.changeset/serialize-duplicate-headers.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix duplicate header fields (notably multiple `Set-Cookie`) being lost when a `Headers`, `Request`, or `Response` is serialized for resumption. Headers were emitted as an object literal, collapsing repeated names to the last value; a repeated name now serializes as the tuple `Headers` form (`new Headers([[name, value], ...])`) so non-combinable fields round-trip.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -156,12 +156,6 @@ The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the in
 
 `writeFormData` appends only entries whose value is a string and silently skips every `File`/`Blob`, even though those are standard `FormData` values. Verified with fields `text="ok"` and `file=new File(["body"], "x.txt")`: the payload reconstructed a `FormData` containing only `text`, with no abort or warning. This is worse than the serializer's normal unsupported-value behavior because hydration proceeds with incomplete state; serialize blob contents/name/type asynchronously, or reject the containing value explicitly until that is supported.
 
-## Preserve duplicate header fields during serialization
-
-`packages/runtime-tags/src/html/serializer.ts:1280` | 2026-07-15 | impact:med | effort:low
-
-`writeHeaders`, `writeRequest`, and `writeResponse` all feed header entries through `stringEntriesToProps`, creating an object literal. Repeated names become duplicate object keys, so all but the last value are discarded; two `set-cookie` fields serialize as `new Headers({"set-cookie":"a=1","set-cookie":"b=2"})` and resume as only `b=2`. Use the iterable/tuple form (`new Headers([[name, value], ...])`) whenever names repeat, or for all headers, so non-combinable fields such as `Set-Cookie` round-trip.
-
 ## Support bigint typed-array instances in the serializer
 
 `packages/runtime-tags/src/html/serializer.ts:886` | 2026-07-15 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -858,6 +858,14 @@ describe("serializer", () => {
         `[_.a=new Headers({a:"1",b:"2"}),_.a]`,
       );
     });
+    it("repeated set-cookie", () =>
+      assertStringify(
+        new Headers([
+          ["set-cookie", "a=1"],
+          ["set-cookie", "b=2"],
+        ]),
+        `new Headers([["set-cookie","a=1"],["set-cookie","b=2"]])`,
+      ));
   });
 
   describe("FormData", () => {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1278,8 +1278,8 @@ function writeURLSearchParams(state: State, val: URLSearchParams) {
 }
 
 function writeHeaders(state: State, val: Headers) {
-  const headers = stringEntriesToProps(val as any);
-  state.buf.push("new Headers" + (headers ? "({" + headers + "})" : ""));
+  const headers = stringEntriesToHeadersInit(val as any);
+  state.buf.push("new Headers" + (headers ? "(" + headers + ")" : ""));
   return true;
 }
 
@@ -1333,10 +1333,10 @@ function writeRequest(state: State, val: Request, ref: Reference) {
     sep = ",";
   }
 
-  const headers = stringEntriesToProps(val.headers as any);
+  const headers = stringEntriesToHeadersInit(val.headers as any);
   state.refs.set(val.headers, new Reference(ref, "headers", state.flush, null));
   if (headers) {
-    options += sep + "headers:{" + headers + "}";
+    options += sep + "headers:" + headers;
     sep = ",";
   }
 
@@ -1395,10 +1395,10 @@ function writeResponse(state: State, val: Response, ref: Reference) {
     sep = ",";
   }
 
-  const headers = stringEntriesToProps(val.headers as any);
+  const headers = stringEntriesToHeadersInit(val.headers as any);
   state.refs.set(val.headers, new Reference(ref, "headers", state.flush, null));
   if (headers) {
-    options += sep + "headers:{" + headers + "}";
+    options += sep + "headers:" + headers;
   }
 
   if (!val.body || val.bodyUsed) {
@@ -1990,15 +1990,31 @@ function hasSymbolIterator(
   return Symbol.iterator in (value as any);
 }
 
-function stringEntriesToProps(entries: Iterable<[string, string]>) {
+function stringEntriesToHeadersInit(entries: Iterable<[string, string]>) {
+  const list = [...entries];
+  if (!list.length) return "";
+  // A Headers iterator keeps `Set-Cookie` split; an object literal would drop
+  // all but the last, so a repeated name uses the tuple form to round-trip.
+  let duplicate = false;
+  const seen = new Set<string>();
+  for (const [key] of list) {
+    if (seen.has(key)) {
+      duplicate = true;
+      break;
+    }
+    seen.add(key);
+  }
+
   let result = "";
   let sep = "";
-  for (const [key, value] of entries) {
-    result += sep + toObjectKey(key) + ":" + quote(value, 0);
+  for (const [key, value] of list) {
+    result += duplicate
+      ? sep + "[" + quote(key, 0) + "," + quote(value, 0) + "]"
+      : sep + toObjectKey(key) + ":" + quote(value, 0);
     sep = ",";
   }
 
-  return result;
+  return duplicate ? "[" + result + "]" : "{" + result + "}";
 }
 
 function typedArrayToInitString(view: TypedArray) {


### PR DESCRIPTION
## Description

`Headers`/`Request`/`Response` header entries were serialized to an **object literal**, so repeated names collapsed to duplicate object keys — all but the last discarded on resume. This matters for `Set-Cookie`, which a `Headers` iterator keeps split (other duplicates pre-combine into one comma-joined value). Two `Set-Cookie` fields serialized as `new Headers({"set-cookie":"a=1","set-cookie":"b=2"})` and resumed as only `b=2`.

When a name repeats, headers now serialize as the tuple form — `new Headers([["set-cookie","a=1"],["set-cookie","b=2"]])` — which round-trips non-combinable fields. The compact object form is kept when every name is unique (no snapshot churn for existing headers, and smaller output).

Added a `repeated set-cookie` round-trip test to the serializer suite (fails without the fix — it serializes the collapsing object form).

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_