### PR TITLE
perf(runtime-tags): drop the redundant position map in the <for> reconciler

### DIFF
--- a/.changeset/shrink-for-reconciler.md
+++ b/.changeset/shrink-for-reconciler.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Shrink the `<for>` reconciler by dropping a redundant map. A keyed list update already builds a key→scope lookup; it now stashes each scope's old index on that same pass, so the longest-increasing-subsequence step that plans moves no longer allocates and fills a second scope→position `Map`. Same behavior, one fewer allocation per reordering update, and a slightly smaller runtime.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26115,
-        "brotli": 9605
+        "min": 26068,
+        "brotli": 9592
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 365
       },
       "runtime": {
-        "min": 6443,
-        "brotli": 2822
+        "min": 6402,
+        "brotli": 2802
       },
       "total": {
-        "min": 7089,
-        "brotli": 3187
+        "min": 7048,
+        "brotli": 3167
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6443 (min) 2822 (brotli)
+// size: 6402 (min) 2802 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) =>
     (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
@@ -396,7 +396,7 @@ function loop(forEach) {
           let branch =
             oldLen &&
             (oldScopesByKey ||= oldScopes.reduce(
-              (map, scope, i) => map.set(scope.M ?? i, scope),
+              (map, scope, i) => map.set(scope.M ?? i, ((scope.I = i), scope)),
               /* @__PURE__ */ new Map(),
             )).get(key);
           (branch
@@ -463,7 +463,6 @@ function loop(forEach) {
           return;
         } else if (start > newEnd) return;
         let diffLen = newEnd - start + 1,
-          oldPos = /* @__PURE__ */ new Map(),
           sources = Array(diffLen),
           pred = Array(diffLen),
           tails = [],
@@ -471,9 +470,7 @@ function loop(forEach) {
           lo,
           hi,
           mid;
-        for (let i = start; i <= oldEnd; i++) oldPos.set(oldScopes[i], i);
-        for (let i = diffLen; i--;)
-          sources[i] = oldPos.get(newScopes[start + i]) ?? -1;
+        for (let i = diffLen; i--;) sources[i] = newScopes[start + i].I ?? -1;
         for (let i = 0; i < diffLen; i++)
           if (~sources[i])
             if (tail < 0 || sources[tails[tail]] < sources[i])

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26115 (min) 9605 (brotli)
+// size: 26068 (min) 9592 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -2150,7 +2150,7 @@ function loop(forEach) {
           let branch =
             oldLen &&
             (oldScopesByKey ||= oldScopes.reduce(
-              (map, scope, i) => map.set(scope.M ?? i, scope),
+              (map, scope, i) => map.set(scope.M ?? i, ((scope.I = i), scope)),
               /* @__PURE__ */ new Map(),
             )).get(key);
           (branch
@@ -2217,7 +2217,6 @@ function loop(forEach) {
           return;
         } else if (start > newEnd) return;
         let diffLen = newEnd - start + 1,
-          oldPos = /* @__PURE__ */ new Map(),
           sources = Array(diffLen),
           pred = Array(diffLen),
           tails = [],
@@ -2225,9 +2224,7 @@ function loop(forEach) {
           lo,
           hi,
           mid;
-        for (let i = start; i <= oldEnd; i++) oldPos.set(oldScopes[i], i);
-        for (let i = diffLen; i--;)
-          sources[i] = oldPos.get(newScopes[start + i]) ?? -1;
+        for (let i = diffLen; i--;) sources[i] = newScopes[start + i].I ?? -1;
         for (let i = 0; i < diffLen; i++)
           if (~sources[i])
             if (tail < 0 || sources[tails[tail]] < sources[i])

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7595,
-        "brotli": 3473
+        "min": 7555,
+        "brotli": 3456
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7134,
-      "brotli": 3256
+      "min": 7092,
+      "brotli": 3242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7397,
-      "brotli": 3332
+      "min": 7355,
+      "brotli": 3321
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7839,
-        "brotli": 3577
+        "min": 7797,
+        "brotli": 3547
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8298,
-        "brotli": 3744
+        "min": 8253,
+        "brotli": 3720
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7789,
-        "brotli": 3548
+        "min": 7747,
+        "brotli": 3543
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15737,
-        "brotli": 6132
+        "min": 15693,
+        "brotli": 6123
       },
       "files": {
         "tags/sections.marko": 736,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8518,
-      "brotli": 3769
+      "min": 8473,
+      "brotli": 3761
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9285,
-      "brotli": 4002
+      "min": 9242,
+      "brotli": 3967
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7426,
-        "brotli": 3373
+        "min": 7384,
+        "brotli": 3354
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7296,
-      "brotli": 3321
+      "min": 7254,
+      "brotli": 3303
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7929,
-      "brotli": 3602
+      "min": 7887,
+      "brotli": 3569
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8001,
-      "brotli": 3611
+      "min": 7959,
+      "brotli": 3590
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7503,
-      "brotli": 3340
+      "min": 7461,
+      "brotli": 3347
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7240,
-      "brotli": 3304
+      "min": 7198,
+      "brotli": 3313
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7042,
-      "brotli": 3238
+      "min": 7000,
+      "brotli": 3240
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7319,
-      "brotli": 3332
+      "min": 7277,
+      "brotli": 3318
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8468,
-      "brotli": 3774
+      "min": 8426,
+      "brotli": 3761
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8290,
-      "brotli": 3727
+      "min": 8248,
+      "brotli": 3724
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6978,
-      "brotli": 3200
+      "min": 6936,
+      "brotli": 3180
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7707,
-        "brotli": 3518
+        "min": 7665,
+        "brotli": 3506
       },
       "files": {
         "tags/list.marko": 296,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8070,
-        "brotli": 3680
+        "min": 8028,
+        "brotli": 3648
       },
       "files": {
         "tags/child.marko": 517,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7060,
-      "brotli": 3198
+      "min": 7018,
+      "brotli": 3185
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7054,
-      "brotli": 3197
+      "min": 7012,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6835,
-      "brotli": 3137
+      "min": 6793,
+      "brotli": 3129
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7047,
-      "brotli": 3244
+      "min": 7005,
+      "brotli": 3223
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7184,
-      "brotli": 3317
+      "min": 7142,
+      "brotli": 3274
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7510,
-        "brotli": 3409
+        "min": 7468,
+        "brotli": 3399
       },
       "files": {
         "tags/inner/index.marko": 1001,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7754,
-        "brotli": 3523
+        "min": 7712,
+        "brotli": 3516
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14665,
-      "brotli": 5678
+      "min": 14623,
+      "brotli": 5668
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8016,
-      "brotli": 3613
+      "min": 7974,
+      "brotli": 3598
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7919,
-      "brotli": 3587
+      "min": 7877,
+      "brotli": 3572
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8647,
-        "brotli": 3903
+        "min": 8605,
+        "brotli": 3884
       },
       "files": {
         "tags/child.marko": 870,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7685,
-      "brotli": 3490
+      "min": 7643,
+      "brotli": 3477
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14818,
-        "brotli": 5801
+        "min": 14774,
+        "brotli": 5785
       },
       "files": {
         "tags/child.marko": 759,

--- a/packages/runtime-tags/src/common/accessor.debug.ts
+++ b/packages/runtime-tags/src/common/accessor.debug.ts
@@ -31,6 +31,7 @@ export enum AccessorProp {
   Id = "#Id",
   Load = "#Load",
   LoopKey = "#LoopKey",
+  LoopIndex = "#LoopIndex",
   ParentBranch = "#ParentBranch",
   PendingEffects = "#PendingEffects",
   PendingRenders = "#PendingRenders",

--- a/packages/runtime-tags/src/common/accessor.ts
+++ b/packages/runtime-tags/src/common/accessor.ts
@@ -31,6 +31,7 @@ export enum AccessorProp {
   Id = "L",
   Load = "X",
   LoopKey = "M",
+  LoopIndex = "I",
   ParentBranch = "N",
   PendingEffects = "J",
   PendingRenders = "W",

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -803,7 +803,11 @@ function loop<T extends unknown[] = unknown[]>(
         let branch =
           oldLen &&
           (oldScopesByKey ||= oldScopes.reduce(
-            (map, scope, i) => map.set(scope[AccessorProp.LoopKey] ?? i, scope),
+            (map, scope, i) =>
+              map.set(
+                scope[AccessorProp.LoopKey] ?? i,
+                ((scope[AccessorProp.LoopIndex] = i), scope),
+              ),
             new Map<unknown, BranchScope>(),
           )).get(key);
         if (branch) {
@@ -902,7 +906,6 @@ function loop<T extends unknown[] = unknown[]>(
 
       // Handle mixed new/moves
       const diffLen = newEnd - start + 1;
-      const oldPos = new Map<BranchScope, number>();
       const sources = new Array<number>(diffLen);
       const pred = new Array<number>(diffLen);
       const tails: number[] = [];
@@ -911,12 +914,8 @@ function loop<T extends unknown[] = unknown[]>(
       let hi: number;
       let mid: number;
 
-      for (let i = start; i <= oldEnd; i++) {
-        oldPos.set(oldScopes[i], i);
-      }
-
       for (let i = diffLen; i--;) {
-        sources[i] = oldPos.get(newScopes[start + i]) ?? -1;
+        sources[i] = newScopes[start + i][AccessorProp.LoopIndex] ?? -1;
       }
 
       for (let i = 0; i < diffLen; i++) {


### PR DESCRIPTION
The keyed list reconciler already builds a key→scope lookup on every update. It then built a *second* `Map` from scope to old position purely to feed the longest-increasing-subsequence move planner. This stashes each scope's index during the first pass and reads it back in the LIS, so the second map — an allocation plus an O(n) fill on every reordering update — goes away.

Behavior is unchanged (full suite passes). One fewer allocation per reorder, and the runtime gets slightly smaller (−47 min / −13 brotli).

Independent of #3521 — this is the size/allocation cleanup on its own, with no reordering-fast-path change.