### PR TITLE
perf: dedup Class-API interop registration to one per renderer

### DIFF
--- a/.changeset/dedup-compat-registration.md
+++ b/.changeset/dedup-compat-registration.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Emit a single Class-API interop registration per renderer, instead of one for each tag occurrence, trimming the redundant scriptlets when the same class component is used multiple times in a template.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -34,17 +34,6 @@ is unaffected (later renders reuse `___marko5Component.___rootNode`), so this is
 dead optimization + a confusing stale-node invariant; verify destroy/move
 semantics before changing to `scope`.
 
-## Interop emits a duplicate registration scriptlet per class-tag occurrence
-
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `translate.exit` | 2026-07-13 | impact:low | effort:low
-
-Each Class-API custom-tag occurrence pushes its own registration statement to
-`program.body` with no dedup by class-file id: three `<class-display/>` uses emit
-three identical `_resume("…",_classDisplay)` (DOM) / `_s("…",_classDisplay)`
-(HTML) statements (the `??=` non-template branch at lines 360-377 duplicates the
-same way). Idempotent, so not incorrect, but N× redundant given "bundle size is a
-feature" — one registration per unique class file would suffice.
-
 ## Represent metadata-only HTML effects without invalid AST sentinels
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `toReturnedFunction` | 2026-07-15 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,54 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
+
+// components/class-counter.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/components/class-counter.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	increment() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", {
+		"class": "class",
+		"data-parent": input.count
+	}, "0", _component, null, 0, { "onclick": _componentDef.d("click", "increment", false) });
+	out.t(state.count, _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+const $template = "<button id=tags> </button><!><!><!>";
+const $walks = " D l%b%c";
+_resume("__tests__/components/class-counter.marko", _marko_template);
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/2");
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag("#text/3");
+const $count = /*@__PURE__*/ _let("count/4", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$dynamicTag($scope, _marko_template, () => ({ count: $scope.count }));
+	$dynamicTag2($scope, _marko_template, () => ({ count: $scope.count }));
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/dom.bundle.js
@@ -1,0 +1,44 @@
+// components/class-counter.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	increment() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", {
+		"class": "class",
+		"data-parent": input.count
+	}, "0", _component, null, 0, { "onclick": _componentDef.d("click", "increment", false) });
+	out.t(state.count, _component);
+	out.ee();
+}, { t: _marko_componentType }, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+_resume("b", _marko_template);
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag(2);
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(3);
+const $count = /*@__PURE__*/ _let(4, ($scope) => {
+	_text($scope.b, $scope.e);
+	$dynamicTag($scope, _marko_template, () => ({ count: $scope.e }));
+	$dynamicTag2($scope, _marko_template, () => ({ count: $scope.e }));
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.e + 1);
+}));
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// components/class-counter.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_attr = /* @__PURE__ */ __toESM(require_attr());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/components/class-counter.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	increment() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button class=class${(0, import_attr.default)("data-parent", input.count)}>`);
+	out.w((0, import_escape_xml.x)(state.count));
+	out.w("</button>");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+
+// template.marko
+s("__tests__/components/class-counter.marko", _marko_template);
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_dynamic_tag($scope0_id, "#text/2", _marko_template, { count });
+	_dynamic_tag($scope0_id, "#text/3", _marko_template, { count });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// components/class-counter.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_attr = /* @__PURE__ */ __toESM(require_attr());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button class=class${(0, import_attr.default)("data-parent", input.count)}>${(0, import_escape_xml.x)(state.count)}</button>`);
+}, { t: _marko_componentType }, {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	increment() {
+		this.state.count++;
+	}
+});
+
+// template.marko
+s("b", _marko_template);
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_dynamic_tag($scope0_id, "c", _marko_template, { count });
+	_dynamic_tag($scope0_id, "d", _marko_template, { count });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/render.debug.md
@@ -1,0 +1,50 @@
+# Render
+```html
+<button
+  id="tags"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="0"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="0"
+>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("#tags").click();
+```
+```html
+<button
+  id="tags"
+>
+  1
+</button>
+<button
+  class="class"
+  data-parent="1"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="1"
+>
+  0
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+UPDATE: button:nth-of-type(2)[data-parent] "0" => "1"
+UPDATE: button:nth-of-type(3)[data-parent] "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/render.md
@@ -1,0 +1,50 @@
+# Render
+```html
+<button
+  id="tags"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="0"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="0"
+>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("#tags").click();
+```
+```html
+<button
+  id="tags"
+>
+  1
+</button>
+<button
+  class="class"
+  data-parent="1"
+>
+  0
+</button>
+<button
+  class="class"
+  data-parent="1"
+>
+  0
+</button>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+UPDATE: button:nth-of-type(2)[data-parent] "0" => "1"
+UPDATE: button:nth-of-type(3)[data-parent] "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/writes.debug.html
@@ -1,0 +1,46 @@
+<button
+  id=tags>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M_[--><!--M#_0--><button
+  class=class
+  data-parent=0>0</button><!--M/--><!--M_]1 #text/2 2--><!--M_[--><!--M#_1--><button
+  class=class data-parent=0>0</button><!--M/--><!--M_]1 #text/3 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    "ConditionalRenderer:#text/2": _._[
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/components/class-counter.marko"
+      ],
+    "ConditionalRenderer:#text/3": _._[
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/components/class-counter.marko"
+      ],
+    count: 0
+  }, {
+    m5c: "_0",
+    m5i: {
+      count: 0
+    }
+  }, {
+    m5c: "_1",
+    m5i: {
+      count: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }],
+      ["_1", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/components/class-counter.marko"
+    ]
+  });
+  M._.r.push(
+    "$compat_setScope 2 3 packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/template.marko_0 1"
+    );
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/__snapshots__/writes.html
@@ -1,0 +1,37 @@
+<button id=tags>0<!--M_*1 b--></button><!--M_*1 a--><!--M_[--><!--M#_0--><button
+  class=class
+  data-parent=0>0</button><!--M/--><!--M_]1 c 2--><!--M_[--><!--M#_1--><button
+  class=class data-parent=0>0</button><!--M/--><!--M_]1 d 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Dc: _._.b,
+    Dd: _._.b,
+    e: 0
+  }, {
+    m5c: "_0",
+    m5i: {
+      count: 0
+    }
+  }, {
+    m5c: "_1",
+    m5i: {
+      count: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }],
+      ["_1", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 2 3 a0 1");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/components/class-counter.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/components/class-counter.marko
@@ -1,0 +1,11 @@
+class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+  increment() {
+    this.state.count++;
+  }
+}
+<button class="class" data-parent=input.count onClick("increment")>
+  ${state.count}
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -1,0 +1,20 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 68529,
+        "brotli": 21257
+      },
+      "files": {
+        "components/class-counter.marko": 1031,
+        "template.marko": 513,
+        "v:template.marko.hydrate-6.js": 110,
+        "v:template.marko.hydrate-5.js": 177
+      }
+    }
+  },
+  "html": {
+    "min": 728,
+    "brotli": 392
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/template.marko
@@ -1,0 +1,6 @@
+<let/count = 0/>
+<button id="tags" onClick() { count++ }>
+  ${count}
+</button>
+<class-counter count=count/>
+<class-counter count=count/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function clickTags(document: Document) {
+  (document.querySelector("#tags") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickTags],
+};

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -70,6 +70,7 @@ import {
   signalHasStatements,
   writeHTMLResumeStatements,
 } from "../../util/signals";
+import { createProgramState } from "../../util/state";
 import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
 import { toMemberExpression } from "../../util/to-property-name";
 import {
@@ -85,6 +86,20 @@ import { getTagRelativePath } from "./custom-tag";
 const kDOMBinding = Symbol("dynamic tag dom binding");
 const kChildOffsetScopeBinding = Symbol("custom tag scope offset");
 const importedDynamicTagResume = new WeakSet<t.Program>();
+
+// Class-API interop registrations are idempotent and keyed by the shared
+// renderer, so one per program suffices no matter how many tags reference it.
+const [getCompatRegistrations] = createProgramState<Set<string>>(
+  () => new Set(),
+);
+function pushCompatRegistration(key: string, statement: t.Statement) {
+  const keys = getCompatRegistrations();
+  if (!keys.has(key)) {
+    keys.add(key);
+    getProgram().node.body.push(statement);
+  }
+}
+
 enum ClassHydration {
   Self = "self",
   Descendant = "descendant",
@@ -323,7 +338,8 @@ export default {
           if (
             isOutputHTML() ? serializeReason || classHydration : serializeReason
           ) {
-            getProgram().node.body.push(
+            pushCompatRegistration(
+              classFile!.metadata.marko.id,
               isOutputHTML()
                 ? t.markoScriptlet(
                     [
@@ -356,17 +372,19 @@ export default {
             );
           }
         } else {
-          getProgram().node.body.push(
+          const rendererName = (tagExpression as t.Identifier).name;
+          pushCompatRegistration(
+            rendererName,
             t.markoScriptlet(
               [
                 t.expressionStatement(
                   t.assignmentExpression(
                     "??=",
                     t.memberExpression(
-                      t.identifier((tagExpression as t.Identifier).name),
+                      t.identifier(rendererName),
                       t.identifier("_"),
                     ),
-                    t.identifier((tagExpression as t.Identifier).name),
+                    t.identifier(rendererName),
                   ),
                 ),
               ],


### PR DESCRIPTION
Each Class-API custom-tag occurrence pushed its own registration scriptlet (`s(...)` / `_resume(...)`) to the program body, so N uses of the same class component emitted N identical registrations. These are idempotent and keyed by the shared renderer, so one per program suffices — a new `pushCompatRegistration` helper dedups both the template and `??=` self-registration branches. New `interop-duplicate-class-tag-registration` fixture (same tag used twice → one registration); existing interop snapshots unchanged.