### PR TITLE
refactor(runtime-tags): writer guard types, comments, and signal builder cleanups

### DIFF
--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -128,7 +128,7 @@ export function _attr_content(
   nodeAccessor: Accessor,
   scopeId: number,
   content: unknown,
-  serializeReason?: 1 | 0,
+  serializeReason?: number,
 ) {
   const shouldResume = serializeReason !== 0;
   const render = normalizeServerRender(content);
@@ -294,7 +294,7 @@ export function _serialize_guard(condition: SerializeReasonValue, key: number) {
 export function _el_resume(
   scopeId: number,
   accessor: Accessor,
-  shouldResume?: 0 | 1,
+  shouldResume?: number,
 ) {
   if (shouldResume === 0) return "";
 
@@ -303,7 +303,7 @@ export function _el_resume(
   return state.mark(ResumeSymbol.Node, scopeId + " " + accessor);
 }
 
-export function _sep(shouldResume: 0 | 1) {
+export function _sep(shouldResume: number) {
   return shouldResume === 0 ? "" : "<!>";
 }
 
@@ -345,9 +345,9 @@ export function _for_of(
   by: Falsy | ((item: unknown, index: number) => unknown),
   scopeId: number,
   accessor: Accessor,
-  serializeBranch?: 0 | 1,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeBranch?: number,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1,
 ): void {
@@ -376,9 +376,9 @@ export function _for_in(
   by: Falsy | ((key: string, v: unknown) => unknown),
   scopeId: number,
   accessor: Accessor,
-  serializeBranch?: 0 | 1,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeBranch?: number,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1,
 ): void {
@@ -410,9 +410,9 @@ export function _for_to(
   by: Falsy | ((v: number) => unknown),
   scopeId: number,
   accessor: Accessor,
-  serializeBranch?: 0 | 1,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeBranch?: number,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1,
 ): void {
@@ -445,9 +445,9 @@ export function _for_until(
   by: Falsy | ((v: number) => unknown),
   scopeId: number,
   accessor: Accessor,
-  serializeBranch?: 0 | 1,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeBranch?: number,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1,
 ): void {
@@ -486,9 +486,9 @@ function forBranches(
   ) => void,
   scopeId: number,
   accessor: Accessor,
-  serializeBranch: undefined | 0 | 1,
-  serializeMarker: undefined | 0 | 1,
-  serializeStateful: undefined | 0 | 1,
+  serializeBranch: undefined | number,
+  serializeMarker: undefined | number,
+  serializeStateful: undefined | number,
   parentEndTag: string | undefined | 0,
   singleNode?: 1,
 ) {
@@ -571,9 +571,9 @@ export function _if(
   cb: () => void | number,
   scopeId: number,
   accessor: Accessor,
-  serializeBranch?: 0 | 1,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeBranch?: number,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1,
 ) {
@@ -615,8 +615,8 @@ export function _if(
 function writeBranchEnd(
   scopeId: number,
   accessor: Accessor,
-  serializeStateful: undefined | 0 | 1,
-  serializeMarker: undefined | 0 | 1,
+  serializeStateful: undefined | number,
+  serializeMarker: undefined | number,
   parentEndTag: string | undefined | 0,
   singleNode?: 1,
   branchIds?: string,
@@ -671,8 +671,8 @@ export function _show_end(
   scopeId: number,
   accessor: Accessor,
   display: unknown,
-  serializeMarker?: 0 | 1,
-  serializeStateful?: 0 | 1,
+  serializeMarker?: number,
+  serializeStateful?: number,
   parentEndTag?: string | 0,
   singleNode?: 1 | 0,
 ) {
@@ -763,7 +763,7 @@ export function _await<T>(
   accessor: Accessor,
   promise: Promise<T> | T,
   content: (value: T) => void,
-  serializeMarker?: 0 | 1,
+  serializeMarker?: number,
 ) {
   const resumeMarker = serializeMarker !== 0;
 

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
+
 import {
   _el_read_error,
   _hoist_read_error,
@@ -260,10 +261,7 @@ export function getScopeById(scopeId: number | undefined) {
   }
 }
 
-// A serialize reason is `1` (serialize everything), `0`/`undefined` (nothing),
-// a bitmask of reason group indices offset by one bit (so group 0 alone is
-// `2`, never colliding with the `1` sentinel), or an object keyed by group
-// index when any group's guard is dynamic.
+// A reason is 1, empty, an offset group bitmask, or a keyed dynamic guard.
 export type SerializeReasonValue =
   undefined | number | Partial<Record<string, 0 | 1>>;
 
@@ -472,11 +470,7 @@ export function _for_until(
   );
 }
 
-// Shared driver for the `_for_*` loop variants: writes branch start/end
-// markers, branch scopes (with the loop key when it differs from the
-// positional index), and the branch scope list when markers are disabled.
-// When the branch is not serialized, `iterate` runs the raw loop (still
-// validating keys under MARKO_DEBUG when a `by` is present).
+// Shared branch and scope writer for every `_for_*` loop variant.
 function forBranches(
   by: unknown,
   iterate: (
@@ -591,9 +585,7 @@ export function _if(
 
   if (shouldWriteBranch && (branchIndex || !resumeMarker)) {
     writeScope(scopeId, {
-      // TODO: technically conditional renderer should only be written when either the
-      // condition is stateful, or if there are direct closures.
-      // It may make sense to pass in another arg for this.
+      // TODO: Write the renderer only for stateful conditions or direct closures.
       [AccessorPrefix.ConditionalRenderer + accessor]: branchIndex || undefined, // we convert 0 to undefined since the runtime defaults branch to 0.
       [AccessorPrefix.BranchScopes + accessor]: resumeMarker
         ? undefined
@@ -647,16 +639,10 @@ function writeBranchEnd(
   }
 }
 
-// These bracket a `<show>` body's statements (rather than taking a content
-// callback, so declarations in the body stay in the parent's scope) and write
-// the marks tracking its node range. The body always renders so it resumes
-// either way; hidden content is wrapped in a `<t hidden>` element, which
-// unlike a `<template>` keeps its children reachable by the resume walker.
+// `<show>` always renders; hidden ranges use `<t>` so the walker reaches them.
 export function _show_start(display: unknown, mark?: unknown) {
   if (display) {
-    // The wrapper is the range's single node, so the start mark is only
-    // written (and its stack entry only popped) when the body renders in
-    // place.
+    // The wrapper itself is the range's single node.
     if (mark) {
       $chunk.writeHTML(
         $chunk.boundary.state.mark(ResumeSymbol.BranchStart, ""),
@@ -713,6 +699,8 @@ let writeScope = (scopeId: number, partialScope: PartialScope) => {
   return scope;
 };
 
+// Module-eval reassignment: must stay immediately after the `let writeScope`
+// declaration above.
 if (MARKO_DEBUG) {
   writeScope = (
     (writeScope) =>
@@ -734,9 +722,7 @@ if (MARKO_DEBUG) {
 
 export { writeScope as _scope };
 
-// Marks the scope as flushing (without writing props itself) so that
-// passive props (eg tag variables) ride along; the empty entry is elided
-// from the wire when nothing else merges in.
+// Lets passive props join an existing scope flush without forcing wire data.
 export function _existing_scope(scopeId: number) {
   return writeScope(scopeId, {});
 }
@@ -1172,9 +1158,7 @@ export class Chunk {
       this.serializeState.readyId &&
       (this.effects || this.scripts || this.serializeState.flushScopes)
     ) {
-      // The chunk's own pending resume data is carried at the head of its
-      // deferred list so it is flushed before any lazy content nested
-      // within it (which may reference its data).
+      // Own resume data precedes nested lazy content that may reference it.
       const deferred = this.fork(this.boundary, null);
       deferred.effects = this.effects;
       deferred.scripts = this.scripts;
@@ -1288,14 +1272,7 @@ export class Chunk {
           concatSequence(resumes, effects && `"${effects}"`),
         );
         if (reservations) {
-          // A ready batch written from a reorder script only executes once
-          // its reordered content arrives, which can be after later
-          // main-stream scripts run — inverting the stream's entry order.
-          // Instead, the main-stream script (always ordered) reserves the
-          // batch's slot with a numeric gate sentinel (a number is never an
-          // effects string, deps marker, or payload, so the browser halts
-          // the stream there), and the reorder script swaps the gate for
-          // the batch when the content arrives.
+          // Main-stream gates reserve ready-batch order until reorders arrive.
           const gate = state.readyGate++;
           reservations.push(state.writeReady(readyId, gate + ""));
           scripts = concatScripts(
@@ -1430,10 +1407,7 @@ export class Chunk {
           cur.flushPlaceholder();
           cur.deferOwnReady();
           const { next } = cur;
-          // These scripts execute when the reordered content arrives, which
-          // may be after later main-stream scripts; ready batches written
-          // here reserve their stream slot in the ordered main-stream
-          // script (below) and only fill it in place.
+          // Reorder-ready batches fill slots reserved by the main stream.
           const readyResumeScripts = cur.flushReadyScripts(readyReservations);
           cur.consumed = true;
           reorderHTML += cur.html;
@@ -1588,9 +1562,7 @@ function flushSerializer(boundary: Boundary, serializeState: SerializeState) {
 
     if (flushes.length || pending) {
       if (isBlockingState && !state.hasGlobals) {
-        // Globals must be stringified before any ready data so that ready
-        // data may reference them, never the reverse — ready data is only
-        // deserialized in the browser once its module loads.
+        // Globals serialize before ready data that may reference them.
         flushSerializerGlobals(boundary);
       }
       serializeState.resumes = concatSequence(
@@ -1721,14 +1693,10 @@ export function _subscribe(
   if (subscribers) {
     const { serializer } = $chunk.boundary.state;
     if (!$chunk.serializeState.readyId && !serializer.written(subscribers)) {
-      // The subscriber rides the set's literal when it has not been
-      // serialized yet (both deserialize in the same main payload, before
-      // any effects run).
+      // An unflushed set carries its subscriber in the same payload.
       subscribers.add(scope);
     } else {
-      // Already flushed sets — and subscribers from lazy streams, which
-      // must not be notified before their module loads and hydrates the
-      // scope — are added through a channel gated call instead.
+      // Flushed or lazy sets add subscribers through their gated channel.
       serializer.writeCall(scope, subscribers, "add", $chunk.serializeState);
     }
   }

--- a/packages/runtime-tags/src/translator/util/serialize-guard.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-guard.ts
@@ -74,14 +74,14 @@ export function getSerializeGuard(
   optional: boolean,
 ) {
   if (!isReasonDynamic(reason) || isCrossSection(section, reason)) {
-    return reason
-      ? optional
-        ? undefined
-        : withLeadingComment(
-            t.numericLiteral(1),
-            getDebugNames(reason === true ? undefined : reason.state),
-          )
-      : t.numericLiteral(0);
+    if (!reason) return t.numericLiteral(0);
+
+    return optional
+      ? undefined
+      : withLeadingComment(
+          t.numericLiteral(1),
+          getDebugNames(reason === true ? undefined : reason.state),
+        );
   }
 
   return getOrHoist(reason, true);

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -609,15 +609,14 @@ export function getSignalFn(signal: Signal): t.Expression {
       continue;
     }
     if (signalHasStatements(value.signal)) {
-      signal.render.push(
-        t.expressionStatement(
-          t.callExpression(value.signal.identifier, [
-            scopeIdentifier,
-            value.value,
-            ...getTranslatedExtraArgs(value.signal),
-          ]),
-        ),
+      const invocation = t.expressionStatement(
+        t.callExpression(value.signal.identifier, [
+          scopeIdentifier,
+          value.value,
+          ...getTranslatedExtraArgs(value.signal),
+        ]),
       );
+      signal.render.push(invocation);
     } else {
       signal.render.push(
         t.expressionStatement(
@@ -918,15 +917,11 @@ export function addValue(
   }
 }
 
-export function getResumeRegisterId(
+function buildResumeRegisterKey(
   section: Section,
   referencedBindings: string | ReferencedBindings,
   type?: string,
 ) {
-  const {
-    markoOpts,
-    opts: { filename },
-  } = getFile();
   let name = "";
   if (referencedBindings) {
     if (typeof referencedBindings === "string") {
@@ -939,11 +934,20 @@ export function getResumeRegisterId(
       name += `_${referencedBindings.name}`;
     }
   }
-  return getTemplateId(
+  return `${section.id}${name}${type ? "/" + type : ""}`;
+}
+
+export function getResumeRegisterId(
+  section: Section,
+  referencedBindings: string | ReferencedBindings,
+  type?: string,
+) {
+  const {
     markoOpts,
-    filename as string,
-    `${section.id}${name}${type ? "/" + type : ""}`,
-  );
+    opts: { filename },
+  } = getFile();
+  const key = buildResumeRegisterKey(section, referencedBindings, type);
+  return getTemplateId(markoOpts, filename as string, key);
 }
 
 export function writeSignals(section: Section) {
@@ -972,6 +976,10 @@ export function writeSignals(section: Section) {
       const effectIdentifier = t.identifier(
         `${signal.identifier.name}__script`,
       );
+      const effectFn = t.arrowFunctionExpression(
+        [scopeIdentifier],
+        toFirstExpressionOrBlock(signal.effect),
+      );
       effectDeclarator = t.variableDeclarator(
         effectIdentifier,
         callRuntime(
@@ -979,10 +987,7 @@ export function writeSignals(section: Section) {
           t.stringLiteral(
             getResumeRegisterId(section, signal.referencedBindings),
           ),
-          t.arrowFunctionExpression(
-            [scopeIdentifier],
-            toFirstExpressionOrBlock(signal.effect),
-          ),
+          effectFn,
         ),
       );
     }

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -44,22 +44,18 @@ export default {
             if (closure.type !== BindingType.constant) {
               const closureSignal = getSignal(childSection, closure);
               if (signalHasStatements(closureSignal)) {
-                addStatement(
-                  "render",
-                  childSection,
-                  undefined,
-                  t.expressionStatement(
-                    t.callExpression(
-                      isDynamicClosure(childSection, closure)
-                        ? closureSignal.identifier
-                        : t.memberExpression(
-                            closureSignal.identifier,
-                            t.identifier("_"),
-                          ),
-                      [scopeIdentifier],
-                    ),
+                const invocation = t.expressionStatement(
+                  t.callExpression(
+                    isDynamicClosure(childSection, closure)
+                      ? closureSignal.identifier
+                      : t.memberExpression(
+                          closureSignal.identifier,
+                          t.identifier("_"),
+                        ),
+                    [scopeIdentifier],
                   ),
                 );
+                addStatement("render", childSection, undefined, invocation);
               }
             }
           });


### PR DESCRIPTION
## Description

Behavior-preserving cleanups extracted from upcoming work so the larger diff stays reviewable: widen `html/writer.ts` serialize-guard params from `0 | 1` to `number` (the runtime only checks zero vs non-zero), condense over-length writer comments to the repo's two-line limit, split the resume register key derivation out of `getResumeRegisterId`, hoist inline-built signal/effect invocation expressions, and flatten `getSerializeGuard`'s nested ternary into early returns. No output changes: the full suite passes against existing snapshots and `build:sizes` reports zero drift.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K2s4QxqWKA2NLuJoZGfWVG

---
_Generated by [Claude Code](https://claude.ai/code/session_01K2s4QxqWKA2NLuJoZGfWVG)_