### PR TITLE
fix(runtime-tags): list `until` in the `&lt;for&gt;` missing-range error

### DIFF
--- a/.changeset/for-until-error-message.md
+++ b/.changeset/for-until-error-message.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Include `until` in the error thrown when a `<for>` tag has no range attribute. `until` is a first-class `<for>` range (`<for until=n>`), but the message only listed `of=`, `in=`, and `to=`, hiding a valid option; it now reads `requires an of=, in=, to=, or until= attribute`.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -187,12 +187,6 @@ and compiles to code that fails at runtime; detecting it through the binding
 graph would surface the same clear compile error. Verify: compile
 `<const/a=b/><const/b=a/>` used as a value and observe no diagnostic.
 
-## Include `until` in the `<for>` missing-range-attribute error message
-
-`packages/runtime-tags/src/translator/core/for.ts` › `analyze` | 2026-07-20 | impact:low | effort:low
-
-When a `<for>` has no range attribute, `analyze` throws "The `<for>` tag requires an `of=`, `in=`, or `to=` attribute." (for.ts:96-98), but `until` is a first-class `<for>` type: it has its own `case "until"` two lines above the throw (92-93), is a member of the `ForType` union (63), maps to the `forUntil`/`_for_until` runtime (570/583), and has its own `attributes.until` description. A developer reaching for `<for until=n>` (or mistyping another range attribute) is told only about of/in/to, hiding a valid option the same file fully supports. Add `until` to the message: "requires an `of=`, `in=`, `to=`, or `until=` attribute." Re-verify: read the `default:` branch of the `switch (forType)` in `analyze` and confirm `until` is a handled case immediately above the throw yet absent from the thrown string.
-
 ## Give array-destructure two-way binding a cause-specific error instead of the generic "Unable to bind to value."
 
 `packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandler` | 2026-07-20 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-dom.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/template.marko:1:1
     > 1 | <for foo=1>
-        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.
+        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, `to=`, or `until=` attribute.
       2 |   Hello
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-dom.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/template.marko:1:1
     > 1 | <for foo=1>
-        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.
+        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, `to=`, or `until=` attribute.
       2 |   Hello
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-html.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/template.marko:1:1
     > 1 | <for foo=1>
-        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.
+        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, `to=`, or `until=` attribute.
       2 |   Hello
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/__snapshots__/error-compile-html.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-for-no-iteration-attr/template.marko:1:1
     > 1 | <for foo=1>
-        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.
+        | ^ The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, `to=`, or `until=` attribute.
       2 |   Hello
       3 | </for>
       4 |

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -94,7 +94,7 @@ export default {
         break;
       default:
         throw tag.buildCodeFrameError(
-          "The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, or `to=` attribute.",
+          "The [`<for>` tag](https://markojs.com/docs/reference/core-tag#for) requires an `of=`, `in=`, `to=`, or `until=` attribute.",
         );
     }
 


### PR DESCRIPTION
## Description

When a `<for>` has no range attribute, `analyze` throws:

> The `<for>` tag requires an `of=`, `in=`, or `to=` attribute.

…but `until` is a first-class `<for>` range — it has its own `case "until"` two lines above the throw, is part of the `ForType` union, and maps to the `_for_until` runtime. A developer reaching for `<for until=n>` (or mistyping a range attribute) was told only about `of`/`in`/`to`, hiding a valid option the same file fully supports. The message now reads:

> requires an `of=`, `in=`, `to=`, or `until=` attribute.

## Verification

- Regenerated the existing `error-for-no-iteration-attr` fixture (its snapshots now include `until=`).
- No other fixture carried the old message.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_