### PR TITLE
fix(runtime-tags): fail loud on unserializable FormData File/Blob entries

### DIFF
--- a/.changeset/serialize-formdata-file-blob.md
+++ b/.changeset/serialize-formdata-file-blob.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Stop silently dropping `File`/`Blob` entries when serializing a `FormData` for resumption. Previously only string entries were kept, so a resumed form reconstructed a `FormData` missing its file entries with no error. Since these values are not yet serializable, they now fail like any other unsupported value (a clear error in development, and the whole value is skipped in production) instead of shipping incomplete state.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -150,12 +150,6 @@ The dynamic-tag change checks compare `renderer?.[RendererProp.Id] || renderer` 
 
 The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the inline TODO calls this out), and the DOM branch creates the element but never sends its getter through the branch's `AccessorProp.TagVariable` callback (`dom/control-flow.ts:547`). Verified by adding `<${input.show && "div"}/el/><script>el().textContent = "set"</script>` to the `dynamic-tag-var` fixture: both CSR and SSR-resume left the `<div>` empty because `el` was never initialized, so its dependent effect never ran. Static native tags instead create a registered `_el(...)` getter; the dynamic-native path needs the equivalent getter tied to the created/resumed branch element in both runtimes.
 
-## Preserve `File` and `Blob` entries when serializing `FormData`
-
-`packages/runtime-tags/src/html/serializer.ts:1286` | 2026-07-15 | impact:med | effort:med
-
-`writeFormData` appends only entries whose value is a string and silently skips every `File`/`Blob`, even though those are standard `FormData` values. Verified with fields `text="ok"` and `file=new File(["body"], "x.txt")`: the payload reconstructed a `FormData` containing only `text`, with no abort or warning. This is worse than the serializer's normal unsupported-value behavior because hydration proceeds with incomplete state; serialize blob contents/name/type asynchronously, or reject the containing value explicitly until that is supported.
-
 ## Make conflicting load triggers for one shared asset deterministic
 
 `packages/runtime-tags/src/html/assets.ts:135` | 2026-07-15 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -907,6 +907,22 @@ describe("serializer", () => {
         `[_.a=["a","1","b","2"].reduce((f,v,i,a)=>i%2&&f.append(a[i-1],v)||f,new FormData),_.a]`,
       );
     });
+    it("aborts on File/Blob values instead of dropping them", () => {
+      const formData = new FormData();
+      formData.append("text", "ok");
+      formData.append("file", new File(["body"], "x.txt"));
+      const serializer = new Serializer();
+      let aborted: unknown;
+      const boundary = {
+        signal: { aborted: false },
+        abort(err: unknown) {
+          aborted = err;
+        },
+      } as any as Boundary;
+      serializer.stringifyScopes([[1, {}, { value: formData }]], boundary);
+      assert.ok(aborted instanceof TypeError);
+      assert.match((aborted as Error).message, /Unable to serialize/);
+    });
   });
 
   describe("generator", () => {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -910,7 +910,7 @@ function writeUnknownObject(state: State, val: object, ref: Reference) {
     case globalThis.Headers:
       return writeHeaders(state, val as Headers);
     case globalThis.FormData:
-      return writeFormData(state, val as FormData);
+      return writeFormData(state, val as FormData, ref);
     case globalThis.ReadableStream:
       return writeReadableStream(state, val as ReadableStream<unknown>, ref);
     case globalThis.Request:
@@ -1287,15 +1287,19 @@ function writeHeaders(state: State, val: Headers) {
   return true;
 }
 
-function writeFormData(state: State, val: FormData) {
+function writeFormData(state: State, val: FormData, ref: Reference) {
   let sep = "[";
   let valStr: string = "";
-  for (const [key, value] of val as unknown as Iterable<[string, string]>) {
-    // TODO: support file/blob
-    if (typeof value === "string") {
-      valStr += sep + quote(key, 0) + "," + quote(value, 0);
-      sep = ",";
+  for (const [key, value] of val as unknown as Iterable<[string, unknown]>) {
+    if (typeof value !== "string") {
+      // `File`/`Blob` entries aren't serializable yet; fail like any other
+      // unsupported value rather than silently dropping the entry.
+      MARKO_DEBUG && throwUnserializable(state, value, ref, key);
+      return false;
     }
+
+    valStr += sep + quote(key, 0) + "," + quote(value, 0);
+    sep = ",";
   }
 
   if (sep === "[") {


### PR DESCRIPTION
## Description

Serializing a `FormData` that contains a `File` or `Blob` for resumption silently dropped those entries. `writeFormData` appended only string-valued entries, so a resumed form reconstructed a `FormData` missing its file entries with no abort or warning — hydration proceeded with incomplete state (e.g. a form with a file upload resumes as if no file was attached).

This routes non-string `FormData` values through the serializer's standard unsupported-value path instead of skipping them: a clear `Unable to serialize` error in development, and the whole value is skipped in production (`return false`), matching how every other unsupported value already behaves. The entry-author's own note was that the silent partial serialization is *worse* than that normal behavior.

Full `File`/`Blob` serialization (reading contents/name/type asynchronously so they round-trip) would be a larger, separate change; this makes the current gap fail safely rather than corrupt resumption state. No client-size impact — the serializer runs server-side only.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_