### PR TITLE
fix: propagate package identity through taglib-imports

### DIFF
--- a/.changeset/nested-taglib-imports-package-identity.md
+++ b/.changeset/nested-taglib-imports-package-identity.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Propagate package identity through `taglib-imports` so tags from a nested imported taglib resolve by their package name instead of a realpath (eg pnpm's virtual store) that may not be importable.

--- a/packages/compiler/src/taglib/loader/Taglib.js
+++ b/packages/compiler/src/taglib/loader/Taglib.js
@@ -18,11 +18,33 @@ function handleImport(taglib, importedTaglib) {
 
   taglib.imports.push(importedTaglib);
 
+  // Tags from a taglib imported within the importing package inherit its identity,
+  // so they resolve by package name instead of a realpath (eg pnpm) that may not import.
+  if (
+    taglib.packageName &&
+    !importedTaglib.packageName &&
+    isWithin(taglib.packageRoot, importedTaglib.dirname)
+  ) {
+    importedTaglib.setPackageName(taglib.packageName, taglib.packageRoot);
+  }
+
   if (importedTaglib.imports) {
     importedTaglib.imports.forEach(function (nestedImportedTaglib) {
       handleImport(taglib, nestedImportedTaglib);
     });
   }
+}
+
+function isWithin(dir, filename) {
+  var rel = path.relative(dir, filename);
+  // `path.relative` walks out of the dir with `..`, or returns an absolute path
+  // when it cannot relate the two at all, eg across windows drives.
+  return (
+    !!rel &&
+    rel !== ".." &&
+    !rel.startsWith(`..${path.sep}`) &&
+    !path.isAbsolute(rel)
+  );
 }
 
 class Taglib {
@@ -32,6 +54,7 @@ class Taglib {
     this.isFromPackageJson = isFromPackageJson === true;
     this.dirname = path.dirname(this.filePath);
     this.packageName = packageName;
+    this.packageRoot = packageName ? this.dirname : undefined;
     this.scriptLang = undefined;
     this.tags = {};
     this.migrators = [];
@@ -76,8 +99,9 @@ class Taglib {
     this.setTagPackage(tag);
   }
 
-  setPackageName(packageName) {
+  setPackageName(packageName, packageRoot) {
     this.packageName = packageName;
+    this.packageRoot = packageRoot || this.dirname;
     for (var name in this.tags) {
       if (hasOwnProperty.call(this.tags, name)) {
         this.setTagPackage(this.tags[name]);
@@ -88,7 +112,7 @@ class Taglib {
   setTagPackage(tag) {
     if (this.packageName) {
       tag.packageName = this.packageName;
-      tag.packageRoot = this.dirname;
+      tag.packageRoot = this.packageRoot;
     }
   }
 


### PR DESCRIPTION
## Description

Tags nested inside a taglib pulled in via `taglib-imports` never inherited their host package's identity. `taglib-imports` loads the imported `marko.json` as a fresh taglib with no `packageName`/`packageRoot`, so its tags fell back to an absolute realpath import. Under pnpm that realpath points into the virtual store, and `mtc`'s composite build then rejects the dependency's `.d.marko` with TS6059/TS6307.

This propagates the importing package's identity to taglibs imported from within its own directory (cross-package imports are left untouched), so those tags resolve by package name — e.g. `@ebay/ebayui-core/dist/components/ebay-icon/icons/…` instead of a `.pnpm` realpath. It also corrects the runtime's emitted import specifiers for the same tags.

Verified against the pnpm reproduction: `mtc` fails on the published compiler and passes with this change.

Resolves marko-js/language-server#565. `@marko/language-tools` and `@marko/type-check` pick this up through their `@marko/compiler` dependency once released.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.