### PR TITLE
docs(runtime-tags): note the lazy load entry's floated rejection is intentional

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -76,17 +76,3 @@ The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the in
 CSR is a runtime-only fix: push `() => childScope[AccessorProp.StartNode]` through the child scope's `TagVariable` callback right after the native branch is created in `dom/control-flow.ts`. SSR-resume is the hard part and needs the translator, not just the runtime. The native branch scope carries no state, so `_var`'s `writeScopePassive` `#TagVariable` slot is never serialized (the server fill contains only the parent scope); a dynamic _component_ tag var only resumes because its scope serializes anyway, carrying `{ "#TagVariable": _(1, "…/var") }`. So on resume there is no callback to invoke from the `BranchEndNativeTag` marker handler (`dom/resume.ts:232`). Runtime-only escapes don't exist: `_dynamic_tag` is never told a tag var is present (the compiler emits a separate `_var`), and forcing every tag var to serialize its scope actively regresses payload size for all of them. Delivering the getter across the dynamic boundary requires the compiler to serialize/reconstruct an element reference (a client-side `_el(id, accessor)` for the resumed branch element) — hence effort:high spanning compiler + runtime + serialization.
 
 A live `@marko/run` app shows this manifests as a HARD SSR 500 in dev, not just an empty render: reading the ref (`<${shape}/mark .../>` then `<effect>{ mark().getBBox() }` or a `<script>` reader) makes the HTML `_dynamic_tag` return `undefined` for `mark`, which the compiler guards with `_assert_hoist(mark)` — throwing MARKO_DEBUG's misleading `Hoisted values must be functions, received type "undefined"` (`packages/runtime-tags/src/common/errors.ts:109-114`), with a stack pointing at compiled runtime rather than the user's tag-variable construct. Under optimize `_assert_hoist` is compiled out, so SSR instead succeeds but serializes `mark: undefined`, and on the client `_hoist("mark")()` throws "undefined is not a function" when the effect/script runs — a silent dev-vs-prod divergence. Beyond the full high-effort compiler+serialization fix already noted, a low-effort, independently-valuable improvement is a compile-time error/warning when a tag variable is placed on a dynamic tag that can resolve to a native tag name, so users get a source-level diagnostic instead of an internal assert (dev) or broken hydration (prod).
-
-## Document-side lazy load entries float rejections and leave the ready channel silent
-
-`packages/runtime-tags/src/translator/visitors/program/index.ts` › `translate` (`isLoadEntry` branch) | 2026-07-16 | impact:low | effort:low
-
-The generated `.load.mjs` entry is `load().then(() => ready(id))` with no
-rejection handler, so a chunk that fails to load from the initial document
-(deploy skew) surfaces only as an unhandled promise rejection and the
-module's ready id never resolves. The lazy tag's own render path recovers
-(`_load_setup`/`_load_template` route their `load()` failures to
-`renderCatch`), but the document-side loader stays noisy and inert. Add a
-`.catch` that reports through a defined channel (or retries). Verify: reject
-the dynamic import in a generated load entry and watch for the unhandled
-rejection with the ready id never firing.

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -146,6 +146,8 @@ export default {
               [t.importSpecifier(t.identifier("ready"), t.identifier("ready"))],
               t.stringLiteral(getRuntimePath("dom")),
             ),
+            // A rejected chunk blocks this ready id, but already surfaces as a
+            // network error, so handling it is not worth the runtime bytes.
             t.expressionStatement(
               t.callExpression(
                 t.memberExpression(


### PR DESCRIPTION
The generated `.load.mjs` entry's `import(...).then(() => ready(id))` has no rejection handler, so a chunk that fails to load (deploy skew) leaves its ready id blocked and the server-rendered content inert. Handling it would cost shared runtime bytes for a failure the browser already surfaces as a network error, so this records the decision at the site and drops the `agent-feedback` entry.