### PR TITLE
perf(runtime-tags): drop the intersection for <for by> selector comparisons

### DIFF
--- a/.changeset/for-selector-key-no-intersection.md
+++ b/.changeset/for-selector-key-no-intersection.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Compile `<for by>` selector comparisons without an intersection. When a keyed list body compares the loop key to an owner value (e.g. `class=(selected === row.id && "danger")`), the key is stable per branch, so the comparison now depends only on the owner value and compiles to a plain for-selector closure instead of an `_or` intersection — smaller output, no per-row intersection coordination, and the comparison no longer re-runs when unrelated row data changes.

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,12 @@
 // template.marko
 const $template = "<table><tbody></tbody></table><button class=remove>remove selected</button><button class=rotate>rotate</button><button class=clear>clear</button>";
 const $walks = "D l b b b";
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_id", ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
 const $for_content__setup = $for_content__selected;
 const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
 	$selected($scope._, $scope.row_id);
 }));
-const $for_content__row_id = /*@__PURE__*/ _const("row_id", ($scope) => {
-	$for_content__selected__OR__row_id($scope);
-	$for_content__row_id__script($scope);
-});
+const $for_content__row_id = /*@__PURE__*/ _const("row_id", $for_content__row_id__script);
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/__snapshots__/dom.bundle.js
@@ -1,14 +1,9 @@
 // template.marko
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope.a, $scope._.e === $scope.f && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector(0, 4, 5, $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 4, 5, ($scope) => _attr_class($scope.a, $scope._.e === $scope.f && "danger"));
 const $for_content__setup = $for_content__selected;
-const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $for_content__row_id = /*@__PURE__*/ _const(5, _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$selected($scope._, $scope.f);
-}));
-const $for_content__row_id = /*@__PURE__*/ _const(5, ($scope) => {
-	$for_content__selected__OR__row_id($scope);
-	$for_content__row_id__script($scope);
-});
+})));
 const $for_content__row_label = ($scope, row_label) => _text($scope.c, row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8454,
-      "brotli": 3788
+      "min": 8312,
+      "brotli": 3709
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,20 @@
 // template.marko
 const $template = "<ul></ul>";
 const $walks = " b";
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/0", "selected", "row_id", $for_content__selected__OR__row_id);
-const $for_content__setup = $for_content__selected;
-const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
+const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/0", "selected", "row_id", ($scope) => _attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger"));
+const $for_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
 	$selected($scope._, $scope._.selected === $scope.row_id ? undefined : $scope.row_id);
 }));
-const $for_content__row_id = /*@__PURE__*/ _const("row_id", ($scope) => {
-	$for_content__selected__OR__row_id($scope);
-	$for_content__row_id__script($scope);
-});
+const $for_content__setup = ($scope) => {
+	$for_content__selected._($scope);
+	$for_content__setup__script($scope);
+};
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);
 	$for_content__row_label($scope, $params2[0]?.label);
 };
+const $for_content__row_id = /*@__PURE__*/ _const("row_id");
 const $selected = /*@__PURE__*/ _let("selected/1", $for_content__selected);
 const $for = /*@__PURE__*/ _for_of("#ul/0", "<li><button class=toggle> </button></li>", " D D m", $for_content__setup, $for_content__$params);
 const $rows = /*@__PURE__*/ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope.a, $scope._.b === $scope.f && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
-const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, ($scope) => _attr_class($scope.a, $scope._.b === $scope.f && "danger"));
+const $for_content__setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$selected($scope._, $scope._.b === $scope.f ? void 0 : $scope.f);
 }));
 const $selected = /*@__PURE__*/ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_for_of(rows, (row) => {
 		const $scope1_id = _scope_id();
 		_html(`<li${selected === row.id ? " class=danger" : ""}><button class=toggle>${_escape(row.label)}</button>${_el_resume($scope1_id, "#button/1")}</li>${_el_resume($scope1_id, "#li/0")}`);
-		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		_script($scope1_id, "__tests__/template.marko_1");
 		writeScope($scope1_id, {
 			row_id: row?.id,
 			_: _scope_with_id($scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/__snapshots__/writes.debug.html
@@ -15,7 +15,7 @@
       row_id: 2,
       _: _(1)
     }],
-    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/template.marko_1_row_id 2 3"
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/template.marko_1 2 3"
   ];
   M._.w()
 </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3587,
-      "brotli": 1744
+      "min": 3472,
+      "brotli": 1693
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.debug.js
@@ -2,16 +2,12 @@
 const $template = "<ul></ul>";
 const $walks = " b";
 const $for_content__if = /*@__PURE__*/ _if("#text/0", "<strong>*</strong>", "b");
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => $for_content__if($scope, $scope._.selected === $scope.row_id ? 0 : 1));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/0", "selected", "row_id", ($scope) => $for_content__if($scope, $scope._.selected === $scope.row_id ? 0 : 1));
 const $for_content__setup = $for_content__selected;
 const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
 	$selected($scope._, $scope.row_id);
 }));
-const $for_content__row_id = /*@__PURE__*/ _const("row_id", ($scope) => {
-	$for_content__selected__OR__row_id($scope);
-	$for_content__row_id__script($scope);
-});
+const $for_content__row_id = /*@__PURE__*/ _const("row_id", $for_content__row_id__script);
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/dom.bundle.js
@@ -1,8 +1,7 @@
 // template.marko
 const $for_content__if = /*@__PURE__*/ _if(0, "<strong>*</strong>", "b");
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => $for_content__if($scope, $scope._.b === $scope.f ? 0 : 1));
-const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
-const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, ($scope) => $for_content__if($scope, $scope._.b === $scope.f ? 0 : 1));
+const $for_content__row_id = /*@__PURE__*/ _const(5, _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$selected($scope._, $scope.f);
-}));
+})));
 const $selected = /*@__PURE__*/ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.debug.md
@@ -100,6 +100,6 @@ document.querySelectorAll("button.select")[n].click();
 ```
 ## Change
 ```
-INSERT: ul > li:nth-of-type(1) > strong
 REMOVE: ul > li:nth-of-type(3) > strong
+INSERT: ul > li:nth-of-type(1) > strong
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/render.md
@@ -100,6 +100,6 @@ document.querySelectorAll("button.select")[n].click();
 ```
 ## Change
 ```
-INSERT: ul > li:nth-of-type(1) > strong
 REMOVE: ul > li:nth-of-type(3) > strong
+INSERT: ul > li:nth-of-type(1) > strong
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6634,
-      "brotli": 3003
+      "min": 6517,
+      "brotli": 2951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,42 @@
+// template.marko
+const $template = "<ul></ul><button class=relabel>relabel</button>";
+const $walks = " b b";
+const $for_content__selected__OR__row_id__OR__row_label = /*@__PURE__*/ _or(8, ($scope) => _text($scope["#text/1"], $scope._.selected === $scope.row_id && $scope.row_label), 2);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/0", "selected", "row_id", ($scope) => {
+	_attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger");
+	$for_content__selected__OR__row_id__OR__row_label($scope);
+});
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/2"], "click", function() {
+	$selected($scope._, $scope.row_id);
+}));
+const $for_content__row_id = /*@__PURE__*/ _const("row_id", ($scope) => {
+	$for_content__selected__OR__row_id__OR__row_label($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = /*@__PURE__*/ _const("row_label", $for_content__selected__OR__row_id__OR__row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /*@__PURE__*/ _let("selected/2", $for_content__selected);
+const $for = /*@__PURE__*/ _for_of("#ul/0", "<li><span> </span><button class=select>x</button></li>", " E l l", $for_content__setup, $for_content__$params);
+const $rows = /*@__PURE__*/ _let("rows/3", ($scope) => $for($scope, [$scope.rows, "id"]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$rows($scope, $scope.rows.map((r) => r.id === 1 ? {
+		id: 1,
+		label: r.label + "!"
+	} : r));
+}));
+function $setup($scope) {
+	$selected($scope, 1);
+	$rows($scope, [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/dom.bundle.js
@@ -1,0 +1,28 @@
+// template.marko
+const $for_content__selected__OR__row_id__OR__row_label = /*@__PURE__*/ _or(8, ($scope) => _text($scope.b, $scope._.c === $scope.f && $scope.h), 2);
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 2, 5, ($scope) => {
+	_attr_class($scope.a, $scope._.c === $scope.f && "danger");
+	$for_content__selected__OR__row_id__OR__row_label($scope);
+});
+const $for_content__setup = $for_content__selected;
+const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+	$selected($scope._, $scope.f);
+}));
+const $for_content__row_id = /*@__PURE__*/ _const(5, ($scope) => {
+	$for_content__selected__OR__row_id__OR__row_label($scope);
+	$for_content__row_id__script($scope);
+});
+const $for_content__row_label = /*@__PURE__*/ _const(7, $for_content__selected__OR__row_id__OR__row_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__row_id($scope, $params2[0]?.id);
+	$for_content__row_label($scope, $params2[0]?.label);
+};
+const $selected = /*@__PURE__*/ _let(2, $for_content__selected);
+const $for = /*@__PURE__*/ _for_of(0, "<li><span> </span><button class=select>x</button></li>", " E l l", $for_content__setup, $for_content__$params);
+const $rows = /*@__PURE__*/ _let(3, ($scope) => $for($scope, [$scope.d, "id"]));
+const $setup__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
+	$rows($scope, $scope.d.map((r) => r.id === 1 ? {
+		id: 1,
+		label: r.label + "!"
+	} : r));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}><span>${_escape(selected === row.id && row.label)}${_el_resume($scope1_id, "#text/1")}</span><button class=select>x</button>${_el_resume($scope1_id, "#button/2")}</li>${_el_resume($scope1_id, "#li/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1_row_id");
+		writeScope($scope1_id, {
+			row_id: row?.id,
+			row_label: row?.label
+		}, "__tests__/template.marko", "4:4", {
+			row_id: ["row.id", "4:8"],
+			row_label: ["row.label", "4:8"]
+		});
+	}, "id", $scope0_id, "#ul/0", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=relabel>relabel</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		selected,
+		rows
+	}, "__tests__/template.marko", 0, {
+		selected: "1:6",
+		rows: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let selected = 1;
+	let rows = [{
+		id: 1,
+		label: "a"
+	}, {
+		id: 2,
+		label: "b"
+	}];
+	_html("<ul>");
+	_for_of(rows, (row) => {
+		const $scope1_id = _scope_id();
+		_html(`<li${selected === row.id ? " class=danger" : ""}><span>${_escape(selected === row.id && row.label)}${_el_resume($scope1_id, "b")}</span><button class=select>x</button>${_el_resume($scope1_id, "c")}</li>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		writeScope($scope1_id, {
+			f: row?.id,
+			h: row?.label
+		});
+	}, "id", $scope0_id, "a", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=relabel>relabel</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		c: selected,
+		d: rows
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/render.debug.md
@@ -1,0 +1,106 @@
+# Render
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a!
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+## Change
+```
+UPDATE: .danger > span::text "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a!!
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+## Change
+```
+UPDATE: .danger > span::text "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/render.md
@@ -1,0 +1,106 @@
+# Render
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a!
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+## Change
+```
+UPDATE: .danger > span::text "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector(selector).click();
+```
+```html
+<ul>
+  <li
+    class="danger"
+  >
+    <span>
+      a!!
+    </span>
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+  <li>
+    <span />
+    <button
+      class="select"
+    >
+      x
+    </button>
+  </li>
+</ul>
+<button
+  class="relabel"
+>
+  relabel
+</button>
+```
+## Change
+```
+UPDATE: .danger > span::text "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<ul>
+  <li class=danger><span>a<!--M_*2 #text/1--></span><button
+      class=select>x</button><!--M_*2 #button/2--></li><!--M_*2 #li/0-->
+  <li><span><!--M_*3 #text/1--></span><button
+      class=select>x</button><!--M_*3 #button/2--></li>
+  <!--M_*3 #li/0--><!--M_}1 #ul/0 3 2-->
+</ul><button class=relabel>relabel</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      selected: 1,
+      rows: [{
+        id: 1,
+        label: "a"
+      }, {
+        id: 2,
+        label: "b"
+      }]
+    }, {
+      row_id: 1,
+      row_label: "a",
+      "#LoopKey": 1
+    }, {
+      row_id: 2,
+      row_label: "b",
+      "#LoopKey": 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/template.marko_1_row_id 2 3 packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/__snapshots__/writes.html
@@ -1,0 +1,28 @@
+<ul>
+  <li class=danger><span>a<!--M_*2 b--></span><button
+      class=select>x</button><!--M_*2 c--></li><!--M_*2 a-->
+  <li><span><!--M_*3 b--></span><button class=select>x</button><!--M_*3 c-->
+  </li><!--M_*3 a--><!--M_}1 a 3 2-->
+</ul><button class=relabel>relabel</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1,
+    d: [{
+      id: 1,
+      label: "a"
+    }, {
+      id: 2,
+      label: "b"
+    }]
+  }, {
+    f: 1,
+    h: "a",
+    M: 1
+  }, {
+    f: 2,
+    h: "b",
+    M: 2
+  }], "a0 2 3 a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3453,
-      "brotli": 1686
+      "min": 8408,
+      "brotli": 3773
     }
   },
   "html": {
-    "min": 635,
-    "brotli": 321
+    "min": 660,
+    "brotli": 351
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/template.marko
@@ -1,0 +1,13 @@
+<let/selected=1/>
+<let/rows=[{ id: 1, label: "a" }, { id: 2, label: "b" }]/>
+<ul>
+  <for|row| of=rows by="id">
+    <li class=(selected === row.id && "danger")>
+      <span>${selected === row.id && row.label}</span>
+      <button.select onClick() { selected = row.id }>x</button>
+    </li>
+  </for>
+</ul>
+<button.relabel onClick() {
+  rows = rows.map((r) => (r.id === 1 ? { id: 1, label: r.label + "!" } : r));
+}>relabel</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (selector: string) => (document: Document) =>
+  (document.querySelector(selector) as HTMLButtonElement).click();
+
+// The span compares the loop key *and* reads the item, so the selector collapse
+// must keep `row` referenced: relabeling row 1 (same id) must update the span.
+export const config: TestConfig = {
+  steps: [{}, click("button.relabel"), click("button.relabel")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.debug.js
@@ -1,15 +1,14 @@
 // template.marko
 const $template = "<button class=add>add</button><ul></ul>";
 const $walks = " b b";
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(5, ($scope) => _attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/1", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#ul/1", "selected", "row_id", ($scope) => _attr_class($scope["#li/0"], $scope._.selected === $scope.row_id && "danger"));
 const $for_content__setup = $for_content__selected;
-const $for_content__row_id = /*@__PURE__*/ _const("row_id", $for_content__selected__OR__row_id);
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/1"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);
 	$for_content__row_label($scope, $params2[0]?.label);
 };
+const $for_content__row_id = /*@__PURE__*/ _const("row_id");
 const $for = /*@__PURE__*/ _for_of("#ul/1", "<li> </li>", " D l", $for_content__setup, $for_content__$params);
 const $rows = /*@__PURE__*/ _let("rows/2", ($scope) => $for($scope, [$scope.rows, "id"]));
 const $selected = /*@__PURE__*/ _let("selected/3", $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/__snapshots__/dom.bundle.js
@@ -1,13 +1,12 @@
 // template.marko
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(5, ($scope) => _attr_class($scope.a, $scope._.d === $scope.e && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector(1, 3, 4, $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector(1, 3, 4, ($scope) => _attr_class($scope.a, $scope._.d === $scope.e && "danger"));
 const $for_content__setup = $for_content__selected;
-const $for_content__row_id = /*@__PURE__*/ _const(4, $for_content__selected__OR__row_id);
 const $for_content__row_label = ($scope, row_label) => _text($scope.b, row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);
 	$for_content__row_label($scope, $params2[0]?.label);
 };
+const $for_content__row_id = /*@__PURE__*/ _const(4);
 const $for = /*@__PURE__*/ _for_of(1, "<li> </li>", " D l", $for_content__setup, $for_content__$params);
 const $rows = /*@__PURE__*/ _let(2, ($scope) => $for($scope, [$scope.c, "id"]));
 const $selected = /*@__PURE__*/ _let(3, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8276,
-      "brotli": 3721
+      "min": 8157,
+      "brotli": 3678
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,12 @@
 // template.marko
 const $template = "<table><tbody></tbody></table>";
 const $walks = "D l";
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_id", $for_content__selected__OR__row_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_id", ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_id && "danger"));
 const $for_content__setup = $for_content__selected;
 const $for_content__row_id__script = _script("__tests__/template.marko_1_row_id", ($scope) => _on($scope["#button/1"], "click", function() {
 	$selected($scope._, $scope.row_id);
 }));
-const $for_content__row_id = /*@__PURE__*/ _const("row_id", ($scope) => {
-	$for_content__selected__OR__row_id($scope);
-	$for_content__row_id__script($scope);
-});
+const $for_content__row_id = /*@__PURE__*/ _const("row_id", $for_content__row_id__script);
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_id($scope, $params2[0]?.id);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
-const $for_content__selected__OR__row_id = /*@__PURE__*/ _or(6, ($scope) => _attr_class($scope.a, $scope._.b === $scope.f && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, $for_content__selected__OR__row_id);
-const $for_content__row_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 5, ($scope) => _attr_class($scope.a, $scope._.b === $scope.f && "danger"));
+const $for_content__row_id = /*@__PURE__*/ _const(5, _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$selected($scope._, $scope.f);
-}));
+})));
 const $selected = /*@__PURE__*/ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,12 @@
 // template.marko
 const $template = "<table><tbody></tbody></table>";
 const $walks = "D l";
-const $for_content__selected__OR__row_user_id = /*@__PURE__*/ _or(7, ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_user_id && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_user_id", $for_content__selected__OR__row_user_id);
+const $for_content__selected = /*@__PURE__*/ _for_selector("#tbody/0", "selected", "row_user_id", ($scope) => _attr_class($scope["#tr/0"], $scope._.selected === $scope.row_user_id && "danger"));
 const $for_content__setup = $for_content__selected;
 const $for_content__row_user_id__script = _script("__tests__/template.marko_1_row_user_id", ($scope) => _on($scope["#button/1"], "click", function() {
 	$selected($scope._, $scope.row_user_id);
 }));
-const $for_content__row_user_id = /*@__PURE__*/ _const("row_user_id", ($scope) => {
-	$for_content__selected__OR__row_user_id($scope);
-	$for_content__row_user_id__script($scope);
-});
+const $for_content__row_user_id = /*@__PURE__*/ _const("row_user_id", $for_content__row_user_id__script);
 const $for_content__row_label = ($scope, row_label) => _text($scope["#text/2"], row_label);
 const $for_content__$params = ($scope, $params2) => {
 	$for_content__row_user_id($scope, $params2[0]?.user?.id);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
-const $for_content__selected__OR__row_user_id = /*@__PURE__*/ _or(7, ($scope) => _attr_class($scope.a, $scope._.b === $scope.g && "danger"));
-const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 6, $for_content__selected__OR__row_user_id);
-const $for_content__row_user_id__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+const $for_content__selected = /*@__PURE__*/ _for_selector(0, 1, 6, ($scope) => _attr_class($scope.a, $scope._.b === $scope.g && "danger"));
+const $for_content__row_user_id = /*@__PURE__*/ _const(6, _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$selected($scope._, $scope.g);
-}));
+})));
 const $selected = /*@__PURE__*/ _let(1, $for_content__selected);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.debug.md
@@ -163,6 +163,6 @@ document.querySelectorAll("button.select")[n].click();
 ```
 ## Change
 ```
-UPDATE: .danger[class] null => "danger"
 UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/render.md
@@ -163,6 +163,6 @@ document.querySelectorAll("button.select")[n].click();
 ```
 ## Change
 ```
-UPDATE: .danger[class] null => "danger"
 UPDATE: table > tbody > tr:nth-of-type(3)[class] "danger" => null
+UPDATE: .danger[class] null => "danger"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3568,
-      "brotli": 1742
+      "min": 3453,
+      "brotli": 1685
     }
   },
   "html": {

--- a/packages/runtime-tags/src/translator/util/for-selector.ts
+++ b/packages/runtime-tags/src/translator/util/for-selector.ts
@@ -4,8 +4,12 @@ import { forEach } from "./optional";
 import {
   type Binding,
   BindingType,
+  bindingUtil,
+  dropReferencedBindings,
   getCanonicalBinding,
   getExpressionReads,
+  type ReferencedBindings,
+  type ReferencedExtra,
 } from "./references";
 import { isDirectClosure, type Section } from "./sections";
 
@@ -61,6 +65,7 @@ function onlyComparesKey(
   keyBinding: Binding,
 ): boolean {
   let found = false;
+  const keyReads = new Map<ReferencedExtra, ReferencedBindings>();
   for (
     let chain: Binding | undefined = closure;
     chain;
@@ -73,20 +78,47 @@ function onlyComparesKey(
         const resolved = read.extra.read;
         const at = resolved && resolvesTo(resolved, canonical);
         if (!at) return;
-        if (
-          at === 2 ||
-          resolved.getter ||
-          !readsKey(read.comparedTo?.extra?.read, keyBinding)
-        ) {
+        const keyRead = read.comparedTo?.extra?.read;
+        if (at === 2 || resolved.getter || !readsKey(keyRead, keyBinding)) {
           other = true;
         } else {
           found = true;
+          // Only drop a key read resolving directly to the key binding; one
+          // reaching it through the item (item read bare) keeps that referenced.
+          if (
+            keyRead &&
+            !keyRead.props &&
+            getCanonicalBinding(keyRead.binding) ===
+              getCanonicalBinding(keyBinding)
+          ) {
+            keyReads.set(
+              expr,
+              bindingUtil.add(keyReads.get(expr), keyRead.binding),
+            );
+          }
         }
       });
       if (other) return false;
     }
   }
+  if (found) {
+    for (const [expr, dropped] of keyReads) {
+      dropKeyReferences(expr, dropped);
+    }
+  }
   return found;
+}
+
+// The key is stable per keyed branch, so drop it from the comparison's
+// referenced bindings — its intersection collapses to a lone closure signal.
+function dropKeyReferences(expr: ReferencedExtra, dropped: ReferencedBindings) {
+  if (dropReferencedBindings(expr, dropped)) {
+    // The dropped key is still read but now schedules nothing, so pin it to
+    // keep the `_const` that stores its value.
+    forEach(dropped, (binding) => {
+      binding.forcePersist = true;
+    });
+  }
 }
 
 function resolvesTo(

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1368,6 +1368,23 @@ export function finalizeReferences() {
   fnReadsByExpression.clear();
 }
 
+// Narrow an expression's already-resolved referenced bindings, but only when a
+// lone binding survives — a smaller intersection would orphan its intersectionMeta.
+export function dropReferencedBindings(
+  expr: ReferencedExtra,
+  drop: ReferencedBindings,
+): boolean {
+  let kept: ReferencedBindings;
+  forEach(expr.referencedBindings, (binding) => {
+    if (!bindingUtil.has(drop, binding)) {
+      kept = bindingUtil.add(kept, binding);
+    }
+  });
+  if (Array.isArray(kept)) return false;
+  expr.referencedBindings = kept;
+  return true;
+}
+
 function getMaxOwnSourceOffset(intersection: Intersection, section: Section) {
   let scopeOffset: Binding | undefined;
 


### PR DESCRIPTION
When a keyed list body compares the loop key to an owner value — the `selected === row.id` selector pattern (e.g. `class=(selected === row.id && "danger")`) — the key is stable per keyed branch, so the comparison needs no referenced binding for it.

For-selector detection now drops the stable key read from the comparison's referenced bindings, so it depends only on the owner value and compiles to a plain `_for_selector` closure signal instead of an `_or` intersection. Result: smaller compiled output for this common pattern, one fewer per-branch signal, and the comparison no longer re-runs when unrelated row data changes.

It's handled entirely within `onlyComparesKey` (which already walks the comparison's reads), with two guards:
- **Only collapse to a lone referenced binding** — larger intersections are left untouched (avoids orphaning `intersectionMeta`).
- **Only drop a key read that resolves directly to the key binding** — if it reaches the key through the item read bare (so `row.id` resolves to `row` + `.id`), that item stays referenced. Regression fixture `for-keyed-selector-mixed-key-read` covers this.

Full suite passes. Two existing fixtures' independent class/content updates reorder within a single synchronous flush (same final DOM).