### PR TITLE
style(runtime-tags): condense over-length comments across src

### DIFF
--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -14,9 +14,8 @@ export function assertValidAttrValue(name: string, value: unknown) {
   }
 
   if (typeof value === "function") {
-    // Consumed handlers (events, applied controllable change handlers,
-    // content) never reach the attribute writers, so a function here would
-    // render as its source code.
+    // Consumed handlers (events, change handlers, content) never reach the
+    // attribute writers, so a function here would render as its source code.
     throw new Error(
       `The \`${name}\` attribute cannot be a function.${
         /Change$/.test(name)

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -79,9 +79,8 @@ export function stringifyStyleObject(name: string, value: unknown) {
 
 export function escapeStyleValue(str: string) {
   let closers = "";
-  // `;` and `{` are hex escaped (unlike the backslash escapes) so escaped
-  // values never contain them raw: a raw `{` is always the rule opener and a
-  // raw `;` a declaration end, which `_style_rule_item` relies on when updating.
+  // `;` and `{` are hex escaped so escaped values never contain them raw, which
+  // `_style_rule_item` relies on: a raw `{` opens a rule and a raw `;` ends a declaration.
   const result = str.replace(/[\\"'{};<>]|\/(?=\*)/g, (c) =>
     c === "<" ? "\\3C " : c === ";" ? "\\3B " : c === "{" ? "\\7B " : "\\" + c,
   );

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -61,12 +61,8 @@ export enum NodeType {
   DocumentFragment = 11,
 }
 
-// Reserved Character Codes
-// 0-31 [control characters]
-// 34 " [double quote]
-// 39 ' [single quote]
-// 92 \ [backslash]
-// 96 ` [backtick]
+// Reserved character codes: 0-31 [control chars], 34 " [double quote],
+// 39 ' [single quote], 92 \ [backslash], 96 ` [backtick]
 export enum WalkCode {
   Get = 32,
   Inside = 36,

--- a/packages/runtime-tags/src/dom/compat.ts
+++ b/packages/runtime-tags/src/dom/compat.ts
@@ -15,10 +15,8 @@ const classIdToBranch = new Map<string, BranchScope>();
 // Injected by the class runtime (runtime-dom.js); revives a serialized
 // class-method event reference, which only the class side can resolve.
 let classEventResolver: ((value: unknown, scope: Scope) => unknown) | undefined;
-// Keyed by the render handle — the one object reachable from both sides
-// of the interop boundary (the class side rebuilds its own $global at
-// hydration, so only the runtimeId/renderId values cross it) — and
-// released with the render when an embedded render is destroyed.
+// Keyed by the render handle, the one object reachable from both sides of the
+// interop boundary, and released with the render when an embedded render is destroyed.
 const scopesByRender = new WeakMap<object, Record<string, Scope>>();
 const getRenderScopes = ($global: Record<string, unknown>) => {
   const render = (self as any)[$global.runtimeId as string]?.[

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -444,11 +444,8 @@ export function _if(
   };
 }
 
-// The `<show>` body is inline parent content that always exists, so this
-// signal never renders anything: it only moves the body's node range between
-// the document and a detached fragment. Server rendered hidden content
-// arrives in a `<t hidden>` wrapper that is dissolved the first time the
-// value changes.
+// The `<show>` body always exists, so this signal never renders; it only moves
+// the body's range in/out of a detached fragment (SSR hides it in a `<t hidden>` wrapper).
 export function _show(
   nodeAccessor: EncodedAccessor,
   startNodeAccessor?: EncodedAccessor,
@@ -488,11 +485,8 @@ export function _show(
       startNode === range[AccessorProp.EndNode] &&
       (startNode as Partial<Element>).tagName === "T"
     ) {
-      // First update after resuming hidden: dissolve the `<t>`
-      // wrapper, leaving its children in place. Only a range resumed from
-      // marks (with a scope id) can hold a wrapper; replacing it with a plain
-      // holder makes this happen at most once so a `<t>` in the body is never
-      // mistaken for the wrapper.
+      // First update after resuming hidden: dissolve the `<t>` wrapper, leaving its
+      // children. Replacing it with a plain holder ensures a body `<t>` is never mistaken for it.
       const wrapper = startNode as Element;
       if (!wrapper.firstChild) wrapper.appendChild(new Text());
       range = scope[rangeAccessor] = {} as BranchScope;
@@ -632,9 +626,8 @@ export let _dynamic_tag = function dynamicTag(
   };
 };
 
-// Specialized `_dynamic_tag` for a content passthrough. The caller guarantees a
-// normalized content `Renderer` (or undefined) rendered with no input or
-// parameters.
+// Specialized `_dynamic_tag` for a content passthrough: the caller guarantees a
+// normalized content `Renderer` (or undefined) rendered with no input or parameters.
 export function _dynamic_tag_content(
   nodeAccessor: EncodedAccessor,
 ): Signal<Renderer | undefined> {

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -196,9 +196,8 @@ export function _enable_catch() {
       scope: Scope,
       branch: BranchScope | undefined,
     ) => {
-      // walk up the branches to see if any have an AwaitCounter with count (i) > 0
-      // if not, return false
-      // if so, return true and push the fn to the pending async queue on the try branch
+      // Defer the fn onto the nearest ancestor try branch still awaiting;
+      // a truthy return means it was deferred.
       while (branch) {
         if (branch[AccessorProp.AwaitCounter]?.i) {
           return (branch[AccessorProp.PendingEffects] ||= []).push(fn, scope);

--- a/packages/runtime-tags/src/dom/renderer.ts
+++ b/packages/runtime-tags/src/dom/renderer.ts
@@ -88,12 +88,8 @@ export function _content(
   params?: Signal<unknown> | 0,
   dynamicScopesAccessor?: Accessor,
 ) {
-  // Walks are required to encode how to "exit" the content
-  // so that we can continue walking across merged child templates.
-  // However at this point we have the full walks string for a branch,
-  // so we trim the trailing `Next`, `Over or `Out` walk codes.
-  // The regexp below replaces trailing values between charcodes `0-49`
-  // 1 is charcode 49 (WalkCode.DynamicTagWithVar)
+  // A branch has the full walks string; trim the trailing exit codes
+  // (Next/Over/Out, charcode >= 50) needed only to cross merged children.
   walks = walks ? walks.replace(/[^\0-1]+$/, "") : "";
   setup = setup ? (setup as { _: SetupFn })._ || setup : undefined;
   params ||= undefined;

--- a/packages/runtime-tags/src/dom/resolve-cursor-position.ts
+++ b/packages/runtime-tags/src/dom/resolve-cursor-position.ts
@@ -7,9 +7,8 @@ export function resolveCursorPosition(
   updatedValue: string,
 ) {
   if (
-    // If initial position is null or false then
-    // either this node is not the active element
-    // or does not support selection ranges.
+    // Null or false initial position means this node is not the active
+    // element or does not support selection ranges.
     (initialPosition || initialPosition === 0) &&
     (initialPosition !== initialValue.length ||
       // short regex to match input types that delete backwards

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -119,11 +119,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
           renders[renderId] || renders(renderId));
         const walk = render.w;
         const scopeLookup: Record<string | number, Scope> = {};
-        // Scopes initialize on creation so a scope that serialized no
-        // props (elided from the fill entirely) is indistinguishable from
-        // an empty one when reached through visits/effects/references.
-        // Globals are scope 0, so `_(0)` lets payloads reference values
-        // first serialized within them.
+        // Lazily creates scopes on first access so one that serialized no
+        // props is indistinguishable from empty; scope 0 is the global.
         const getScope = (id: string | number) =>
           scopeLookup[id] ||
           (+id
@@ -152,10 +149,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
               scopeId += partial;
             } else {
               if (scopeId) {
-                // Adopts the partial as the scope when it is new (assigning
-                // it onto itself is a no-op); merging into an existing scope
-                // re-initializes it so a closest branch id arriving in this
-                // fill applies.
+                // Adopt the partial as the scope when new, else merge into
+                // the existing one; re-init so a closest branch id applies.
                 initScope(
                   Object.assign(
                     (scopeLookup[scopeId] ||=
@@ -237,10 +232,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
                 curBranchScopes = push(curBranchScopes, branch);
                 if (accessor) {
                   visitScope[accessor] = curBranchScopes;
-                  // Serialized scope data is applied before visits, so a
-                  // serialized owner (non-lexical content) always wins; the
-                  // marker's scope fills lexical branches whose owner was
-                  // not serialized.
+                  // Scope data is applied before visits, so a serialized
+                  // owner wins; this fills only branches without one.
                   forEach(
                     curBranchScopes,
                     (scope) => (scope[AccessorProp.Owner] ??= visitScope),
@@ -329,10 +322,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
               if (!(
                 readyIds &&
                 serialized.every(
-                  // A dep's data is always flushed before a marker that
-                  // names it (bindings only reference already written
-                  // values), so its resumes are guaranteed present once
-                  // its module has loaded.
+                  // A dep's data is flushed before any marker naming it, so
+                  // its resumes are present once its module has loaded.
                   (dep) =>
                     readyIds!.has(dep as string) && !render.b![dep].length,
                 )
@@ -344,11 +335,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
               // when the reordered content arrives.
               break;
             } else {
-              // Gates cannot reach here: they only occur in ready streams,
-              // which are processed with `readyIds` set. A payload either
-              // returns its fill array directly, or applies it through the
-              // serialize context and ends in `,0` so its return value can
-              // never be mistaken for a fill.
+              // Gates can't reach here (only in ready streams, readyIds set);
+              // a payload returns its fill or applies it and ends in `,0`.
               const scopes = (serialized as ResumeFn)(serializeContext);
               if (Array.isArray(scopes)) applyScopes(scopes);
             }
@@ -411,9 +399,8 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
             } else if (branchesEnabled) {
               (visitBranches ||= createVisitBranches())();
             } else if (render.b) {
-              // Pending ready data means a lazily loaded module may still
-              // enable branches; its visits ride the same flush as the
-              // ready data, so they are compacted in place to reprocess.
+              // A lazily loaded module may still enable branches, so retain
+              // (compact) these visits to reprocess once the ready data lands.
               visits[retained++] = visit;
             }
           }

--- a/packages/runtime-tags/src/html/assets.ts
+++ b/packages/runtime-tags/src/html/assets.ts
@@ -84,9 +84,8 @@ export function withPageAssets(
         }
       }
 
-      // The client half of the runtimeId contract is baked into the
-      // compiled browser entry, so the compiled value must win for the
-      // halves to agree.
+      // The compiled browser entry bakes in its runtimeId, so the compiled
+      // value must win for the client and server halves to agree.
       g.runtimeId = runtimeId;
     }
     addAsset(g, assetId);

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -411,9 +411,8 @@ function writeControlledScope(
   nodeAccessor: Accessor,
   value: unknown,
   valueChange: unknown,
-  // The controlled `type` is only read back on resume by the spread resume path
-  // (`_attrs_script`). Statically-typed controllables resume through a typed
-  // `_script` that never reads it, so it is only serialized when requested.
+  // Only the spread resume path (`_attrs_script`) reads the controlled `type`
+  // back; typed controllables never do, so it is only serialized when requested.
   serializeType?: 1,
 ) {
   if (MARKO_DEBUG) {
@@ -455,9 +454,8 @@ function nonVoidAttr(name: string, value: unknown) {
   return " " + name + attrAssignment(value + "");
 }
 
-// Every character reference starts `&#` or `&` + an ASCII letter — and
-// parsers also decode semicolon-less numeric and legacy named references —
-// so any such `&` must be escaped to round-trip (a bare `&` never decodes).
+// A `&` only decodes before `#` or an ASCII letter (parsers accept even
+// semicolon-less numeric and legacy named refs), so only those need escaping.
 const singleQuoteAttrReplacements = /'|&(?=[#a-zA-Z])/g;
 const doubleQuoteAttrReplacements = /"|&(?=[#a-zA-Z])/g;
 const needsQuotedAttr = /["'>\s]|&[#a-zA-Z]|\/$/g;

--- a/packages/runtime-tags/src/html/content.ts
+++ b/packages/runtime-tags/src/html/content.ts
@@ -28,10 +28,8 @@ export function _escape(val: unknown) {
   return val ? escapeXMLStr(val + "") : val === 0 ? "0" : "";
 }
 
-// Neutralizes the sequences that shift the script-data tokenizer state:
-// `</script` (close tag) plus `<!--` and `<script`, whose combination puts
-// the parser in the double-escaped state where a real `</script>` no longer
-// closes the element and the rest of the page is swallowed into it.
+// Escapes `</script`, `<!--`, and `<script`: their combination shifts the parser
+// into the double-escaped state where a real `</script>` no longer closes it.
 const unsafeScriptReg = /<(\/?script|!--)/gi;
 const escapeScriptStr = (str: string) =>
   unsafeScriptReg.test(str) ? str.replace(unsafeScriptReg, "\\x3C$1") : str;

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1345,11 +1345,8 @@ export class Chunk {
       needsWalk = true;
     }
 
-    // While the stream is blocked on in-order async content, the resume
-    // markers for everything already rendered after that content have not
-    // been written -- running effects now could cascade state updates into
-    // scopes whose nodes aren't in the document yet. Hold effects on the
-    // blocked chunk so they flush once its async content completes.
+    // A chunk blocked on in-order async content holds its effects until it
+    // completes: running them now could update scopes whose nodes aren't live.
     const effects = this.async ? "" : this.effects;
     let { html, scripts } = this;
 

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -125,9 +125,8 @@ export default {
 
     const byAttr = getKnownAttrValues(tag.node).by;
 
-    // Only `<for of>` accepts a string `by` (a property-name key shorthand); the
-    // `in`/`to`/`until` runtimes invoke `by` as a function, so a string would
-    // throw at render. Reject it at compile time with a helpful message.
+    // Only `<for of>` accepts a string `by` (property-name shorthand); `in`/`to`/`until`
+    // invoke `by` as a function, so reject a string at compile time rather than at render.
     if (forType !== "of" && byAttr?.type === "StringLiteral") {
       throw tag.hub.buildError(
         byAttr,
@@ -137,9 +136,8 @@ export default {
       );
     }
 
-    // `by=` is evaluated once, before the loop runs, so the loop parameters
-    // are not in scope there. Keying a loop by its own parameter otherwise
-    // dies at render time with a bare undefined-variable error.
+    // `by=` is evaluated once before the loop runs, so loop parameters are not in
+    // scope; keying by one otherwise dies at render with an undefined-variable error.
     if (
       byAttr?.type === "Identifier" &&
       !tag.scope.getBinding(byAttr.name) &&
@@ -247,11 +245,8 @@ export default {
           isStaticSerializeReason(branchSerializeReason) &&
           isStaticSerializeReason(markerSerializeReason)
         ) {
-          // Every iteration's branch id unconditionally rides a resume
-          // marker with the parent scope id, and the state driven loop
-          // expression keeps the loop signal (which enables branch visits)
-          // in any bundle that can update these scopes, so the owner is
-          // linked at resume instead of serialized.
+          // Each branch id rides a resume marker with the parent scope id, and the
+          // stateful loop keeps the branch-visiting signal, so link owner at resume.
           setSectionOwnerResumedByMarker(bodySection);
         }
 

--- a/packages/runtime-tags/src/translator/core/html-comment.ts
+++ b/packages/runtime-tags/src/translator/core/html-comment.ts
@@ -110,9 +110,8 @@ export default {
       if (isOutputHTML()) {
         const { body } = tag.node.body;
         if (nodeBinding && isEmptiableCommentBody(body)) {
-          // A resumable comment must serialize with content, otherwise its
-          // trailing resume marker claims a stray text node over the comment.
-          // Pad an otherwise-empty body with a space.
+          // A resumable comment must serialize with content, else its trailing
+          // resume marker claims a stray text node; pad an empty body with a space.
           if (body.length) {
             write`${t.logicalExpression(
               "||",

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -148,12 +148,8 @@ export const IfTag = {
               ),
             )
           ) {
-            // This branch always returns its index (so when rendered its id
-            // rides the resume marker), the marker always renders, and the
-            // state driven condition keeps the conditional signal (which
-            // enables branch visits) in any bundle that can update these
-            // scopes, so the owner is linked at resume instead of
-            // serialized.
+            // The branch id rides the always-rendered resume marker and the
+            // state driven condition keeps the signal, so the owner resumes.
             setSectionOwnerResumedByMarker(bodySection);
           }
           writer.flushInto(tag);
@@ -393,17 +389,13 @@ export const ElseTag = {
   ],
 };
 
-// An `<if>`/`<else-if>`/`<else>` chain whose branches only render text can be
-// collapsed into a single text placeholder, e.g.
-//   <if=show>Hi</><else>Bye</>  ->  ${show ? "Hi" : "Bye"}
-// This avoids the branch scopes and `_if` runtime entirely.
+// Collapse a text-only `<if>`/`<else-if>`/`<else>` chain into a single text
+// placeholder, avoiding the branch scopes and `_if` runtime entirely.
 export function flattenTextOnlyConditional(rootTag: t.NodePath<t.MarkoTag>) {
   if (!isCoreTagName(rootTag, "if")) return;
 
-  // Only convert when the conditional renders inside a native element. There it
-  // becomes a normal text node; at the root of a template or component body the
-  // content is instead treated as a dynamic renderer (with different SSR and
-  // DOM output shapes), so the placeholder rewrite would not be equivalent.
+  // Only convert inside a native element (a text node); at a template or component
+  // root the content is a dynamic renderer with different output, so the rewrite differs.
   const tagBody = rootTag.parentPath;
   if (!tagBody.isMarkoTagBody()) return;
   const parentTag = tagBody.parentPath;
@@ -460,9 +452,8 @@ export function flattenTextOnlyConditional(rootTag: t.NodePath<t.MarkoTag>) {
     (isCoreTagName(cur, "else-if") || isCoreTagName(cur, "else"))
   );
 
-  // Converting bypasses the analyze phase (and its validation), so ensure the
-  // chain is well formed before doing so; invalid chains fall through to the
-  // normal handling where the appropriate error is reported.
+  // Converting bypasses the analyze phase, so validate first; invalid chains
+  // fall through to the normal handling where the error is reported.
   for (const branchTag of branches) {
     assertValidCondition(branchTag);
   }

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -122,9 +122,8 @@ export default {
       // Reserves the TagVariableChange accessor at `id + 1`.
       binding.reserveSize = 1;
       setBindingDownstream(binding, tagExtra);
-      // The serialized change handler is only ever invoked by an assignment
-      // to the tag variable (the render path always receives a fresh handler
-      // before reading it), so it does not resume when nothing assigns.
+      // The serialized change handler is only invoked by an assignment to the
+      // tag variable, so it does not resume when nothing assigns.
       if (binding.assignmentSections) {
         addSerializeReason(
           tagSection,

--- a/packages/runtime-tags/src/translator/core/show.ts
+++ b/packages/runtime-tags/src/translator/core/show.ts
@@ -85,10 +85,8 @@ export default {
 
       const tagSection = getOrCreateSection(tag);
 
-      // Bindings are created in walk order. The parent element (only child
-      // case) is visited before the body's own bindings, so it is created
-      // here; otherwise a marker binding starts the body's node range and the
-      // reference node is created at analyze exit (visited after the body).
+      // Bindings are created in walk order: the only-child parent, or the body
+      // range's start marker, precedes the body and so is created here.
       if (getOnlyChildParentTagName(tag)) {
         getOptimizedOnlyChildNodeBinding(tag, tagSection);
       } else {
@@ -207,9 +205,8 @@ export default {
           }
         }
 
-        // The runtime calls bracket the body's statements rather than
-        // receiving a callback so declarations in them (e.g. from `<let>`)
-        // stay readable by later statements.
+        // The runtime calls bracket the body's statements (rather than taking a
+        // callback) so declarations in them stay readable by later statements.
         for (const replacement of tag.replaceWithMultiple([
           t.expressionStatement(
             callRuntime("_show_start", t.cloneNode(display, true), startMark),

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -87,9 +87,8 @@ export default {
       checkDynamicStylePlacement(tag);
     }
 
-    // Resolve the style up front so the page entry builder can link it in for
-    // server only templates (which never reach translate). The path is cached
-    // on the node for translate to reuse.
+    // Resolve up front so the page entry builder can link it for server-only
+    // templates (which never reach translate); cached on the node for reuse.
     const importPath = getStyleImportPath(file, node, names);
     (node.extra ??= {}).styleImportPath = importPath;
     if (importPath) {
@@ -350,9 +349,8 @@ function buildStyleDecls(node: t.MarkoTag) {
 }
 
 /**
- * Resolves a `<style>` block's text content to its client side import path
- * (eg `./template.marko.css`) by handing the css off to the configured
- * `resolveVirtualDependency` hook.
+ * Resolves a `<style>` block's text to its client-side import path by handing
+ * the css to the configured `resolveVirtualDependency` hook.
  */
 function getStyleImportPath(
   file: t.BabelFile,

--- a/packages/runtime-tags/src/translator/util/analyze-errors.ts
+++ b/packages/runtime-tags/src/translator/util/analyze-errors.ts
@@ -3,12 +3,8 @@ import { diagnosticError } from "@marko/compiler/babel-utils";
 
 import { createProgramState } from "./state";
 
-// Analyze failures are recorded as error diagnostics so one compile reports
-// every mistake in the template (the compiler throws them together at the
-// end of the analyze stage, and editors compiling with `errorRecovery` keep
-// them as recoverable diagnostics instead of a thrown error). Code-frame
-// errors built by the compiler carry their original `label`/`loc`, so
-// nothing is lost converting a caught error into a diagnostic.
+// Recorded as diagnostics rather than thrown so one compile reports every
+// mistake, and `errorRecovery` editors keep them as recoverable diagnostics.
 
 const [getHasAnalyzeErrors, setHasAnalyzeErrors] = createProgramState(
   () => false,

--- a/packages/runtime-tags/src/translator/util/binding-prop-tree.ts
+++ b/packages/runtime-tags/src/translator/util/binding-prop-tree.ts
@@ -73,11 +73,8 @@ export function getBindingPropTree(binding: Binding) {
   return props;
 }
 
-// Whether a binding's only consumer is a no-input content passthrough
-// (`<${binding}/>`) in the section the value is received in. Only params
-// supplied by a known parent (template `input` or a `<define>` body) reach
-// here, so such content is always a `_content(...)` renderer and can use the
-// leaner `_dynamic_tag_content` signal.
+// A binding whose sole consumer is a no-input `<${binding}/>` passthrough is always a
+// `_content(...)` renderer (only known-parent `input`/`<define>` params reach here) — use the leaner `_dynamic_tag_content` signal.
 function isDirectContentBinding(binding: Binding) {
   if (binding.reads.size !== 1) {
     return false;

--- a/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
+++ b/packages/runtime-tags/src/translator/util/body-to-text-literal.ts
@@ -18,16 +18,14 @@ export function bodyToTextLiteral(body: t.MarkoTagBody) {
   return buildTextLiteral(body, toText, false);
 }
 
-// Pre-analyze: same, but interpolations stay raw (the output-specific `_to_text`
-// import can't precede translate) and a lone interpolation stays bare so the
-// placeholder coerces it directly; `injectTextCoercion` finishes the rest.
+// Pre-analyze variant: interpolations stay raw (the output-specific `_to_text` import
+// can't precede translate); a lone interpolation stays bare so the placeholder coerces it.
 export function bodyToRawTextLiteral(body: t.MarkoTagBody) {
   return buildTextLiteral(body, (value) => value, true);
 }
 
-// Translate: wrap each raw interpolation from `bodyToRawTextLiteral` in
-// `_to_text`, in place so analyze bindings survive. Recurse the conditional;
-// stop at each template literal (its expressions are the values themselves).
+// Translate: wrap each raw interpolation from `bodyToRawTextLiteral` in `_to_text`,
+// mutating in place so analyze bindings survive.
 export function injectTextCoercion(expr: t.Expression) {
   switch (expr.type) {
     case "ConditionalExpression":

--- a/packages/runtime-tags/src/translator/util/entry-builder.ts
+++ b/packages/runtime-tags/src/translator/util/entry-builder.ts
@@ -36,9 +36,8 @@ export default {
     if (state.init) {
       const isPage = entryFile.path.node.extra.page;
       const initHelper: DOMRuntimeHelpers = isPage ? "init" : "initEmbedded";
-      // The main entry import below pulls in every template (and therefore each
-      // of their client assets) transitively, so the collected asset imports
-      // are not needed here.
+      // The main entry import below pulls in every template (and their client assets)
+      // transitively, so the collected asset imports are not needed here.
       body.push(
         t.importDeclaration(
           [
@@ -80,9 +79,8 @@ export default {
           : t.expressionStatement(initExpression),
       );
     } else {
-      // A server only page has no runtime to initialize, so its client assets
-      // (which an interactive page receives transitively through the main entry
-      // import) must be linked in directly.
+      // A server only page has no runtime to initialize, so its client assets must be
+      // linked directly (an interactive page receives them transitively via the main entry import).
       for (const asset of state.assets) {
         body.push(t.importDeclaration([], t.stringLiteral(asset)));
       }
@@ -113,9 +111,8 @@ export default {
       state.init = true;
     }
 
-    // Link the template's known client side assets (styles, css imports, etc)
-    // into the page entry so that static routes still ship them. These are
-    // collected onto the metadata during analyze.
+    // Link the template's known client side assets (styles, css imports, etc) into
+    // the page entry so that static routes still ship them; collected during analyze.
     if (assetImports) {
       for (const request of assetImports) {
         state.assets.add(resolveRelativeToEntry(entryFile, file, request));

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -673,9 +673,8 @@ function analyzeAttrs(
         rootAttrExprs.add(attrExtra);
         addSetupExpr(section, attr.value);
         setBindingDownstream(templateExportAttr.binding, attrExtra);
-        // A cross template child that only ever invokes this input makes the
-        // attribute `invokeOnly`. Same program prop trees may still be
-        // mid-analysis with incomplete reads, so they are skipped.
+        // A cross template child that only ever invokes this input makes the attribute
+        // `invokeOnly`; same-program prop trees may be mid-analysis with incomplete reads, so skipped.
         if (
           getRootSection(templateExportAttr.binding.section) !==
             getProgram().node.extra.section &&

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -736,12 +736,8 @@ function createBindingsAndTrackReferences(
               scope,
               section,
               patternBinding,
-              // A rest element mirrors the shifted tail of its source; the tail
-              // is carried by `excludeProperties` + `restOffset`, so it must be
-              // created without a `property` (matching the object-pattern rest
-              // above). Passing the array pattern's own `property` here would
-              // route the rest through the property-alias branch of
-              // `createBinding` and collide with a sibling element binding.
+              // A rest element mirrors the shifted tail via `excludeProperties` +
+              // `restOffset`; passing its own `property` would collide with a sibling binding.
               undefined,
               excludeProperties,
               i,
@@ -823,9 +819,8 @@ export function mergeReferences<T extends t.Node>(
   for (const node of nodes) {
     if (!node) continue;
     const extra = (node.extra ??= {});
-    // The target can appear in its own node list (eg related controllable
-    // attrs); merging it into itself would create a `merged` cycle and
-    // double its reads.
+    // The target can appear in its own node list; merging it into itself would
+    // create a `merged` cycle and double its reads.
     if (extra === targetExtra) continue;
     extra.merged = targetExtra;
     if (isReferencedExtra(extra)) {
@@ -1571,10 +1566,8 @@ export function mergeSources(a: undefined | Sources, b: undefined | Sources) {
 function unionParamSources(a: Sources["param"], b: Sources["param"]) {
   const merged = bindingUtil.union(a, b);
   if (merged && Array.isArray(merged)) {
-    // When merging param sources we filter out
-    // any property aliases that are already a part of the merged set.
-    // Eg if `input` is present, we don't need properties like `input.foo`
-    // even though for params properties are seen as discrete sources.
+    // Filter out property aliases already in the merged set (eg drop `input.foo`
+    // when `input` is present); params otherwise treat properties as discrete sources.
     return filter(merged, (binding) => {
       let alias = binding.upstreamAlias;
       while (alias) {
@@ -1688,11 +1681,8 @@ function addReadToExpression(
   const fnRoot = getFnRoot(root);
   const exprRoot = getExprRoot(fnRoot || root);
   const section = getOrCreateSection(exprRoot);
-  // Reads recorded after the owning expression was merged into another
-  // node's extra (anything tracked at identifier-visit time -- eg `$global`
-  // reads -- after an `<if>`'s analyze merged its test into the tag extra)
-  // must land on the merge target, or the expression's references split
-  // and the merged extra resolves with the read missing.
+  // Reads recorded after the owning expression merged into another node's extra
+  // must land on the merge target, else its references split and the read is lost.
   const exprExtra = getCanonicalExtra(
     (exprRoot.node.extra ??= { section }) as ReferencedExtra,
   );
@@ -2094,10 +2084,8 @@ export function getReadReplacement(
   }
 }
 
-// A binding whose receiving template can never observe its value: every read
-// is in an `invokeOnly` expression and nothing else (an assignment, hoist,
-// getter, or property access) can see it. An attribute providing such an
-// input is itself `invokeOnly` for the parent.
+// A binding the receiving template can never observe: every read is in an
+// `invokeOnly` expression and nothing else (assignment, hoist, getter, access) sees it.
 export function isInvokeOnlyBinding(binding: Binding): boolean {
   if (
     binding.assignmentSections ||
@@ -2269,12 +2257,8 @@ function addBindingGetter(binding: Binding, { invoked, hoisted }: Getter) {
   }
 }
 
-// A lazy read is excluded from its expression's `referencedBindings` and
-// instead reads the binding's scope slot when its containing function is
-// invoked. Sound when the expression is `invokeOnly`, the read is deferred,
-// and the emitted read is a plain own scope slot that can be kept current
-// without a subscriber (so not a change handler read, an alias slot, or a
-// `local` from an ancestor section).
+// A lazy read is excluded from `referencedBindings` and instead reads the
+// binding's own scope slot on invocation; sound only for a subscriber-free own slot.
 function isLazyRead(
   expr: { section: Section; invokeOnly?: true },
   read: Read,

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -481,9 +481,8 @@ function compareParamGroups(
 
 function isNativeNode(tag: t.NodePath<t.MarkoTag>) {
   if (isCoreTag(tag)) {
-    // The `<show>` body, like the html-* tags' content, is always rendered
-    // exactly once, so it compiles inline into the parent section rather
-    // than as its own section.
+    // The `<show>` body, like the html-* tags' content, always renders exactly
+    // once, so it compiles inline into the parent section rather than its own.
     switch (tag.node.name.value) {
       case "html-comment":
       case "html-script":

--- a/packages/runtime-tags/src/translator/util/serialize-reasons.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-reasons.ts
@@ -161,9 +161,8 @@ export function isStaticSerializeReason(
   return !!reason && !isReasonDynamic(reason);
 }
 
-// A reason backed by state sources specifically. State only serializes when
-// it can change client side, which keeps the state's signal (and everything
-// it renders) in the bundle.
+// A reason backed by state sources. State only serializes when it can change
+// client side, keeping its signal (and everything it renders) in the bundle.
 export function isStateSerializeReason(
   reason: undefined | SerializeReason,
 ): reason is Sources {

--- a/packages/runtime-tags/src/translator/util/setup-statements.ts
+++ b/packages/runtime-tags/src/translator/util/setup-statements.ts
@@ -4,16 +4,8 @@ import type { Section } from "./sections";
 import { createSectionState } from "./state";
 
 /**
- * Tracks, during analyze, whether translate will add statements to a
- * section's setup signal (the signal keyed by no referenced bindings).
- * Sites that key statements by an expression's resolved references register
- * the expression with `addSetupExpr`; sites that always target the setup
- * signal call `addSetupStatement`. Expressions that resolve references
- * through `mergeReferences` are covered centrally by `finalizeReferences`.
- *
- * This lets a template's analyze phase prove its setup export is a noop so
- * parent templates can skip importing and calling it. The proof is checked
- * when the template itself is translated (see `visitors/program/dom.ts`).
+ * Tracks during analyze whether translate will add setup-signal statements, so a
+ * template can prove its setup export is a noop and parents can skip calling it.
  */
 
 const [getSetupInfo] = createSectionState("setupStatements", () => ({

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -120,9 +120,8 @@ export const [getTryHasPlaceholder, setTryHasPlaceholder] = createSectionState<
   true | undefined
 >("tryWithPlaceholder");
 
-// A branch section whose scope ids are guaranteed to ride a resume marker
-// carrying the parent scope id whenever its scopes serialize; the client
-// links the owner from the marker so `_` is not serialized.
+// A branch section whose scope ids ride a resume marker carrying the parent scope
+// id when its scopes serialize, so the client links the owner and `_` is not serialized.
 const [getOwnerResumedByMarker, setOwnerResumedByMarker] = createSectionState<
   true | undefined
 >("ownerResumedByMarker");
@@ -1633,9 +1632,8 @@ function getBuildAssignment(extra: AssignedBindingExtra) {
     return (section: Section, value: t.Expression) => {
       let scopeRead: t.Expression;
       if (assignmentTo.pruned) {
-        // The change binding was pruned because an ancestor binding is
-        // already tracked. Read the change handler via property chain
-        // from the nearest non-pruned ancestor.
+        // The change binding was pruned (an ancestor is already tracked), so read
+        // the change handler via property chain from the nearest non-pruned ancestor.
         let cur = assignmentTo;
         const props: string[] = [];
         while (cur.pruned && cur.property !== undefined && cur.upstreamAlias) {

--- a/packages/runtime-tags/src/translator/util/static-text.ts
+++ b/packages/runtime-tags/src/translator/util/static-text.ts
@@ -3,12 +3,8 @@ import { types as t } from "@marko/compiler";
 import { isNotVoid, isVoid } from "../../common/helpers";
 import evaluate from "./evaluate";
 
-// A run of adjacent static text -- literal `MarkoText` and confident, non-void
-// escaped `${...}` placeholders (comments between them are stripped, so the
-// surrounding text merges) -- is written into the template as a single DOM
-// text node. Exactly one node in the run may contribute a walk step, so each
-// node emits its own step only when it starts a run, i.e. when its previous
-// meaningful sibling is not itself static text.
+// A run of adjacent static text (literal `MarkoText` and confident non-void escaped
+// `${...}`) becomes one DOM text node; only the node starting a run emits a walk step.
 export function isStaticText(node?: t.Node) {
   switch (node?.type) {
     case "MarkoText":

--- a/packages/runtime-tags/src/translator/util/walks.ts
+++ b/packages/runtime-tags/src/translator/util/walks.ts
@@ -95,13 +95,6 @@ export function visit(
   path: t.NodePath<t.MarkoTag | t.MarkoPlaceholder | t.Program>,
   code: VisitCodes,
 ) {
-  // const { binding } = path.node.extra!;
-  // if (code && (!binding || binding.type !== BindingType.dom)) {
-  //   throw path.buildCodeFrameError(
-  //     "Tried to visit a node that was not marked as needing to visit during analyze.",
-  //   );
-  // }
-
   if (isOutputHTML()) {
     return;
   }

--- a/packages/runtime-tags/src/translator/visitors/function.ts
+++ b/packages/runtime-tags/src/translator/visitors/function.ts
@@ -158,9 +158,8 @@ function shouldAlwaysRegister(markoRoot: MarkoExprRootPath) {
   switch (analyzeTagNameType(tag)) {
     case TagNameType.DynamicTag:
     case TagNameType.NativeTag:
-      // Passing a function to a dynamic tag could always be potentially serialized.
-      // Native tag event handlers are skipped in the `canIgnoreRegister`
-      // if it's anything else we need to unconditionally serialize.
+      // A function passed to a dynamic tag may always be serialized; native-tag event
+      // handlers are already skipped in `canIgnoreRegister`, so anything else must serialize.
       return true;
     case TagNameType.AttributeTag:
       if (

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -37,10 +37,8 @@ export default {
     const { source } = node;
     const { value } = source;
 
-    // Link known client side asset imports (eg css) into the page entry so that
-    // server only templates still ship them. Only top level imports are linked;
-    // imports within a `client` statement already mark the program interactive
-    // (pulling their template in), and `server` imports never run on the client.
+    // Link client-side asset imports (eg css) into the page entry so server-only
+    // templates still ship them. Only top-level imports need linking.
     if (
       t.isProgram(importDecl.parent) &&
       isClientAssetImport(importDecl.hub.file, value)

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -70,10 +70,8 @@ export default {
     if (confident && isVoid(computed)) return;
 
     if (isStaticText(node)) {
-      // Only the node that starts a merged static-text run emits the walk step
-      // for it. Defer when a previous sibling is static text (it owns the step);
-      // deferring on a *following* static sibling instead would drop the step
-      // entirely for a run made up solely of static placeholders.
+      // Only the run's first node emits the walk step; defer to a previous static sibling that owns it.
+      // Deferring to a following sibling instead would drop the step entirely for an all-static run.
       if (isStaticText(getPrevStaticSibling(placeholder))) {
         (node.extra ??= {})[kSharedText] = true;
       }
@@ -137,9 +135,8 @@ export default {
           walks.visit(placeholder, WalkCode.Replace);
         } else {
           if (isHTML) {
-            // A preceding element/comment would be claimed as the text node
-            // when the value serializes empty, so it gets the same
-            // protective separator as sibling text.
+            // A preceding element/comment would be claimed as the text node when
+            // the value serializes empty, so it gets the same protective separator.
             if (
               siblingText === SiblingText.NodeBefore &&
               markerSerializeReason
@@ -194,11 +191,8 @@ export default {
   },
 } satisfies TemplateVisitor<t.MarkoPlaceholder>;
 
-// Produces an expression equivalent to `_escape(value)` but only escapes the
-// parts that need it: static strings are escaped at compile time and dynamic
-// leaves are wrapped individually, recursing through the branches of a
-// conditional and the parts of a template literal so we escape as little as
-// possible.
+// Produces an expression equivalent to `_escape(value)` that escapes as little as
+// possible: static strings at compile time, dynamic leaves wrapped individually.
 function buildEscapedTextExpression(value: t.Expression): t.Expression {
   const { _escape } = getHTMLRuntime();
   switch (value.type) {
@@ -220,9 +214,8 @@ function buildEscapedTextExpression(value: t.Expression): t.Expression {
         parts.push(_escape(quasi.value.cooked ?? ""));
         const expression = value.expressions[i];
         if (expression) {
-          // Match the coercion a template literal would apply (e.g. `null`
-          // stringifies to `"null"`, not `""`) before escaping, so this stays
-          // equivalent to escaping the whole template literal.
+          // Match the coercion a template literal applies (`null` becomes `"null"`,
+          // not `""`) before escaping, so this equals escaping the whole literal.
           parts.push(
             callRuntime(
               "_escape",
@@ -333,8 +326,7 @@ function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
 }
 
 // Returns the owner tag when `parent` is the body of a tag that inlines its
-// content into the surrounding section (currently only `<show>`), meaning the
-// body's edge nodes render adjacent to the tag's siblings.
+// content into the surrounding section (currently only `<show>`).
 function getInlinedBodyTag(parent: t.NodePath) {
   if (parent.isMarkoTagBody()) {
     const tag = parent.parentPath;

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -169,9 +169,8 @@ export default {
 
       const setup = getSetup(section);
       if (domExports.setupEmpty && setup && written.has(setup)) {
-        // Parent templates have skipped calling the setup export based on
-        // the analyze phase proving it would be a noop; a non noop setup
-        // here means that proof was wrong and must fail loudly.
+        // Parents skip calling this setup export because analyze proved it a noop;
+        // a non-noop setup here means that proof was wrong, so fail loudly.
         throw program.buildCodeFrameError(
           "Marko internal error: analysis marked this template's setup export as empty but translation produced statements for it. Please open an issue with a reproduction.",
         );

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -171,11 +171,8 @@ export default {
           "_template",
           t.stringLiteral(program.hub.file.metadata.marko.id),
           contentId ? t.identifier(contentId) : contentFn,
-          // A non-page template renders as an "embed" with a randomized render
-          // id so that multiple can be placed in the same document without their
-          // scope ids colliding. That only matters for real builds that link
-          // client assets; without `linkAssets` (eg. most test/SSR-only setups)
-          // treat every template as a page so its render id stays deterministic.
+          // A non-page template gets a randomized render id ("embed") so several
+          // can share a document without colliding; without linkAssets, use a fixed page id.
           program.node.extra!.page || !getMarkoOpts().linkAssets
             ? t.numericLiteral(1)
             : undefined,

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -93,9 +93,8 @@ export default {
     },
 
     exit(program) {
-      // Analyze failures were reported as diagnostics (the compiler throws
-      // them together right after this stage); failed tags were skipped, so
-      // skip finalization work that assumes an error-free template.
+      // Analyze failures were already reported as diagnostics and their tags
+      // skipped, so skip finalization work that assumes an error-free template.
       if (hasAnalyzeErrors()) return;
       finalizeReferences();
       const programExtra = program.node.extra!;

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -46,11 +46,8 @@ function normalizeBody(
   }
 }
 
-// Pulls the unconditional leading/trailing static parts of a template literal
-// placeholder into adjacent text nodes so they can be written statically (and
-// tree-shaken) instead of escaped at runtime, e.g.
-//   ${`Message ${data}`}  ->  Message ${data}
-// Only escape-invariant text is moved, since a text node is written raw.
+// Moves a placeholder's unconditional leading/trailing static text into adjacent
+// text nodes so it writes statically; only escape-invariant text, since text is raw.
 function hoistStaticPlaceholderText(
   placeholder: t.NodePath<t.MarkoPlaceholder>,
 ) {

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -94,10 +94,8 @@ export default {
       }
 
       if (tagExtra.tagNameLoad || !childExtra.domExports?.setupEmpty) {
-        // The child's setup call lands in this section's setup unless the
-        // child template proved its setup export is a noop (a mid analysis
-        // child, eg a circular reference, has no flag yet and is assumed to
-        // have a setup). Load tags always wire up `_load_setup`.
+        // Add the child's setup call unless it proved its setup export a noop
+        // (mid-analysis children assumed to have one); load tags always wire it up.
         addSetupStatement(getOrCreateSection(tag));
       }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/index.ts
@@ -19,10 +19,8 @@ declare module "@marko/compiler/dist/types" {
 export default {
   analyze: {
     enter(tag) {
-      // Analyze failures become error diagnostics (instead of aborting on
-      // the first) so a template with several mistakes reports them all
-      // together; the compiler throws them at the end of the stage. A failed
-      // tag's subtree is skipped to limit cascading follow-on errors.
+      // Collect analyze failures as diagnostics instead of aborting on the first,
+      // so all mistakes report together; skip the subtree to limit cascading errors.
       try {
         const tagDef = getTagDef(tag);
         const type = analyzeTagNameType(tag);
@@ -69,21 +67,6 @@ export default {
         reportAnalyzeError(tag, err);
         return;
       }
-
-      // switch (analyzeTagNameType(tag)) {
-      //   case TagNameType.NativeTag:
-      //     // NativeTag.analyze.exit(tag);
-      //     break;
-      //   case TagNameType.CustomTag:
-      //     // CustomTag.analyze.exit(tag);
-      //     break;
-      //   case TagNameType.AttributeTag:
-      //     // AttributeTag.analyze.exit(tag);
-      //     break;
-      //   case TagNameType.DynamicTag:
-      //     // DynamicTag.analyze.exit(tag);
-      //     break;
-      // }
     },
   },
   translate: {

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -1482,9 +1482,8 @@ function buildAttrExpression(
     : t.stringLiteral(serialized);
 }
 
-// Hoist a shared `name=` prefix out of a conditional with two literal branches
-// so it folds into the static HTML, e.g. `x ? ' class=on' : ' class=off'` ->
-// ` class=${x ? "on" : "off"}`. Each value keeps its own quoting.
+// Hoist a shared `name=` prefix out of a conditional's two literal branches so it folds
+// into static HTML: `x ? ' class=on' : ' class=off'` -> ` class=${x ? "on" : "off"}`.
 function factorAttrConditional(value: t.Expression): t.Expression {
   if (value.type !== "ConditionalExpression") {
     return value;
@@ -1572,9 +1571,8 @@ function buildStringAttrAnd(
   }
 }
 
-// Resolve a static-base `class` object/array at build time, referencing each
-// toggle once: 1 toggle picks a precomputed literal; a few index a hoisted table
-// packed from the toggles; more concatenate the string for `_attr_class`.
+// Resolve a static-base `class` object/array at build time, referencing each toggle once:
+// 1 picks a precomputed literal; a few index a hoisted table; more concatenate for `_attr_class`.
 const MAX_PRECOMPUTED_CLASS_TOGGLES = 4;
 function buildClassAttrExpression(value: t.Expression) {
   if (value.type !== "ObjectExpression" && value.type !== "ArrayExpression") {
@@ -1777,10 +1775,8 @@ function trackDelimitedAttrObjectProperties(
 }
 
 function isDynamicControllable(controllable: RelatedControllable) {
-  // We can treat an otherwise controllable attr as a normal attribute if:
-  // * It does not have a possible change handler.
-  // * It is not "special" (eg checkedValue)
-  // * It can never be updated (no referenced bindings).
+  // An otherwise controllable attr is a plain attribute when it is not "special",
+  // has no change handler, and can never update (no referenced bindings).
   if (controllable) {
     return (
       controllable.special ||

--- a/packages/runtime-tags/src/translator/visitors/text.ts
+++ b/packages/runtime-tags/src/translator/visitors/text.ts
@@ -17,10 +17,8 @@ export default {
   analyze(text) {
     if (isNonHTMLText(text)) return;
 
-    // Adjacent static text merges into a single DOM text node, so only the node
-    // that starts the run emits its walk step. Defer when a previous sibling is
-    // static text -- otherwise two `MarkoText`s in one run (e.g. `a${"x"}b`)
-    // would each emit a step and over-count the walk.
+    // Adjacent static text merges into one DOM text node, so only the run's first node emits
+    // its walk step; defer when the previous sibling is static text so a run doesn't over-count.
     if (isStaticText(getPrevStaticSibling(text))) {
       (text.node.extra ??= {})[kSharedText] = true;
     }


### PR DESCRIPTION
## Description

Applies the AGENTS.md comment guideline (comments are a last resort, never exceed two lines, capture intent) across `packages/runtime-tags/src`. Over-length comments are condensed to two intent-preserving lines, and two blocks of commented-out dead code are removed.

Irreplaceable multi-line specs are intentionally left intact (the walks-string laws, the serialize wire protocol, the abort-id cross-compile invariant, the `pureDOMFunctions` soundness contract, and a few others).

Comments-only: no code, `@__PURE__`/`@__NO_SIDE_EFFECTS__` annotations, or type/lint/format directives were touched, so generated output and bundle sizes are unaffected.

## Checklist:

- [ ] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.

_Comments-only change with no user-facing behavior, so no docs or tests apply._


---
_Generated by [Claude Code](https://claude.ai/code/session_016f4xvuZjNQuZtyimskRQC5)_