### PR TITLE
fix(runtime-tags): retain streamed chunks for a slow for-await consumer

### DIFF
--- a/.changeset/stream-async-iterator-chunk-loss.md
+++ b/.changeset/stream-async-iterator-chunk-loss.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `template.render()`'s async iterator (`for await`) silently dropping HTML chunks — truncating the streamed document with no error — when the consumer took longer than a flush tick between reads. Buffered chunks are now retained until the consumer reads them.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -621,30 +621,6 @@ ch.length; ... }`). Re-verify: `resolveCursorPosition("", 5, "(𠮷𠮸𠮹) x",
 𠮸𠮹y")` returns 10 (end of value) where 8 is correct, while the all-BMP
 `resolveCursorPosition("", 5, "(5405) 810-9227", "(540) 581-0922")` returns 7.
 
-## Clear the pending `resolve`/`reject` in the async iterator so a slow consumer does not silently lose stream chunks
-
-`packages/runtime-tags/src/html/template.ts` › `ServerRendered[Symbol.asyncIterator]` | 2026-07-23 | impact:high | effort:low
-
-The `onWrite` callback passed to `#read` is `(html) => { value += html; if
-(resolve) { resolve({ value, done }); value = ""; } }`, but `resolve`/`reject`
-(assigned by the inner `exec` executor) are never cleared once their promise
-settles. A stale `resolve` is therefore still truthy on the next flush: calling
-it is a no-op on the already-settled promise, yet `value = ""` still runs and
-discards the buffered HTML. Because `#read` gates flushes on `queueTick`
-(setImmediate), any `for await` body that takes longer than one tick loses every
-chunk written while it was busy; worse, `onClose` also hits the stale `resolve`,
-so `done` flips to true and the iterator ends normally — the caller gets a
-truncated document with a 200 and no error. `toReadable()`/`pipe()` are
-unaffected because they push unconditionally, so the loss is specific to the
-documented `for await (const chunk of template.render(...))` API. Fix: capture
-the settler into a local, null out `resolve`/`reject` before invoking it, and
-add a fixture/unit test that consumes a multi-`<await>` render with an
-artificial per-chunk delay. Re-verify with `node -r ~ts` on a script that
-renders a template with four staggered `_await`s and consumes it via `for await`
-with `await new Promise(r=>setTimeout(r,60))` in the loop body: today it yields
-only the first chunk, and should yield the same joined HTML as a zero-delay
-consumer.
-
 ## Make the hidden `<show>` wrapper legal in table/select insertion contexts; `<t hidden>` is foster-parented and the hidden content renders
 
 `packages/runtime-tags/src/html/writer.ts` › `_show_start` | 2026-07-23 | impact:high | effort:med

--- a/packages/runtime-tags/src/__tests__/html-stream.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-stream.test.ts
@@ -1,0 +1,70 @@
+import assert from "assert/strict";
+import path from "path";
+
+import type { Template } from "@marko/runtime-tags/common/types";
+
+import * as tagsTranslator from "../translator";
+import { createServerRunner } from "./utils/bundle";
+
+const streamDir = path.join(__dirname, "html-stream");
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+const deferred = <T>(ms: number, value: T) =>
+  new Promise<T>((resolve) => setTimeout(() => resolve(value), ms));
+
+describe("runtime-tags/html async iterator", () => {
+  let template: Template;
+  let disposeServer: () => void;
+
+  before(async function () {
+    this.timeout(60000);
+    const runner = await createServerRunner(
+      streamDir,
+      { template: "./template.marko" },
+      {
+        translator: tagsTranslator as any,
+        optimize: false,
+        babelConfig: {
+          babelrc: false,
+          configFile: false,
+          browserslistConfigFile: false,
+        },
+      },
+    );
+    ({ template } = await runner.runServer());
+    disposeServer = runner.disposeServer;
+  });
+
+  after(() => disposeServer?.());
+
+  // Staggered awaits flush on separate ticks, so a consumer that pauses
+  // between reads must still receive every chunk the fast one does.
+  it("does not drop chunks when the consumer is slower than a flush tick", async () => {
+    const makeInput = () => ({
+      a: deferred(10, "A"),
+      b: deferred(20, "B"),
+      c: deferred(30, "C"),
+      d: deferred(40, "D"),
+    });
+
+    const fast: string[] = [];
+    for await (const chunk of template.render(makeInput())) fast.push(chunk);
+
+    const input = makeInput();
+    const settled = Promise.allSettled(Object.values(input));
+    const slow: string[] = [];
+    for await (const chunk of template.render(input)) {
+      slow.push(chunk);
+      await settled;
+      await tick();
+      await tick();
+    }
+
+    assert.equal(slow.join(""), fast.join(""));
+    for (const letter of ["A", "B", "C", "D"]) {
+      assert.ok(
+        slow.join("").includes(`${letter}:${letter}`),
+        `slow consumer dropped ${letter}`,
+      );
+    }
+  });
+});

--- a/packages/runtime-tags/src/__tests__/html-stream/template.marko
+++ b/packages/runtime-tags/src/__tests__/html-stream/template.marko
@@ -1,0 +1,12 @@
+<await|v|=input.a>
+  <p>A:${v}</p>
+</await>
+<await|v|=input.b>
+  <p>B:${v}</p>
+</await>
+<await|v|=input.c>
+  <p>C:${v}</p>
+</await>
+<await|v|=input.d>
+  <p>D:${v}</p>
+</await>

--- a/packages/runtime-tags/src/html/template.ts
+++ b/packages/runtime-tags/src/html/template.ts
@@ -113,8 +113,8 @@ class ServerRendered implements RenderedTemplate {
 
   [Symbol.asyncIterator]() {
     type Iter = { value: string; done: boolean };
-    let resolve: (value: Iter) => void;
-    let reject: (reason: unknown) => void;
+    let resolve: ((value: Iter) => void) | undefined;
+    let reject: ((reason: unknown) => void) | undefined;
     let value = "";
     let done = false;
     let aborted = false;
@@ -122,8 +122,12 @@ class ServerRendered implements RenderedTemplate {
     const boundary = this.#read(
       (html) => {
         value += html;
+        // Clear the settler before running it; a stale one still empties
+        // `value`, dropping whatever buffered while the consumer was busy.
         if (resolve) {
-          resolve({ value, done });
+          const settle = resolve;
+          resolve = reject = undefined;
+          settle({ value, done });
           value = "";
         }
       },
@@ -132,13 +136,17 @@ class ServerRendered implements RenderedTemplate {
         reason = err;
 
         if (reject) {
-          reject(err);
+          const settle = reject;
+          resolve = reject = undefined;
+          settle(err);
         }
       },
       () => {
         done = true;
         if (resolve) {
-          resolve({ value, done: !value });
+          const settle = resolve;
+          resolve = reject = undefined;
+          settle({ value, done: !value });
           value = "";
         }
       },


### PR DESCRIPTION
`template.render()`'s async iterator (`for await`) silently dropped HTML chunks — truncating the streamed document with no error — when the consumer took longer than one flush tick between reads: `resolve`/`reject` were assigned once and never cleared, so a stale settler kept running `value = ""` and discarding the buffer. This nulls the settler before invoking it in all three `#read` callbacks, and adds a streaming regression test (staggered `<await>` boundaries consumed by a delayed `for await`, asserted equal to the fast-consumer output).