### PR TITLE
perf(runtime-tags): hoist the thrice-shipped consumed-result error string

### DIFF
--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -98,12 +98,6 @@ Every scope written as a value emits `_(id)` after `trackScope` (`serializer.ts:
 
 Profiling a 464 KB data-heavy payload (product records: nested objects, arrays, long strings) — after the prototype-dispatch and char-code key-escaping fast paths already landed — shows the remaining cost is dominated by intrinsic per-value bookkeeping: ~12% GC, driven by a `new Reference` (`serializer.ts:307`) allocated in `writeReferenceOr` (`serializer.ts:608`) / `writeString` (`serializer.ts:723`) for every object, array, and >12-char string, plus ~12% in output `StringAdd` and ~8% across the `refs`/`REGISTRY`/`strs` Map probes. Most of those References back a value that is written once and never referenced again, so they are immediate garbage. A lazy scheme — record only the buffer position on first write, upgrade to a full Reference only on a second occurrence — would remove the bulk of the allocation, but is blocked by cross-flush dedup: a value first written in one flush and reused in a later one resolves through `assignId`'s parent/accessor walk (`serializer.ts:1868`), which needs pos+parent+accessor+flush retained from the first write (essentially the whole Reference). Splitting within-flush dedup (the common case, which only needs `pos` via `assignId`'s early return) from the cross-flush path would let the first write store a cheap position marker and allocate a Reference only when one is actually reused. Output-preserving, but a deep change to the reference model, not a spot fix.
 
-## Hoist the thrice-shipped "consumed render result" error string
-
-`packages/runtime-tags/src/html/template.ts` › `ServerRendered.#promise` | 2026-07-13 | impact:low | effort:low
-
-The 41-char literal `"Cannot read from a consumed render result"` is written verbatim three times — lines 274, 302 and 335 — and none is behind a `MARKO_DEBUG` guard, so all three ship. The minifier does not hoist repeated string literals into a shared binding. Hoist to a module-scope `const` and reference it in the three `new Error(...)` sites to drop ~80 bytes from the SSR runtime.
-
 ## Remove the second-stage dynamic import from load entries
 
 `packages/runtime-tags/src/translator/visitors/program/index.ts` › `translate.enter` | 2026-07-13 | impact:high | effort:low

--- a/packages/runtime-tags/src/html/template.ts
+++ b/packages/runtime-tags/src/html/template.ts
@@ -16,6 +16,8 @@ import {
   writeWaitReady,
 } from "./writer";
 
+const CONSUMED_RESULT_MESSAGE = "Cannot read from a consumed render result";
+
 export type ServerRenderer = ((...args: unknown[]) => unknown) & {
   [RendererProp.Id]?: string;
   [RendererProp.Embed]?: boolean;
@@ -271,7 +273,7 @@ class ServerRendered implements RenderedTemplate {
       this.#head = null;
 
       if (!head) {
-        return reject(new Error("Cannot read from a consumed render result"));
+        return reject(new Error(CONSUMED_RESULT_MESSAGE));
       }
 
       const { boundary } = head;
@@ -302,7 +304,7 @@ class ServerRendered implements RenderedTemplate {
     this.#head = null;
 
     if (!head) {
-      onAbort(new Error("Cannot read from a consumed render result"));
+      onAbort(new Error(CONSUMED_RESULT_MESSAGE));
       return;
     }
 
@@ -337,7 +339,7 @@ class ServerRendered implements RenderedTemplate {
   toString() {
     const head = this.#head;
     this.#head = null;
-    if (!head) throw new Error("Cannot read from a consumed render result");
+    if (!head) throw new Error(CONSUMED_RESULT_MESSAGE);
     const { boundary } = head;
     switch (boundary.flush()) {
       case FlushStatus.aborted:


### PR DESCRIPTION
## Description

`ServerRendered` constructs the 41-char message `"Cannot read from a consumed render result"` at three sites (`#promise`, `#read`, `toString`), none behind `MARKO_DEBUG`, so it ships verbatim three times. esbuild does **not** dedup identical string literals (verified: an isolated 3-literal module minifies to 252 bytes vs 176 hoisted — ~76 bytes), so this hoists the message into a module-scope const referenced at all three sites.

Behavior-identical — the message text is unchanged — so no changeset. The `counter`/`comments` size fixtures don't exercise these async server-render consumption paths, so committed `.sizes` are unchanged; the saving lands in app bundles that include them.

Also removes the now-resolved `agent-feedback/perf.md` entry.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_