### PR TITLE
chore: won't-fix serializeReasonCache flavor collision (latent)

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -169,12 +169,6 @@ module's ready id never resolves. The lazy tag's own render path recovers
 the dynamic import in a generated load entry and watch for the unhandled
 rejection with the ready id never firing.
 
-## Key `serializeReasonCache` on the `properties` flavor; it currently returns cross-flavor reasons
-
-`packages/runtime-tags/src/translator/util/references.ts` › `getAllSerializeReasonsForBinding` | 2026-07-20 | impact:med | effort:med
-
-`serializeReasonCache` is keyed only on the `Binding` (references.ts:2560/2600), but the value cached there depends on the `properties` argument: the upstream-alias contribution is merged only when `properties !== true` (2568) and same-section aliases are recursed with that same `properties` (2591). Two distinct flavors reach the same binding within one compilation — `getAllSerializeReasonsForExtra` always queries with `true` (2543) while `getSectionRegisterReasons` queries with `downstreamBinding.properties` (sections.ts:332-334), which is always a non-`true` `"content"`-suffixed list (set-tag-sections-downstream.ts) — and a cache hit skips the whole compute block, so whichever flavor runs first poisons the other. For a binding with an `upstreamAlias` (or properties-dependent aliases), a `true`-first order drops the upstream-alias reason from a later properties query (potential under-serialization / resume gap), while a non-`true`-first order over-includes it in a later `true` query (bytes that are not needed). Fix by adding the flavor to the cache key (e.g. `[binding, properties === true]`) or by memoizing only the properties-independent portion (base reason + reads) and recomputing the upstream-alias/alias terms per call. Re-verify: add the flavor bit to the key and run `npm run test:parallel`; any serialize/resume snapshot diff proves the memo was returning a value computed for a different `properties`.
-
 ## Dedup a Request/Response's headers against an already-serialized Headers instead of re-emitting inline and clobbering its ref
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeRequest` | 2026-07-20 | impact:low | effort:med

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -2536,6 +2536,10 @@ export function getAllSerializeReasonsForBinding(
   binding: Binding,
   properties?: Opt<string> | true,
 ): undefined | SerializeReason {
+  // The upstream-alias term is merged only for `properties !== true`, but it can
+  // only promote a binding that has no other reason — i.e. one never read in an
+  // expression, so never queried with `true`. A binding seen in both flavors
+  // therefore can't differ by flavor, so a single binding key is safe.
   let reason = serializeReasonCache.get(binding);
 
   if (reason === undefined) {


### PR DESCRIPTION
Marks the "key serializeReasonCache on the properties flavor" item as won't-fix, after investigating whether it can actually affect output.

The collision is structurally present — the cached reason depends on `properties` (the upstream-alias term is merged only when `properties !== true`), and instrumentation confirmed bindings with an `upstreamAlias` are queried under both flavors. But it cannot change output: the upstream term only *promotes* a binding's reason when the binding has no other reason source — i.e. one that is never read in an expression, hence never queried with `true`. Any binding queried in the `true` flavor already has a reason from that read, which makes the upstream term redundant. So "flavor difference" and "queried in both flavors" are mutually exclusive by construction.

Verified: a flavor-keyed cache produces byte-identical output across the whole suite (9600+ tests), and ~8 hand-built candidates designed to trigger it (const-alias to stateful state, spread-attr content rendered via `<${x}/>`, a binding both read via `<if=x>` and rendered) all failed to manifest. Captured the structural reasoning as a code comment and dropped the agent-feedback entry. No behavior change.