### PR TITLE
Stub the preset-typescript version read in dist/babel.js

### DIFF
--- a/.changeset/babel-preset-typescript-bundled.md
+++ b/.changeset/babel-preset-typescript-bundled.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix `dist/babel.js` shipping an unresolvable `require("@babel/preset-typescript/package.json")`, which broke bundling the compiler — `@marko/ts-plugin` and `marko-vscode` both failed with `Could not resolve "@babel/preset-typescript/package.json"`.

--- a/packages/compiler/scripts/bundle-babel.mts
+++ b/packages/compiler/scripts/bundle-babel.mts
@@ -2,10 +2,29 @@ import path from "node:path";
 
 import { build } from "rolldown";
 
+// @babel/core reads this version to decide whether to suggest upgrading, in the
+// catch block that reports a failed `.cts` config load. The preset itself is an
+// optional dependency babel `require`s inside a `try`, so bundlers treat it as
+// optional — but this read is in a `catch`, so an unresolved specifier here is a
+// hard error for anyone bundling the compiler. Stub the version rather than
+// pulling the preset in: the value only gates a suggestion, and reporting the
+// threshold keeps it quiet so the real config error surfaces.
+const PRESET_TS_PKG = "@babel/preset-typescript/package.json";
+const presetTypeScriptVersionStub = {
+  name: "stub-preset-typescript-version",
+  resolveId(id: string) {
+    return id === PRESET_TS_PKG ? `\0${PRESET_TS_PKG}` : null;
+  },
+  load(id: string) {
+    return id === `\0${PRESET_TS_PKG}` ? '{ "version": "7.21.4" }' : null;
+  },
+};
+
 await Promise.all(
   (["browser", "node"] as const).map((platform) =>
     build({
       platform,
+      plugins: [presetTypeScriptVersionStub],
       input: "internal/babel/index.ts",
       cwd: path.join(import.meta.dirname, ".."),
       external: ["browserslist", "path", "assert", "fs"],


### PR DESCRIPTION
`@marko/compiler@5.41.5` ships a `dist/babel.js` with a dangling `require("@babel/preset-typescript/package.json")`, so anything bundling the compiler fails:

```
✘ [ERROR] Could not resolve "@babel/preset-typescript/package.json"
  @marko/compiler/dist/babel.js:50263:32
```

Nothing here uses the preset. The reference is `@babel/core`'s own, from `lib/config/files/module-types.js`: it reads the preset's `package.json` version to decide whether to suggest an upgrade when a `.cts` config file fails to load. Babel `require`s the preset *itself* inside a `try`, which bundlers treat as optional — but this version read sits in a `catch`, so it resolves eagerly. Once the package stopped being installed, it stayed in the bundle as a dangling specifier.

This resolves it to a stub reporting the threshold version rather than adding the preset back, so the preset stays the optional dependency babel already reports properly when a `.cts` config genuinely needs it. It costs 160 bytes instead of 7.5 KB, and needs no `external` entry from consumers.

Bisected: 5.41.3 ✅, 5.41.4 ✅, 5.41.5 ❌ — 5.41.5 is simply the first release to rebuild the bundle after the devDependency was dropped.

Verified against a packed tarball: the whole `marko-js/language-server` build passes **unmodified**, including `ts-plugin` and `marko-vscode` (the two packages that inline the compiler; the others externalize bare imports and were never affected). Suite 9683 passing, lint clean.
