### PR TITLE
fix(runtime-tags): serialize bigint typed arrays for resumption

### DIFF
--- a/.changeset/serialize-bigint-typed-arrays.md
+++ b/.changeset/serialize-bigint-typed-arrays.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Support serializing `BigInt64Array` and `BigUint64Array` for resumption. These views previously aborted with `Unable to serialize` because instance dispatch and the internal `TypedArray` type only covered number-backed arrays. They now round-trip, emitting bigint element literals with the `n` suffix and using the compact length form for zero-filled views.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -156,12 +156,6 @@ The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the in
 
 `writeFormData` appends only entries whose value is a string and silently skips every `File`/`Blob`, even though those are standard `FormData` values. Verified with fields `text="ok"` and `file=new File(["body"], "x.txt")`: the payload reconstructed a `FormData` containing only `text`, with no abort or warning. This is worse than the serializer's normal unsupported-value behavior because hydration proceeds with incomplete state; serialize blob contents/name/type asynchronously, or reject the containing value explicitly until that is supported.
 
-## Support bigint typed-array instances in the serializer
-
-`packages/runtime-tags/src/html/serializer.ts:886` | 2026-07-15 | impact:low | effort:low
-
-The known-value registry includes `BigInt64Array` and `BigUint64Array` constructors, but instance dispatch and the `TypedArray` union include only number-backed arrays; the two corresponding tests remain commented out at `src/__tests__/serializer.test.ts:812`. A direct `new BigInt64Array([1n, 2n])` probe aborts with `Unable to serialize (reading value)`. Add both constructors to dispatch and emit bigint element literals with the `n` suffix; the zero fast path must compare against `0n` for these views.
-
 ## Make conflicting load triggers for one shared asset deterministic
 
 `packages/runtime-tags/src/html/assets.ts:135` | 2026-07-15 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -809,10 +809,18 @@ describe("serializer", () => {
       assert.equal(result.head.buffer, result.tail.buffer);
     });
 
-    // it("BigInt64Array", () =>
-    //   assertStringify(new BigInt64Array([1n, 2n, 3n]), `new BigInt64Array([1n,2n,3n])`));
-    // it("BigUint64Array", () =>
-    //   assertStringify(new BigUint64Array([1n, 2n, 3n]), `new BigUint64Array([1n,2n,3n])`));
+    it("BigInt64Array", () =>
+      assertStringify(
+        new BigInt64Array([1n, 2n, 3n]),
+        `new BigInt64Array([1n,2n,3n])`,
+      ));
+    it("BigUint64Array", () =>
+      assertStringify(
+        new BigUint64Array([1n, 2n, 3n]),
+        `new BigUint64Array([1n,2n,3n])`,
+      ));
+    it("BigInt64Array zero-filled", () =>
+      assertStringify(new BigInt64Array(3), `new BigInt64Array(3)`));
   });
 
   describe("URL", () => {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -43,7 +43,9 @@ type TypedArray =
   | Int32Array
   | Uint32Array
   | Float32Array
-  | Float64Array;
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;
 
 const REGISTRY = new WeakMap<WeakKey, Registered>();
 const KNOWN_SYMBOLS = (() => {
@@ -892,6 +894,8 @@ function writeUnknownObject(state: State, val: object, ref: Reference) {
     case Uint32Array:
     case Float32Array:
     case Float64Array:
+    case BigInt64Array:
+    case BigUint64Array:
       return writeTypedArray(state, val as TypedArray, ref);
     case WeakSet:
       return writeWeakSet(state);
@@ -2018,10 +2022,11 @@ function stringEntriesToHeadersInit(entries: Iterable<[string, string]>) {
 }
 
 function typedArrayToInitString(view: TypedArray) {
+  const suffix = typeof view[0] === "bigint" ? "n" : "";
   let result = "[";
   let sep = "";
   for (let i = 0; i < view.length; i++) {
-    result += sep + view[i];
+    result += sep + view[i] + suffix;
     sep = ",";
   }
 
@@ -2030,8 +2035,9 @@ function typedArrayToInitString(view: TypedArray) {
 }
 
 function hasOnlyZeros(typedArray: TypedArray) {
+  const zero = typeof typedArray[0] === "bigint" ? 0n : 0;
   for (let i = 0; i < typedArray.length; i++) {
-    if (typedArray[i] !== 0) return false;
+    if (typedArray[i] !== zero) return false;
   }
 
   return true;


### PR DESCRIPTION
## Description

Serializing a `BigInt64Array` or `BigUint64Array` for resumption aborted with `Unable to serialize (reading value)`. The known-value registry already listed both constructors, but instance dispatch and the internal `TypedArray` type only covered the number-backed views, so bigint instances fell through to the unsupported-value path.

This adds both views to the dispatch switch and the `TypedArray` union, and fixes the two element-emitting helpers for bigint semantics:

- `typedArrayToInitString` now appends the `n` suffix per element, so the output (`new BigInt64Array([1n,2n,3n])`) is valid — the number form `[1,2,3]` throws `Cannot convert 1 to a BigInt` on hydration.
- `hasOnlyZeros` compares against `0n` for these views, so an all-zero bigint array still uses the compact length form (`new BigInt64Array(3)`) instead of a full element list.

The previously commented-out `BigInt64Array`/`BigUint64Array` tests are enabled, plus a zero-filled case covering the fast path. No bundle-size impact (the serializer runs server-side only).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_