### PR TITLE
docs: cover $global sharing, scoped styles, and TypeScript in the cheatsheet

### DIFF
--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -18,36 +18,6 @@ The same `0n`/`NaN` drop also occurs on the **style-object** surface, where the 
 
 The intuitive two-`<script>` pattern for restoring then persisting state through localStorage silently clobbers saved state. Given a restore script (`const s = localStorage.getItem('k'); if (s) board = JSON.parse(s)`, assign-only, first in source) followed by a persist script (`localStorage.setItem('k', JSON.stringify(board))`, which reads `board`, second in source), on mount the persist script runs before the restore script and writes the DEFAULT board to storage, destroying the previously-saved state; the restore then reads back the just-clobbered default, so state does not survive a reload — with no error or hydration-mismatch warning. This is correct fine-grained-reactivity behavior, not a bug: a state-reading `<script>` compiles as a downstream of its `<let>` signal, so `$setup` running `$board($scope, DEFAULT)` at the `<let>` position immediately queues the persist effect via `_script` → `queueEffect` (`dom/signals.ts:386-390`), while the assign-only restore script is a plain mount effect queued later at its own source position; `runEffects` (`dom/queue.ts`) runs them in queue order, so persist(read) precedes restore(assign). It is undocumented and surprising: no docs page mentions localStorage or `<script>` execution order, and `core-tag.md`'s `<script>` section (`:304`) says only that it runs "when the template has finished rendering", implying source order. The working idiom is `<lifecycle onMount(){ restore } onUpdate(){ persist } />` (onMount runs first with the pre-restore value, onUpdate persists after), but nothing points users there, and a `<let>` init expression cannot read localStorage because it also runs during SSR. Direction: a guide page on persisting state to localStorage recommending `<lifecycle>`, plus a note in the `<script>` reference that state reads run at dependency-init time; optionally a MARKO_DEBUG warning when a `<script>` both depends on state and writes storage before that state is initialized.
 
-## Add a 'TypeScript in .marko' section to the cheatsheet and best-practices skill
-
-`packages/runtime-tags/cheatsheet.md` › `Marko 6 cheat sheet` | 2026-07-18 | impact:med | effort:low
-
-Building a typed component library requires knowledge that appears nowhere in `cheatsheet.md` or `skills/marko-best-practices/SKILL.md`: `export interface Input` in the template, `Marko.Body` for content, `Marko.AttrTag<T>` for repeated attribute tags, generic `Input<T>` tags, tag-variable type annotations, and — critically — that type checking requires `mtc` from @marko/type-check because `npx tsc --noEmit` silently skips `.marko` files entirely (a strict-mode project passes tsc with type-broken templates, e.g. `<let/bad:string = 123>` exits 0, giving false confidence). Both files have zero hits for "interface", "Marko.Body", "AttrTag", "type-check", or "typescript". A short section covering the Input interface, Marko.Body/Marko.AttrTag, generics, `mtc`, and the exact-camelCase event-attr naming rule would close the gap; today each piece must be rediscovered by grepping reference apps.
-
-## Add a serialization caveat to the cheatsheet's `$global.data` guidance
-
-`packages/runtime-tags/cheatsheet.md` › `Async (<await>)` | 2026-07-18 | impact:med | effort:low
-
-Line 89 teaches loading data in a @marko/run route handler and rendering with `<await|user|=$global.data.user>`, but Marko serializes only the `$global` properties allow-listed in `$global.serializedGlobals` (`getFilteredGlobals` in packages/runtime-tags/src/html/writer.ts:1630), and @marko/run defaults that list to `params`/`url` only. Any client-recomputed `<const>`/`<let>`/event-handler expression over `$global.data` therefore throws a TypeError after resume even though SSR output looks correct — a first-interaction crash for anyone following this exact pattern. One sentence here, or a DON'T-table row ("`$global.x` in client-reactive code without `serializedGlobals`"), noting that such values must be opted in (e.g. `context.serializedGlobals.data = true` under @marko/run) would prevent it.
-
-## Add a "sharing data across components" section to the cheatsheet (`$global` as the context replacement)
-
-`packages/runtime-tags/cheatsheet.md` › `Async (<await>)` | 2026-07-18 | impact:med | effort:low
-
-Making data (an i18n dictionary, the current user, a theme) available to all components is a top-5 real-app need, and Marko 6's answer — there is no context API; use request-scoped `$global`, populated under @marko/run by `next(data)` — is currently undiscoverable: the cheatsheet's only `$global` mention is one incidental clause inside the Async section (line 89), and `skills/marko-5-to-6-migration/api-mapping.md:72` just says `<context>` has "no equivalent — pass data through `input` or `$global`" with no example. Add a short section covering: prop drilling via `input` vs request-scoped `$global`, how `$global` is populated (`template.render({ $global: ... })` / @marko/run middleware `next(data)` → `$global.data`), and the serialization caveat when interactive (client-reactive) code reads `$global` values.
-
-## Add the scoped `<style/name>` CSS-modules form to the cheatsheet
-
-`packages/runtime-tags/cheatsheet.md` › `Client-side effects (rare — prefer state/const)` | 2026-07-18 | impact:med | effort:low
-
-The cheatsheet's only styling guidance is "`<style>` = real CSS, extracted & global", implying global classes are the only option, while the scoped CSS-modules form — `<style/styles> .card {...} </style>` then `class=styles.card`, plus the destructured `<style/{card}>` variant — is entirely absent (grep for `style/` finds nothing). The feature is real and tested (`packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-default/template.marko`, `style-tag-modules-destructured`) and is the dominant styling pattern in reference apps, so anyone working from the cheatsheet alone hand-namespaces global classes instead. Add one line to the styling bullet showing the `<style/name>` form, and ideally a DON'T-table row pairing hand-namespaced global classes against it.
-
-## Add an `on-attach`/`on-detach` row to the 5-to-6 migration lifecycle mapping
-
-`skills/marko-5-to-6-migration/api-mapping.md` › `Lifecycle` | 2026-07-18 | impact:med | effort:low
-
-Marko 5's `on-attach(fn)`/`on-detach(fn)` (implemented in `packages/runtime-class/src/runtime/components/attach-detach.js`, where an `on-detach` listener can defer the node's removal until it calls `event.detach()`, the hook exit animations rely on) appear nowhere in api-mapping.md or patterns.md — grep for "attach" across the skill only hits the legacy-widget `init` row at line 158. The official Marko 5 todomvc example uses both (`on-attach(animateIn)` / `on-detach(animateOut)` on todo-item), so anyone porting that flagship example or any app with exit animations is left guessing whether the Marko 6 answer is CSS transitions, `<lifecycle onDestroy>`, or that deferred removal has no equivalent. Add an explicit row to the Lifecycle table, even one saying "no direct equivalent; use CSS animations — `<lifecycle onDestroy>` cannot delay removal."
-
 ## Document that a derived `<const>` read inside an event handler is stale until the microtask flush
 
 `packages/runtime-tags/src/dom/signals.ts` › `_let` | 2026-07-19 | impact:med | effort:low

--- a/packages/runtime-tags/cheatsheet.md
+++ b/packages/runtime-tags/cheatsheet.md
@@ -113,6 +113,12 @@ Don't fetch while rendering: start data loads early, pass the PROMISE through th
 - `class=` / `style=` accept strings, objects, arrays: `class=["btn", { active }]`, `style={ color }` (single braces). `style=` keys are kebab-case CSS names (`{ "background-color": c }`), not camelCase.
 - `<id/x>` mints a collision-free id for label/input wiring (`<label for=x>`/`<input id=x>`) — don't hardcode ids in reusable tags; `<id/x=input.id>` reuses a caller's.
 
+## Sharing data (`$global`)
+
+- No provider/consumer context API. Prop-drill through `input`, or read request-scoped `$global` from any template with no threading: `${$global.messages.title}`.
+- Populate at the render call: `template.render({ $global: { messages } })`. Under @marko/run a middleware's `return next({ messages })` merges into `$global.data`.
+- `$global` is NOT serialized by default, so client-reactive reads (`<const>`, `<let>` init, handlers) throw after resume even though SSR looked fine. Allow-list first: `$global.serializedGlobals = { messages: true }` (@marko/run ships only `params`/`url`; add `context.serializedGlobals.data = true`). SSR-only markup needs no opt-in.
+
 ## Client-side effects (rare — prefer state/const)
 
 ```marko
@@ -125,7 +131,7 @@ Don't fetch while rendering: start data loads early, pass the PROMISE through th
 </script>
 ```
 
-`<style>` = real CSS, extracted & global. `<script>` = reactive effect, NOT an HTML script tag.
+`<style>` = real CSS, extracted & global; `<style/styles>` scopes it (CSS modules) — `.card {...}` then `class=styles.card`, or `<style/{card}>` then `class=card`. Don't hand-namespace globals. `<script>` = reactive effect, NOT an HTML script tag.
 
 Imperative libs (charts, maps) needing mount/update/destroy: use `<lifecycle>`, not a hand-wired `<script>`. `this` persists across all three; return an object from `onMount` to stash the instance:
 
@@ -146,6 +152,22 @@ Defer a tag's JS into its own bundle until a trigger fires: `render`, `visible#s
 import PriceChart from "<price-chart>" with { load: "visible#chart" }
 <div#chart><PriceChart symbol=input.symbol/></div>
 ```
+
+## TypeScript
+
+`export interface Input` types `input` — generic as `Input<T>`, body content as `Marko.Body<[params]>`, repeated attr tags as `Marko.AttrTag<T>`.
+
+```marko
+export interface Input<T> {
+  value: T;
+  onSelect?: (index: number) => void;              // event attrs: exact camelCase
+  then?: Marko.AttrTag<{ content: Marko.Body<[T]> }>;
+}
+
+<${input.then}(input.value)/>
+```
+
+`tsc` silently SKIPS `.marko` — a type-broken template still exits 0. Check with `mtc` (`@marko/type-check`).
 
 ## DON'T (these are errors or silently wrong)
 
@@ -172,3 +194,7 @@ import PriceChart from "<price-chart>" with { load: "visible#chart" }
 | hand-rolled radios `checked=x checkedChange(v){…}`          | `checkedValue:=picked` on each radio (shared var, distinct `value=`)                 |
 | hand-rolled `IntersectionObserver` to defer a widget's JS   | `import W from "<w>" with { load: "visible#sel" }`                                   |
 | imperative lib wired through `<script>` mount + cleanup     | `<lifecycle onMount/onUpdate/onDestroy>` (keeps `this` across all three)             |
+| `createContext`/provider to share data                      | `input` (prop drilling) or request-scoped `$global`                                  |
+| `$global.x` in client-reactive code, not allow-listed       | `$global.serializedGlobals = { x: true }` first, or it throws after resume           |
+| hand-namespaced global classes (`.my-card-title`)           | `<style/styles>` + `class=styles.card` (scoped CSS modules)                          |
+| `tsc --noEmit` to type check templates                      | `mtc` — `tsc` skips `.marko` files and exits 0                                       |

--- a/skills/marko-5-to-6-migration/api-mapping.md
+++ b/skills/marko-5-to-6-migration/api-mapping.md
@@ -115,8 +115,12 @@ Serialization in 6 is **need-based, not blanket**: the compiler computes what mu
 | `onRender(out)`                                                          | usually deleted — it was mostly used for derivations (→ `<const>`)                                                         |
 | `onCreate(input, out)`                                                   | initial values of `<let>` tags                                                                                             |
 | lifecycle _events_ (`this.on("update", fn)`, `this.once("destroy", fn)`) | same replacements as the methods                                                                                           |
+| `on-attach(fn)` on an element                                            | `<script>` or `<lifecycle onMount>` — both run with the element in the DOM                                                 |
+| `on-detach(fn)` on an element                                            | no equivalent — nothing can delay removal (see below)                                                                      |
 
 Prefer plain state and `<script>`; use `<lifecycle>` only to host imperative third-party instances (maps, charts) where a stable `this` across `onMount`/`onUpdate`/`onDestroy` is genuinely needed.
+
+Exit animations need rework. Marko 5's `on-detach` handler could hold a node in the DOM (`event.preventDefault()`, then `event.detach()` once the animation finished); nothing in Marko 6 can delay removal — `<lifecycle onDestroy>` only observes teardown, and `<show=false>` parks its nodes in a detached fragment, so a transition never runs. Stage it in state instead: keep the item rendered while marking it exiting (`class={ exiting: id === leavingId }`), then drop it from the list in a `transitionend`/`animationend` handler.
 
 ### Events
 

--- a/skills/marko-best-practices/SKILL.md
+++ b/skills/marko-best-practices/SKILL.md
@@ -26,3 +26,4 @@ Documentation and this skill target **Marko 6**. Do not use Marko 5 syntax.
 - [ ] Event handlers use function form: `onClick() { ... }` or a reference, not string names.
 - [ ] Component stays small and readable; consider splitting large templates.
 - [ ] No unnecessary client-side JS; prefer built-in browser APIs and HTML/CSS features over scripts.
+- [ ] Props are declared with an exported `Input` interface, and templates are type checked with `mtc` (`@marko/type-check`) — `tsc` skips `.marko` files and reports nothing.


### PR DESCRIPTION
Closes four `unclear.md` documentation gaps, all verified against source:

- **Sharing data across components** — new section: no context API, use `input` or request-scoped `$global`, with the serialization caveat. Only allow-listed keys are serialized (`getFilteredGlobals`), and @marko/run defaults to `params`/`url` only, so client-reactive code reading `$global.data` throws after resume while the SSR HTML looks correct.
- **Scoped `<style/name>`** — the cheatsheet implied global CSS was the only option.
- **TypeScript** — new section: exported `Input` interface, `Marko.Body`, `Marko.AttrTag`, generics, and that `tsc` silently skips `.marko` files so `mtc` is needed.
- **`on-attach`/`on-detach`** — added to the 5-to-6 lifecycle table, noting `<lifecycle onDestroy>` cannot defer removal the way Marko 5 could.

Plus four DON'T-table rows and an `mtc` checklist item in the best-practices skill.