### PR TITLE
fix(runtime-tags): emit one walk step for static text split by a non-rendering tag

### DIFF
--- a/.changeset/static-text-split-walk-step.md
+++ b/.changeset/static-text-split-walk-step.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Emit one walk step for a run of static text split by a sibling that renders nothing. Adjacent static text merges into a single DOM text node even when a `<const>`, `<let>`, `<script>`, `<lifecycle>`, scriptlet, or import sits between the two runs, but each run still claimed its own step, so every accessor after that point in the section was off by one sibling. A client render then bound to the wrong node, which surfaced as a `TypeError` on the first event handler attach rather than as visibly wrong output.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1194,37 +1194,6 @@ without `${""}`; the walk comments differ (`next(1), over(1), replace, out(1)`
 vs `next(1), get, out(1)`) even though the DOM the two describe is the same
 shape.
 
-## Skip non-rendering siblings in `getPrevStaticSibling` so a split static-text run emits one walk step, not two
-
-`packages/runtime-tags/src/translator/util/static-text.ts` › `getPrevStaticSibling` | 2026-07-23 | impact:high | effort:low
-
-Adjacent static text merges into a single DOM text node in the generated
-template string even when a sibling that renders nothing sits between the two
-runs (`<const>`, `<let>`, `<script>`, `<lifecycle>`, `<effect>`, a top-level
-`static` scriptlet, an `import`/`export`). But `getPrevStaticSibling` only walks
-past `MarkoComment` and confidently-void placeholders, so
-`isStaticText(getPrevStaticSibling(...))` is false for the second run and
-neither `visitors/text.ts` (analyze, `kSharedText`) nor
-`visitors/placeholder.ts` (analyze, `isStaticText(node)` branch) defers its walk
-step — each run calls `walks.enterShallow`, producing `over(2)` for one text
-node. Every accessor claimed after that point in the section is off by one
-sibling, so DOM refs and event bindings attach to the wrong node (silently in
-optimize, where accessors are numeric). Fix direction: make the skip predicate
-"emits no DOM node" — `getNodeContentType(prev, "endType") === null` from
-`util/sections.ts` already returns null for scriptlets, comments, import/export
-and every non-rendering core tag (`placeholder.ts`'s own `analyzeSiblingText`
-already uses it and is therefore correct) — while keeping the existing
-void-placeholder skip. Re-verify: add a fixture whose `template.marko` is
-`<let/n=1/>` + `<div>` Hello / `<const/m=n*2/>` / World / `<button onClick(){ n =
-n + m }>click</button>` / `<span>${n}</span>` `</div>` with `steps: [{}, click]`
-— the `csr` test throws `TypeError: Cannot read properties of undefined (reading
-'$click')` from `_on`, because the extra `over` consumed the `<button>` and
-`$scope["#button/0"]` is never populated (`ssr`/`html`/`dom` all pass, so this is
-CSR-only). Compiling the same template with `pnpm run compile -o dom -d` shows
-`$walks` = `next(1), over(2), get, over(1), next(1), get, out(2)` over a
-`$template` holding a single `Hello  World ` text node; deleting only the
-`<const>` line yields the same node shape with `over(1)`.
-
 ## Strip the `load` import attribute from HTML output — it is emitted verbatim and Node rejects it
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<div>Hello  World <button>click</button><span> </span></div>";
+const $walks = "Db bD m";
+const $m = /*@__PURE__*/ _const("m");
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => {
+	_text($scope["#text/1"], $scope.n);
+	$m($scope, $scope.n * 2);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + $scope.m);
+}));
+function $setup($scope) {
+	$n($scope, 1);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $m = /*@__PURE__*/ _const(3);
+const $n = /*@__PURE__*/ _let(2, ($scope) => {
+	_text($scope.b, $scope.c);
+	$m($scope, $scope.c * 2);
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, $scope.c + $scope.d);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 1;
+	const m = n * 2;
+	_html(`<div>Hello  World <button>click</button>${_el_resume($scope0_id, "#button/0")}<span>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</span></div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		n,
+		m
+	}, "__tests__/template.marko", 0, {
+		n: "1:6",
+		m: "4:10"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/html.bundle.js
@@ -1,0 +1,14 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 1;
+	const m = n * 2;
+	_html(`<div>Hello  World <button>click</button>${_el_resume($scope0_id, "a")}<span>${_escape(n)}${_el_resume($scope0_id, "b")}</span></div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: n,
+		d: m
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/render.debug.md
@@ -1,0 +1,32 @@
+# Render
+```html
+<div>
+  Hello  World 
+  <button>
+    click
+  </button>
+  <span>
+    1
+  </span>
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div>
+  Hello  World 
+  <button>
+    click
+  </button>
+  <span>
+    3
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: div > span::text "1" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/render.md
@@ -1,0 +1,32 @@
+# Render
+```html
+<div>
+  Hello  World 
+  <button>
+    click
+  </button>
+  <span>
+    1
+  </span>
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div>
+  Hello  World 
+  <button>
+    click
+  </button>
+  <span>
+    3
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: div > span::text "1" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<div>Hello World
+  <button>click</button><!--M_*1 #button/0--><span>1<!--M_*1 #text/1--></span>
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 1,
+      m: 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<div>Hello World <button>click</button><!--M_*1 a--><span>1<!--M_*1 b--></span>
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 1,
+    d: 2
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2706,
+      "brotli": 1353
+    }
+  },
+  "html": {
+    "min": 398,
+    "brotli": 263
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/template.marko
@@ -1,0 +1,8 @@
+<let/n=1/>
+<div>
+  Hello
+  <const/m=n*2/>
+  World
+  <button onClick(){ n = n + m }>click</button>
+  <span>${n}</span>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/util/static-text.ts
+++ b/packages/runtime-tags/src/translator/util/static-text.ts
@@ -2,6 +2,7 @@ import { types as t } from "@marko/compiler";
 
 import { isNotVoid, isVoid } from "../../common/helpers";
 import evaluate from "./evaluate";
+import { getNodeContentType } from "./sections";
 
 // A run of adjacent static text (literal `MarkoText` and confident non-void escaped
 // `${...}`) becomes one DOM text node; only the node starting a run emits a walk step.
@@ -21,9 +22,11 @@ export function isStaticText(node?: t.Node) {
 
 export function getPrevStaticSibling(path: t.NodePath) {
   let prev = path.getPrevSibling();
+  // A sibling that renders no node does not break the run, so the text on both
+  // sides still merges into one node and must emit only one walk step.
   while (
     prev.node &&
-    (prev.isMarkoComment() ||
+    (getNodeContentType(prev as t.NodePath<t.Statement>, "endType") === null ||
       (prev.isMarkoPlaceholder() && isEmptyPlaceholder(prev.node)))
   ) {
     prev = prev.getPrevSibling();


### PR DESCRIPTION
Adjacent static text merges into a single DOM text node even when a sibling that renders nothing sits between the two runs, but `getPrevStaticSibling` only walked past comments and void placeholders. Each run therefore claimed its own walk step, so this emitted `over(2)` for one text node:

```marko
<div>Hello <const/m=n*2/> World <button onClick(){ n = n + m }>click</button></div>
```

Every accessor after that point in the section landed a sibling early, so the button binding resolved to `undefined` and CSR threw on mount while SSR rendered fine.

Skips on `getNodeContentType(prev, "endType") === null`, the predicate `analyzeSiblingText` already uses for the same question, so scriptlets, imports, and every non-rendering core tag are covered. A real element still breaks the run. No existing snapshot changed, which is why this went unnoticed.