### PR TITLE
refactor(runtime-tags): mark HTML effects with a flag, not an undefined statement

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -17,12 +17,6 @@ is unaffected (later renders reuse `___marko5Component.___rootNode`), so this is
 dead optimization + a confusing stale-node invariant; verify destroy/move
 semantics before changing to `scope`.
 
-## Represent metadata-only HTML effects without invalid AST sentinels
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `toReturnedFunction` | 2026-07-15 | impact:low | effort:low
-
-`addHTMLEffectCall` deliberately passes `undefined as any` to `addStatement`, which pushes it into a `t.Statement[]`; `traverseReplace` and Babel generation happen to skip the falsy array member. The call exists to mark effect dependencies/side effects rather than to add executable syntax, but it violates the signal and Babel AST types and makes every downstream consumer tolerate an invalid node. Add an explicit metadata-only effect operation (or let `addStatement` accept an omitted statement without pushing it) and remove the cast/TODO.
-
 ---
 
 ## Pre-existing comments exceeding the two-line rule

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -83,6 +83,7 @@ export interface Signal {
   renderReferencedBindings: ReferencedBindings;
   effect: t.Statement[];
   effectReferencedBindings: ReferencedBindings;
+  hasHTMLEffect: boolean;
   hasSideEffect: boolean;
   forcePersist: boolean;
   inline: { value: t.Expression } | undefined;
@@ -263,6 +264,7 @@ export function getSignal(
         renderReferencedBindings: undefined,
         effect: [],
         effectReferencedBindings: undefined,
+        hasHTMLEffect: false,
         build: undefined,
         export: !!exportName,
         hasSideEffect: !!(
@@ -420,6 +422,7 @@ export function signalHasStatements(signal: Signal): boolean {
     signal.forcePersist ||
     signal.render.length ||
     signal.effect.length ||
+    signal.hasHTMLEffect ||
     signal.values.length ||
     signal.intersection
   ) {
@@ -1161,8 +1164,8 @@ export function addHTMLEffectCall(
   section: Section,
   referencedBindings?: ReferencedBindings,
 ) {
-  // TODO: this should not add an undefined statement.
-  addStatement("effect", section, referencedBindings, undefined as any, false);
+  const signal = getSignal(section, referencedBindings);
+  signal.hasHTMLEffect = signal.hasSideEffect = true;
 }
 
 export function writeHTMLResumeStatements(
@@ -1262,7 +1265,7 @@ export function writeHTMLResumeStatements(
   // Mount-effect order is unspecified: hydration replays these in reverse
   // signal order, CSR runs the signal graph forward — the two paths differ.
   for (let i = allSignals.length; i--;) {
-    if (allSignals[i].effect.length) {
+    if (allSignals[i].hasHTMLEffect) {
       const signalRefs = allSignals[i].referencedBindings;
       body.push(
         t.expressionStatement(


### PR DESCRIPTION
`addHTMLEffectCall` pushed `undefined as any` into the signal's `t.Statement[]` — an invalid AST node that survived only because `traverseReplace` and Babel generation skip falsy array members. Its actual job was to make `effect.length` read truthy so the HTML resume pass emits `_script(...)`.

Replaced it with an explicit `hasHTMLEffect` flag, so `effect` only ever holds real statements. Generated output is unchanged — the full suite regenerates with zero snapshot diffs.