### PR TITLE
ci: drop redundant build from @ci:version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.ts",
     "@ci:test": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 c8 pnpm run test:parallel",
     "@ci:test:fast": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 pnpm run test:parallel",
-    "@ci:version": "pnpm run build && changeset version && prettier --write --log-level=warn \"**/package.json\" && pnpm install --lockfile-only",
+    "@ci:version": "changeset version && prettier --write --log-level=warn \"**/package.json\" && pnpm install --lockfile-only",
     "audit": "pnpm audit --prod",
     "build": "pnpm -r --if-present run build && pnpm run build:types",
     "build:sizes": "node -r ~ts scripts/sizes",


### PR DESCRIPTION
The changesets `version` path (`@ci:version`) only bumps `package.json` + changelogs and regenerates the lockfile — none of it reads `dist`/`.d.ts`. The `build` CI job is already a `needs:` prerequisite of the `release` job, so the leading `pnpm run build` was rebuilding for nothing (~64s of `tsc -b`) on every release-PR update. The publish path (`@ci:release`) keeps its build, since publishing needs `dist`.