### PR TITLE
test(runtime-class): order the out-of-order await fixtures by ticks

### DIFF
--- a/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order-after/template.marko
+++ b/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order-after/template.marko
@@ -1,9 +1,9 @@
 ---
 BEFORE-OUT-OF-ORDER
-<await(new Promise(r => setTimeout(r, 20))) name="a" client-reorder>
+<await(data.ticks(1)) name="a" client-reorder>
     <@then>
         BEFORE-IN-ORDER
-        <await(new Promise(r => setTimeout(r, 20))) name="b">
+        <await(data.ticks(1)) name="b">
             <@then>INSIDE-IN-ORDER</>
         </>
         <await(Promise.resolve()) name="c" client-reorder>
@@ -12,7 +12,7 @@ BEFORE-OUT-OF-ORDER
         AFTER-IN-ORDER
     </>
 </>
-<await(new Promise(r => setTimeout(r, 60))) name="d">
+<await(data.ticks(6)) name="d">
     <@then>BEFORE-AFTER-OUT-OF-ORDER</>
 </>
 AFTER-OUT-OF-ORDER

--- a/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order-after/test.js
+++ b/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order-after/test.js
@@ -1,7 +1,13 @@
-const { callbackProvider } = require("../../../__util__/async-helpers");
+const {
+  callbackProvider,
+  promiseProvider,
+} = require("../../../__util__/async-helpers");
 
 exports.templateData = {
   testDataProvider: callbackProvider(1, { name: "Frank" }),
+  // Ordering is by immediate-tick count rather than wall clock so that a loaded
+  // machine cannot reorder the out-of-order flush against the in-order `d`.
+  ticks: promiseProvider,
 };
 
 exports.skip_vdom = "client-reorder/placeholders are not supported in vdom";

--- a/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order/template.marko
+++ b/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order/template.marko
@@ -1,9 +1,9 @@
 ---
 BEFORE-OUT-OF-ORDER
-<await(new Promise(r => setTimeout(r, 20))) name="a" client-reorder>
+<await(data.ticks(1)) name="a" client-reorder>
     <@then>
         BEFORE-IN-ORDER
-        <await(new Promise(r => setTimeout(r, 20))) name="b">
+        <await(data.ticks(1)) name="b">
             <@then>INSIDE-IN-ORDER</>
         </>
         <await(Promise.resolve()) name="c" client-reorder>

--- a/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order/test.js
+++ b/packages/runtime-class/test/render/fixtures-async-callback/await-out-of-order-with-in-order/test.js
@@ -1,7 +1,13 @@
-const { callbackProvider } = require("../../../__util__/async-helpers");
+const {
+  callbackProvider,
+  promiseProvider,
+} = require("../../../__util__/async-helpers");
 
 exports.templateData = {
   testDataProvider: callbackProvider(1, { name: "Frank" }),
+  // Ordering is by immediate-tick count rather than wall clock so that a loaded
+  // machine cannot reorder the nested out-of-order flush.
+  ticks: promiseProvider,
 };
 
 exports.skip_vdom = "client-reorder/placeholders are not supported in vdom";


### PR DESCRIPTION
`await-out-of-order-with-in-order-after` asserted an ordering that hinged on a 20ms wall-clock margin: the `client-reorder` awaits `a` and `b` at 20ms each against the in-order `d` at 60ms. Under load the 20ms timers drift past `d`, and the `afc` div carrying `NESTED-OUT-OF-ORDER` moves relative to the reorder `<script>`. Raising just those two timers to 40ms reproduces the CI diff exactly. It has failed `test: node@24` on runs 30143056340 (main) and 30160587063.

Both fixtures now build their promises from `promiseProvider`, the existing helper that resolves after a count of `setImmediate` ticks, so the relative order is fixed by tick count rather than elapsed time. These were the only two templates in the suite using `setTimeout`. `expected.html` is unchanged in both, so the asserted output is identical.
