### PR TITLE
chore(runtime-tags): note the interop scope-registration cache is safe module-global

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -61,22 +61,6 @@ translator to surface interactivity on `metadata.marko`, `getClassHydrationMode`
 to return DESCENDANT for interactive tags children, and the boundary to actually
 resume.
 
-## `COMPAT_REGISTRY` caches `[id, scopeId]` for the module lifetime
-
-`packages/runtime-tags/src/html/compat.ts` › `compat.toJSON` | 2026-07-13 | impact:med | effort:med
-
-`toJSON`'s `COMPAT_REGISTRY` is a module-global `WeakMap` keyed by the registered
-function, and the `_script(scopeId, SET_SCOPE_REGISTER_ID)` side-effect (line 79)
-runs only on the first `toJSON()` for that function object, ever. For any
-registered function reused across renders (a module-level/hoisted `renderBody`,
-or a memoized handler), render #2 returns render #1's cached `scopeId` (per-render
-scope counters reset via `new State`) and never re-emits the `SET_SCOPE`
-registration, so its serialized reference points at a stale scope id and the
-client `getRenderScopes(...)[id]` lookup misses → broken hydration / dead bridged
-handler. Server-side the WeakMap persists across requests, so this is a
-cross-request hazard. Fix: key the cache per-render/per-`State` rather than
-module-globally.
-
 ## `_dynamic_tag` compares only the renderer id, conflating instances of the same content
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_dynamic_tag` | 2026-07-14 | impact:high | effort:med

--- a/packages/runtime-tags/src/html/compat.ts
+++ b/packages/runtime-tags/src/html/compat.ts
@@ -24,6 +24,8 @@ import {
 } from "./writer";
 
 const K_TAGS_API_STATE = Symbol();
+// Module-global is safe: a scope-bound serializable function is a fresh closure
+// per render, so the same object is never reused (or re-scoped) across renders.
 const COMPAT_REGISTRY = new WeakMap<
   WeakKey,
   [registryId: string, scopeId: unknown]


### PR DESCRIPTION
The `COMPAT_REGISTRY` (tags/class interop `toJSON`) is a module-global `WeakMap` keyed by the registered function, and its `_script(SET_SCOPE)` side effect runs only on the first `toJSON()` per function object. In theory that's a cross-render/cross-request hazard: a function reused across renders would keep a stale scope registration.

But it can't actually happen: the trigger requires a function that is **both** reused across renders (same object) **and** scope-bound. Those are mutually exclusive — a scope-bound serializable function is a fresh closure per render (it closes over the render scope), while a hoisted/reused function has no scope (so nothing to re-register). Verified empirically: interop fixtures render byte-identical across two renders of the same memoized server module, and no static/hoisted handler or renderBody produces a `SET_SCOPE` to skip.

So a per-render key would change nothing observable. Rather than ship a no-op refactor, this records the invariant with a comment at the declaration (mirroring the `serializeReasonCache` resolution) and clears the `agent-feedback` entry. Runtime unchanged (comment only).