### PR TITLE
docs: note why createInteropTranslator does not guard optionalTaglibs

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -51,12 +51,6 @@ feature" — one registration per unique class file would suffice.
 
 `addHTMLEffectCall` deliberately passes `undefined as any` to `addStatement`, which pushes it into a `t.Statement[]`; `traverseReplace` and Babel generation happen to skip the falsy array member. The call exists to mark effect dependencies/side effects rather than to add executable syntax, but it violates the signal and Babel AST types and makes every downstream consumer tolerate an invalid node. Add an explicit metadata-only effect operation (or let `addStatement` accept an omitted statement without pushing it) and remove the cast/TODO.
 
-## Interop translator calls `resolveOptionalTaglibs` without the `|| []` guard the compiler's own caller uses
-
-`packages/runtime-tags/src/translator/interop/index.ts` › `createInteropTranslator` | 2026-07-19 | impact:low | effort:low
-
-The interop translator crashes cryptically at module-eval when merged with a Class-API translator that does not export the optional `optionalTaglibs` field. `createInteropTranslator` calls `taglib.resolveOptionalTaglibs(translate5.optionalTaglibs)` with no fallback and no `onError` (`translator/interop/index.ts:31`), whereas the compiler's own caller guards it: `resolveOptionalTaglibs(translator.optionalTaglibs || [], onError)` (`compiler/src/taglib/index.js:40`). `resolveOptionalTaglibs` iterates unguarded — `for (const id of taglibIds)` (`compiler/src/taglib/index.js:97`) — so a missing field throws `TypeError: taglibIds is not iterable` with no source frame indicating which translator/field is at fault. `optionalTaglibs` is genuinely optional (runtime-class exports it, runtime-tags does not), so the interop path assumes a field the merge partner may not provide. Latent for the shipped runtime-class translator (it exports `optionalTaglibs`), but any class-side translator lacking the field crashes. Mirror the compiler's guard: `resolveOptionalTaglibs(translate5.optionalTaglibs || [], onError)`. Not in any existing feedback file.
-
 ---
 
 ## Pre-existing comments exceeding the two-line rule

--- a/packages/runtime-tags/src/translator/interop/index.ts
+++ b/packages/runtime-tags/src/translator/interop/index.ts
@@ -26,6 +26,8 @@ export function createInteropTranslator(translate5: any) {
       ...translate6.tagDiscoveryDirs,
       ...translate5.tagDiscoveryDirs,
     ],
+    // translate5 is the runtime-class translator, which always provides
+    // optionalTaglibs; a missing field should surface loudly, not be masked.
     taglibs: mergeTaglibs(
       taglib
         .resolveOptionalTaglibs(translate5.optionalTaglibs)


### PR DESCRIPTION
Resolves the `resolveOptionalTaglibs` `cleanup.md` entry as **won't-fix** — replacing the proposed `|| []` guard (originally #3512) with a comment.

The entry suggested mirroring the compiler's `resolveOptionalTaglibs(x || [], onError)` guard. But the compiler handles arbitrary translators where a missing `optionalTaglibs` is normal, whereas the **interop path's `translate5` is always the runtime-class translator, which provides the field**. So the guard would defend a case that cannot occur — and worse, silently mask a real regression: if runtime-class ever dropped `optionalTaglibs`, a loud `taglibs is not iterable` at module-eval is preferable to `|| []` quietly continuing.

Adds a two-line comment capturing the invariant at the call site and removes the entry. No behavior/size change.