### PR TITLE
chore: document the live tags-compat "preserve" boundary mode and drop its unused constant

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,23 +2,6 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
-## Interop `preserveBoundary` / `"preserve"` registration arg is inert (dead code)
-
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `translate.exit` | 2026-07-13 | impact:low | effort:med
-
-The tags translator carefully computes `preserveBoundary` and conditionally
-appends `t.stringLiteral("preserve")` to the compat `s(id, renderer[, mode])`
-registration, but the runtime `register` (`tags-compat/runtime-html.js:240`) does
-`boundaryModeByRenderer.set(renderer, boundaryMode || true)` and only ever reads
-the value as a truthy `forceBoundary`. The `PRESERVE_BOUNDARY = "preserve"`
-constant (`runtime-html.js:11`) is defined but never referenced anywhere. So the
-translator's `preserveBoundary` branch produces no behavioral difference, and
-because `register` coerces to `true`, any `s(id, renderer)` forces the boundary
-for that renderer's inert uses in other templates (over-serialization), since
-`boundaryModeByRenderer` is keyed by the shared renderer object. Strongly
-suggests an intended `boundaryMode === PRESERVE_BOUNDARY` runtime branch that was
-never wired up — either implement it or drop the dead constant + arg.
-
 ## Compat re-render writes scope nodes onto a DOM node instead of the branch scope
 
 `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js` › `renderAndMorph` | 2026-07-13 | impact:low | effort:low

--- a/packages/runtime-class/src/node_modules/@internal/components-beginComponent/index.js
+++ b/packages/runtime-class/src/node_modules/@internal/components-beginComponent/index.js
@@ -42,6 +42,8 @@ module.exports = function beginComponent(
   if (componentsContext.___forceBoundary) {
     var forceBoundary = componentsContext.___forceBoundary;
     componentsContext.___forceBoundary = false;
+    // `"preserve"` is set by the tags-compat registration for a preserved
+    // boundary (interop dynamic-tag); any other truthy mode is a plain split.
     if (forceBoundary === "preserve") {
       isSplitComponent = true;
     } else {

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
@@ -8,7 +8,6 @@ const {
 const createRenderer = require("../../components/renderer");
 const defaultCreateOut = require("../../createOut");
 const dynamicTag5 = require("../dynamic-tag");
-const PRESERVE_BOUNDARY = "preserve";
 
 exports.p = function (htmlCompat) {
   const writersByGlobal = new WeakMap();

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -330,6 +330,8 @@ export default {
         // We use the dynamic tag when a custom tag from the class runtime is used
 
         if (classTagTemplate) {
+          // The `"preserve"` mode below is matched by beginComponent
+          // (`___forceBoundary === "preserve"`) to emit a split component.
           const preserveBoundary =
             !tagsSerializeReason &&
             (classHydration === ClassHydration.Descendant ||


### PR DESCRIPTION
A feedback entry claimed the interop `preserveBoundary` / `"preserve"` registration arg was inert dead code. It is not: `beginComponent` matches `___forceBoundary === "preserve"` to emit a split component instead of a will-rerender boundary, so removing it breaks SSR/CSR equivalence for a preserved-boundary child (verified: it fails `interop-inert-class-parent-stateful-child`).

Only the local `PRESERVE_BOUNDARY` constant in `runtime-html.js` was genuinely unused (`beginComponent` hardcodes its own `"preserve"`). This drops that constant and documents the live producer→consumer linkage at both ends so the mechanism is not mistaken for dead code again. No behavior change; interop suite green with no snapshot changes.