### PR TITLE
docs(runtime-tags): record that dynamic native tag var resume needs compiler work

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -146,9 +146,11 @@ The dynamic-tag change checks compare `renderer?.[RendererProp.Id] || renderer` 
 
 ## Initialize tag variables for dynamic native tags
 
-`packages/runtime-tags/src/html/dynamic-tag.ts:146` | 2026-07-15 | impact:med | effort:med
+`packages/runtime-tags/src/html/dynamic-tag.ts:146` | 2026-07-15 | impact:med | effort:high
 
 The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the inline TODO calls this out), and the DOM branch creates the element but never sends its getter through the branch's `AccessorProp.TagVariable` callback (`dom/control-flow.ts:547`). Verified by adding `<${input.show && "div"}/el/><script>el().textContent = "set"</script>` to the `dynamic-tag-var` fixture: both CSR and SSR-resume left the `<div>` empty because `el` was never initialized, so its dependent effect never ran. Static native tags instead create a registered `_el(...)` getter; the dynamic-native path needs the equivalent getter tied to the created/resumed branch element in both runtimes.
+
+CSR is a runtime-only fix: push `() => childScope[AccessorProp.StartNode]` through the child scope's `TagVariable` callback right after the native branch is created in `dom/control-flow.ts`. SSR-resume is the hard part and needs the translator, not just the runtime. The native branch scope carries no state, so `_var`'s `writeScopePassive` `#TagVariable` slot is never serialized (the server fill contains only the parent scope); a dynamic _component_ tag var only resumes because its scope serializes anyway, carrying `{ "#TagVariable": _(1, "…/var") }`. So on resume there is no callback to invoke from the `BranchEndNativeTag` marker handler (`dom/resume.ts:232`). Runtime-only escapes don't exist: `_dynamic_tag` is never told a tag var is present (the compiler emits a separate `_var`), and forcing every tag var to serialize its scope actively regresses payload size for all of them. Delivering the getter across the dynamic boundary requires the compiler to serialize/reconstruct an element reference (a client-side `_el(id, accessor)` for the resumed branch element) — hence effort:high spanning compiler + runtime + serialization.
 
 ## Make conflicting load triggers for one shared asset deterministic
 


### PR DESCRIPTION
## Description

Refines the "Initialize tag variables for dynamic native tags" entry in `agent-feedback/bugs.md` after investigating the fix. The original entry estimated `effort:med` and read as a runtime-only change; it's actually `effort:high` and spans the compiler.

Findings recorded:
- **CSR** is a clean runtime-only fix (push the element getter through the child scope's `TagVariable` callback when the native branch is created in `dom/control-flow.ts`).
- **SSR-resume** cannot be done in the runtime alone. The native branch scope carries no state, so `_var`'s passive `#TagVariable` slot is never serialized (the server fill contains only the parent scope). A dynamic *component* tag var only resumes because its scope serializes anyway and carries the callback; the native branch has nothing to piggyback on, so on resume there's no callback for the `BranchEndNativeTag` marker handler to invoke. `_dynamic_tag` is never told a tag var exists (the compiler emits a separate `_var`), and forcing every tag var to serialize actively regresses payload size — so delivering the getter across the dynamic boundary requires the translator to serialize/reconstruct an element reference.

Docs-only; no code or behavior change. Recording this so a future contributor doesn't repeat the investigation.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt75Udw2kovfrKzLnDpiiT)_