### PR TITLE
docs(agent-feedback): record findings surfaced during persisted pages development

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -249,3 +249,42 @@ The one docs example meant to teach typed tag parameters ships a pattern that fa
 `packages/runtime-tags/src/dom/schedule.ts` › `triggerMacroTask` | 2026-07-19 | impact:med | effort:low
 
 In a DOM environment lacking a usable `MessageChannel`, the reactive scheduler applies the FIRST update and then silently drops every later one. `schedule()` sets `isScheduled = 1` (`dom/schedule.ts:17`), and the flag is reset to `0` in exactly one place — the `channel.port1.onmessage` handler (`:36`) — reachable only if `new MessageChannel()` (`:34`) succeeds. When `MessageChannel` is absent, `:34` throws inside the `requestAnimationFrame` callback `triggerMacroTask`, the handler is never installed, `isScheduled` stays `1` forever, and every subsequent `schedule()` short-circuits at `:7`. The first update still lands because `flushAndWaitFrame` runs `run()` synchronously (`:28`), and `run()`→`runRenders()` (`dom/queue.ts:83-95,131-167`) applies the queued renders without touching the channel — the channel is only the next-frame reset. That asymmetry is the trap for agentic workflows: a one-click smoke test goes green (false confidence) while a two-step interaction test fails with no test-visible error — the throw surfaces only as a jsdom window `error` event — so an agent cannot tell whether its component logic or its harness is at fault. It bites hand-rolled jsdom and jest+jsdom harnesses (which historically ship no `MessageChannel`, the same gap React 18's scheduler hit), the exact throwaway setups agents reach for to self-verify. Reset the flag in a `finally` (or degrade to `setTimeout`/`queueMicrotask` for the macrotask boundary) plus add a `MARKO_DEBUG` assert naming the missing `MessageChannel`, turning a silent misattributed wedge into a deterministic, self-explaining failure fixable from the error string alone.
+
+## An empty-bodied `<html-comment>` resumes as a text node instead of the comment
+
+`packages/runtime-tags/src/dom/resume.ts` › `init` | 2026-07-14 | impact:med | effort:med
+
+For an `<html-comment>${c}</html-comment>` whose body serializes empty, SSR
+writes `<!---->` immediately before the resume marker, and the node-claim
+heuristic in the `ResumeSymbol.Node` visit (`prev.nodeType < 8 || prev.data`)
+refuses the empty comment and binds a fresh Text instead; it exists to skip
+empty `<!>` separators and cannot tell an intentional empty comment apart.
+After hydration, updating the body renders visible text where a pure client
+render produces `<!--...-->`. Fix direction: a dedicated resume symbol for
+html-comment markers that claims the preceding sibling unconditionally.
+Verify: SSR + resume an empty-bodied `<html-comment>`, set its body, and
+compare the DOM with a client-side render.
+
+## Document-side lazy load entries float rejections and leave the ready channel silent
+
+`packages/runtime-tags/src/translator/visitors/program/index.ts` › `translate` (`isLoadEntry` branch) | 2026-07-16 | impact:low | effort:low
+
+The generated `.load.mjs` entry is `load().then(() => ready(id))` with no
+rejection handler, so a chunk that fails to load from the initial document
+(deploy skew) surfaces only as an unhandled promise rejection and the
+module's ready id never resolves. The lazy tag's own render path recovers
+(`_load_setup`/`_load_template` route their `load()` failures to
+`renderCatch`), but the document-side loader stays noisy and inert. Add a
+`.catch` that reports through a defined channel (or retries). Verify: reject
+the dynamic import in a generated load entry and watch for the unhandled
+rejection with the ready id never firing.
+
+## `analyzeExpressionTagName` const-follow has no cycle guard
+
+`packages/runtime-tags/src/translator/util/tag-name-type.ts` › `analyzeExpressionTagName` | 2026-07-20 | impact:low | effort:low
+
+Following a `<const>` tag's value pushes the bound expression with no visited
+set, so mutually-referential `<const/a=b>` / `<const/b=a>` used as a tag name
+loop forever during analysis. Guard the follow with a visited-tag set.
+Verify: compile a template whose dynamic tag name resolves through two
+`<const>` tags that reference each other.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -58,3 +58,14 @@ feature" — one registration per unique class file would suffice.
 The interop translator crashes cryptically at module-eval when merged with a Class-API translator that does not export the optional `optionalTaglibs` field. `createInteropTranslator` calls `taglib.resolveOptionalTaglibs(translate5.optionalTaglibs)` with no fallback and no `onError` (`translator/interop/index.ts:31`), whereas the compiler's own caller guards it: `resolveOptionalTaglibs(translator.optionalTaglibs || [], onError)` (`compiler/src/taglib/index.js:40`). `resolveOptionalTaglibs` iterates unguarded — `for (const id of taglibIds)` (`compiler/src/taglib/index.js:97`) — so a missing field throws `TypeError: taglibIds is not iterable` with no source frame indicating which translator/field is at fault. `optionalTaglibs` is genuinely optional (runtime-class exports it, runtime-tags does not), so the interop path assumes a field the merge partner may not provide. Latent for the shipped runtime-class translator (it exports `optionalTaglibs`), but any class-side translator lacking the field crashes. Mirror the compiler's guard: `resolveOptionalTaglibs(translate5.optionalTaglibs || [], onError)`. Not in any existing feedback file.
 
 ---
+
+## Pre-existing comments exceeding the two-line rule
+
+`packages/compiler/src/config.js`, `packages/runtime-tags/src/**` | 2026-07-18 | impact:low | effort:med
+
+A sweep for the two-line comment rule surfaced roughly ninety comment blocks
+longer than two lines (config option JSDoc in `compiler/src/config.js`,
+several `translator/util/references.ts` and `dom/resume.ts` blocks, and
+commented-out `serializer.test.ts` cases). Condensing them is a standalone
+cleanup. Verify: grep for comment runs of three or more consecutive `//`
+lines under the cited paths.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -130,3 +130,60 @@ The universal DOM/JSX idiom `event.currentTarget.value` (and `event.target.value
 `packages/runtime-tags/src/dom/walker.ts` › `walker` | 2026-07-19 | impact:low | effort:low
 
 A throwaway node script — the fastest way an agent confirms a compiled component actually works before writing a full test setup — is mined with two import-order traps whose error strings point nowhere near the cause. (1) The DOM runtime evaluates `document.createTreeWalker(document)` at module top level (`dom/walker.ts:12`), so requiring the compiled `dom` output before a DOM global is installed throws `ReferenceError: document is not defined` at a `marko/dist` line. (2) `@marko/compiler`'s `modules.js` decides at first-require whether it is running in a browser via `typeof document === "object"` (`packages/compiler/modules.js:3`); installing jsdom globals (which define `global.document`) BEFORE requiring `@marko/compiler` takes that branch and sets `exports.resolve`/`tryResolve` to `null` (`:8-9`), so the first attempt to load a translator throws `TypeError: _modules.default.resolve is not a function` with no hint that a DOM global caused it (the branch is evaluated once and cached for the module lifetime). The only working order — compile with no DOM globals, THEN install jsdom, THEN require the runtime — is undocumented and easy to get backwards. `@marko/vite` and `@marko/testing-library` sequence this correctly, but an agent hand-rolling a verification script gets no guidance and burns turns guessing against two opaque messages. Lazy-init the walker on first `walk()` (drop the top-level `document` read), and either make the compiler's browser sniff robust to a node process that merely has jsdom installed or throw an error naming the cause; at minimum document a compile-then-shim-then-import recipe so headless self-checks are reliable.
+
+## Mutation-tracker jsdom workaround silently hides real text updates in snapshots
+
+`packages/runtime-tags/src/__tests__/utils/track-mutations.ts` › `formatMutationRecord` | 2026-07-14 | impact:low | effort:low
+
+The characterData filter drops records where the new value starts with the
+old value and the boundary is whitespace, to hide jsdom's duplicate records
+(jsdom#3261) — but it also matches real updates of that shape: a step
+changing text "draft" to "draft edited" produces no `## Change` entry and no
+html block, so the step looks like a no-op in the render snapshot while the
+DOM did update, which costs real debugging time on new fixtures. Fix
+direction: re-check the jsdom issue, or drop a record only when an adjacent
+record re-reports the same target, or always emit the html block even when
+every record was filtered. Verify: a fixture step appending to an existing
+text node currently yields an empty snapshot entry.
+
+## `npm run build:sizes` dirties `.sizes*` on a clean checkout
+
+`.sizes/dom.js` | 2026-07-14 | impact:med | effort:low
+
+With lockfile-installed deps (rolldown 1.1.4, linux) and zero source changes,
+a fresh `node -r ~ts scripts/sizes` run rewrites `.sizes.json` (+8 min /
++2 brotli on `dom.js`) and all `.sizes/**` outputs: the minifier emits
+`for (; i && a[i - 1].x > y;) (i--, f())` where the committed files have
+`for (; i && a[--i].x > y;) f()`, and the shared-chunk hash flips. The
+committed `.sizes*` no longer reproduce from the committed lockfile, so
+every next commit's pre-commit size diff carries unrelated noise. Fix:
+regenerate and commit `.sizes*` once (confirming which toolchain produced
+the committed files), or pin the minifier the sizes script uses. Verify:
+run `npm run build && npm run build:sizes` on a clean checkout and check
+`git status`.
+
+## `npm test <file>` appends to the default spec glob instead of scoping to the file
+
+`.mocharc.json` | 2026-07-15 | impact:low | effort:low
+
+Passing an explicit test file (`npm test -- <path>.test.ts`) does not scope
+the run: mocha adds positional file args to the configured spec glob, so the
+whole suite runs anyway — silently, since the named file is also included.
+Scoping to one file requires bypassing the config
+(`npx mocha --no-config --no-package --timeout 10000 --require ~ts <file>`),
+which is undocumented and easy to get wrong. Either document that
+incantation in CLAUDE.md next to the `--grep` guidance, or add a `test:file`
+script that forwards to mocha without the default spec. Verify:
+`npm test -- packages/runtime-tags/src/__tests__/serializer.test.ts` runs
+every spec file.
+
+## Error-compile fixtures never refresh or clean `sizes.json`
+
+`packages/runtime-tags/src/__tests__/main.test.ts` › `hasCompilerError` sizes gate | 2026-07-20 | impact:low | effort:low
+
+The optimize `after()` sizes assertion is gated on `!hasCompilerError`, so a
+fixture that later becomes `error_compiler: true` keeps its last generated
+`sizes.json` forever — neither asserted nor rewritten by `test:update`. The
+harness could delete (or assert the absence of) `sizes.json` for error
+fixtures. Verify: add `sizes.json` to any `error_compiler` fixture and watch
+`npm run test:update` leave it untouched.


### PR DESCRIPTION
## Description

Backports the agent-feedback entries from the persisted-pages branch that stand on their own against `main` (nothing here depends on the feature landing): an SSR/resume divergence for empty `<html-comment>` bodies, unhandled rejections in generated lazy load entries, a missing cycle guard in tag-name analysis, two test-harness gaps (the mutation-tracker jsdom filter hiding real text updates, error-compile fixtures never refreshing `sizes.json`), `.sizes*` reproducibility drift, `npm test <file>` not scoping to the file, and a sweep of pre-existing over-long comments.

Entries tied to persisted-pages machinery remain on that branch. Citations follow the new stable-symbol convention.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WG7cTpGW6AbgCTCGw1QBAS

---
_Generated by [Claude Code](https://claude.ai/code/session_01WG7cTpGW6AbgCTCGw1QBAS)_