### PR TITLE
docs(agent-feedback): drop stale empty-<html-comment> resume entry

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -181,21 +181,6 @@ A custom tag that fails to resolve (a component referenced by kebab tag name wit
 
 In a DOM environment lacking a usable `MessageChannel`, the reactive scheduler applies the FIRST update and then silently drops every later one. `schedule()` sets `isScheduled = 1` (`dom/schedule.ts:17`), and the flag is reset to `0` in exactly one place — the `channel.port1.onmessage` handler (`:36`) — reachable only if `new MessageChannel()` (`:34`) succeeds. When `MessageChannel` is absent, `:34` throws inside the `requestAnimationFrame` callback `triggerMacroTask`, the handler is never installed, `isScheduled` stays `1` forever, and every subsequent `schedule()` short-circuits at `:7`. The first update still lands because `flushAndWaitFrame` runs `run()` synchronously (`:28`), and `run()`→`runRenders()` (`dom/queue.ts:83-95,131-167`) applies the queued renders without touching the channel — the channel is only the next-frame reset. That asymmetry is the trap for agentic workflows: a one-click smoke test goes green (false confidence) while a two-step interaction test fails with no test-visible error — the throw surfaces only as a jsdom window `error` event — so an agent cannot tell whether its component logic or its harness is at fault. It bites hand-rolled jsdom and jest+jsdom harnesses (which historically ship no `MessageChannel`, the same gap React 18's scheduler hit), the exact throwaway setups agents reach for to self-verify. Reset the flag in a `finally` (or degrade to `setTimeout`/`queueMicrotask` for the macrotask boundary) plus add a `MARKO_DEBUG` assert naming the missing `MessageChannel`, turning a silent misattributed wedge into a deterministic, self-explaining failure fixable from the error string alone.
 
-## An empty-bodied `<html-comment>` resumes as a text node instead of the comment
-
-`packages/runtime-tags/src/dom/resume.ts` › `init` | 2026-07-14 | impact:med | effort:med
-
-For an `<html-comment>${c}</html-comment>` whose body serializes empty, SSR
-writes `<!---->` immediately before the resume marker, and the node-claim
-heuristic in the `ResumeSymbol.Node` visit (`prev.nodeType < 8 || prev.data`)
-refuses the empty comment and binds a fresh Text instead; it exists to skip
-empty `<!>` separators and cannot tell an intentional empty comment apart.
-After hydration, updating the body renders visible text where a pure client
-render produces `<!--...-->`. Fix direction: a dedicated resume symbol for
-html-comment markers that claims the preceding sibling unconditionally.
-Verify: SSR + resume an empty-bodied `<html-comment>`, set its body, and
-compare the DOM with a client-side render.
-
 ## Document-side lazy load entries float rejections and leave the ready channel silent
 
 `packages/runtime-tags/src/translator/visitors/program/index.ts` › `translate` (`isLoadEntry` branch) | 2026-07-16 | impact:low | effort:low


### PR DESCRIPTION
The bugs.md entry "An empty-bodied `<html-comment>` resumes as a text node instead of the comment" (2026-07-14) is already fixed. Commit b3752c95fa ("fix(runtime-tags): claim empty html-comments on resume") pads an emptiable resumable comment with a space (`html-comment.ts:112-123`, comment: "its trailing resume marker claims a stray text node"), so the node-claim heuristic sees truthy `prev.data` and claims the comment. Verified by the passing `html-comment-empty-dynamic` fixture (SSR resume + reveal). Removing the stale entry so it is not re-attempted.