### PR TITLE
fix: clearer error when two-way binding to an array-destructured value

### DIFF
--- a/.changeset/array-destructure-bind-error.md
+++ b/.changeset/array-destructure-bind-error.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Give a cause-specific error when two-way binding (`value:=x`) to a value from array destructuring, explaining that it has no change handler and suggesting object destructuring or an explicit `Change` attribute, instead of the generic "Unable to bind to value."

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -187,12 +187,6 @@ and compiles to code that fails at runtime; detecting it through the binding
 graph would surface the same clear compile error. Verify: compile
 `<const/a=b/><const/b=a/>` used as a value and observe no diagnostic.
 
-## Give array-destructure two-way binding a cause-specific error instead of the generic "Unable to bind to value."
-
-`packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandler` | 2026-07-20 | impact:low | effort:low
-
-`value:=x` where `x` comes from object destructuring works, because `getChangeHandler` (`pre-analyze.ts:203-243`) auto-generates a sibling `xChange` key via `getChangeHandlerFromObjectPattern`, but the same shorthand on an array-destructured value throws the opaque `Unable to bind to value.` (pre-analyze.ts:226): the array-pattern element's `parentPath` is neither `binding.path` nor an `ObjectProperty`, so `changeAttrExpr` stays undefined. The message names neither the cause nor a fix, and the identical string is reused at pre-analyze.ts:260 for an unrelated failure mode (an existing change handler whose binding has no Marko root to host the injected `const`), so it cannot disambiguate. This is a real footgun given the asymmetry: an author who binds `value:=a` off `{ a }` reasonably expects `value:=x` off `[ x ]` to work too. Branch the message on the array-pattern case (an array element has no positional change key) to suggest object destructuring or an explicit `valueChange` handler, mirroring the already-specific "Bound attribute refinement shorthand must be a valid JavaScript identifier." diagnostic at pre-analyze.ts:197; note the `error-bound-attr-array-pattern` snapshot pins the current text and must be regenerated. Re-verify: `npm run compile -- -o dom` on `<const/[ x ] = input.pair/>` + `<input value:=x/>` throws `Unable to bind to value.`, while `<const/{ a } = input/>` + `<input value:=a/>` compiles cleanly (emitting `$aChange2` from `input.aChange`).
-
 ## Forward the translator cheatsheet through `createInteropTranslator` so the agent fix-guide fires for interop (Marko 5 and mixed 5/6) compiles
 
 `packages/runtime-tags/src/translator/interop/index.ts` › `createInteropTranslator` | 2026-07-20 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-dom.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/template.marko:2:15
       1 | <const/[ a ] = [1]/>
     > 2 | <input value:=a/>
-        |               ^ Unable to bind to value.
+        |               ^ Cannot two-way bind to `a` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit `valueChange` attribute.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-dom.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/template.marko:2:15
       1 | <const/[ a ] = [1]/>
     > 2 | <input value:=a/>
-        |               ^ Unable to bind to value.
+        |               ^ Cannot two-way bind to `a` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit `valueChange` attribute.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-html.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/template.marko:2:15
       1 | <const/[ a ] = [1]/>
     > 2 | <input value:=a/>
-        |               ^ Unable to bind to value.
+        |               ^ Cannot two-way bind to `a` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit `valueChange` attribute.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/__snapshots__/error-compile-html.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-bound-attr-array-pattern/template.marko:2:15
       1 | <const/[ a ] = [1]/>
     > 2 | <input value:=a/>
-        |               ^ Unable to bind to value.
+        |               ^ Cannot two-way bind to `a` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit `valueChange` attribute.
       3 |

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -220,7 +220,12 @@ function getChangeHandler(
         : undefined;
 
       if (!changeAttrExpr) {
-        throw tag.hub.buildError(attr.value, "Unable to bind to value.");
+        throw tag.hub.buildError(
+          attr.value,
+          bindingIdentifierPath?.parentPath?.isArrayPattern()
+            ? `Cannot two-way bind to \`${attr.value.name}\` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit \`${changeAttrName}\` attribute.`
+            : "Unable to bind to value.",
+        );
       }
 
       if (modifier && t.isIdentifier(changeAttrExpr)) {


### PR DESCRIPTION
Two-way binding a value that comes from array destructuring (`<const/[ x ] = pair/>` then `<input value:=x/>`) threw the opaque "Unable to bind to value." — the same string reused for an unrelated failure mode. It now explains the cause (array destructuring has no change handler) and suggests object destructuring or an explicit `Change` attribute, since the object-destructure form (`{ x }`) works. Only the array-pattern branch is changed; the object case still compiles cleanly.