### PR TITLE
fix(runtime-tags): dedup Request/Response headers already serialized standalone

### DIFF
--- a/.changeset/dedup-request-response-headers.md
+++ b/.changeset/dedup-request-response-headers.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+When a `Request`/`Response` is serialized after its `headers` object was already serialized standalone, reuse that reference instead of re-emitting the header entries inline and overwriting it. This dedups the emitted data and keeps other references to those headers consistent on resume.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -163,12 +163,6 @@ module's ready id never resolves. The lazy tag's own render path recovers
 the dynamic import in a generated load entry and watch for the unhandled
 rejection with the ready id never firing.
 
-## Dedup a Request/Response's headers against an already-serialized Headers instead of re-emitting inline and clobbering its ref
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeRequest` | 2026-07-20 | impact:low | effort:med
-
-`writeRequest` (and `writeResponse`) always serialize `val.headers` inline via `stringEntriesToHeadersInit` and then unconditionally `state.refs.set(val.headers, new Reference(ref, "headers", …))` (serializer.ts:1318-1319, 1380-1381). When the same Headers object was already serialized standalone (it already has a Reference), this both fails to dedup (the headers data is emitted twice) and overwrites the prior ref, so referential identity is lost. `{a: req.headers, b: req}` serializes `a` as its own `new Headers({…})` and then re-emits the headers inline inside the Request, so on resume `a !== b.headers` even though originally `a === req.headers`; the reverse order `{b: req, a: req.headers}` works and is the only order the existing `headers` test covers. Guard the `state.refs.set` (set only when absent) and emit `headers:<deduped ref>` when `state.refs.has(val.headers)`. Re-verify: `assertStringify({a: req.headers, b: req}, …)` with `const req = new Request("https://x/", {headers:{a:"1"}, method:"POST"})` emits a standalone `new Headers({a:"1"})` plus a second inline `{a:"1"}`, and the deserialized `a !== b.headers`.
-
 ## Route a failed lazy input-signal chunk to the `@catch` boundary instead of swallowing it and hanging the branch
 
 `packages/runtime-tags/src/dom/load.ts` › `insertLoaded` | 2026-07-20 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -1594,6 +1594,22 @@ describe("serializer", () => {
       );
     });
 
+    it("headers deduped when serialized before the request", () => {
+      const req = new Request("https://ebay.com/", {
+        headers: { "content-type": "text/plain" },
+        method: "POST",
+      });
+      // Headers already serialized standalone: the request reuses that ref
+      // instead of re-emitting the entries inline and clobbering it.
+      const [result] = assertSerializer().assertStringify(
+        { a: req.headers, b: req, c: req.headers },
+        `{a:_.a=new Headers({"content-type":"text/plain"}),b:new Request("https://ebay.com/",{headers:_.a,method:"POST"}),c:_.a}`,
+      ) as [{ a: Headers; b: Request; c: Headers }];
+      assert.equal(result.a, result.c);
+      assert.equal(result.a.get("content-type"), "text/plain");
+      assert.equal(result.b.headers.get("content-type"), "text/plain");
+    });
+
     it("cache", () =>
       assertStringify(
         new Request("https://ebay.com/", { cache: "no-store" }),

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1340,11 +1340,22 @@ function writeRequest(state: State, val: Request, ref: Reference) {
     sep = ",";
   }
 
-  const headers = stringEntriesToHeadersInit(val.headers as any);
-  state.refs.set(val.headers, new Reference(ref, "headers", state.flush, null));
-  if (headers) {
-    options += sep + "headers:" + headers;
+  const seenHeaders = state.refs.get(val.headers);
+  if (seenHeaders) {
+    // Dedup against the already-serialized Headers instead of re-emitting the
+    // entries inline (which also clobbered its reference).
+    options += sep + "headers:" + ensureId(state, seenHeaders);
     sep = ",";
+  } else {
+    state.refs.set(
+      val.headers,
+      new Reference(ref, "headers", state.flush, null),
+    );
+    const headers = stringEntriesToHeadersInit(val.headers as any);
+    if (headers) {
+      options += sep + "headers:" + headers;
+      sep = ",";
+    }
   }
 
   if (val.integrity) {
@@ -1402,10 +1413,20 @@ function writeResponse(state: State, val: Response, ref: Reference) {
     sep = ",";
   }
 
-  const headers = stringEntriesToHeadersInit(val.headers as any);
-  state.refs.set(val.headers, new Reference(ref, "headers", state.flush, null));
-  if (headers) {
-    options += sep + "headers:" + headers;
+  const seenHeaders = state.refs.get(val.headers);
+  if (seenHeaders) {
+    // Dedup against the already-serialized Headers instead of re-emitting the
+    // entries inline (which also clobbered its reference).
+    options += sep + "headers:" + ensureId(state, seenHeaders);
+  } else {
+    state.refs.set(
+      val.headers,
+      new Reference(ref, "headers", state.flush, null),
+    );
+    const headers = stringEntriesToHeadersInit(val.headers as any);
+    if (headers) {
+      options += sep + "headers:" + headers;
+    }
   }
 
   if (!val.body || val.bodyUsed) {


### PR DESCRIPTION
`writeRequest`/`writeResponse` always serialized `val.headers` inline via `stringEntriesToHeadersInit` and then **unconditionally** set a new reference for it. So when the same `Headers` object had already been serialized standalone (`{ a: req.headers, b: req }`), the entries were emitted **twice** and the prior reference was **clobbered** — a later `c: req.headers` then pointed at a different copy than `a`.

Now reuse the existing reference when `val.headers` is already in `state.refs`, emitting `headers:<ref>` instead of re-inlining. The reverse order (`{ req, headers: req.headers }`) already worked and is unchanged.

Note: `req.headers` identity itself can't be restored — `Request`/`Response` copy their `headers` init into a fresh read-only `headers` slot (verified), so the constructed request's headers is always a distinct object. The fix is about not duplicating the data and keeping the standalone references consistent (e.g. `{ a: req.headers, b: req, c: req.headers }` now round-trips with `a === c`).

Added a regression test for the pre-request order (fails without the fix). Full suite green (9592); runtime size unchanged (0 brotli delta).