### PR TITLE
fix(runtime-tags): controlled `0n`/`NaN` value normalization matches the DOM

### DIFF
--- a/.changeset/controlled-select-0n-nan.md
+++ b/.changeset/controlled-select-0n-nan.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a controlled `<select>` / `<input type=checkbox|radio>` selecting a different option on the server than on the client when its value is `0n` or `NaN`. The SSR value normalizer (`normalizeStrAttrValue`) dropped `0n`/`NaN` to `""` while the DOM normalizer wrote `"0"`/`"NaN"`, so e.g. a controlled `<select value=0n>` with `<option value=0>` and `<option value="">` marked the empty option selected under SSR but the `0` option on the client, a hydration mismatch. The HTML normalizer now mirrors the DOM one (`isNotVoid(value) && value !== true`), so both pick the same option. (`false` already agreed, normalizing to `""` on both sides.)

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -58,12 +58,6 @@ but it is one flush-ordering change away from a silent hydration freeze. A
 queue (or firing the pending callback before re-assigning) would make the
 inline runtime robust; weigh against inline-runtime byte cost.
 
-## SSR controlled-form value normalization diverges from DOM for `0n`/`NaN`/`false`, causing a hydration mismatch
-
-`packages/runtime-tags/src/html/attrs.ts` › `normalizeStrAttrValue` | 2026-07-14 | impact:low | effort:low
-
-`normalizeStrAttrValue` computes `(value && value !== true) || value === 0 ? value + "" : ""`, so `0n` (falsy, `0n === 0` is false), `NaN`, and `false` all normalize to `""`. The DOM counterpart used for the identical selection/checked computation, `normalizeStrProp` (`dom/controllable.ts`) → `normalizeAttrValue` (`dom/dom.ts`), returns `value + ""`, giving `"0"`/`"NaN"`/`"false"`. This normalizer feeds `normalizedValueMatches`, which decides `selected` for controlled `<select>`/`<option>` and `checked` for `<input type=checkbox|radio>`, so SSR and CSR can select different options/checkboxes for the same value. Example: a controlled `<select value=0n>` with `<option value=0>` and `<option value="">` — SSR marks the empty option selected, CSR marks the `value=0` option selected, a genuine hydration mismatch. Unlike ordinary text rendering, where the SSR and DOM helpers both deliberately render `0n` as empty, these controlled-value paths use different formulas and disagree. Latent (no fixture feeds these as controlled values today). Fix: make `normalizeStrAttrValue` agree with the DOM normalizer for non-void, non-`true` values.
-
 ## Multiple-select change observer compares controlled value to DOM selection index-by-index
 
 `packages/runtime-tags/src/dom/controllable.ts` › `_attr_select_value_script` | 2026-07-14 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<select><option value>empty</option><option value=0>zero</option><option value=1>one</option></select>";
+const $walks = " b";
+const $value = /*@__PURE__*/ _let("value/1", ($scope) => _attr_select_value($scope, "#select/0", $scope.value, $valueChange($scope)));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_select_value_script($scope, "#select/0"));
+function $setup($scope) {
+	$value($scope, 0n);
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $value = /*@__PURE__*/ _let(1, ($scope) => _attr_select_value($scope, "a", $scope.b, $valueChange($scope)));
+const $setup__script = _script("a1", ($scope) => _attr_select_value_script($scope, "a"));
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = 0n;
+	_attr_select_value($scope0_id, "#select/0", value, _resume(function(v) {
+		value = v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("")}>empty</option><option${_attr_option_value(0)}>zero</option><option${_attr_option_value(1)}>one</option></select>`);
+	});
+	_html(_el_resume($scope0_id, "#select/0"));
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = 0n;
+	_attr_select_value($scope0_id, "a", value, _resume(function(v) {
+		value = v;
+	}, "a0", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("")}>empty</option><option${_attr_option_value(0)}>zero</option><option${_attr_option_value(1)}>one</option></select>`);
+	});
+	_html(_el_resume($scope0_id, "a"));
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/render.debug.md
@@ -1,0 +1,21 @@
+# Render
+```html
+<select>
+  <option
+    value=""
+  >
+    empty
+  </option>
+  <option
+    selected=""
+    value="0"
+  >
+    zero
+  </option>
+  <option
+    value="1"
+  >
+    one
+  </option>
+</select>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/render.md
@@ -1,0 +1,21 @@
+# Render
+```html
+<select>
+  <option
+    value=""
+  >
+    empty
+  </option>
+  <option
+    selected=""
+    value="0"
+  >
+    zero
+  </option>
+  <option
+    value="1"
+  >
+    one
+  </option>
+</select>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<select>
+  <option value>empty</option>
+  <option value=0 selected>zero</option>
+  <option value=1>one</option>
+</select><!--M_*1 #select/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#select/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<select>
+  <option value>empty</option>
+  <option value=0 selected>zero</option>
+  <option value=1>one</option>
+</select><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ea: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 4049,
+      "brotli": 1801
+    }
+  },
+  "html": {
+    "min": 441,
+    "brotli": 272
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/template.marko
@@ -1,0 +1,6 @@
+<let/value=0n/>
+<select value=value valueChange(v) { value = v }>
+  <option value="">empty</option>
+  <option value=0>zero</option>
+  <option value=1>one</option>
+</select>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// A controlled `<select value=0n>` selects the `0` option (not the empty one),
+// identically under SSR and CSR.
+export const config: TestConfig = {
+  steps: [{}],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<select><option value>empty</option><option value=NaN>nan</option><option value=0>zero</option></select>";
+const $walks = " b";
+const $value = /*@__PURE__*/ _let("value/1", ($scope) => _attr_select_value($scope, "#select/0", $scope.value, $valueChange($scope)));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_select_value_script($scope, "#select/0"));
+function $setup($scope) {
+	$value($scope, NaN);
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $value = /*@__PURE__*/ _let(1, ($scope) => _attr_select_value($scope, "a", $scope.b, $valueChange($scope)));
+const $setup__script = _script("a1", ($scope) => _attr_select_value_script($scope, "a"));
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = NaN;
+	_attr_select_value($scope0_id, "#select/0", value, _resume(function(v) {
+		value = v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("")}>empty</option><option${_attr_option_value(NaN)}>nan</option><option${_attr_option_value(0)}>zero</option></select>`);
+	});
+	_html(_el_resume($scope0_id, "#select/0"));
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = NaN;
+	_attr_select_value($scope0_id, "a", value, _resume(function(v) {
+		value = v;
+	}, "a0", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("")}>empty</option><option${_attr_option_value(NaN)}>nan</option><option${_attr_option_value(0)}>zero</option></select>`);
+	});
+	_html(_el_resume($scope0_id, "a"));
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/render.debug.md
@@ -1,0 +1,21 @@
+# Render
+```html
+<select>
+  <option
+    value=""
+  >
+    empty
+  </option>
+  <option
+    selected=""
+    value="NaN"
+  >
+    nan
+  </option>
+  <option
+    value="0"
+  >
+    zero
+  </option>
+</select>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/render.md
@@ -1,0 +1,21 @@
+# Render
+```html
+<select>
+  <option
+    value=""
+  >
+    empty
+  </option>
+  <option
+    selected=""
+    value="NaN"
+  >
+    nan
+  </option>
+  <option
+    value="0"
+  >
+    zero
+  </option>
+</select>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<select>
+  <option value>empty</option>
+  <option value=NaN selected>nan</option>
+  <option value=0>zero</option>
+</select><!--M_*1 #select/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#select/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<select>
+  <option value>empty</option>
+  <option value=NaN selected>nan</option>
+  <option value=0>zero</option>
+</select><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ea: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 4049,
+      "brotli": 1801
+    }
+  },
+  "html": {
+    "min": 443,
+    "brotli": 280
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/template.marko
@@ -1,0 +1,6 @@
+<let/value=NaN/>
+<select value=value valueChange(v) { value = v }>
+  <option value="">empty</option>
+  <option value=NaN>nan</option>
+  <option value=0>zero</option>
+</select>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// A controlled `<select value=NaN>` selects the `NaN` option (not the empty one),
+// identically under SSR and CSR.
+export const config: TestConfig = {
+  steps: [{}],
+};

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -514,5 +514,5 @@ function normalizedValueMatches(a: unknown, b: unknown) {
 }
 
 function normalizeStrAttrValue(value: unknown) {
-  return (value && value !== true) || value === 0 ? value + "" : "";
+  return isNotVoid(value) && value !== true ? value + "" : "";
 }


### PR DESCRIPTION
## Description

A controlled `<select>` / `<input type=checkbox|radio>` could select a different option on the server than on the client when its value is `0n` or `NaN`.

SSR's `normalizeStrAttrValue` computed `(value && value !== true) || value === 0 ? value + "" : ""`, dropping `0n`/`NaN` to `""`, while the DOM normalizer (`normalizeStrProp` → `normalizeAttrValue`) writes `"0"`/`"NaN"`. Both feed the same `selected`/`checked` matching (`normalizedValueMatches`), so e.g. a controlled `<select value=0n>` with `<option value=0>` and `<option value="">` marked the **empty** option selected under SSR but the **`0`** option on the client — a hydration mismatch.

Fix: mirror the DOM formula (`isNotVoid(value) && value !== true ? value + "" : ""`) so both sides pick the same option. New `controllable-select-value-bigint` and `-nan` fixtures show SSR and CSR now agree.

> Note: the source finding also listed `false`, but `false` already agreed — `isNotVoid(false)` is false, so both sides normalize it to `""`. Only `0n`/`NaN` actually diverged.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_