### PR TITLE
Publish internal/babel as ESM, matching what it ships

### DIFF
--- a/.changeset/internal-babel-module-type.md
+++ b/.changeset/internal-babel-module-type.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Stop publishing `internal/babel` as `"type": "commonjs"`. The directory ships only the ESM `index.ts` that `exports["./internal/babel"].types` points at, so the CommonJS marker made TypeScript reject it under `verbatimModuleSyntax` with `TS1295: ECMAScript imports and exports cannot be written in a CommonJS file`.

--- a/packages/compiler/internal/babel/package.json
+++ b/packages/compiler/internal/babel/package.json
@@ -2,6 +2,5 @@
   "type": "module",
   "main": "index.ts",
   "types": "index.ts",
-  "main:override": "../../dist/babel.js",
-  "type:override": "commonjs"
+  "main:override": "../../dist/babel.js"
 }


### PR DESCRIPTION
`@marko/compiler@5.41.5` and `5.41.6` publish `internal/babel/package.json` with `"type": "commonjs"`, which breaks `tsc` for consumers:

```
node_modules/@marko/compiler/internal/babel/index.ts(8,10):
error TS1295: ECMAScript imports and exports cannot be written in a CommonJS file
under 'verbatimModuleSyntax'.
```

That directory ships nothing executable — only `index.ts`, `modules.d.ts` and its `package.json` — and `exports["./internal/babel"].types` points straight at the ESM `index.ts`. The runtime entry resolves to `dist/babel.js`, which sits under the package root and takes its module type from there, so the CommonJS marker never governed it. The only thing that reads it is TypeScript, deciding the module kind of `index.ts`.

5.41.4 published no `type` field and was unaffected; the `type:override` was added alongside the native type-stripping work. Dropping it restores a correct `"type": "module"`, matching the file it describes.

Verified: a simulated `pkg-override` publish ships `"type": "module"`; `require("@marko/compiler/internal/babel")` still resolves to `dist/babel.js` and returns the babel namespace; suite 9683 passing. Against a packed tarball the full `marko-js/language-server` build goes from failing to **0 TypeScript errors** across all five packages — that repo's CI is currently red on 5.41.6 (marko-js/language-server#577).
