### PR TITLE
fix(runtime-tags): clear dev errors for invalid `<for>` inputs

### DIFF
--- a/.changeset/for-runtime-input-guards.md
+++ b/.changeset/for-runtime-input-guards.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Throw clear development errors for invalid `<for>` inputs instead of failing opaquely. A `<for of>` whose value is a truthy non-iterable (a number, plain object, `Date`, …) previously surfaced the engine's `x is not iterable` with a stack pointing into compiled runtime; it now names the `of` attribute. A `<for to>`/`<for until>` with a non-finite bound previously rendered nothing (`NaN`) or looped forever (`Infinity`, hanging server rendering); it now reports the offending attribute and value. These checks are development-only, so production output is unchanged.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `of` attribute must be an iterable, such as an array, but received `5`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+const $for_content__item = ($scope, item) => _text($scope["#text/0"], item);
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<li> </li>", "D l", 0, $for_content__$params);
+const $input_value = ($scope, input_value) => $for($scope, [input_value]);
+const $input = ($scope, input) => $input_value($scope, input.value);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0), $si__input_value = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.value, (item) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(item)}${_el_resume($scope1_id, "#text/0", $sg__input_value)}</li>`);
+		$si__input_value && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_value, $sg__input_value, $sg__input_value, 0, 1);
+	$si__input_value && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `of` attribute must be an iterable, such as an array, but received `5`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/template.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.value>
+  <li>${item}</li>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ value: 5 }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `to` attribute must be a finite number, but received `Infinity`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+const $for_content__setup = ($scope) => _text($scope["#text/0"], $scope["#LoopKey"]);
+const $for = /*@__PURE__*/ _for_to("#text/0", "<li> </li>", "D l", $for_content__setup);
+const $input_to = ($scope, input_to) => $for($scope, [
+	input_to,
+	0,
+	1
+]);
+const $input = ($scope, input) => $input_to($scope, input.to);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_to = _serialize_guard($scope0_reason, 0), $si__input_to = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_to(input.to, 0, 1, (i) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(i)}</li>`);
+		$si__input_to && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_to, $sg__input_to, $sg__input_to, 0, 1);
+	$si__input_to && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `to` attribute must be a finite number, but received `Infinity`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/template.marko
@@ -1,0 +1,3 @@
+<for|i| to=input.to>
+  <li>${i}</li>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ to: Infinity }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `until` attribute must be a finite number, but received `Infinity`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+const $for_content__setup = ($scope) => _text($scope["#text/0"], $scope["#LoopKey"]);
+const $for = /*@__PURE__*/ _for_until("#text/0", "<li> </li>", "D l", $for_content__setup);
+const $input_until = ($scope, input_until) => $for($scope, [
+	input_until,
+	0,
+	1
+]);
+const $input = ($scope, input) => $input_until($scope, input.until);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_until = _serialize_guard($scope0_reason, 0), $si__input_until = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_until(input.until, 0, 1, (i) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(i)}</li>`);
+		$si__input_until && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_until, $sg__input_until, $sg__input_until, 0, 1);
+	$si__input_until && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `until` attribute must be a finite number, but received `Infinity`.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/template.marko
@@ -1,0 +1,3 @@
+<for|i| until=input.until>
+  <li>${i}</li>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ until: Infinity }],
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -78,6 +78,34 @@ export function assertValidLoopKey(key: unknown, seenKeys?: Set<unknown>) {
   }
 }
 
+export function assertValidList(value: unknown) {
+  if (
+    value &&
+    typeof (value as Iterable<unknown>)[Symbol.iterator] !== "function"
+  ) {
+    throw new Error(
+      `A \`<for>\` tag's \`of\` attribute must be an iterable, such as an array, but received ${describeForValue(value)}.`,
+    );
+  }
+}
+
+export function assertValidRangeBound(name: string, value: unknown) {
+  // `isFinite` coerces like the range arithmetic, so a debug throw matches production.
+  if (!isFinite(value as number)) {
+    throw new Error(
+      `A \`<for>\` tag's \`${name}\` attribute must be a finite number, but received ${describeForValue(value)}.`,
+    );
+  }
+}
+
+function describeForValue(value: unknown) {
+  return typeof value === "number" || typeof value === "bigint"
+    ? `\`${value}\``
+    : value === null
+      ? "null"
+      : `type "${typeof value}"`;
+}
+
 export function assertValidAttrName(name: string) {
   if (htmlAttrNameReg.test(name)) {
     throw new Error(`Invalid attribute name: ${JSON.stringify(name)}`);

--- a/packages/runtime-tags/src/common/for.ts
+++ b/packages/runtime-tags/src/common/for.ts
@@ -1,3 +1,4 @@
+import { assertValidList, assertValidRangeBound } from "./errors";
 import type { Falsy } from "./types";
 
 export function forIn(
@@ -13,6 +14,7 @@ export function forOf(
   list: Falsy | Iterable<unknown>,
   cb: (item: unknown, index: number) => void,
 ) {
+  if (MARKO_DEBUG) assertValidList(list);
   if (list) {
     let i = 0;
     for (const item of list) {
@@ -27,6 +29,7 @@ export function forTo(
   step: number | Falsy,
   cb: (index: number) => void,
 ) {
+  if (MARKO_DEBUG) assertValidRangeBound("to", to);
   const start = from || 0;
   const delta = step || 1;
   for (let steps = (to - start) / delta, i = 0; i <= steps; i++) {
@@ -40,6 +43,7 @@ export function forUntil(
   step: number | Falsy,
   cb: (index: number) => void,
 ) {
+  if (MARKO_DEBUG) assertValidRangeBound("until", until);
   const start = from || 0;
   const delta = step || 1;
   for (let steps = (until - start) / delta, i = 0; i < steps; i++) {


### PR DESCRIPTION
## Description

Adds `MARKO_DEBUG` assertions for invalid `<for>` inputs so misuse throws a clear, attribute-named error in development instead of failing opaquely:

- **`<for of>` with a truthy non-iterable** (a number, plain object, `Date`, …) previously surfaced the engine's `x is not iterable` with a stack pointing into compiled runtime. It now throws `` A `<for>` tag's `of` attribute must be an iterable, such as an array, but received `5`. ``
- **`<for to>` / `<for until>` with a non-finite bound** previously rendered nothing (`NaN`) or looped forever (`Infinity`, hanging server rendering). It now throws `` A `<for>` tag's `to` attribute must be a finite number, but received `Infinity`. ``

Development-only: the guards compile out under `MARKO_DEBUG`, so production output is unchanged. Falsy `of` values (`null`/`undefined`/`false`/`0`) still render nothing, so conditional patterns like `of=(cond && items)` are unaffected — only truthy non-iterables (which already crashed) throw.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_