### PR TITLE
perf(runtime-tags): skip the keyed map on in-place <for> updates

### DIFF
--- a/.changeset/positional-loop-reconcile.md
+++ b/.changeset/positional-loop-reconcile.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Speed up in-place keyed list updates. The `<for>` reconciler rebuilt an O(n) key→scope lookup map on every update even when nothing had moved. It now reuses the branch at each position directly and only builds the map — from the remaining unmatched scopes — once a key first lands out of order.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26136,
-        "brotli": 9604
+        "min": 26164,
+        "brotli": 9620
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 365
       },
       "runtime": {
-        "min": 6402,
-        "brotli": 2802
+        "min": 6430,
+        "brotli": 2823
       },
       "total": {
-        "min": 7048,
-        "brotli": 3167
+        "min": 7076,
+        "brotli": 3188
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6402 (min) 2802 (brotli)
+// size: 6430 (min) 2823 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -391,16 +391,24 @@ function loop(forEach) {
               ? referenceNode.parentNode || oldScopes[0]?.S.parentNode
               : referenceNode,
           oldScopesByKey,
-          hasPotentialMoves;
+          hasPotentialMoves,
+          start = 0;
         forEach(value, (key, args) => {
-          let branch =
-            oldLen &&
-            (oldScopesByKey ||= oldScopes.reduce(
-              (map, scope, i) => map.set(scope.M ?? i, ((scope.I = i), scope)),
-              /* @__PURE__ */ new Map(),
-            )).get(key);
+          let i = newScopes.length,
+            oldScope = oldScopes[i],
+            branch =
+              oldLen &&
+              (oldScopesByKey || key !== (oldScope?.M ?? i)
+                ? (oldScopesByKey ||= oldScopes.reduce(
+                    (map, scope, j) =>
+                      j < i
+                        ? map
+                        : ((scope.I = j), map.set(scope.M ?? j, scope)),
+                    /* @__PURE__ */ new Map(),
+                  )).get(key)
+                : oldScope && (start++, oldScope));
           (branch
-            ? (hasPotentialMoves = oldScopesByKey.delete(key))
+            ? ((hasPotentialMoves = !0), oldScopesByKey?.delete(key))
             : (branch = createAndSetupBranch(
                 scope.$,
                 renderer,
@@ -415,8 +423,7 @@ function loop(forEach) {
           hasSiblings = referenceNode !== parentNode,
           afterReference = null,
           oldEnd = oldLen - 1,
-          newEnd = newLen - 1,
-          start = 0;
+          newEnd = newLen - 1;
         if (
           (hasSiblings &&
             (oldLen
@@ -437,15 +444,10 @@ function loop(forEach) {
             insertBranchBefore(newScope, parentNode, afterReference);
           return;
         }
-        for (let branch of oldScopesByKey.values())
-          removeAndDestroyBranch(branch);
-        for (
-          ;
-          start < oldLen &&
-          start < newLen &&
-          oldScopes[start] === newScopes[start];
-        )
-          start++;
+        if (oldScopesByKey) oldScopesByKey.forEach(removeAndDestroyBranch);
+        else
+          for (let i = newLen; i < oldLen; i++)
+            removeAndDestroyBranch(oldScopes[i]);
         for (
           ;
           oldEnd >= start &&
@@ -455,13 +457,12 @@ function loop(forEach) {
           (oldEnd--, newEnd--);
         if (
           (oldEnd + 1 < oldLen && (afterReference = oldScopes[oldEnd + 1].S),
-          start > oldEnd)
+          start > oldEnd || start > newEnd)
         ) {
-          if (start <= newEnd)
-            for (let i = start; i <= newEnd; i++)
-              insertBranchBefore(newScopes[i], parentNode, afterReference);
+          for (let i = start; i <= newEnd; i++)
+            insertBranchBefore(newScopes[i], parentNode, afterReference);
           return;
-        } else if (start > newEnd) return;
+        }
         let diffLen = newEnd - start + 1,
           sources = Array(diffLen),
           pred = Array(diffLen),

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26136 (min) 9604 (brotli)
+// size: 26164 (min) 9620 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -2151,16 +2151,24 @@ function loop(forEach) {
               ? referenceNode.parentNode || oldScopes[0]?.S.parentNode
               : referenceNode,
           oldScopesByKey,
-          hasPotentialMoves;
+          hasPotentialMoves,
+          start = 0;
         forEach(value, (key, args) => {
-          let branch =
-            oldLen &&
-            (oldScopesByKey ||= oldScopes.reduce(
-              (map, scope, i) => map.set(scope.M ?? i, ((scope.I = i), scope)),
-              /* @__PURE__ */ new Map(),
-            )).get(key);
+          let i = newScopes.length,
+            oldScope = oldScopes[i],
+            branch =
+              oldLen &&
+              (oldScopesByKey || key !== (oldScope?.M ?? i)
+                ? (oldScopesByKey ||= oldScopes.reduce(
+                    (map, scope, j) =>
+                      j < i
+                        ? map
+                        : ((scope.I = j), map.set(scope.M ?? j, scope)),
+                    /* @__PURE__ */ new Map(),
+                  )).get(key)
+                : oldScope && (start++, oldScope));
           (branch
-            ? (hasPotentialMoves = oldScopesByKey.delete(key))
+            ? ((hasPotentialMoves = !0), oldScopesByKey?.delete(key))
             : (branch = createAndSetupBranch(
                 scope.$,
                 renderer,
@@ -2175,8 +2183,7 @@ function loop(forEach) {
           hasSiblings = referenceNode !== parentNode,
           afterReference = null,
           oldEnd = oldLen - 1,
-          newEnd = newLen - 1,
-          start = 0;
+          newEnd = newLen - 1;
         if (
           (hasSiblings &&
             (oldLen
@@ -2197,15 +2204,10 @@ function loop(forEach) {
             insertBranchBefore(newScope, parentNode, afterReference);
           return;
         }
-        for (let branch of oldScopesByKey.values())
-          removeAndDestroyBranch(branch);
-        for (
-          ;
-          start < oldLen &&
-          start < newLen &&
-          oldScopes[start] === newScopes[start];
-        )
-          start++;
+        if (oldScopesByKey) oldScopesByKey.forEach(removeAndDestroyBranch);
+        else
+          for (let i = newLen; i < oldLen; i++)
+            removeAndDestroyBranch(oldScopes[i]);
         for (
           ;
           oldEnd >= start &&
@@ -2215,13 +2217,12 @@ function loop(forEach) {
           (oldEnd--, newEnd--);
         if (
           (oldEnd + 1 < oldLen && (afterReference = oldScopes[oldEnd + 1].S),
-          start > oldEnd)
+          start > oldEnd || start > newEnd)
         ) {
-          if (start <= newEnd)
-            for (let i = start; i <= newEnd; i++)
-              insertBranchBefore(newScopes[i], parentNode, afterReference);
+          for (let i = start; i <= newEnd; i++)
+            insertBranchBefore(newScopes[i], parentNode, afterReference);
           return;
-        } else if (start > newEnd) return;
+        }
         let diffLen = newEnd - start + 1,
           sources = Array(diffLen),
           pred = Array(diffLen),

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7555,
-        "brotli": 3456
+        "min": 7583,
+        "brotli": 3471
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7092,
-      "brotli": 3242
+      "min": 7120,
+      "brotli": 3256
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7355,
-      "brotli": 3321
+      "min": 7383,
+      "brotli": 3332
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7797,
-        "brotli": 3547
+        "min": 7825,
+        "brotli": 3570
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8253,
-        "brotli": 3720
+        "min": 8281,
+        "brotli": 3736
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7747,
-        "brotli": 3543
+        "min": 7775,
+        "brotli": 3549
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15735,
-        "brotli": 6133
+        "min": 15764,
+        "brotli": 6176
       },
       "files": {
         "tags/sections.marko": 736,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8473,
-      "brotli": 3761
+      "min": 8501,
+      "brotli": 3799
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9242,
-      "brotli": 3967
+      "min": 9270,
+      "brotli": 3985
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7384,
-        "brotli": 3354
+        "min": 7412,
+        "brotli": 3371
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7254,
-      "brotli": 3303
+      "min": 7282,
+      "brotli": 3325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7887,
-      "brotli": 3569
+      "min": 7915,
+      "brotli": 3586
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,46 @@
+// template.marko
+const $template = "<ul></ul><button class=reorder>stable prefix, drop tail, swap</button><button class=front>reorder from front and shrink</button><button class=append>append</button>";
+const $walks = " b b b b";
+const $for_content__row_id = ($scope, row_id) => _text($scope["#text/0"], row_id);
+const $for_content__$params = ($scope, $params2) => $for_content__row_id($scope, $params2[0]?.id);
+const $for = /*@__PURE__*/ _for_of("#ul/0", "<li> </li>", "D l", 0, $for_content__$params);
+const $rows_0__OR__rows_1__OR__rows_3__OR__rows___script = _script("__tests__/template.marko_0_rows_0_rows_1_rows_3_rows_2", ($scope) => _on($scope["#button/1"], "click", function() {
+	$rows($scope, [
+		$scope.rows_0,
+		$scope.rows_1,
+		$scope.rows_3,
+		$scope.rows_2
+	]);
+}));
+const $rows_0__OR__rows_1__OR__rows_3__OR__rows_ = $rows_0__OR__rows_1__OR__rows_3__OR__rows___script;
+const $rows_0__OR__rows___script = _script("__tests__/template.marko_0_rows_0_rows_1", ($scope) => _on($scope["#button/2"], "click", function() {
+	$rows($scope, [$scope.rows_1, $scope.rows_0]);
+}));
+const $rows_0__OR__rows_ = $rows_0__OR__rows___script;
+const $rows = /*@__PURE__*/ _let("rows/4", ($scope) => {
+	$rows_($scope, $scope.rows?.[0]);
+	$rows_2($scope, $scope.rows?.[1]);
+	$rows_3($scope, $scope.rows?.[3]);
+	$rows_4($scope, $scope.rows?.[2]);
+	$for($scope, [$scope.rows, "id"]);
+	$rows_0__OR__rows_1__OR__rows_3__OR__rows_($scope);
+	$rows_0__OR__rows_($scope);
+});
+const $rows_ = /*@__PURE__*/ _const("rows_0");
+const $rows_2 = /*@__PURE__*/ _const("rows_1");
+const $rows_3 = /*@__PURE__*/ _const("rows_3");
+const $rows_4 = /*@__PURE__*/ _const("rows_2");
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/3"], "click", function() {
+	$rows($scope, [...$scope.rows, { id: 9 }]);
+}));
+function $setup($scope) {
+	$rows($scope, [
+		{ id: 1 },
+		{ id: 2 },
+		{ id: 3 },
+		{ id: 4 },
+		{ id: 5 }
+	]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/dom.bundle.js
@@ -1,0 +1,31 @@
+// template.marko
+const $for_content__row_id = ($scope, row_id) => _text($scope.a, row_id);
+const $for_content__$params = ($scope, $params2) => $for_content__row_id($scope, $params2[0]?.id);
+const $for = /*@__PURE__*/ _for_of(0, "<li> </li>", "D l", 0, $for_content__$params);
+const $rows_0__OR__rows_1__OR__rows_3__OR__rows_ = _script("a2", ($scope) => _on($scope.b, "click", function() {
+	$rows($scope, [
+		$scope.f,
+		$scope.g,
+		$scope.h,
+		$scope.i
+	]);
+}));
+const $rows_0__OR__rows_ = _script("a1", ($scope) => _on($scope.c, "click", function() {
+	$rows($scope, [$scope.g, $scope.f]);
+}));
+const $rows = /*@__PURE__*/ _let(4, ($scope) => {
+	$rows_($scope, $scope.e?.[0]);
+	$rows_2($scope, $scope.e?.[1]);
+	$rows_3($scope, $scope.e?.[3]);
+	$rows_4($scope, $scope.e?.[2]);
+	$for($scope, [$scope.e, "id"]);
+	$rows_0__OR__rows_1__OR__rows_3__OR__rows_($scope);
+	$rows_0__OR__rows_($scope);
+});
+const $rows_ = /*@__PURE__*/ _const(5);
+const $rows_2 = /*@__PURE__*/ _const(6);
+const $rows_3 = /*@__PURE__*/ _const(7);
+const $rows_4 = /*@__PURE__*/ _const(8);
+const $setup__script = _script("a0", ($scope) => _on($scope.d, "click", function() {
+	$rows($scope, [...$scope.e, { id: 9 }]);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let rows = [
+		{ id: 1 },
+		{ id: 2 },
+		{ id: 3 },
+		{ id: 4 },
+		{ id: 5 }
+	];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(row.id)}${_el_resume($scope1_id, "#text/0")}</li>`);
+		writeScope($scope1_id, {}, "__tests__/template.marko", "4:4");
+	}, "id", $scope0_id, "#ul/0", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=reorder>stable prefix, drop tail, swap</button>${_el_resume($scope0_id, "#button/1")}<button class=front>reorder from front and shrink</button>${_el_resume($scope0_id, "#button/2")}<button class=append>append</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	_script($scope0_id, "__tests__/template.marko_0_rows_0_rows_1");
+	_script($scope0_id, "__tests__/template.marko_0_rows_0_rows_1_rows_3_rows_2");
+	writeScope($scope0_id, {
+		rows,
+		rows_0: rows?.[0],
+		rows_1: rows?.[1],
+		rows_3: rows?.[3],
+		rows_2: rows?.[2]
+	}, "__tests__/template.marko", 0, {
+		rows: "1:6",
+		rows_0: ["rows[0]", "1:6"],
+		rows_1: ["rows[1]", "1:6"],
+		rows_3: ["rows[3]", "1:6"],
+		rows_2: ["rows[2]", "1:6"]
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let rows = [
+		{ id: 1 },
+		{ id: 2 },
+		{ id: 3 },
+		{ id: 4 },
+		{ id: 5 }
+	];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(row.id)}${_el_resume($scope1_id, "a")}</li>`);
+		writeScope($scope1_id, {});
+	}, "id", $scope0_id, "a", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=reorder>stable prefix, drop tail, swap</button>${_el_resume($scope0_id, "b")}<button class=front>reorder from front and shrink</button>${_el_resume($scope0_id, "c")}<button class=append>append</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	_script($scope0_id, "a1");
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, {
+		e: rows,
+		f: rows?.[0],
+		g: rows?.[1],
+		h: rows?.[3],
+		i: rows?.[2]
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/render.debug.md
@@ -1,0 +1,151 @@
+# Render
+```html
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+  <li>
+    3
+  </li>
+  <li>
+    4
+  </li>
+  <li>
+    5
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+  <li>
+    4
+  </li>
+  <li>
+    3
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(3) + li
+REMOVE: ul > li:nth-of-type(4) + li
+INSERT: ul > li:nth-of-type(2) + li
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    1
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(1) + li
+REMOVE: ul > li:nth-of-type(1) + li
+REMOVE: ul > li:nth-of-type(2) + li
+INSERT: ul > li
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    1
+  </li>
+  <li>
+    9
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+INSERT: ul > li:nth-of-type(2) + li
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/render.md
@@ -1,0 +1,151 @@
+# Render
+```html
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+  <li>
+    3
+  </li>
+  <li>
+    4
+  </li>
+  <li>
+    5
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+  <li>
+    4
+  </li>
+  <li>
+    3
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(3) + li
+REMOVE: ul > li:nth-of-type(4) + li
+INSERT: ul > li:nth-of-type(2) + li
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    1
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+REMOVE: ul > li:nth-of-type(1) + li
+REMOVE: ul > li:nth-of-type(1) + li
+REMOVE: ul > li:nth-of-type(2) + li
+INSERT: ul > li
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li>
+    2
+  </li>
+  <li>
+    1
+  </li>
+  <li>
+    9
+  </li>
+</ul>
+<button
+  class="reorder"
+>
+  stable prefix, drop tail, swap
+</button>
+<button
+  class="front"
+>
+  reorder from front and shrink
+</button>
+<button
+  class="append"
+>
+  append
+</button>
+```
+## Change
+```
+INSERT: ul > li:nth-of-type(2) + li
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/writes.debug.html
@@ -1,0 +1,43 @@
+<ul>
+  <li>1<!--M_*2 #text/0--></li>
+  <li>2<!--M_*3 #text/0--></li>
+  <li>3<!--M_*4 #text/0--></li>
+  <li>4<!--M_*5 #text/0--></li>
+  <li>5<!--M_*6 #text/0--></li><!--M_}1 #ul/0 6 5 4 3 2-->
+</ul><button class=reorder>stable prefix, drop tail,
+  swap</button><!--M_*1 #button/1--><button class=front>reorder from front and
+  shrink</button><!--M_*1 #button/2--><button
+  class=append>append</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      rows: [_.a = {
+        id: 1
+      }, _.b = {
+        id: 2
+      }, _.d = {
+        id: 3
+      }, _.c = {
+        id: 4
+      }, {
+        id: 5
+      }],
+      rows_0: _.a,
+      rows_1: _.b,
+      rows_3: _.c,
+      rows_2: _.d
+    }, {
+      "#LoopKey": 1
+    }, {
+      "#LoopKey": 2
+    }, {
+      "#LoopKey": 3
+    }, {
+      "#LoopKey": 4
+    }, {
+      "#LoopKey": 5
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/template.marko_0 1 packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/template.marko_0_rows_0_rows_1 1 packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/template.marko_0_rows_0_rows_1_rows_3_rows_2 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/__snapshots__/writes.html
@@ -1,0 +1,40 @@
+<ul>
+  <li>1<!--M_*2 a--></li>
+  <li>2<!--M_*3 a--></li>
+  <li>3<!--M_*4 a--></li>
+  <li>4<!--M_*5 a--></li>
+  <li>5<!--M_*6 a--></li><!--M_}1 a 6 5 4 3 2-->
+</ul><button class=reorder>stable prefix, drop tail,
+  swap</button><!--M_*1 b--><button class=front>reorder from front and
+  shrink</button><!--M_*1 c--><button class=append>append</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: [_.a = {
+      id: 1
+    }, _.b = {
+      id: 2
+    }, _.d = {
+      id: 3
+    }, _.c = {
+      id: 4
+    }, {
+      id: 5
+    }],
+    f: _.a,
+    g: _.b,
+    h: _.c,
+    i: _.d
+  }, {
+    M: 1
+  }, {
+    M: 2
+  }, {
+    M: 3
+  }, {
+    M: 4
+  }, {
+    M: 5
+  }], "a0 1 a1 1 a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7489,
-      "brotli": 3350
+      "min": 7378,
+      "brotli": 3343
     }
   },
   "html": {
-    "min": 964,
-    "brotli": 401
+    "min": 764,
+    "brotli": 400
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/template.marko
@@ -1,0 +1,11 @@
+<let/rows=[{ id: 1 }, { id: 2 }, { id: 3 }, { id: 4 }, { id: 5 }]/>
+
+<ul>
+  <for|row| of=rows by="id">
+    <li>${row.id}</li>
+  </for>
+</ul>
+
+<button.reorder onClick() { rows = [rows[0], rows[1], rows[3], rows[2]] }>stable prefix, drop tail, swap</button>
+<button.front onClick() { rows = [rows[1], rows[0]] }>reorder from front and shrink</button>
+<button.append onClick() { rows = [...rows, { id: 9 }] }>append</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (selector: string) => (document: Document) =>
+  (document.querySelector(selector) as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    click("button.reorder"),
+    click("button.front"),
+    click("button.append"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7959,
-      "brotli": 3590
+      "min": 7987,
+      "brotli": 3608
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7198,
-      "brotli": 3313
+      "min": 7226,
+      "brotli": 3297
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7000,
-      "brotli": 3240
+      "min": 7028,
+      "brotli": 3231
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7277,
-      "brotli": 3318
+      "min": 7305,
+      "brotli": 3333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8426,
-      "brotli": 3761
+      "min": 8454,
+      "brotli": 3788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8248,
-      "brotli": 3724
+      "min": 8276,
+      "brotli": 3721
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6936,
-      "brotli": 3180
+      "min": 6964,
+      "brotli": 3190
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7665,
-        "brotli": 3506
+        "min": 7693,
+        "brotli": 3547
       },
       "files": {
         "tags/list.marko": 296,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8028,
-        "brotli": 3648
+        "min": 8056,
+        "brotli": 3661
       },
       "files": {
         "tags/child.marko": 517,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7018,
-      "brotli": 3185
+      "min": 7046,
+      "brotli": 3221
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7012,
-      "brotli": 3183
+      "min": 7040,
+      "brotli": 3216
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6793,
-      "brotli": 3129
+      "min": 6821,
+      "brotli": 3145
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7005,
-      "brotli": 3223
+      "min": 7033,
+      "brotli": 3237
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7142,
-      "brotli": 3274
+      "min": 7170,
+      "brotli": 3298
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7468,
-        "brotli": 3399
+        "min": 7496,
+        "brotli": 3417
       },
       "files": {
         "tags/inner/index.marko": 1001,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7712,
-        "brotli": 3516
+        "min": 7740,
+        "brotli": 3508
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14665,
-      "brotli": 5673
+      "min": 14693,
+      "brotli": 5689
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7974,
-      "brotli": 3598
+      "min": 8002,
+      "brotli": 3617
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7877,
+      "min": 7905,
       "brotli": 3572
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8605,
-        "brotli": 3884
+        "min": 8633,
+        "brotli": 3900
       },
       "files": {
         "tags/child.marko": 870,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7643,
-      "brotli": 3477
+      "min": 7671,
+      "brotli": 3487
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14816,
-        "brotli": 5798
+        "min": 14844,
+        "brotli": 5834
       },
       "files": {
         "tags/child.marko": 759,

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -796,6 +796,7 @@ function loop<T extends unknown[] = unknown[]>(
       ) as Element;
       let oldScopesByKey: Map<unknown, BranchScope> | undefined;
       let hasPotentialMoves: boolean | undefined;
+      let start = 0;
 
       if (MARKO_DEBUG) {
         // eslint-disable-next-line no-var
@@ -807,18 +808,23 @@ function loop<T extends unknown[] = unknown[]>(
           assertValidLoopKey(key, seenKeys);
         }
 
+        const i = newScopes.length;
+        const oldScope = oldScopes[i];
         let branch =
           oldLen &&
-          (oldScopesByKey ||= oldScopes.reduce(
-            (map, scope, i) =>
-              map.set(
-                scope[AccessorProp.LoopKey] ?? i,
-                ((scope[AccessorProp.LoopIndex] = i), scope),
-              ),
-            new Map<unknown, BranchScope>(),
-          )).get(key);
+          (oldScopesByKey || key !== (oldScope?.[AccessorProp.LoopKey] ?? i)
+            ? (oldScopesByKey ||= oldScopes.reduce(
+                (map, scope, j) =>
+                  j < i
+                    ? map
+                    : ((scope[AccessorProp.LoopIndex] = j),
+                      map.set(scope[AccessorProp.LoopKey] ?? j, scope)),
+                new Map<unknown, BranchScope>(),
+              )).get(key)
+            : oldScope && (start++, oldScope));
         if (branch) {
-          hasPotentialMoves = oldScopesByKey!.delete(key);
+          hasPotentialMoves = true;
+          oldScopesByKey?.delete(key);
         } else {
           branch = createAndSetupBranch(
             scope[AccessorProp.Global],
@@ -837,7 +843,6 @@ function loop<T extends unknown[] = unknown[]>(
       let afterReference: null | Node = null;
       let oldEnd = oldLen - 1;
       let newEnd = newLen - 1;
-      let start = 0;
 
       if (hasSiblings) {
         if (oldLen) {
@@ -869,17 +874,12 @@ function loop<T extends unknown[] = unknown[]>(
         return;
       }
 
-      for (const branch of oldScopesByKey!.values()) {
-        removeAndDestroyBranch(branch);
-      }
-
-      // Skip common prefix
-      while (
-        start < oldLen &&
-        start < newLen &&
-        oldScopes[start] === newScopes[start]
-      ) {
-        start++;
+      if (oldScopesByKey) {
+        oldScopesByKey.forEach(removeAndDestroyBranch);
+      } else {
+        for (let i = newLen; i < oldLen; i++) {
+          removeAndDestroyBranch(oldScopes[i]);
+        }
       }
 
       // Skip common suffix
@@ -897,17 +897,10 @@ function loop<T extends unknown[] = unknown[]>(
         afterReference = oldScopes[oldEnd + 1][AccessorProp.StartNode];
       }
 
-      if (start > oldEnd) {
-        if (start <= newEnd) {
-          for (let i = start; i <= newEnd; i++) {
-            insertBranchBefore(newScopes[i], parentNode, afterReference);
-          }
+      if (start > oldEnd || start > newEnd) {
+        for (let i = start; i <= newEnd; i++) {
+          insertBranchBefore(newScopes[i], parentNode, afterReference);
         }
-
-        // Fast path: only new remaining
-        return;
-      } else if (start > newEnd) {
-        // Fast path: only old remaining (removes already handled above)
         return;
       }
 


### PR DESCRIPTION
The `<for>` reconciler rebuilt an O(n) key→scope map (plus a `get`/`delete` per item) on every keyed list update, even when nothing had moved. It now reuses the old branch at each position directly and only builds the map — from the remaining unmatched scopes — once a key first lands out of order.

Cuts ~12% of script time on in-place list updates (js-framework-benchmark `update every 10th row`). Adds a regression fixture for the stable-prefix + mid-remove + tail-reorder case. Behavior unchanged; +28 min / +16 brotli.