### PR TITLE
fix(changeset): target the marko package for the for-step docs example

### DIFF
--- a/.changeset/for-step-docs-example.md
+++ b/.changeset/for-step-docs-example.md
@@ -1,5 +1,5 @@
 ---
-"@marko/runtime-class": patch
+"marko": patch
 ---
 
 Correct the stepped-`<for>` TypeScript documentation example to use `step=2` (the increment) instead of `by=2` (the hydration key), which failed type-checking and silently iterated by one.


### PR DESCRIPTION
The `for-step-docs-example` changeset (added in #3498) named `@marko/runtime-class`, but the `packages/runtime-class` directory publishes under the npm name **`marko`** (Marko 5) — `@marko/runtime-class` is only its internal translator id. Changesets validates against workspace `package.json` `name` fields, so it errored on main:

```
🦋  error Found changeset for-step-docs-example for package @marko/runtime-class which is not in the workspace
```

Retargeting the changeset to `marko` fixes it. `npx changeset status` now passes and reports `marko` + `@marko/runtime-tags` to be bumped at patch. The change is a docs correction to the `marko` package, so a `marko` patch is the right bump.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qm9BdxbRQyQJeWbcBTTsJp)_