### PR TITLE
fix(runtime-tags): support loop params in registered functions on attribute tags

### DIFF
--- a/.changeset/proud-poems-clap.md
+++ b/.changeset/proud-poems-clap.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix event handlers on attribute tags referencing `<for>` loop params

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,10 @@
 {
   "$schema": "https://json.schemastore.org/lintstagedrc.schema.json",
-  "*.{ts,js}": ["oxlint --fix", "oxfmt --with-node-modules"],
-  "*.{json,md,css}": ["oxfmt --with-node-modules"]
+  "*.{ts,js}": [
+    "oxlint --fix",
+    "oxfmt --with-node-modules --no-error-on-unmatched-pattern"
+  ],
+  "*.{json,md,css}": [
+    "oxfmt --with-node-modules --no-error-on-unmatched-pattern"
+  ]
 }

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1651,3 +1651,33 @@ Re-verify: compile `<textarea>a &amp; b</textarea>` with `-o html` and check the
 emitted `_textarea_value("a &amp; b")`; at runtime it returns `"a &amp;amp; b"`,
 where the correct output is `"a &amp; b"` (matching `<title>a &amp; b</title>`,
 which compiles to raw static text).
+
+## Custom tag with a tag variable evaluates its child render before attribute tag statements (TDZ crash)
+
+`packages/runtime-tags/src/translator/util/known-tag.ts` › `translateHTML` | 2026-07-24 | impact:med | effort:med
+
+For a custom tag with both a tag variable and attribute tags under control flow
+(eg `<my-menu/menuEl><for|x| of=list><@item label=x/></for></my-menu>`), the
+HTML output emits `let menuEl = _myMenu({ item: $item })` via `translateVar`'s
+`tag.insertBefore` _before_ the `let $item; forOf(...)` statements produced by
+`translateAttrs`, so the render call reads `$item` in its temporal dead zone
+and SSR throws a ReferenceError. The DOM output has the same ordering problem.
+The call needs to be sequenced after the attr-tag statements (as the
+non-tag-variable path does by pushing the call onto `statements`).
+Re-verify: compile the template above with `pnpm run compile -o html -d` and
+observe the call precedes the `$item` declaration.
+
+## Reject (or support) assignments to attribute tag `<for>` params inside event handlers
+
+`packages/runtime-tags/src/translator/util/references.ts` › `trackAssignment` | 2026-07-24 | impact:low | effort:low
+
+An assignment like `<@item onClick() { foo = "x" }>` where `foo` is an
+attribute-tag `<for>` param (BindingType.local) is routed through the
+change-handler assignment path, generating code that calls a nonexistent
+change handler and throws at click time. Reads of such params in handlers now
+work (see `referencedLocalBindingsInFunction`), which makes the silent write
+failure more confusing by contrast. Since these loops re-run wholesale on
+input change, assignment has no meaningful reactive semantics; a compile
+error in `trackAssignment` when `binding.type === BindingType.local` would
+be cheap and clear. Re-verify: compile the template above with
+`pnpm run compile -o dom -d` and inspect the emitted assignment.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -701,3 +701,19 @@ names would make O(1). Re-verify by replacing the condition with
 scoped to a fixture with intersections (e.g. `--grep "runtime-tags/translator
 for-tag "`): snapshots must be unchanged, since the two expressions are equal by
 construction on the sorted intersection arrays.
+
+## Defer `_resume_locals` scope serialization until the registered function is actually serialized
+
+`packages/runtime-tags/src/html/writer.ts` › `_resume_locals` | 2026-07-24 | impact:low | effort:med
+
+`_resume_locals` eagerly `writeScope`s a per-iteration scope holding attr-tag
+loop params referenced by a registered function, so those values ride the
+resume payload on every SSR render even when the child template never
+serializes the handler (eg it only renders some attribute tags). The
+serializer already tracks registered-value scopes lazily at reference time
+(`writeRegistered` › `trackScope` in `packages/runtime-tags/src/html/serializer.ts`);
+a channel that flushes a scope's props only once the registered value is
+written would drop the dead weight, but it is serializer surgery rather than
+a helper tweak. Re-verify: SSR a template whose attr-tag `<for>` handler is
+never spread onto a native tag and observe the `{foo}` scope still in the
+payload.

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ const $content = (input) => {
 				_await($scope2_id, "#text/0", resolveAfter(0), () => {
 					const $scope3_id = _scope_id();
 					$si__input_level && _script($scope3_id, "__tests__/tags/recurse.marko_3_input_level/pending");
-					const $childScope = _peek_scope_id();
 					_set_serialize_reason($sg__input_level);
+					const $childScope = _peek_scope_id();
 					$content({ level: input.level - 1 });
 					$si__input_level && writeScope($scope3_id, {
 						_: _scope_with_id($scope2_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.js
@@ -13,8 +13,8 @@ const $content = (input) => {
 				_await($scope2_id, "a", resolveAfter(0), () => {
 					const $scope3_id = _scope_id();
 					$si__input_level && _script($scope3_id, "b0");
-					const $childScope = _peek_scope_id();
 					_set_serialize_reason($sg__input_level);
+					const $childScope = _peek_scope_id();
 					$content({ level: input.level - 1 });
 					$si__input_level && writeScope($scope3_id, {
 						_: _scope_with_id($scope2_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { x } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_x,
 		1: $sg__input_x,
@@ -39,6 +38,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			})
 		});
 	}
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ thing: $thing });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js
@@ -13,7 +13,6 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { x } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_x,
 		1: $sg__input_x,
@@ -36,6 +35,7 @@ var template_default = _template("a", (input) => {
 			_html("Goodbye");
 		})
 	});
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ thing: $thing });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { a: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let x = true;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $item;
 	if (x) {
@@ -22,6 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "4:10");
 		}) });
 	}
+	const $childScope = _peek_scope_id();
 	hello_default({ item: $item });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
@@ -11,7 +11,6 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let x = true;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $item;
 	$item = attrTag({ content: _content("a0", (y) => {
@@ -20,6 +19,7 @@ var template_default = _template("a", (input) => {
 		_html(`y: ${_sep($sg__y)}${_escape(y)}${_el_resume($scope1_id, "a", $sg__y)}`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) });
+	const $childScope = _peek_scope_id();
 	hello_default({ item: $item });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,36 @@
+// tags/my-menu/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $for_content__item__script = _script("__tests__/tags/my-menu/index.marko_1_item", ($scope) => _attrs_script($scope, "#button/0"));
+const $for_content__item = /*@__PURE__*/ _const("item", ($scope) => {
+	_attrs_content($scope, "#button/0", $scope.item);
+	$for_content__item__script($scope);
+});
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " b", 0, $for_content__$params);
+const $input_item = ($scope, input_item) => $for($scope, [input_item]);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $item_content = _content_resume("__tests__/template.marko_1_content", "Click", "b");
+function $setup($scope) {
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: $onClick({ "foo/4": foo }),
+			content: $item_content($scope)
+		});
+	});
+	$input_item($scope["#childScope/0"], $item);
+}
+function $onClick($locals) {
+	return function(ev) {
+		ev.target.textContent = $locals["foo/4"];
+	};
+}
+_resume("__tests__/template.marko_0/onClick", $onClick);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// tags/my-menu/index.marko
+const $for_content__item__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
+
+// template.marko
+const $item_content = _content_resume("a1", "Click", "b");
+function $onClick($locals) {
+	return function(ev) {
+		ev.target.textContent = $locals.e;
+	};
+}
+_resume("a0", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "#button/0", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
+		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function(ev) {
+				ev.target.textContent = foo;
+			}, "__tests__/template.marko_0/onClick", { "foo/4": foo }),
+			content: _content_resume("__tests__/template.marko_1_content", () => {
+				_scope_reason();
+				const $scope1_id = _scope_id();
+				_html("Click");
+			}, $scope0_id)
+		});
+	});
+	my_menu_default({ item: $item });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.js
@@ -1,0 +1,34 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "a", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "b0");
+		writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function(ev) {
+				ev.target.textContent = foo;
+			}, "a0", { e: foo }),
+			content: _content_resume("a1", () => {
+				_scope_reason();
+				_scope_id();
+				_html("Click");
+			}, $scope0_id)
+		});
+	});
+	my_menu_default({ item: $item });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/render.debug.md
@@ -1,0 +1,45 @@
+# Render
+```html
+<button>
+  Click
+</button>
+<button>
+  Click
+</button>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  Click
+</button>
+```
+## Change
+```
+REMOVE: button:nth-of-type(1)::text("Click")
+INSERT: button:nth-of-type(1)::text("a")
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+```
+## Change
+```
+REMOVE: button:nth-of-type(2)::text("Click")
+INSERT: button:nth-of-type(2)::text("b")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/render.md
@@ -1,0 +1,45 @@
+# Render
+```html
+<button>
+  Click
+</button>
+<button>
+  Click
+</button>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  Click
+</button>
+```
+## Change
+```
+REMOVE: button:nth-of-type(1)::text("Click")
+INSERT: button:nth-of-type(1)::text("a")
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+```
+## Change
+```
+REMOVE: button:nth-of-type(2)::text("Click")
+INSERT: button:nth-of-type(2)::text("b")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/writes.debug.html
@@ -1,0 +1,29 @@
+<button>Click</button><!--M_*5 #button/0--><button>Click</button><!--M_*7 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      "foo/4": "a"
+    }, {
+      "foo/4": "b"
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(2,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(6),
+      "ConditionalRenderer:#button/0": _.a =
+        "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/template.marko_1_content"
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(3,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(8),
+      "ConditionalRenderer:#button/0": _.a
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/tags/my-menu/index.marko_1_item 5 7"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/writes.html
@@ -1,0 +1,22 @@
+<button>Click</button><!--M_*5 a--><button>Click</button><!--M_*7 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    e: "a"
+  }, {
+    e: "b"
+  }, 1, {
+    Ia: {
+      click: _(2, "a0")
+    },
+    Aa: _(6),
+    Da: "a1"
+  }, 1, {
+    Ia: {
+      click: _(3, "a0")
+    },
+    Aa: _(8),
+    Da: "a1"
+  }], "b0 5 7"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6323,
+        "brotli": 2603
+      },
+      "files": {
+        "tags/my-menu/index.marko": 138,
+        "template.marko": 217
+      }
+    }
+  },
+  "html": {
+    "min": 472,
+    "brotli": 293
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/tags/my-menu/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/tags/my-menu/index.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.item>
+  <button ...item/>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/template.marko
@@ -1,0 +1,5 @@
+<my-menu>
+  <for|foo| of=["a", "b"]>
+    <@item onClick(ev) { ev.target.textContent = foo }>Click</@item>
+  </for>
+</my-menu>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickFirst(document: Document) {
+  document.querySelectorAll("button")[0].click();
+}
+
+function clickSecond(document: Document) {
+  document.querySelectorAll("button")[1].click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickFirst, clickSecond],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// tags/my-menu/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $for_content__item__script = _script("__tests__/tags/my-menu/index.marko_1_item", ($scope) => _attrs_script($scope, "#button/0"));
+const $for_content__item = /*@__PURE__*/ _const("item", ($scope) => {
+	_attrs_content($scope, "#button/0", $scope.item);
+	$for_content__item__script($scope);
+});
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " b", 0, $for_content__$params);
+const $input_item = ($scope, input_item) => $for($scope, [input_item]);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div> </div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&D l`)("b%c");
+const $item_content = /*@__PURE__*/ _content_closures(_content_resume("__tests__/template.marko_1_content", " ", " b"), { $foo($scope) {
+	_text($scope["#text/0"], $scope.$foo);
+} });
+const $foo2 = /*@__PURE__*/ _let("foo/2", ($scope) => _text($scope["#text/1"], $scope.foo));
+function $setup($scope) {
+	let $item;
+	forOf(["a", "b"], ($foo) => {
+		$item = attrTags($item, {
+			onClick: $onClick({ "$foo/4": $foo }),
+			content: $item_content($scope, { $foo })
+		});
+	});
+	$input_item($scope["#childScope/0"], $item);
+	$foo2($scope, "outer");
+}
+function $onClick($locals) {
+	return function(ev) {
+		ev.target.textContent = $locals["$foo/4"];
+	};
+}
+_resume("__tests__/template.marko_0/onClick", $onClick);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// tags/my-menu/index.marko
+const $for_content__item__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
+
+// template.marko
+const $item_content = /*@__PURE__*/ _content_closures(_content_resume("a1", " ", " b"), { 4($scope) {
+	_text($scope.a, $scope.e);
+} });
+function $onClick($locals) {
+	return function(ev) {
+		ev.target.textContent = $locals.e;
+	};
+}
+_resume("a0", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,38 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "#button/0", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
+		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let foo = "outer";
+	let $item;
+	forOf(["a", "b"], ($foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function(ev) {
+				ev.target.textContent = $foo;
+			}, "__tests__/template.marko_0/onClick", { "$foo/4": $foo }),
+			content: _content_resume("__tests__/template.marko_1_content", () => {
+				_scope_reason();
+				const $scope1_id = _scope_id();
+				_html(`${_escape($foo)}${_el_resume($scope1_id, "#text/0")}`);
+				writeScope($scope1_id, {}, "__tests__/template.marko", "4:6");
+			}, $scope0_id)
+		});
+	});
+	my_menu_default({ item: $item });
+	_html(`<div>${_escape(foo)}</div>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
@@ -1,0 +1,38 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "a", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "b0");
+		writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let foo = "outer";
+	let $item;
+	forOf(["a", "b"], ($foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function(ev) {
+				ev.target.textContent = $foo;
+			}, "a0", { e: $foo }),
+			content: _content_resume("a1", () => {
+				_scope_reason();
+				const $scope1_id = _scope_id();
+				_html(`${_escape($foo)}${_el_resume($scope1_id, "a")}`);
+				writeScope($scope1_id, {});
+			}, $scope0_id)
+		});
+	});
+	my_menu_default({ item: $item });
+	_html(`<div>${_escape(foo)}</div>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/render.debug.md
@@ -1,0 +1,54 @@
+# Render
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+## Change
+```
+REMOVE: button:nth-of-type(1)::text("a")
+INSERT: button:nth-of-type(1)::text("a")
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+## Change
+```
+REMOVE: button:nth-of-type(2)::text("b")
+INSERT: button:nth-of-type(2)::text("b")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/render.md
@@ -1,0 +1,54 @@
+# Render
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+## Change
+```
+REMOVE: button:nth-of-type(1)::text("a")
+INSERT: button:nth-of-type(1)::text("a")
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<div>
+  outer
+</div>
+```
+## Change
+```
+REMOVE: button:nth-of-type(2)::text("b")
+INSERT: button:nth-of-type(2)::text("b")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/writes.debug.html
@@ -1,0 +1,30 @@
+<button>a<!--M_*6 #text/0--></button><!--M_*5 #button/0--><button>b<!--M_*8 #text/0--></button><!--M_*7 #button/0-->
+<div>outer</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      "$foo/4": "a"
+    }, {
+      "$foo/4": "b"
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(2,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(6),
+      "ConditionalRenderer:#button/0": _.a =
+        "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/template.marko_1_content"
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(3,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(8),
+      "ConditionalRenderer:#button/0": _.a
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/tags/my-menu/index.marko_1_item 5 7"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/writes.html
@@ -1,0 +1,23 @@
+<button>a<!--M_*6 a--></button><!--M_*5 a--><button>b<!--M_*8 a--></button><!--M_*7 a-->
+<div>outer</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    e: "a"
+  }, {
+    e: "b"
+  }, 1, {
+    Ia: {
+      click: _(2, "a0")
+    },
+    Aa: _(6),
+    Da: "a1"
+  }, 1, {
+    Ia: {
+      click: _(3, "a0")
+    },
+    Aa: _(8),
+    Da: "a1"
+  }], "b0 5 7"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6320,
+        "brotli": 2598
+      },
+      "files": {
+        "tags/my-menu/index.marko": 138,
+        "template.marko": 294
+      }
+    }
+  },
+  "html": {
+    "min": 506,
+    "brotli": 311
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/tags/my-menu/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/tags/my-menu/index.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.item>
+  <button ...item/>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/template.marko
@@ -1,0 +1,7 @@
+<let/foo="outer"/>
+<my-menu>
+  <for|foo| of=["a", "b"]>
+    <@item onClick(ev) { ev.target.textContent = foo }>${foo}</@item>
+  </for>
+</my-menu>
+<div>${foo}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickFirst(document: Document) {
+  document.querySelectorAll("button")[0].click();
+}
+
+function clickSecond(document: Document) {
+  document.querySelectorAll("button")[1].click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickFirst, clickSecond],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,46 @@
+// tags/my-menu/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $for_content__item__script = _script("__tests__/tags/my-menu/index.marko_1_item", ($scope) => _attrs_script($scope, "#button/0"));
+const $for_content__item = /*@__PURE__*/ _const("item", ($scope) => {
+	_attrs_content($scope, "#button/0", $scope.item);
+	$for_content__item__script($scope);
+});
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " b", 0, $for_content__$params);
+const $input_item = ($scope, input_item) => $for($scope, [input_item]);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div> </div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&D l`)("b%c");
+const $item_content = /*@__PURE__*/ _content_closures(_content_resume("__tests__/template.marko_1_content", "Click <!>", "b%b"), { foo($scope) {
+	_text($scope["#text/0"], $scope.foo);
+} });
+const $clicked = /*@__PURE__*/ _let("clicked/2", ($scope) => {
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: $onClick({
+				_: $scope,
+				"foo/4": foo
+			}),
+			content: $item_content($scope, { foo })
+		});
+	});
+	$input_item($scope["#childScope/0"], $item);
+	_text($scope["#text/1"], $scope.clicked);
+});
+function $setup($scope) {
+	$clicked($scope, "");
+}
+function $onClick($locals) {
+	return function() {
+		const $scope = $locals._;
+		$clicked($scope, $scope.clicked + $locals["foo/4"]);
+	};
+}
+_resume("__tests__/template.marko_0/onClick", $onClick);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,35 @@
+// tags/my-menu/index.marko
+const $for_content__item__script = _script("b0", ($scope) => _attrs_script($scope, "a"));
+const $for_content__item = /*@__PURE__*/ _const(2, ($scope) => {
+	_attrs_content($scope, "a", $scope.c);
+	$for_content__item__script($scope);
+});
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $for = /*@__PURE__*/ _for_of(0, "<button></button>", " b", 0, $for_content__$params);
+const $input_item = ($scope, input_item) => $for($scope, [input_item]);
+
+// template.marko
+const $item_content = /*@__PURE__*/ _content_closures(_content_resume("a1", "Click <!>", "b%b"), { 4($scope) {
+	_text($scope.a, $scope.e);
+} });
+const $clicked = /*@__PURE__*/ _let(2, ($scope) => {
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: $onClick({
+				_: $scope,
+				e: foo
+			}),
+			content: $item_content($scope, { 4: foo })
+		});
+	});
+	$input_item($scope.a, $item);
+	_text($scope.b, $scope.c);
+});
+function $onClick($locals) {
+	return function() {
+		const $scope = $locals._;
+		$clicked($scope, $scope.c + $locals.e);
+	};
+}
+_resume("a0", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,44 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "#button/0", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
+		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicked = "";
+	_set_serialize_reason(1);
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function() {
+				clicked += foo;
+			}, "__tests__/template.marko_0/onClick", { "foo/4": foo }, $scope0_id),
+			content: _content_resume("__tests__/template.marko_1_content", () => {
+				_scope_reason();
+				const $scope1_id = _scope_id();
+				_html(`Click <!>${_escape(foo)}${_el_resume($scope1_id, "#text/0")}`);
+				writeScope($scope1_id, {}, "__tests__/template.marko", "4:6");
+			}, $scope0_id)
+		});
+	});
+	const $childScope = _peek_scope_id();
+	my_menu_default({ item: $item });
+	_html(`<div>${_escape(clicked)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	writeScope($scope0_id, {
+		clicked,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { clicked: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,44 @@
+// tags/my-menu/index.marko
+var my_menu_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, (item) => {
+		const $scope1_id = _scope_id();
+		_html("<button");
+		_attrs_content(item, "a", $scope1_id, "button");
+		_html(`</button>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "b0");
+		writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicked = "";
+	_set_serialize_reason(1);
+	let $item;
+	forOf(["a", "b"], (foo) => {
+		$item = attrTags($item, {
+			onClick: _resume_locals(function() {
+				clicked += foo;
+			}, "a0", { e: foo }, $scope0_id),
+			content: _content_resume("a1", () => {
+				_scope_reason();
+				const $scope1_id = _scope_id();
+				_html(`Click <!>${_escape(foo)}${_el_resume($scope1_id, "a")}`);
+				writeScope($scope1_id, {});
+			}, $scope0_id)
+		});
+	});
+	const $childScope = _peek_scope_id();
+	my_menu_default({ item: $item });
+	_html(`<div>${_escape(clicked)}${_el_resume($scope0_id, "b")}</div>`);
+	writeScope($scope0_id, {
+		c: clicked,
+		a: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/render.debug.md
@@ -1,0 +1,50 @@
+# Render
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div />
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div>
+  a
+</div>
+```
+## Change
+```
+UPDATE: div::text "" => "a"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div>
+  ab
+</div>
+```
+## Change
+```
+UPDATE: div::text "a" => "ab"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/render.md
@@ -1,0 +1,50 @@
+# Render
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div />
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div>
+  a
+</div>
+```
+## Change
+```
+UPDATE: div::text "" => "a"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  Click a
+</button>
+<button>
+  Click b
+</button>
+<div>
+  ab
+</div>
+```
+## Change
+```
+UPDATE: div::text "a" => "ab"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/writes.debug.html
@@ -1,0 +1,36 @@
+<button>Click <!>a<!--M_*6 #text/0--></button><!--M_*5 #button/0--><button>Click
+  <!>b<!--M_*8 #text/0--></button><!--M_*7 #button/0--><!--M_|4 #text/0 7 5-->
+<div><!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      clicked: "",
+      "#childScope/0": _(4)
+    }, {
+      "foo/4": "a",
+      _: _(1)
+    }, {
+      "foo/4": "b",
+      _: _(1)
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(2,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(6),
+      "ConditionalRenderer:#button/0": _.a =
+        "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/template.marko_1_content"
+    }, 1, {
+      "EventAttributes:#button/0": {
+        click: _(3,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/template.marko_0/onClick"
+          )
+      },
+      "BranchScopes:#button/0": _(8),
+      "ConditionalRenderer:#button/0": _.a
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/tags/my-menu/index.marko_1_item 5 7"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<button>Click <!>a<!--M_*6 a--></button><!--M_*5 a--><button>Click <!>
+    b<!--M_*8 a--></button><!--M_*7 a--><!--M_|4 a 7 5-->
+<div><!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: "",
+    a: _(4)
+  }, {
+    e: "a",
+    _: _(1)
+  }, {
+    e: "b",
+    _: _(1)
+  }, 1, {
+    Ia: {
+      click: _(2, "a0")
+    },
+    Aa: _(6),
+    Da: "a1"
+  }, 1, {
+    Ia: {
+      click: _(3, "a0")
+    },
+    Aa: _(8),
+    Da: "a1"
+  }], "b0 5 7"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 14802,
+        "brotli": 5748
+      },
+      "files": {
+        "tags/my-menu/index.marko": 541,
+        "template.marko": 633
+      }
+    }
+  },
+  "html": {
+    "min": 577,
+    "brotli": 335
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/tags/my-menu/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/tags/my-menu/index.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.item>
+  <button ...item/>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/template.marko
@@ -1,0 +1,7 @@
+<let/clicked=""/>
+<my-menu>
+  <for|foo| of=["a", "b"]>
+    <@item onClick() { clicked += foo }>Click ${foo}</@item>
+  </for>
+</my-menu>
+<div>${clicked}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickFirst(document: Document) {
+  document.querySelectorAll("button")[0].click();
+}
+
+function clickSecond(document: Document) {
+  document.querySelectorAll("button")[1].click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickFirst, clickSecond],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_cond = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { cond } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_cond,
 		1: $sg__input_cond,
@@ -24,6 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$x = attrTag({ value: 1 });
 		$y = attrTag({ value: 2 });
 	}
+	const $childScope = _peek_scope_id();
 	custom_tag_default({
 		x: $x,
 		y: $y

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.js
@@ -12,7 +12,6 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_cond = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { cond } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_cond,
 		1: $sg__input_cond,
@@ -24,6 +23,7 @@ var template_default = _template("a", (input) => {
 		$x = attrTag({ value: 1 });
 		$y = attrTag({ value: 2 });
 	}
+	const $childScope = _peek_scope_id();
 	custom_tag_default({
 		x: $x,
 		y: $y

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.debug.js
@@ -35,11 +35,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { c, d, e, f, g, h } = input;
 	_html(`<div class=${$class[(c ? 1 : 0) + (d ? 2 : 0)]}></div>${_el_resume($scope0_id, "#div/0", $sg__input_c__OR__input_d)}<div class="a b"></div><div class="a b c"></div><div${c ? " class=active" : ""}></div>${_el_resume($scope0_id, "#div/1", _serialize_guard($scope0_reason, 8))}<div${_attr_class("base" + (c ? " c" : "") + (d ? " d" : "") + (e ? " e" : "") + (f ? " f" : "") + (g ? " g" : "") + (h ? " h" : ""))}></div>${_el_resume($scope0_id, "#div/2", _serialize_guard($scope0_reason, 7))}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_c__OR__input_d,
 		2: $sg__input_c__OR__input_d
 	});
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ class: ["a", {
 		b: c,
 		d

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.js
@@ -32,11 +32,11 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const { c, d, e, f, g, h } = input;
 	_html(`<div class=${$class[(c ? 1 : 0) + (d ? 2 : 0)]}></div>${_el_resume($scope0_id, "a", $sg__input_c__OR__input_d)}<div class="a b"></div><div class="a b c"></div><div${c ? " class=active" : ""}></div>${_el_resume($scope0_id, "b", _serialize_guard($scope0_reason, 8))}<div${_attr_class("base" + (c ? " c" : "") + (d ? " d" : "") + (e ? " e" : "") + (f ? " f" : "") + (g ? " g" : "") + (h ? " h" : ""))}></div>${_el_resume($scope0_id, "c", _serialize_guard($scope0_reason, 7))}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_c__OR__input_d,
 		2: $sg__input_c__OR__input_d
 	});
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ class: ["a", {
 		b: c,
 		d

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.debug.js
@@ -28,11 +28,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_color = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<div${_attr_style({ color: input.color })}></div>${_el_resume($scope0_id, "#div/0", $sg__input_color)}<div style=width:100px></div><div style="color: green"></div><div${input.color ? " style=color:red" : ""}></div>${_el_resume($scope0_id, "#div/1", $sg__input_color)}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_color,
 		2: $sg__input_color
 	});
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ style: { color: input.color } });
 	custom_tag_default({ style: { width: "100px" } });
 	custom_tag_default({ style: "color: green" });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.js
@@ -25,11 +25,11 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_color = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<div${_attr_style({ color: input.color })}></div>${_el_resume($scope0_id, "a", $sg__input_color)}<div style=width:100px></div><div style="color: green"></div><div${input.color ? " style=color:red" : ""}></div>${_el_resume($scope0_id, "b", $sg__input_color)}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_color,
 		2: $sg__input_color
 	});
+	const $childScope = _peek_scope_id();
 	custom_tag_default({ style: { color: input.color } });
 	custom_tag_default({ style: { width: "100px" } });
 	custom_tag_default({ style: "color: green" });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.debug.js
@@ -10,12 +10,12 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
 	let $item;
 	forUntil(1, 0, 1, (i) => {
 		$item = attrTags($item, { value: i });
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		item: $item

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.js
@@ -10,12 +10,12 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
 	let $item;
 	forUntil(1, 0, 1, (i) => {
 		$item = attrTags($item, { value: i });
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		item: $item

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.js
@@ -13,8 +13,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.debug.js
@@ -14,16 +14,16 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		value: { text: clickCount },
 		onClick: _resume(function() {
 			clickCount++;
 		}, "__tests__/template.marko_0/onClick", $scope0_id)
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	my_button_default({
 		onClick: _resume(function() {
 			clickCount++;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
@@ -14,16 +14,16 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		value: { text: clickCount },
 		onClick: _resume(function() {
 			clickCount++;
 		}, "a0", $scope0_id)
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	my_button_default({
 		onClick: _resume(function() {
 			clickCount++;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.debug.js
@@ -14,8 +14,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.js
@@ -13,8 +13,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.debug.js
@@ -11,12 +11,12 @@ const $content = (input) => {
 		_if(() => {
 			if (comment.comments) {
 				const $scope2_id = _scope_id();
-				const $childScope = _peek_scope_id();
 				_set_serialize_reason({
 					0: $sg__input_comments__OR__input_path,
 					1: $sg__input_comments,
 					2: _serialize_guard($scope0_reason, 2)
 				});
+				const $childScope = _peek_scope_id();
 				$content({
 					comments: comment.comments,
 					path: id
@@ -51,12 +51,12 @@ var comments_default = _template("__tests__/tags/comments.marko", $content);
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	comments_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.js
@@ -11,12 +11,12 @@ const $content = (input) => {
 		_if(() => {
 			if (comment.comments) {
 				const $scope2_id = _scope_id();
-				const $childScope = _peek_scope_id();
 				_set_serialize_reason({
 					0: $sg__input_comments__OR__input_path,
 					1: $sg__input_comments,
 					2: _serialize_guard($scope0_reason, 2)
 				});
+				const $childScope = _peek_scope_id();
 				$content({
 					comments: comment.comments,
 					path: id
@@ -46,12 +46,12 @@ var comments_default = _template("b", $content);
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	comments_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { a: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.debug.js
@@ -17,8 +17,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		const $scope1_id = _scope_id();
 		_for_of(items, (inner) => {
 			const $scope2_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ name: `${outer}.${inner}` });
 			writeScope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:4");
 		}, 0, $scope1_id, "#text/0", 1, 1, 1, 0, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.js
@@ -17,8 +17,8 @@ var template_default = _template("a", (input) => {
 		const $scope1_id = _scope_id();
 		_for_of(items, (inner) => {
 			const $scope2_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ name: `${outer}.${inner}` });
 			writeScope($scope2_id, { a: _existing_scope($childScope) });
 		}, 0, $scope1_id, "a", 1, 1, 1, 0, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.debug.js
@@ -22,8 +22,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let x = 1;
 	let y = 2;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: x,
 		content: _content_resume("__tests__/template.marko_1_content", (outer) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
@@ -19,8 +19,8 @@ var template_default = _template("a", (input) => {
 	let x = 1;
 	let y = 2;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: x,
 		content: _content_resume("a1", (outer) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
@@ -27,8 +27,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $x__closures = new Set();
 	let x = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(8);
+	const $childScope = _peek_scope_id();
 	counter_default({
 		count: x,
 		countChange: _resume((_new_x) => {
@@ -43,8 +43,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_resume_branch($scope1_id);
 		})
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(8);
+	const $childScope2 = _peek_scope_id();
 	counter_default({
 		count: x,
 		id: "uncontrolled",

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
@@ -23,8 +23,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $x__closures = /* @__PURE__ */ new Set();
 	let x = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(8);
+	const $childScope = _peek_scope_id();
 	counter_default({
 		count: x,
 		countChange: _resume((_new_x) => {
@@ -39,8 +39,8 @@ var template_default = _template("a", (input) => {
 			_resume_branch($scope1_id);
 		})
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(8);
+	const $childScope2 = _peek_scope_id();
 	counter_default({
 		count: x,
 		id: "uncontrolled",

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
@@ -18,8 +18,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}) };
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	Wrap.content({ a: "z" + n });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ var template_default = _template("a", (input) => {
 	}) };
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	Wrap.content({ a: "z1" });
 	_script($scope0_id, "a2");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.debug.js
@@ -30,8 +30,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/0")}<div></div>${_el_resume($scope0_id, "#div/1")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: item

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
@@ -27,8 +27,8 @@ var template_default = _template("a", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "a")}<div></div>${_el_resume($scope0_id, "b")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: item

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.debug.js
@@ -31,8 +31,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_for_of(items, (outerItem) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: `${outerItem}`
@@ -40,8 +40,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_for_of(items, (middleItem) => {
 			const $scope2_id = _scope_id();
 			_html("<div>");
-			const $childScope2 = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope2 = _peek_scope_id();
 			child_default({
 				write,
 				name: `${outerItem}.${middleItem}`

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.js
@@ -28,8 +28,8 @@ var template_default = _template("a", (input) => {
 	_for_of(items, (outerItem) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: `${outerItem}`
@@ -37,8 +37,8 @@ var template_default = _template("a", (input) => {
 		_for_of(items, (middleItem) => {
 			const $scope2_id = _scope_id();
 			_html("<div>");
-			const $childScope2 = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope2 = _peek_scope_id();
 			child_default({
 				write,
 				name: `${outerItem}.${middleItem}`

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.debug.js
@@ -30,8 +30,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/0")}<div></div>${_el_resume($scope0_id, "#div/1")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: item

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.js
@@ -27,8 +27,8 @@ var template_default = _template("a", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "a")}<div></div>${_el_resume($scope0_id, "b")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			write,
 			name: item

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.debug.js
@@ -14,8 +14,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	display_intersection_default({ value: count });
 	_html(`<button></button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	display_intersection_default({ value: count });
 	_html(`<button></button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
@@ -23,8 +23,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = new Set();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	sections_default({ section: attrTag({
 		onClick: _resume(function() {
 			count++;

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
@@ -23,8 +23,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = /* @__PURE__ */ new Set();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	sections_default({ section: attrTag({
 		onClick: _resume(function() {
 			count++;

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.debug.js
@@ -11,11 +11,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}) };
 	let n = 2;
 	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	Wrap.content([undefined, n]);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	Wrap.content([n, 10]);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.js
@@ -10,11 +10,11 @@ var template_default = _template("a", (input) => {
 	}) };
 	let n = 2;
 	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	Wrap.content([void 0, n]);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	Wrap.content([n, 10]);
 	_script($scope0_id, "a1");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
@@ -11,11 +11,11 @@ var row_default = _template("__tests__/tags/row/index.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	_html("<div class=row>");
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
 	cell_default({ value: input.name });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 2));
+	const $childScope2 = _peek_scope_id();
 	cell_default({ value: input.quantity });
 	_html("</div>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
@@ -30,8 +30,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let quantity = 2;
 	_html(`<button>add</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	row_default({
 		name: "Widget",
 		quantity

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
@@ -11,11 +11,11 @@ var row_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	_html("<div class=row>");
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
 	cell_default({ value: input.name });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 2));
+	const $childScope2 = _peek_scope_id();
 	cell_default({ value: input.quantity });
 	_html("</div>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
@@ -30,8 +30,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let quantity = 2;
 	_html(`<button>add</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	row_default({
 		name: "Widget",
 		quantity

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.debug.js
@@ -12,8 +12,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	show_result_default({ get: function() {
 		return count;
 	} });

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	show_result_default({ get: function() {
 		return count;
 	} });

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_html("<span>The thing</span>");
 		})
 	};
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({ thing: myThing });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.js
@@ -21,8 +21,8 @@ var template_default = _template("a", (input) => {
 			_html("<span>The thing</span>");
 		})
 	};
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({ thing: myThing });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
@@ -8,11 +8,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
-				const $childScope = _peek_scope_id();
 				_set_serialize_reason({
 					0: $sg__input_bar,
 					2: $sg__input_bar
 				});
+				const $childScope = _peek_scope_id();
 				Foo.content({ message: input.bar });
 				$si__input_bar && writeScope($scope2_id, {
 					_: _scope_with_id($scope1_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
@@ -8,11 +8,11 @@ var template_default = _template("a", (input) => {
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
-				const $childScope = _peek_scope_id();
 				_set_serialize_reason({
 					0: $sg__input_bar,
 					2: $sg__input_bar
 				});
+				const $childScope = _peek_scope_id();
 				Foo.content({ message: input.bar });
 				$si__input_bar && writeScope($scope2_id, {
 					_: _scope_with_id($scope1_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.debug.js
@@ -9,8 +9,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(a)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 1))}|${_sep($sg__rest)}${_escape(JSON.stringify(rest))}${_el_resume($scope1_id, "#text/1", $sg__rest)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content(x, "two", "three");
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.js
@@ -9,8 +9,8 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(a)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 1))}|${_sep($sg__rest)}${_escape(JSON.stringify(rest))}${_el_resume($scope1_id, "b", $sg__rest)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content(x, "two", "three");
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.debug.js
@@ -9,8 +9,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(b)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 1))}|${_sep($sg__c)}${_escape(c)}${_el_resume($scope1_id, "#text/1", $sg__c)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.js
@@ -9,8 +9,8 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(b)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 1))}|${_sep($sg__c)}${_escape(c)}${_el_resume($scope1_id, "b", $sg__c)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.debug.js
@@ -9,8 +9,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(a)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 1))}|${_sep($sg__b)}${_escape(b)}${_el_resume($scope1_id, "#text/1", $sg__b)}|${_sep($sg__c)}${_escape(c)}${_el_resume($scope1_id, "#text/2", $sg__c)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(18);
+	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.js
@@ -9,8 +9,8 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(a)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 1))}|${_sep($sg__b)}${_escape(b)}${_el_resume($scope1_id, "b", $sg__b)}|${_sep($sg__c)}${_escape(c)}${_el_resume($scope1_id, "c", $sg__c)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(18);
+	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.debug.js
@@ -9,8 +9,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(number)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content({ number: x });
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.js
@@ -9,8 +9,8 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(number)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content({ number: x });
 	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			MyTag.content({ value: x });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "8:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			MyTag.content({ value: x });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.debug.js
@@ -10,8 +10,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>Hello ${_sep($sg__name)}${_escape(name)}${_el_resume($scope1_id, "#text/0", $sg__name)} ${_sep($sg__count)}${_escape(count)}${_el_resume($scope1_id, "#text/1", $sg__count)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "6:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	MyTag.content({
 		name: "Ryan",
 		count

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.js
@@ -10,8 +10,8 @@ var template_default = _template("a", (input) => {
 		_html(`<div>Hello ${_sep($sg__name)}${_escape(name)}${_el_resume($scope1_id, "a", $sg__name)} ${_sep($sg__count)}${_escape(count)}${_el_resume($scope1_id, "b", $sg__count)}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	MyTag.content({
 		name: "Ryan",
 		count

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -22,8 +22,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ show });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -22,8 +22,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ show });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			list_default({ count });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.js
@@ -21,8 +21,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			list_default({ count });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -22,8 +22,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ count });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -22,8 +22,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ count });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
@@ -24,8 +24,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			leaf_default({ n });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.js
@@ -24,8 +24,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			leaf_default({ n });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.debug.js
@@ -33,8 +33,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			wrapper_default({ show });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.js
@@ -33,8 +33,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			wrapper_default({ show });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -25,8 +25,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ show });
 			writeScope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -25,8 +25,8 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			child_default({ show });
 			writeScope($scope1_id, { a: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.debug.js
@@ -25,8 +25,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			"ClosureScopes:input_name": $si__input_name && $Child_content__input_name__closures
 		}, "__tests__/template.marko", "6:2", { input_name: ["input.name", "6:15"] });
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	Child.content({ count });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.js
@@ -25,8 +25,8 @@ var template_default = _template("a", (input) => {
 			f: $si__input_name && $Child_content__input_name__closures
 		});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	Child.content({ count });
 	_script($scope0_id, "a1");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
@@ -11,11 +11,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:1");
 	}) };
 	const { text } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_text,
 		1: $sg__input_text
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({
 		text: input.text,
 		content: _content("__tests__/template.marko_2_content", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
@@ -11,11 +11,11 @@ var template_default = _template("a", (input) => {
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
 	const { text } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_text,
 		1: $sg__input_text
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({
 		text: input.text,
 		content: _content("a1", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = "hi";
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_input_default({
 		value,
 		valueChange: _resume((_new_value) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = "hi";
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	my_input_default({
 		value,
 		valueChange: _resume((_new_value) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let n = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({ n });
 	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
@@ -11,8 +11,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let n = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({ n });
 	_html(`<button>inc</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.debug.js
@@ -10,12 +10,12 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_a = _serialize_guard($scope0_reason, 1), $sg__input_b = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_a__OR__input_b,
 		1: $sg__input_a,
 		2: $sg__input_b
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		a: input.a,
 		b: input.b
@@ -26,12 +26,12 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(input.a)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 1))}</div><div>${_escape(input.b)}${_el_resume($scope1_id, "#text/1", _serialize_guard($scope1_reason, 2))}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "3:2");
 	}) };
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_a__OR__input_b,
 		1: $sg__input_a,
 		2: $sg__input_b
 	});
+	const $childScope2 = _peek_scope_id();
 	Child.content({
 		a: input.a,
 		b: input.b

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.js
@@ -10,12 +10,12 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_a = _serialize_guard($scope0_reason, 1), $sg__input_b = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_a__OR__input_b,
 		1: $sg__input_a,
 		2: $sg__input_b
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		a: input.a,
 		b: input.b
@@ -26,12 +26,12 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(input.a)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 1))}</div><div>${_escape(input.b)}${_el_resume($scope1_id, "b", _serialize_guard($scope1_reason, 2))}</div>`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input_a__OR__input_b,
 		1: $sg__input_a,
 		2: $sg__input_b
 	});
+	const $childScope2 = _peek_scope_id();
 	Child.content({
 		a: input.a,
 		b: input.b

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.debug.js
@@ -12,11 +12,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		(_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _subscribe($si__input && $input__closures, writeScope($scope1_id, { _: $si__input && _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2"));
 		_resume_branch($scope1_id);
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content(...args);
 	MyTag.content(7, 8, 9);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $cgrp;
 	if (x) {
@@ -24,6 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	} else {
 		$cgrp = attrTag({ y: 2 });
 	}
+	const $childScope2 = _peek_scope_id();
 	MyTag.content(...args, {
 		cgrp: $cgrp,
 		row: attrTag({ r: x })

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js
@@ -12,14 +12,14 @@ var template_default = _template("a", (input) => {
 		(_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _subscribe($si__input && $input__closures, writeScope($scope1_id, { _: $si__input && _scope_with_id($scope0_id) }));
 		_resume_branch($scope1_id);
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	MyTag.content(...args);
 	MyTag.content(7, 8, 9);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $cgrp;
 	$cgrp = attrTag({ y: 1 });
+	const $childScope2 = _peek_scope_id();
 	MyTag.content(...args, {
 		cgrp: $cgrp,
 		row: attrTag({ r: x })

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.debug.js
@@ -13,8 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		first: n,
 		row: attrTag({ x: 1 }),

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.js
@@ -13,8 +13,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		first: n,
 		row: attrTag({ x: 1 }),

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.debug.js
@@ -17,13 +17,13 @@ var child_default = _template("__tests__/tags/child/index.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { title, ...rest } = input;
 	_html(`<h1>${_escape(title)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 1))}</h1>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__rest,
 		1: $sg__rest,
 		2: $sg__rest,
 		3: $sg__rest
 	});
+	const $childScope = _peek_scope_id();
 	inner_default({ stuff: rest });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _serialize_if($scope0_reason, 2) && _existing_scope($childScope) }, "__tests__/tags/child/index.marko", 0);
 });
@@ -34,7 +34,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
 	let $cond;
 	if (cond) {
@@ -42,6 +41,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	} else {
 		$cond = attrTag({ a: 2 });
 	}
+	const $childScope = _peek_scope_id();
 	child_default({
 		title: "t",
 		cond: $cond,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.js
@@ -17,13 +17,13 @@ var child_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	const { title, ...rest } = input;
 	_html(`<h1>${_escape(title)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 1))}</h1>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__rest,
 		1: $sg__rest,
 		2: $sg__rest,
 		3: $sg__rest
 	});
+	const $childScope = _peek_scope_id();
 	inner_default({ stuff: rest });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _serialize_if($scope0_reason, 2) && _existing_scope($childScope) });
 });
@@ -34,10 +34,10 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
 	let $cond;
 	$cond = attrTag({ a: 1 });
+	const $childScope = _peek_scope_id();
 	child_default({
 		title: "t",
 		cond: $cond,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.debug.js
@@ -12,9 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
 	if (true) {} else if (false) {} else {}
+	const $childScope = _peek_scope_id();
 	child_default({
 		a: n,
 		junk: attrTag({ foo: 2 }),

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({
 		a: n,
 		junk: attrTag({ foo: 2 }),

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.debug.js
@@ -12,8 +12,8 @@ var mid_default = _template("__tests__/tags/mid.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { first, group: { keep, ...rest } } = input;
 	_html(`<p>${_escape(first)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 1))} ${_sep($sg__input_group_keep)}${_escape(keep)}${_el_resume($scope0_id, "#text/1", $sg__input_group_keep)}</p>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 3));
+	const $childScope = _peek_scope_id();
 	leaf_default({ data: rest });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/2": _serialize_if($scope0_reason, 3) && _existing_scope($childScope) }, "__tests__/tags/mid.marko", 0);
 });
@@ -24,8 +24,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(26);
+	const $childScope = _peek_scope_id();
 	mid_default({
 		first: "f",
 		group: {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ var mid_default = _template("c", (input) => {
 	const $scope0_id = _scope_id();
 	const { first, group: { keep, ...rest } } = input;
 	_html(`<p>${_escape(first)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 1))} ${_sep($sg__input_group_keep)}${_escape(keep)}${_el_resume($scope0_id, "b", $sg__input_group_keep)}</p>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 3));
+	const $childScope = _peek_scope_id();
 	leaf_default({ data: rest });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { c: _serialize_if($scope0_reason, 3) && _existing_scope($childScope) });
 });
@@ -24,8 +24,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(26);
+	const $childScope = _peek_scope_id();
 	mid_default({
 		first: "f",
 		group: {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.debug.js
@@ -11,11 +11,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_script($scope1_id, "__tests__/template.marko_1_a");
 		writeScope($scope1_id, { input_a: input.a }, "__tests__/template.marko", "1:2", { input_a: ["input.a", "1:15"] });
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 1),
 		1: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({
 		a: input.a,
 		b: input.b

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.js
@@ -11,11 +11,11 @@ var template_default = _template("a", (input) => {
 		_script($scope1_id, "a2");
 		writeScope($scope1_id, { e: input.a });
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 1),
 		1: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({
 		a: input.a,
 		b: input.b

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.debug.js
@@ -14,8 +14,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const j2 = { a: 6 };
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_b_default({
 		...j1,
 		...j2,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("a", (input) => {
 	const j2 = { a: 6 };
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_b_default({
 		...j1,
 		...j2,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
@@ -11,8 +11,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const Bar = { content: _content("__tests__/template.marko_2_content", (input) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		const $childScope = _peek_scope_id();
 		Foo.content(input);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");
 	}) };

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
@@ -11,8 +11,8 @@ var template_default = _template("a", (input) => {
 	({ content: _content("a1", (input) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		const $childScope = _peek_scope_id();
 		Foo.content(input);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, { a: _existing_scope($childScope) });
 	}) }).content({});

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.debug.js
@@ -24,24 +24,24 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	};
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_a_default({
 		a: n,
 		...extras
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope2 = _peek_scope_id();
 	child_a_default({
 		...extras,
 		a: n
 	});
-	const $childScope3 = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope3 = _peek_scope_id();
 	child_c_default(input.settings);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.js
@@ -24,24 +24,24 @@ var template_default = _template("a", (input) => {
 	};
 	let n = 1;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_a_default({
 		a: n,
 		...extras
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope2 = _peek_scope_id();
 	child_a_default({
 		...extras,
 		a: n
 	});
-	const $childScope3 = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope3 = _peek_scope_id();
 	child_c_default(input.settings);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.debug.js
@@ -14,8 +14,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (count % 2 === 0) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(10);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({
 				label: "x",
 				value: count

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(10);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({
 				label: "x",
 				value: count

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-auto/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-auto/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button class=load>load</button>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button class=load>load</button>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button id=load>load</button>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button id=load>load</button>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			writeScope($scope1_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.js
@@ -21,8 +21,8 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			writeScope($scope1_id, { b: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.debug.js
@@ -12,8 +12,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	_html(`<!DOCTYPE html><html><head><title>Head Flush Test</title>${_flush_head()}</head><body>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_trailers("</body></html>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	_html(`<!DOCTYPE html><html><head><title>Head Flush Test</title>${_flush_head()}</head><body>`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_trailers("</body></html>");
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			writeScope($scope1_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.js
@@ -21,8 +21,8 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			writeScope($scope1_id, { b: _existing_scope($childScope) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.debug.js
@@ -14,8 +14,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let show = true;
 	let value = 0;
 	_html(`<button class=toggle>Toggle</button>${_el_resume($scope0_id, "#button/0")}<button class=inc>Inc</button>${_el_resume($scope0_id, "#button/1")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_dynamic_tag($scope0_id, "#text/4", show ? $Child_withLoadAssets : null, { value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("b", (input) => {
 	let show = true;
 	let value = 0;
 	_html(`<button class=toggle>Toggle</button>${_el_resume($scope0_id, "a")}<button class=inc>Inc</button>${_el_resume($scope0_id, "b")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_dynamic_tag($scope0_id, "e", $Child_withLoadAssets, { value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.debug.js
@@ -19,8 +19,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.js
@@ -19,8 +19,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.debug.js
@@ -18,8 +18,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.js
@@ -18,8 +18,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.debug.js
@@ -19,8 +19,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button id=inc>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.js
@@ -19,8 +19,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button id=inc>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.debug.js
@@ -18,8 +18,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.js
@@ -18,8 +18,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.debug.js
@@ -24,11 +24,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	$ChildA_withLoadAssets({ value });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	$ChildB_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.js
@@ -24,11 +24,11 @@ var template_default = _template("c", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	$ChildA_withLoadAssets({ value });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	$ChildB_withLoadAssets({ value });
 	_script($scope0_id, "c0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.debug.js
@@ -24,8 +24,8 @@ var child_default = _template("__tests__/child.marko", (input) => {
 	_await($scope0_id, "#text/2", resolveAfter(10, 1), (value) => {
 		const $scope1_id = _scope_id();
 		_html(`<span id=child-await>${_escape(value)}</span>`);
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		$GrandChild_withLoadAssets({ value: count });
 		_subscribe($count__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.js
@@ -24,8 +24,8 @@ var child_default = _template("a", (input) => {
 	_await($scope0_id, "c", resolveAfter(10, 1), (value) => {
 		const $scope1_id = _scope_id();
 		_html(`<span id=child-await>${_escape(value)}</span>`);
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		$GrandChild_withLoadAssets({ value: count });
 		_subscribe($count__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.debug.js
@@ -12,8 +12,8 @@ const $GrandChild_withLoadAssets = withLoadAssets(grand_child_default, "ready:__
 var child_default = _template("__tests__/child.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$GrandChild_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/child.marko", 0);
 });
@@ -23,8 +23,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ const $GrandChild_withLoadAssets = withLoadAssets(grand_child_default, "_b");
 var child_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$GrandChild_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 });
@@ -23,8 +23,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a");
 var template_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button class=parent>parent: <!>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button class=parent>parent: <!>${_escape(value)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1_content", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ value: count });
 		_subscribe($count__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	_try($scope0_id, "a", _content_resume("b1", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ value: count });
 		_subscribe($count__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.debug.js
@@ -12,8 +12,8 @@ const $Child_withLoadAssets$1 = withLoadAssets(child_default, "ready:__tests__/t
 var parent_a_default = _template("__tests__/tags/parent-a.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets$1({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/tags/parent-a.marko", 0);
 });
@@ -23,8 +23,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/tag
 var parent_b_default = _template("__tests__/tags/parent-b.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value * 2 });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/tags/parent-b.marko", 0);
 });
@@ -35,11 +35,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 1;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	parent_a_default({ value });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	parent_b_default({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.js
@@ -12,8 +12,8 @@ const $Child_withLoadAssets$1 = withLoadAssets(child_default, "_b");
 var parent_a_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets$1({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 });
@@ -23,8 +23,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_b");
 var parent_b_default = _template("d", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value * 2 });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 });
@@ -35,11 +35,11 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 1;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason(1);
 	parent_a_default({ value });
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	parent_b_default({ value });
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-auto/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-auto/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.debug.js
@@ -16,8 +16,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { b: _existing_scope($childScope) });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.debug.js
@@ -19,8 +19,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 3;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: count,
 		valueChange: _resume((_new_count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 3;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: count,
 		valueChange: _resume((_new_count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.debug.js
@@ -20,8 +20,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let initial = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		initial,
 		onValue: _resume(() => {}, "__tests__/template.marko_0/onValue")

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.js
@@ -16,8 +16,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let initial = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(6);
+	const $childScope = _peek_scope_id();
 	child_default({
 		initial,
 		onValue: _resume(() => {}, "a0")

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
@@ -31,8 +31,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let source = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: source,
 		valueChange: _resume((_new_source) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.js
@@ -25,8 +25,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let source = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({
 		value: source,
 		valueChange: _resume((_new_source) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
@@ -11,14 +11,14 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const B = { content: _content("__tests__/template.marko_2_content", ({ value }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		const $childScope = _peek_scope_id();
 		A.content({ value: value.length });
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "4:1");
 	}) };
 	let value = "";
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	B.content({ value });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope2) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
@@ -11,14 +11,14 @@ var template_default = _template("a", (input) => {
 	const B = { content: _content("a1", ({ value }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		const $childScope = _peek_scope_id();
 		A.content({ value: value.length });
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, { a: _existing_scope($childScope) });
 	}) };
 	let value = "";
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope2 = _peek_scope_id();
 	B.content({ value });
 	_script($scope0_id, "a2");
 	writeScope($scope0_id, { a: _existing_scope($childScope2) });

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
@@ -32,8 +32,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count1 = 0;
 	let count2 = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	_2counters_default({
 		count1,
 		count1Change: _resume((_new_count1) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.js
@@ -25,8 +25,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count1 = 0;
 	let count2 = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	_2counters_default({
 		count1,
 		count1Change: _resume((_new_count1) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, 0, $scope1_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "3:2");
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $item;
 	forUntil(size, 0, 1, (i) => {
@@ -27,6 +26,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			writeScope($scope3_id, {}, "__tests__/template.marko", "11:6");
 		}, $scope0_id) });
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({ item: $item });
 	_html(`<button>Add</button>${_el_resume($scope0_id, "#button/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
@@ -16,7 +16,6 @@ var template_default = _template("a", (input) => {
 		}, 0, $scope1_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}) };
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
 	let $item;
 	forUntil(size, 0, 1, (i) => {
@@ -27,6 +26,7 @@ var template_default = _template("a", (input) => {
 			writeScope($scope3_id, {});
 		}, $scope0_id) });
 	});
+	const $childScope = _peek_scope_id();
 	Child.content({ item: $item });
 	_html(`<button>Add</button>${_el_resume($scope0_id, "b")}`);
 	_script($scope0_id, "a3");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_html("<div");
 	_attrs_content(input.head, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	echo_default(input.head);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input_head");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ var my_box_default = _template("c", (input) => {
 	_html("<div");
 	_attrs_content(input.head, "a", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	echo_default(input.head);
 	_script($scope0_id, "c0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
@@ -15,8 +15,8 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_html("<div");
 	_attrs_content(input, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	echo_default(input);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.js
@@ -15,8 +15,8 @@ var my_box_default = _template("c", (input) => {
 	_html("<div");
 	_attrs_content(input, "a", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	echo_default(input);
 	_script($scope0_id, "c0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
@@ -17,8 +17,8 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+			const $childScope = _peek_scope_id();
 			render_input_default({ data: input });
 			writeScope($scope1_id, { "#childScope/0": _serialize_if($scope0_reason, 0) && _existing_scope($childScope) }, "__tests__/tags/my-box.marko", "8:4");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.debug.js
@@ -30,8 +30,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const output = _el($scope0_id, "__tests__/template.marko_0_#div");
 	_html(`<div></div>${_el_resume($scope0_id, "#div/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		foo: input.foo,
 		output

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.js
@@ -26,8 +26,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const output = _el($scope0_id, "a0");
 	_html(`<div></div>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		foo: input.foo,
 		output

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.debug.js
@@ -31,8 +31,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			item,
 			show,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.js
@@ -28,8 +28,8 @@ var template_default = _template("a", (input) => {
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(1);
+		const $childScope = _peek_scope_id();
 		child_default({
 			item,
 			show,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.debug.js
@@ -10,8 +10,8 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/wrap.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.js
@@ -10,8 +10,8 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { a: _existing_scope($childScope) });
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
@@ -19,11 +19,11 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1)
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.js
@@ -19,11 +19,11 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1)
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
@@ -19,11 +19,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const Wrap = { content: _content("__tests__/template.marko_2_content", ({ class: _class, ...rest }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason({
 			0: _serialize_guard($scope2_reason, 0),
 			1: _serialize_guard($scope2_reason, 1)
 		});
+		const $childScope = _peek_scope_id();
 		Child.content({
 			class: _class,
 			...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.js
@@ -19,11 +19,11 @@ var template_default = _template("a", (input) => {
 	({ content: _content("a2", ({ class: _class, ...rest }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason({
 			0: _serialize_guard($scope2_reason, 0),
 			1: _serialize_guard($scope2_reason, 1)
 		});
+		const $childScope = _peek_scope_id();
 		Child.content({
 			class: _class,
 			...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.debug.js
@@ -13,12 +13,12 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.js
@@ -13,12 +13,12 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),
 		2: _serialize_guard($scope0_reason, 2)
 	});
+	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.debug.js
@@ -10,14 +10,14 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		value: "override"
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope2 = _peek_scope_id();
 	child_default({
 		value: "default",
 		...input

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.js
@@ -10,14 +10,14 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		value: "override"
 	});
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope2 = _peek_scope_id();
 	child_default({
 		value: "default",
 		...input

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.debug.js
@@ -10,11 +10,11 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
+	_set_serialize_reason($sg__input_class__OR__input_value);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
 	child_default(input);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason($sg__input_class__OR__input_value);
+	const $childScope2 = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
 		"#childScope/0": _existing_scope($childScope),

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.js
@@ -10,11 +10,11 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
+	_set_serialize_reason($sg__input_class__OR__input_value);
 	const $childScope = _peek_scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
 	child_default(input);
-	const $childScope2 = _peek_scope_id();
 	_set_serialize_reason($sg__input_class__OR__input_value);
+	const $childScope2 = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {
 		a: _existing_scope($childScope),

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.debug.js
@@ -10,8 +10,8 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		...{ a: 1 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.js
@@ -10,8 +10,8 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		a: 1

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
@@ -11,8 +11,8 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		value,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
@@ -11,8 +11,8 @@ var wrap_default = _template("d", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		value,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
@@ -27,8 +27,8 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	}, _content_resume("__tests__/tags/wrap.marko_1_content", () => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+		const $childScope = _peek_scope_id();
 		child_default({ foo: input.foo });
 		_subscribe($si__input_foo && $input_foo__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),
@@ -52,12 +52,12 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input,
 		2: $sg__input,
 		3: $sg__input
 	});
+	const $childScope = _peek_scope_id();
 	wrap_default({
 		"data-one": 2,
 		"data-foo": 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.js
@@ -27,8 +27,8 @@ var wrap_default = _template("c", (input) => {
 	}, _content_resume("c0", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		const $childScope = _peek_scope_id();
 		_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+		const $childScope = _peek_scope_id();
 		child_default({ foo: input.foo });
 		_subscribe($si__input_foo && $input_foo__closures, writeScope($scope1_id, {
 			_: _scope_with_id($scope0_id),
@@ -48,12 +48,12 @@ var wrap_default = _template("c", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason({
 		0: $sg__input,
 		2: $sg__input,
 		3: $sg__input
 	});
+	const $childScope = _peek_scope_id();
 	wrap_default({
 		"data-one": 2,
 		"data-foo": 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.debug.js
@@ -11,8 +11,8 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		value,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.js
@@ -11,8 +11,8 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default({
 		value,
 		...rest

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.debug.js
@@ -10,8 +10,8 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/wrap.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.js
@@ -10,8 +10,8 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { a: _existing_scope($childScope) });
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.debug.js
@@ -17,8 +17,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		});
 	}) };
 	_html(`<button>Increment</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	Foo.content({
 		value: count,
 		content: _content_resume("__tests__/template.marko_1_content", (v) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
@@ -14,8 +14,8 @@ var template_default = _template("a", (input) => {
 		});
 	}) };
 	_html(`<button>Increment</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
 	Foo.content({
 		value: count,
 		content: _content_resume("a1", (v) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.debug.js
@@ -6,8 +6,8 @@ const $content = (input) => {
 	_if(() => {
 		if (input.depth) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason($sg__input_depth);
+			const $childScope = _peek_scope_id();
 			$content({ depth: input.depth - 1 });
 			$si__input_depth && writeScope($scope1_id, {
 				_: _scope_with_id($scope0_id),
@@ -27,8 +27,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 2;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	tree_default({ depth: n });
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.js
@@ -6,8 +6,8 @@ const $content = (input) => {
 	_if(() => {
 		if (input.depth) {
 			const $scope1_id = _scope_id();
-			const $childScope = _peek_scope_id();
 			_set_serialize_reason($sg__input_depth);
+			const $childScope = _peek_scope_id();
 			$content({ depth: input.depth - 1 });
 			$si__input_depth && writeScope($scope1_id, {
 				_: _scope_with_id($scope0_id),
@@ -27,8 +27,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 2;
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	tree_default({ depth: n });
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
@@ -32,8 +32,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		});
 	}) };
 	let x = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(26);
+	const $childScope = _peek_scope_id();
 	Wrap.content({
 		as: "div",
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
@@ -25,8 +25,8 @@ var template_default = _template("a", (input) => {
 		});
 	}) };
 	let x = 1;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(26);
+	const $childScope = _peek_scope_id();
 	Wrap.content({
 		as: "div",
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -66,6 +66,7 @@ export {
   _peek_scope_id,
   _resume,
   _resume_branch,
+  _resume_locals,
   _scope,
   _scope_id,
   _scope_reason,

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -175,6 +175,20 @@ export function _resume<T extends WeakKey>(
   );
 }
 
+// Registers a function closing over render-only locals (attr tag control flow
+// params), written into a dedicated scope with the section scope as its owner.
+export function _resume_locals<T extends WeakKey>(
+  val: T,
+  id: string,
+  locals: Record<string, unknown>,
+  ownerScopeId?: number,
+): T {
+  if (ownerScopeId !== undefined) {
+    locals[AccessorProp.Owner] = _scope_with_id(ownerScopeId);
+  }
+  return serializerRegister(id, val, writeScope(_scope_id(), locals));
+}
+
 export function _el(scopeId: number, id: string) {
   return _resume(() => _el_read_error(), id, scopeId);
 }

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -207,11 +207,18 @@ export function knownTagTranslateHTML(
 
   if (childScopeSerializeReason) {
     const peekScopeId = generateUidIdentifier(childScopeBinding?.name);
-    tag.insertBefore(
-      t.variableDeclaration("const", [
-        t.variableDeclarator(peekScopeId, callRuntime("_peek_scope_id")),
-      ]),
-    );
+    const peekScopeDeclaration = t.variableDeclaration("const", [
+      t.variableDeclarator(peekScopeId, callRuntime("_peek_scope_id")),
+    ]);
+    if (tagVar) {
+      // A tag variable renders the child from a declaration inserted before
+      // these statements, so the peek must precede it.
+      tag.insertBefore(peekScopeDeclaration);
+    } else {
+      // After the attr statements: building attribute tags can consume scope
+      // ids (eg `_resume_locals`), and the peek must see the child's root id.
+      statements.push(peekScopeDeclaration);
+    }
 
     setBindingSerializedValue(
       section,

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -5,7 +5,7 @@ import type { AccessorPrefix } from "../../common/accessor.debug";
 import { decodeAccessor } from "../../common/helpers";
 import { toAccess } from "../../html/serializer";
 import { finalizeFunctionRegistry } from "../visitors/function";
-import { scopeIdentifier } from "../visitors/program";
+import { localsIdentifier, scopeIdentifier } from "../visitors/program";
 import * as BindingType from "./constants/binding-type";
 import { forEachIdentifierPath } from "./for-each-identifier";
 import { generateUid } from "./generate-uid";
@@ -152,6 +152,8 @@ interface ExtraRead {
   props: Opt<string>;
   ownVar: boolean;
   getter: Getter | undefined;
+  /** Set for same-section local reads: the function root that owns the read. */
+  localFn?: ReferencedFunctionExtra;
 }
 
 declare module "@marko/compiler/dist/types" {
@@ -176,6 +178,7 @@ declare module "@marko/compiler/dist/types" {
   export interface FunctionExtra {
     referencesScope?: boolean;
     referencedBindingsInFunction?: ReferencedBindings;
+    referencedLocalBindingsInFunction?: Opt<Binding>;
     constantBindingsInFunction?: ReferencedBindings;
     name?: string;
     registerId?: string;
@@ -502,6 +505,21 @@ function trackReferencesForBinding(babelBinding: t.Binding, binding: Binding) {
       refSection !== binding.section
     ) {
       trackReference(ref, binding);
+    } else {
+      // Same-section local reads stay lexical unless their function root ends
+      // up registered (hoisted), so the read records that root for translate.
+      const fnRoot = getFnRoot(ref);
+      if (fnRoot) {
+        const fnExtra = (fnRoot.node.extra ??= {}) as ReferencedFunctionExtra;
+        fnExtra.referencedLocalBindingsInFunction = bindingUtil.add(
+          fnExtra.referencedLocalBindingsInFunction,
+          binding,
+        );
+        const refExtra = (ref.node.extra ??= {});
+        refExtra.section = refSection;
+        refExtra.read = createRead(binding, undefined);
+        refExtra.read.localFn = fnExtra;
+      }
     }
   }
 
@@ -1827,6 +1845,11 @@ export function getScopeAccessor(
   return canonicalBinding.scopeAccessor ?? canonicalBinding.name;
 }
 
+// Always includes the id so a debug accessor cannot collide with the owner key.
+export function getLocalsScopeAccessor(binding: Binding) {
+  return getScopeAccessor(binding, false, true);
+}
+
 // Value-coupled prefixes use reserved ids instead of prepending a letter;
 // other prefixes (and debug output) keep the letter scheme.
 export function getPrefixedScopeAccessor(
@@ -1967,6 +1990,20 @@ export function getReadReplacement(
       }
 
       if (isOutputDOM()) {
+        if (read.localFn) {
+          // A registered function receives its serialized locals scope; an
+          // inline one keeps the lexical reference (following renames).
+          if (isRegisteredFnExtra(read.localFn)) {
+            return toMemberExpression(
+              localsIdentifier,
+              getLocalsScopeAccessor(readBinding),
+            );
+          }
+          if (node.type === "Identifier" && node.name !== readBinding.name) {
+            node.name = readBinding.name;
+          }
+          return;
+        }
         const inlined = getSignals(extra.section!).get(readBinding)?.inline
           ?.value;
         if (inlined) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -7,7 +7,7 @@ import {
 
 import { type AccessorPrefix, AccessorProp } from "../../common/types";
 import { getSectionReturnValueIdentifier } from "../core/return";
-import { scopeIdentifier } from "../visitors/program";
+import { localsIdentifier, scopeIdentifier } from "../visitors/program";
 import { forEachIdentifier } from "./for-each-identifier";
 import { isForSelectorValue } from "./for-selector";
 import { generateUid, generateUidIdentifier } from "./generate-uid";
@@ -29,6 +29,7 @@ import {
   getDebugScopeAccess,
   getPrefixedScopeAccessor,
   getReadReplacement,
+  getLocalsScopeAccessor,
   getScopeAccessor,
   getScopeAccessorLiteral,
   getSectionInstancesAccessorLiteral,
@@ -1111,11 +1112,37 @@ export function writeRegisteredFns() {
   if (registeredFns) {
     for (const registeredFn of registeredFns) {
       let fn: t.FunctionDeclaration;
-      if (registeredFn.referencedBindings || registeredFn.referencesScope) {
+      if (
+        registeredFn.referencedBindings ||
+        registeredFn.referencesScope ||
+        registeredFn.referencedLocals
+      ) {
+        let params: (t.Identifier | t.Pattern)[];
+        let prologue: t.Statement[] | undefined;
+        if (registeredFn.referencedLocals) {
+          // The scope hop stays inside the returned function: resume may call
+          // the factory before its scopes hydrate (stubs fill in place).
+          params = [localsIdentifier];
+          if (registeredFn.referencedBindings || registeredFn.referencesScope) {
+            prologue = [
+              t.variableDeclaration("const", [
+                t.variableDeclarator(
+                  scopeIdentifier,
+                  t.memberExpression(
+                    localsIdentifier,
+                    t.identifier(getAccessorProp().Owner),
+                  ),
+                ),
+              ]),
+            ];
+          }
+        } else {
+          params = [scopeIdentifier];
+        }
         fn = t.functionDeclaration(
           t.identifier(registeredFn.id),
-          [scopeIdentifier],
-          t.blockStatement(toReturnedFunction(registeredFn.node)),
+          params,
+          t.blockStatement(toReturnedFunction(registeredFn.node, prologue)),
         );
       } else if (
         registeredFn.node.type === "FunctionDeclaration" &&
@@ -1153,8 +1180,14 @@ export function writeRegisteredFns() {
   }
 }
 
-function toReturnedFunction(rawFn: t.Function) {
+function toReturnedFunction(rawFn: t.Function, prologue?: t.Statement[]) {
   const fn = simplifyFunction(rawFn);
+  if (prologue) {
+    if (fn.body.type !== "BlockStatement") {
+      fn.body = t.blockStatement([t.returnStatement(fn.body)]);
+    }
+    fn.body.body.unshift(...prologue);
+  }
   return fn.type === "FunctionDeclaration"
     ? [fn, t.returnStatement(fn.id!)]
     : [t.returnStatement(fn)];
@@ -1668,6 +1701,7 @@ const registeredFnsForProgram = new WeakMap<
     section: Section;
     referencesScope: undefined | boolean;
     referencedBindings: ReferencedBindings;
+    referencedLocals: Opt<Binding>;
   }[]
 >();
 export function replaceRegisteredFunctionNode(node: t.Node) {
@@ -1706,6 +1740,7 @@ function getRegisteredFnExpression(node: t.Function) {
     const id = extra.name;
     const referencesScope = extra.referencesScope;
     const referencedBindings = extra.referencedBindingsInFunction;
+    const referencedLocals = extra.referencedLocalBindingsInFunction;
     let registeredFns = registeredFnsForProgram.get(getProgram().node);
     if (!registeredFns) {
       registeredFnsForProgram.set(getProgram().node, (registeredFns = []));
@@ -1718,9 +1753,32 @@ function getRegisteredFnExpression(node: t.Function) {
       section: extra.section,
       referencesScope,
       referencedBindings,
+      referencedLocals,
     });
 
-    if (referencesScope || referencedBindings) {
+    if (referencedLocals) {
+      // The argument mirrors the locals scope `_resume_locals` serializes.
+      const properties: t.ObjectExpression["properties"] = [];
+      if (referencesScope || referencedBindings) {
+        properties.push(
+          t.objectProperty(
+            t.identifier(getAccessorProp().Owner),
+            scopeIdentifier,
+          ),
+        );
+      }
+      forEach(referencedLocals, (binding) => {
+        properties.push(
+          toObjectProperty(
+            getLocalsScopeAccessor(binding),
+            getDeclaredBindingExpression(binding),
+          ),
+        );
+      });
+      return t.callExpression(t.identifier(id), [
+        t.objectExpression(properties),
+      ]);
+    } else if (referencesScope || referencedBindings) {
       return t.callExpression(t.identifier(id), [scopeIdentifier]);
     } else {
       return t.identifier(id);

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -5,12 +5,14 @@ import {
   getSharedUid,
   usedSharedUid,
 } from "../../util/generate-uid";
+import { getDeclaredBindingExpression } from "../../util/get-declared-binding-expression";
 import isStatic from "../../util/is-static";
 import { getMarkoOpts } from "../../util/marko-config";
 import { forEach } from "../../util/optional";
 import {
   BindingType,
   getReadReplacement,
+  getLocalsScopeAccessor,
   getSectionInstancesAccessor,
   isRegisteredFnExtra,
 } from "../../util/references";
@@ -32,6 +34,7 @@ import {
   writeHTMLResumeStatements,
 } from "../../util/signals";
 import { simplifyFunction } from "../../util/simplify-fn";
+import { toObjectProperty } from "../../util/to-property-name";
 import { traverseReplace } from "../../util/traverse";
 import type { TemplateVisitor } from "../../util/visitors";
 import { flushInto } from "../../util/writer";
@@ -307,6 +310,31 @@ function getRegisteredFnExpression(
 ) {
   const { extra } = node;
   if (isRegisteredFnExtra(extra)) {
+    const referencedLocals = extra.referencedLocalBindingsInFunction;
+    if (referencedLocals) {
+      // Locals only exist while this render runs, so they're written into a
+      // dedicated scope the client reads them back out of on resume.
+      const localProperties: t.ObjectExpression["properties"] = [];
+      forEach(referencedLocals, (binding) => {
+        localProperties.push(
+          toObjectProperty(
+            getLocalsScopeAccessor(binding),
+            getDeclaredBindingExpression(binding),
+          ),
+        );
+      });
+      return callRuntime(
+        "_resume_locals",
+        simplifyFunction(node) as
+          | t.FunctionExpression
+          | t.ArrowFunctionExpression,
+        t.stringLiteral(extra.registerId),
+        t.objectExpression(localProperties),
+        (extra.referencedBindingsInFunction || extra.referencesScope) &&
+          getScopeIdIdentifier(extra.section),
+      );
+    }
+
     return callRuntime(
       "_resume",
       simplifyFunction(node) as

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -35,6 +35,7 @@ import programHTML from "./html";
 import { preAnalyze } from "./pre-analyze";
 
 export let scopeIdentifier: t.Identifier;
+export let localsIdentifier: t.Identifier;
 export function isScopeIdentifier(node: t.Node): node is t.Identifier {
   return node === scopeIdentifier;
 }
@@ -115,6 +116,9 @@ export default {
     enter(program) {
       scopeIdentifier = isOutputDOM()
         ? generateUidIdentifier("scope")
+        : (null as any as t.Identifier);
+      localsIdentifier = isOutputDOM()
+        ? generateUidIdentifier("locals")
         : (null as any as t.Identifier);
       {
         const markoOpts = getMarkoOpts();


### PR DESCRIPTION
Event handlers (and other resume-registered functions) on attribute tags inside a `<for>` were hoisted to module scope with dangling references to the loop params — a ReferenceError on click in CSR and after resume:

```marko
<my-menu>
  <for|foo| of=["Foo"]>
    <@item onClick() { console.log(foo) }>Click</@item>
  </for>
</my-menu>
```

Same-section local reads inside function roots are now tracked; when the function registers, they translate to member reads on a locals scope the function receives (`$onClick({ _: $scope, e: foo })` in CSR), and on the server `_resume_locals` writes that scope per instance so resume reconstructs the closure. Local values that can't change per closure instance are carried directly; everything else still reads through the section scope (linked as the locals scope's owner). The custom-tag child-scope peek moves after the attribute statements since building them can now consume scope ids.

Fixtures cover the handler + state case, a locals-only handler, and a param shadowing a `<let>` (binding rename).