### PR TITLE
test: fix per-fixture memory retention so full serial runs complete

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,9 +1,13 @@
 {
   "bail": true,
   "timeout": 10000,
-  "no-warnings": true,
-  "enable-source-maps": true,
-  "experimental-vm-modules": true,
+  "node-option": [
+    "no-warnings",
+    "enable-source-maps",
+    "experimental-vm-modules",
+    "max-old-space-size=8192",
+    "max-semi-space-size=128"
+  ],
   "require": ["~ts"],
   "spec": ["packages/*/@(src|test)/**/*.test.@(js|ts)"]
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "report": "open ./coverage/lcov-report/index.html",
     "test": "mocha",
     "test:parallel": "node scripts/test-parallel.js",
-    "test:update": "UPDATE_EXPECTATIONS=1 mocha"
+    "test:update": "UPDATE_EXPECTATIONS=1 mocha",
+    "test:update:parallel": "cross-env UPDATE_EXPECTATIONS=1 node scripts/test-parallel.js"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -154,6 +154,12 @@ function testFixtures(interop?: true) {
             }
             browsers.length = 0;
             getModeOpts.reset();
+            // The runner can survive in mocha's suite graph, so the fixture's
+            // server module is dropped explicitly.
+            ssrRunner.peek()?.then(
+              (runner) => runner.disposeServer(),
+              () => {},
+            );
             ssrRunner.reset();
             csr.reset();
             ssr.reset();
@@ -507,6 +513,7 @@ function stripDefaultScript(html: string) {
 function once<T>(fn: () => T) {
   let cached: T | undefined;
   return Object.assign(() => (cached ??= fn()), {
+    peek: () => cached,
     reset() {
       cached = undefined;
     },

--- a/packages/runtime-tags/src/__tests__/utils/bundle.ts
+++ b/packages/runtime-tags/src/__tests__/utils/bundle.ts
@@ -6,7 +6,7 @@ import { build, type Plugin, type RolldownOutput } from "rolldown";
 import { minifySync } from "rolldown/utils";
 import zlib from "zlib";
 
-import { importWithContext } from "./import-with-context";
+import { importEvictable, importWithContext } from "./import-with-context";
 
 type RunDOM = typeof import("@marko/runtime-tags/dom").run;
 
@@ -36,6 +36,7 @@ export async function createServerRunner<T extends Record<string, string>>(
 ): Promise<{
   assets: string;
   runServer(): Promise<Record<keyof T, Template>>;
+  disposeServer(): void;
   clientRunner?: (ctx: any) => Promise<{ template: Template; run: RunDOM }>;
   domBundle(): Promise<SnapshotResult>;
   htmlBundle(): Promise<SnapshotResult>;
@@ -45,12 +46,79 @@ export async function createServerRunner<T extends Record<string, string>>(
   const out = path.join(cwd, "dist", optimize ? "optimize" : "debug");
   const htmlOut = path.join(out, "html");
   const domOut = path.join(out, "dom");
-  const virtual = virtualPlugin(cwd);
-  const domEntry = entryPlugin();
   const entryNames = Object.keys(entries);
   const csrEntryId = optimize
     ? undefined
     : path.join(cwd, path.basename(entries[entryNames[0]])) + csrExt;
+  const builds = createBuilds(
+    cwd,
+    entries,
+    entryNames,
+    csrEntryId,
+    optimize,
+    interop,
+    config,
+    htmlOut,
+    domOut,
+  );
+  const domResult = await builds.domBuilt;
+  const htmlResult = await builds.htmlBuilt;
+  builds.clearRefs();
+
+  const csrFileName =
+    csrEntryId &&
+    domResult.output.find((c) => c.type === "chunk" && c.name === "csr")
+      ?.fileName;
+  const clientRunner = csrFileName
+    ? (ctx: any): Promise<{ template: Template; run: RunDOM }> =>
+        importWithContext(
+          path.join(domOut, csrFileName),
+          { browser: true },
+          ctx,
+        )
+    : undefined;
+
+  let server: Promise<Record<keyof T, Template>> | undefined;
+  return {
+    assets: domOut,
+    // Memoized so server module state lives across a fixture's renders, as on
+    // a real server; disposed by the fixture teardown because mocha's suite
+    // graph can retain this runner for the whole run.
+    runServer: () =>
+      (server ||= importEvictable<Record<keyof T, Template>>(
+        path.join(htmlOut, "main.mjs"),
+      )),
+    disposeServer: () => {
+      server = undefined;
+    },
+    clientRunner,
+    domBundle: () => buildSnapshot(domResult, cwd, optimize),
+    htmlBundle: () => buildSnapshot(htmlResult, cwd),
+    diagnostics: [...builds.diagnosticsByFile].map(([id, items]) => ({
+      id,
+      items,
+    })),
+  };
+}
+
+// Rolldown's native binding keeps global handles to every function handed to
+// `build()` beyond close(), and each function object pins its defining
+// scope's context. Everything that flows into `build()` is therefore created
+// in this activation — never the runner scope holding the awaited outputs —
+// and `clearRefs` empties the heavy captures once the builds settle.
+function createBuilds(
+  cwd: string,
+  entries: Record<string, string>,
+  entryNames: string[],
+  csrEntryId: string | undefined,
+  optimize: boolean,
+  interop: boolean | undefined,
+  config: compiler.Config,
+  htmlOut: string,
+  domOut: string,
+) {
+  const virtual = virtualPlugin(cwd);
+  const domEntry = entryPlugin();
   const compileOpts: compiler.Config = {
     ...config,
     cache: new Map(),
@@ -69,6 +137,7 @@ export async function createServerRunner<T extends Record<string, string>>(
     if (diagnostics.length) diagnosticsByFile.set(id, diagnostics);
   };
 
+  const domBuiltBox: { promise?: Promise<RolldownOutput> } = {};
   const domBuilt = build({
     cwd,
     ...(csrEntryId ? { input: { csr: csrEntryId } } : {}),
@@ -135,6 +204,7 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
       manualChunks: (id) => (testUtilRe.test(id) ? "test-utils" : undefined),
     },
   });
+  domBuiltBox.promise = domBuilt;
   const htmlBuilt = build({
     cwd,
     input: {
@@ -194,7 +264,7 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
 }`,
         },
         async renderChunk(_code, _chunk, _options, meta) {
-          const { output } = await domBuilt;
+          const { output } = await domBuiltBox.promise!;
           const manifest: {
             [entry: string]: {
               block?: string;
@@ -233,32 +303,14 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
     },
   });
 
-  const domResult = await domBuilt;
-  const htmlResult = await htmlBuilt;
-
-  const csrFileName =
-    csrEntryId &&
-    domResult.output.find((c) => c.type === "chunk" && c.name === "csr")
-      ?.fileName;
-  const clientRunner = csrFileName
-    ? (ctx: any): Promise<{ template: Template; run: RunDOM }> =>
-        importWithContext(
-          path.join(domOut, csrFileName),
-          { browser: true },
-          ctx,
-        )
-    : undefined;
-
   return {
-    assets: domOut,
-    runServer: () =>
-      import(path.join(htmlOut, "main.mjs")) as Promise<
-        Record<keyof T, Template>
-      >,
-    clientRunner,
-    domBundle: () => buildSnapshot(domResult, cwd, optimize),
-    htmlBundle: () => buildSnapshot(htmlResult, cwd),
-    diagnostics: [...diagnosticsByFile].map(([id, items]) => ({ id, items })),
+    domBuilt,
+    htmlBuilt,
+    diagnosticsByFile,
+    clearRefs() {
+      domBuiltBox.promise = undefined;
+      (compileOpts.cache as Map<unknown, unknown>).clear();
+    },
   };
 }
 

--- a/packages/runtime-tags/src/__tests__/utils/import-with-context.ts
+++ b/packages/runtime-tags/src/__tests__/utils/import-with-context.ts
@@ -1,7 +1,41 @@
 import { readFileSync } from "node:fs";
+import { pathToFileURL } from "node:url";
 import vm from "node:vm";
 
 import { type ResolveOptions, resolveSync } from "resolve-sync";
+
+/** Imports an ESM file into the *current* realm through a vm module, so its
+ * namespace is collectable once the caller drops it — Node's ESM loader cache
+ * (`ModuleLoader.loadCache`) retains ordinary dynamic imports for the life of
+ * the process. Imports it contains delegate to the host loader (shared
+ * externals stay cached). */
+export async function importEvictable<T>(entry: string): Promise<T> {
+  const url = pathToFileURL(entry).href;
+  const mod = new vm.SourceTextModule(readFileSync(entry, "utf8"), {
+    identifier: url,
+    initializeImportMeta(meta) {
+      meta.url = url;
+    },
+    importModuleDynamically: linkHosted,
+  });
+  await mod.link(linkHosted);
+  await mod.evaluate();
+  return mod.namespace as T;
+}
+
+async function linkHosted(id: string, parent: vm.Module | vm.Script) {
+  const target = await import(
+    /^[./]/.test(id) ? new URL(id, (parent as vm.Module).identifier).href : id
+  );
+  const keys = Object.keys(target);
+  return new vm.SyntheticModule(
+    keys,
+    function (this: vm.SyntheticModule) {
+      for (const key of keys) this.setExport(key, target[key]);
+    },
+    { identifier: id },
+  );
+}
 
 interface State {
   cache: Map<string, Promise<vm.Module>>;


### PR DESCRIPTION
A full serial `pnpm test` retained each fixture's bundle output and SSR module, OOMing the default heap before finishing (verified on `main`: hard OOM ~3min in). Heap-snapshot retainer paths named two causes:

1. **Rolldown holds the functions passed to `build()` beyond `close()`**, and a function pins its defining scope's V8 context — so the inline `manualChunks` arrow retained each fixture's whole `RolldownOutput` graph. Build options now originate in module-level `createBuilds`, whose heavy captures are cleared once the builds settle. (Worth an upstream rolldown issue: if it released callback handles on close, this scope discipline would be unnecessary.)
2. **Node's ESM loader cache retains every dynamically imported SSR bundle.** `runServer` now evaluates the bundle as a current-realm `vm.SourceTextModule`, memoized per runner (server module state still spans a fixture's renders) and dropped at fixture teardown.

Measured retention across 300 fixture teardowns: ~200 MiB → ~18 MiB. The full serial suite now completes at the default heap — verified twice, 9510 passing, peak RSS ~6.0 GiB, vs a hard OOM on `main`. `.mocharc.json` additionally carries CI's heap flags as headroom (mocha stops forwarding top-level node flags once `node-option` is present, so the existing ones move into the list). Also adds `test:update:parallel` to regenerate all snapshots via the parallel runner (~45s instead of minutes; fixture shards are disjoint so writes can't collide).

Test-only change, no changeset. `test:parallel` failure baseline unchanged from `main`.