### PR TITLE
test: set NODE_PATH on parallel workers so workspace translators resolve

### DIFF
--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -143,6 +143,13 @@ function runBin(bin, index, slicedFiles, mochaArgs) {
   const args = [MOCHA, "--config", CONFIG, "--reporter", "dot", "--exit"];
   args.push(...mochaArgs);
   const env = { ...process.env };
+  // Workers spawn mocha's JS entry with bare `node`, bypassing pnpm's `.bin`
+  // shims. Those shims export NODE_PATH ending in pnpm's private hoist dir so
+  // bare workspace specifiers (e.g. `marko/translator`) resolve from the repo
+  // root; mirror it here or the compiler can't find the translator packages.
+  env.NODE_PATH =
+    path.join(ROOT, "node_modules/.pnpm/node_modules") +
+    (env.NODE_PATH ? path.delimiter + env.NODE_PATH : "");
   if (bin.slots.length) {
     args.push(...slicedFiles);
     env.MARKO_TEST_SLOTS = bin.slots.join(",");


### PR DESCRIPTION
`scripts/test-parallel.js` spawns mocha workers with bare `node`, bypassing pnpm's `.bin` shims that export `NODE_PATH` ending in pnpm's private hoist dir (`node_modules/.pnpm/node_modules`). Without it the compiler can't resolve bare workspace translator specifiers (`marko/translator`, `@marko/runtime-tags/translator`) from the repo root, so `node scripts/test-parallel.js` fails on a fresh checkout with ~2300 module-not-found errors. CI only stays green because `@ci:test:fast` wraps the run in `cross-env`, whose own shim happens to set `NODE_PATH`. This sets it explicitly in the worker env to match the shims, so `pnpm run test:parallel` works directly and CI no longer depends on that accident.