### PR TITLE
Repair conflict-damaged agent-feedback entries and retire resolved ones

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -267,7 +267,6 @@ packages/runtime-tags/src/translator/core/for.ts | sed
 packages/runtime-tags/src/translator/core/client.ts
 packages/runtime-tags/src/translator/core/server.ts` reports only the four
 keyword/description lines.
-||||||| parent of 001ef3300e (Replace @babel/register with native Node type stripping)
 
 ## Stray debug `console.error` in the mocha patch
 
@@ -275,8 +274,8 @@ keyword/description lines.
 
 The repo's only mocha patch adds a bare `console.error(requireErr)` in `lib/nodejs/esm-utils.js`'s `requireModule` catch block, printing the full require error every time a spec file fails plain `require()` before mocha's `import()` fallback succeeds. With `.mocharc` `"no-warnings"` runs this is silent today only because spec requires no longer throw, but any environment where the require path fails first (e.g. an older Node loading `.ts` specs) spews stack traces for tests that then load fine. Looks like leftover debugging, not intentional patching. Fix: regenerate the patch without the `console.error` line (`pnpm patch mocha@11.7.6`), or delete the patch if that line was its only content — inspect with `cat patches/mocha@11.7.6.patch` (it is currently a single-hunk, one-line addition).
 
-## Dead markoc test fixture requires a removed devDependency
+## Delete or resurrect the dead `test/markoc` suite — mocha loads it every run for zero tests
 
-`packages/runtime-class/test/markoc/babel-register.js` | 2026-07-23 | impact:low | effort:low
+`packages/runtime-class/test/markoc/index.test.js` | 2026-07-24 | impact:low | effort:low
 
-The markoc CLI test (`test/markoc/index.test.js`) has been fully commented out for a long time, and its helper `babel-register.js` requires `@babel/register` — a devDependency that no longer exists since the native type-stripping migration. Nothing loads the file (the only reference is inside the commented-out test), so nothing breaks, but the fixture can never work again as written. Either delete `test/markoc/` or resurrect the test without babel (spawn `bin/markoc` with `-r ~ts`). Verify: `grep -rn "babel-register" packages/runtime-class/test/markoc/`.
+The mocha spec glob (`packages/*/@(src|test)/**/*.test.@(js|ts)`) matches this file, so every suite run loads it — and it defines no tests at all. Its entire `autotest` body has been commented out for years; the eight live lines only `require` `../__util__/test-init`, `chai`, and `../../compiler`, so the run pays that load cost for nothing. The commented body also now references `./babel-register`, which was deleted with the native-type-stripping migration, so it cannot be uncommented as written, and seven unused fixture directories remain under `fixtures/`. Either delete `test/markoc/` outright or resurrect the test by spawning `bin/markoc` with `-r ~ts` instead of a babel hook. Verify: `grep -vn "^\s*//" packages/runtime-class/test/markoc/index.test.js` lists eight non-comment lines and no `describe`/`it`.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -2,12 +2,6 @@
 
 Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
 
-## `c8` coverage crashes generating lcov when the wrapped process loads `~ts`
-
-`scripts/test-parallel.js` | 2026-07-02 | impact:med | effort:med
-
-`c8 node -r ~ts <script>` (i.e. any c8-wrapped process that loads `scripts/babel-register.js` via `-r ~ts`) throws `TypeError: Cons is not a constructor` at `istanbul-reports/index.js:22` during c8's report step while constructing the `lcov` reporter — no `coverage/lcov.info` is written and the process exits 1. Coverage collection itself succeeds (the text-summary reporter prints correct numbers); only lcov report generation dies. This is why `scripts/test-parallel.js` is deliberately plain CommonJS (its spawned mocha workers still load `~ts` via `.mocharc.parallel.json`, which does _not_ trigger the bug — only `-r ~ts` on the c8-monitored process does). Worth root-causing, since it silently blocks lcov/codecov for any future `node -r ~ts` script someone wraps in `c8`; likely a c8@11 ↔ @babel/register require-hook interaction.
-
 ## Migrate to Babel 8 and chai 6 as dedicated efforts (deferred from the deps upgrade)
 
 `patches/@babel+types+7.29.7.patch` | 2026-07-07 | impact:med | effort:high
@@ -52,6 +46,14 @@ and merge the istanbul JSON at the end (the ~50s remap work splits cleanly
 per dump); prewarm the babel cache with one serial require pass in
 `scripts/test-parallel.js` before spawning workers on a cold cache (~6s net,
 needs a hardcoded heavy-module list that can rot).
+
+**Both profiles above predate the drop of `@babel/register` and must be
+re-measured before anyone acts on them.** Node now strips types natively, so
+the ~13% `@babel/register` TS transform, the ~12s cold-cache penalty on fresh
+CI checkouts, and the babel-cache prewarm suggestion no longer describe
+anything that exists. The parallel-remap win was since implemented in
+`scripts/coverage-report.js`. Whether the run is still CPU-bound — the entry's
+actual conclusion — is untested against the current tooling.
 
 ## Emit a compile-time diagnostic when an unenclosed `>`/`>=` truncates an attribute-value expression
 
@@ -565,10 +567,12 @@ compile -o dom -d /tmp/x.marko` → "Cannot find module
 '@marko/runtime-tags/translator'"; `pnpm run compile -o dom -d -t <abs path to
 packages/runtime-tags/src/translator/index.ts> /tmp/x.marko` → succeeds and
 writes `/tmp/x.marko.js`.
-||||||| parent of 001ef3300e (Replace @babel/register with native Node type stripping)
-Several built-ins still fall through the constructor dispatch to `throwUnserializable`, each a one-case addition: `DataView` is the only `ArrayBuffer` view missing while every `TypedArray` is handled, which is an inconsistency rather than a considered omission; boxed primitives (`Object(1)`, `Object("x")`, `Object(true)`) resume as nothing; and `DOMException`, `AbortSignal`, and `Event` reach templates through request handling yet cannot cross to the browser. `DataView` and the boxed primitives are pure wins with obvious constructor forms (`new DataView(buffer, byteOffset, byteLength)`, `Object(value)`); the DOM types are lower value and only worth adding if a real template needs them. Re-verify: pass each through `Serializer#stringifyScopes` and observe the value is omitted from the payload, against `new URL("https://a.b")` as a supported control.
 
-Several built-ins still fall through the constructor dispatch to `throwUnserializable`, each a one-case addition: `DataView` is the only `ArrayBuffer` view missing while every `TypedArray` is handled, which is an inconsistency rather than a considered omission; boxed primitives (`Object(1)`, `Object("x")`, `Object(true)`) resume as nothing; and `DOMException`, `AbortSignal`, and `Event` reach templates through request handling yet cannot cross to the browser. `DataView` and the boxed primitives are pure wins with obvious constructor forms (`new DataView(buffer, byteOffset, byteLength)`, `Object(value)`); the DOM types are lower value and only worth adding if a real template needs them. Re-verify: pass each through `Serializer#stringifyScopes` and observe the value is omitted from the payload, against `new URL("https://a.b")` as a supported control.
+## Serialize `DataView` and boxed primitives
+
+`packages/runtime-tags/src/html/serializer.ts` › `writeUnknownObject` | 2026-07-24 | impact:low | effort:low
+
+`DataView` is the only `ArrayBuffer` view that falls through the constructor dispatch to `throwUnserializable` while every `TypedArray` is handled, which is an inconsistency rather than a considered omission; boxed primitives (`Object(1)`, `Object("x")`, `Object(true)`) likewise resume as nothing. Both are one-case additions with obvious constructor forms (`new DataView(buffer, byteOffset, byteLength)` and `Object(value)`), making them pure wins — the DOM built-ins originally recorded alongside them are tracked separately in "Serialize the remaining DOM built-ins reachable from browser code". Re-verify: pass each through `Serializer#stringifyScopes` and observe the value is omitted from the payload, against `new URL("https://a.b")` as a supported control.
 
 ## Coverage modernization: c8 numbers are inflated, but a monocart switch needs a dedicated PR
 

--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -9,9 +9,8 @@
 // A plain `pnpm test` is untouched — it stays serial, which is what a scoped
 // `--grep` dev run wants. This is the "run everything, fast" path used by CI.
 //
-// Plain CommonJS on purpose: this orchestrator is what `c8` wraps for coverage,
-// and loading the `~ts` hook in that process breaks c8's report
-// step. The mocha workers it spawns still get `~ts` via `.mocharc.parallel.json`.
+// Plain CommonJS because it needs no types and is spawned directly by `node`;
+// the mocha workers it spawns get `~ts` via `.mocharc.parallel.json`.
 //
 // Usage: node scripts/test-parallel.js [extra mocha args...]
 //        MARKO_TEST_WORKERS=8 node scripts/test-parallel.js


### PR DESCRIPTION
Two `|||||||` merge-conflict markers had been committed into `agent-feedback/dx.md` and `cleanup.md`; in dx.md the marker was trailed by two identical unheaded copies of a serializer note, so the half not already covered elsewhere (`DataView`, boxed primitives) is restored as a proper entry and the duplicates dropped.

Retires two entries the native-type-stripping migration resolved. The c8 lcov crash no longer reproduces — `c8 --reporter=lcov node -r ~ts <script>` exits 0 and writes `lcov.info` — which also invalidates the stated reason `test-parallel.js` must be plain CommonJS, so that comment is corrected. The markoc entry is narrowed: deleting `babel-register.js` fixed the dangling devDependency, but the spec glob still loads a test file defining no tests. Finally, flags the `test:parallel` profiling numbers as pre-dating the babel removal.

Docs and one comment only; no functional change.