### PR TITLE
ci: trim release format, parallelize build+lint, skip docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize]
+    paths-ignore:
+      - "**/*.md"
+      - "LICENSE"
   push:
     branches: [main, v3, v4]
 
@@ -25,10 +28,14 @@ jobs:
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Build
-        run: pnpm run @ci:build
-      - name: Lint Code
-        run: pnpm run @ci:lint
+      - name: Build & Lint
+        run: |
+          set +e
+          pnpm run @ci:build & build=$!
+          pnpm run @ci:lint & lint=$!
+          wait $build; build_status=$?
+          wait $lint; lint_status=$?
+          exit $(( build_status | lint_status ))
   test:
     runs-on: ubuntu-latest
     name: "test: node@${{ matrix.node }}"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.ts",
     "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 c8 pnpm run test:parallel",
     "@ci:test:fast": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 pnpm run test:parallel",
-    "@ci:version": "pnpm run build && pnpm run format && changeset version && pnpm install --lockfile-only",
+    "@ci:version": "pnpm run build && changeset version && prettier --write --log-level=warn \"**/package.json\" && pnpm install --lockfile-only",
     "audit": "pnpm audit --prod",
     "build": "pnpm -r --if-present run build && pnpm run build:types",
     "build:sizes": "node -r ~ts scripts/sizes",


### PR DESCRIPTION
Speeds up the CI/release pipelines without touching the test run or coverage.

- **`@ci:version`**: replace the whole-repo `format` (eslint `--fix` + prettier over everything) with prettier on just the changeset-bumped `package.json` files, run after `changeset version`. `CHANGELOG.md` is already prettier-ignored and `build` only writes to `dist/`, so the full-repo pass was wasted work on every push to main.
- **build job**: run build and lint concurrently in one step (~47s → ~max(26s)); the job still fails if either does.
- **PRs**: `paths-ignore` docs-only changes (`**/*.md`, `LICENSE`). PR-only, so pushes to main still trigger releases; `build`/`test` aren't required checks (only EasyCLA is), so this won't block docs PRs.