### PR TITLE
fix: guard tags-compat ___deserialize against a not-yet-resumed scope

### DIFF
--- a/.changeset/compat-deserialize-guard.md
+++ b/.changeset/compat-deserialize-guard.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Guard the tags-compat `ComponentDef.___deserialize` override against a not-yet-resumed scope. A streaming or out-of-order resume of a Class-API child inside a Tags-API parent could make `getScope` return `undefined`, throwing a `TypeError`; it now optional-chains like every other consumer.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -87,21 +87,6 @@ translator to surface interactivity on `metadata.marko`, `getClassHydrationMode`
 to return DESCENDANT for interactive tags children, and the boundary to actually
 resume.
 
-## Compat `___deserialize` override dereferences a possibly-undefined scope
-
-`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js` › `ComponentDef.___deserialize` | 2026-07-13 | impact:low | effort:low
-
-The compat `ComponentDef.___deserialize` override does
-`o[2] = domCompat.getScope(global, o[2]).m5i` with no null guard, but
-`compat.getScope` returns `getRenderScopes($global)?.[scopeId]`, which is
-legitimately `undefined` when the tags scope carrying `m5i` has not been resumed
-yet. Every other consumer uses optional chaining; the sibling comment at line 38
-even notes "a split parent may not be hydrated yet when the child resumes."
-Under the normal init6-before-init5 ordering the tags scope is registered first,
-so this is not hit today, but any streaming/out-of-order resume of a
-class-in-tags child before its `writeSetScopeForComponent` scope would throw
-`TypeError`. Defensive fix: `getScope(global, o[2])?.m5i`.
-
 ## `COMPAT_REGISTRY` caches `[id, scopeId]` for the module lifetime
 
 `packages/runtime-tags/src/html/compat.ts` › `compat.toJSON` | 2026-07-13 | impact:med | effort:med

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js
@@ -70,7 +70,9 @@ exports.p = function (domCompat) {
   const defDeserialize = ComponentDef.___deserialize;
   ComponentDef.___deserialize = function (o, types, global, registry) {
     if (typeof o[2] === "number") {
-      o[2] = domCompat.getScope(global, o[2]).m5i;
+      // `getScope` can return undefined for a not-yet-resumed scope (streaming /
+      // out-of-order resume of a class-in-tags child); match every other consumer.
+      o[2] = domCompat.getScope(global, o[2])?.m5i;
     }
     return defDeserialize(o, types, global, registry);
   };

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66873,
-        "brotli": 20548
+        "min": 66874,
+        "brotli": 20560
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68489,
+        "min": 68490,
         "brotli": 21249
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68374,
-        "brotli": 21226
+        "min": 68375,
+        "brotli": 21183
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66873,
-        "brotli": 20548
+        "min": 66874,
+        "brotli": 20560
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66771,
-        "brotli": 20518
+        "min": 66772,
+        "brotli": 20512
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66812,
-        "brotli": 20517
+        "min": 66813,
+        "brotli": 20540
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68484,
-        "brotli": 21220
+        "min": 68485,
+        "brotli": 21194
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68600,
-        "brotli": 21217
+        "min": 68601,
+        "brotli": 21239
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66909,
-        "brotli": 20587
+        "min": 66910,
+        "brotli": 20588
       },
       "files": {
         "components/tags-pinger.marko": 663,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68785,
-        "brotli": 21341
+        "min": 68786,
+        "brotli": 21338
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 70011,
-        "brotli": 21656
+        "min": 70012,
+        "brotli": 21617
       },
       "files": {
         "components/tags-pinger.marko": 706,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68423,
-        "brotli": 21185
+        "min": 68424,
+        "brotli": 21196
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68489,
-        "brotli": 21237
+        "min": 68490,
+        "brotli": 21233
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67178,
-        "brotli": 20749
+        "min": 67179,
+        "brotli": 20701
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66850,
-        "brotli": 20558
+        "min": 66851,
+        "brotli": 20562
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68929,
-        "brotli": 21429
+        "min": 68930,
+        "brotli": 21377
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68431,
-        "brotli": 21173
+        "min": 68432,
+        "brotli": 21206
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68101,
-        "brotli": 21143
+        "min": 68102,
+        "brotli": 21076
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68597,
-        "brotli": 21264
+        "min": 68598,
+        "brotli": 21287
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 68204,
-        "brotli": 21103
+        "min": 68205,
+        "brotli": 21057
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 67234,
-        "brotli": 20731
+        "min": 67235,
+        "brotli": 20738
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 69289,
-        "brotli": 21582
+        "min": 69290,
+        "brotli": 21529
       },
       "files": {
         "components/class-layout.marko": 1245,


### PR DESCRIPTION
`getScope` can return `undefined` for a scope not resumed yet (streaming / out-of-order resume of a Class-API child inside a Tags-API parent), so the tags-compat `ComponentDef.___deserialize` override threw a `TypeError` dereferencing `.m5i`. Optional-chain it, matching every other `getScope` consumer.

Behavior is unchanged for the normal (resumed-scope) path; only the interop fixture `sizes.json` shift (the `?.`). No fixture reproduces the out-of-order streaming scenario (which is why it's latent), so no test is added — the change is a defensive guard aligning with existing patterns.