### PR TITLE
fix(runtime-tags): keep controllable slots a spread does not own

### DIFF
--- a/.changeset/spread-controllable-slots.md
+++ b/.changeset/spread-controllable-slots.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Keep two-way bindings alive when a controllable is declared as a static attribute next to a spread, both at client-render mount and whenever the spread re-runs.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26418,
-        "brotli": 9835
+        "min": 26420,
+        "brotli": 9814
       }
     },
     {
@@ -19,11 +19,11 @@
       },
       "runtime": {
         "min": 3904,
-        "brotli": 1735
+        "brotli": 1733
       },
       "total": {
         "min": 4065,
-        "brotli": 1854
+        "brotli": 1852
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6430,
-        "brotli": 2833
+        "min": 6429,
+        "brotli": 2826
       },
       "total": {
-        "min": 7075,
-        "brotli": 3197
+        "min": 7074,
+        "brotli": 3190
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6430 (min) 2833 (brotli)
+// size: 6429 (min) 2826 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -48,9 +48,9 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         walker.nextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
-  cloneCache = {},
   registeredValues = {},
   branchesEnabled,
+  cloneCache = {},
   _for_of = /* @__PURE__ */ loop(([all, by = bySecondArg], cb) => {
     typeof by == "string"
       ? forOf(all, (item, i) => cb(item[by], [item, i]))
@@ -195,6 +195,12 @@ function _script(id, fn) {
 function walk(startNode, walkCodes, branch) {
   ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
+function enableBranches() {
+  branchesEnabled || ((branchesEnabled = 1), skipDestroyedRenders());
+}
+function _resume(id, obj) {
+  return (registeredValues[id] = obj);
+}
 function createBranch($global, renderer, parentScope, parentNode) {
   let branch = createScope($global);
   return (
@@ -251,12 +257,6 @@ function createCloneableHTML(html, ns) {
             (branch.K = clone.lastChild));
         }
   );
-}
-function enableBranches() {
-  branchesEnabled || ((branchesEnabled = 1), skipDestroyedRenders());
-}
-function _resume(id, obj) {
-  return (registeredValues[id] = obj);
 }
 function _to_text(value) {
   return value || value === 0 ? value + "" : "";

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 3904 (min) 1735 (brotli)
+// size: 3904 (min) 1733 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -48,8 +48,8 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         walker.nextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
-  cloneCache = {},
   registeredValues = {},
+  cloneCache = {},
   rendering,
   runId = 2,
   pendingEffects = [],
@@ -133,6 +133,9 @@ function _script(id, fn) {
 function walk(startNode, walkCodes, branch) {
   ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
+function _resume(id, obj) {
+  return (registeredValues[id] = obj);
+}
 function createBranch($global, renderer, parentScope, parentNode) {
   let branch = createScope($global);
   return (
@@ -183,9 +186,6 @@ function createCloneableHTML(html, ns) {
             (branch.K = clone.lastChild));
         }
   );
-}
-function _resume(id, obj) {
-  return (registeredValues[id] = obj);
 }
 function _to_text(value) {
   return value || value === 0 ? value + "" : "";

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26418 (min) 9835 (brotli)
+// size: 26420 (min) 9814 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -22,7 +22,6 @@ let empty = [],
   decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
     (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
-  R = /[^\p{L}\p{N}]/gu,
   parsers = {},
   nextScopeId = 1e6,
   collectingScopes,
@@ -71,13 +70,14 @@ let empty = [],
         walker.nextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
-  cloneCache = {},
   registeredValues = {},
   curRenders,
   branchesEnabled,
   embedRenders,
   readyIds,
   isResuming,
+  cloneCache = {},
+  R = /[^\p{L}\p{N}]/gu,
   inputType = "",
   controllableScripts = {},
   controllableRenders = {},
@@ -130,6 +130,7 @@ let empty = [],
               childScope,
               "a",
               (inputIsArgs ? args[0] : args) || {},
+              controllableRenders[childScope.a.tagName],
             ),
               (childScope.Ia || childScope.Ea) && queueEffect(childScope, dynamicTagScript));
           else {
@@ -378,22 +379,6 @@ function handleDelegated(ev) {
   for (; target;)
     (target["$" + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
-}
-function resolveCursorPosition(inputType, initialPosition, initialValue, updatedValue) {
-  if (
-    (initialPosition || initialPosition === 0) &&
-    (initialPosition !== initialValue.length || /kw/.test(inputType))
-  ) {
-    let before = initialValue.slice(0, initialPosition),
-      after = initialValue.slice(initialPosition);
-    if (updatedValue.startsWith(before)) return initialPosition;
-    if (updatedValue.endsWith(after)) return updatedValue.length - after.length;
-    let count = before.replace(R, "").length,
-      pos = 0;
-    for (; count && updatedValue[pos];) updatedValue[pos++].replace(R, "") && count--;
-    return pos;
-  }
-  return -1;
 }
 function parseHTML(html, ns) {
   let parser = (parsers[ns] ||= document.createElementNS(ns, "template"));
@@ -678,74 +663,6 @@ function _hoist_resume(id, ...path) {
 function walk(startNode, walkCodes, branch) {
   ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
-function createBranch($global, renderer, parentScope, parentNode) {
-  let branch = createScope($global);
-  return (
-    (branch._ = renderer.e || parentScope),
-    setParentBranch(branch, parentScope?.F),
-    renderer.b?.(branch, parentNode.namespaceURI),
-    branch
-  );
-}
-function setParentBranch(branch, parentBranch) {
-  (parentBranch &&
-    ((branch.N = parentBranch), (parentBranch.D ||= /* @__PURE__ */ new Set()).add(branch)),
-    (branch.F = branch));
-}
-function createAndSetupBranch($global, renderer, parentScope, parentNode) {
-  return setupBranch(renderer, createBranch($global, renderer, parentScope, parentNode));
-}
-function setupBranch(renderer, branch) {
-  return (renderer.c && queueRender(branch, renderer.c, -1), branch);
-}
-function _content(id, template, walks, setup, params, dynamicScopesAccessor) {
-  ((walks = walks ? walks.replace(/[^\0-1]+$/, "") : ""),
-    (setup = setup ? setup._ || setup : void 0),
-    (params ||= void 0));
-  let clone = template
-    ? (branch, ns) => {
-        ((cloneCache[ns] ||= {})[template] ||= createCloneableHTML(template, ns))(branch, walks);
-      }
-    : (branch) => {
-        walk((branch.S = branch.K = new Text()), walks, branch);
-      };
-  return (owner) => ({
-    a: id,
-    b: clone,
-    e: owner,
-    c: setup,
-    d: params,
-    f: dynamicScopesAccessor,
-  });
-}
-function _content_resume(id, template, walks, setup, params, dynamicScopesAccessor) {
-  return _resume(id, _content(id, template, walks, setup, params, dynamicScopesAccessor));
-}
-function _content_closures(renderer, closureFns) {
-  let closureSignals = {};
-  for (let key in closureFns) closureSignals[key] = _const(+key, closureFns[key]);
-  return (owner, closureValues) => {
-    let instance = renderer(owner);
-    return ((instance.g = closureSignals), (instance.h = closureValues), instance);
-  };
-}
-function createCloneableHTML(html, ns) {
-  let { firstChild, lastChild } = parseHTML(html, ns),
-    parent = document.createElementNS(ns, "t");
-  return (
-    insertChildNodes(parent, null, firstChild, lastChild),
-    firstChild === lastChild && firstChild.nodeType < 8
-      ? (branch, walks) => {
-          walk((branch.S = branch.K = firstChild.cloneNode(!0)), walks, branch);
-        }
-      : (branch, walks) => {
-          let clone = parent.cloneNode(!0);
-          (walk(clone.firstChild, walks, branch),
-            (branch.S = clone.firstChild),
-            (branch.K = clone.lastChild));
-        }
-  );
-}
 function enableBranches() {
   branchesEnabled || ((branchesEnabled = 1), skipDestroyedRenders());
 }
@@ -1009,6 +926,272 @@ function _var_resume(id, signal) {
 }
 function _el(id, accessor) {
   return ((accessor = decodeAccessor(accessor)), _resume(id, (scope) => () => scope[accessor]));
+}
+function createBranch($global, renderer, parentScope, parentNode) {
+  let branch = createScope($global);
+  return (
+    (branch._ = renderer.e || parentScope),
+    setParentBranch(branch, parentScope?.F),
+    renderer.b?.(branch, parentNode.namespaceURI),
+    branch
+  );
+}
+function setParentBranch(branch, parentBranch) {
+  (parentBranch &&
+    ((branch.N = parentBranch), (parentBranch.D ||= /* @__PURE__ */ new Set()).add(branch)),
+    (branch.F = branch));
+}
+function createAndSetupBranch($global, renderer, parentScope, parentNode) {
+  return setupBranch(renderer, createBranch($global, renderer, parentScope, parentNode));
+}
+function setupBranch(renderer, branch) {
+  return (renderer.c && queueRender(branch, renderer.c, -1), branch);
+}
+function _content(id, template, walks, setup, params, dynamicScopesAccessor) {
+  ((walks = walks ? walks.replace(/[^\0-1]+$/, "") : ""),
+    (setup = setup ? setup._ || setup : void 0),
+    (params ||= void 0));
+  let clone = template
+    ? (branch, ns) => {
+        ((cloneCache[ns] ||= {})[template] ||= createCloneableHTML(template, ns))(branch, walks);
+      }
+    : (branch) => {
+        walk((branch.S = branch.K = new Text()), walks, branch);
+      };
+  return (owner) => ({
+    a: id,
+    b: clone,
+    e: owner,
+    c: setup,
+    d: params,
+    f: dynamicScopesAccessor,
+  });
+}
+function _content_resume(id, template, walks, setup, params, dynamicScopesAccessor) {
+  return _resume(id, _content(id, template, walks, setup, params, dynamicScopesAccessor));
+}
+function _content_closures(renderer, closureFns) {
+  let closureSignals = {};
+  for (let key in closureFns) closureSignals[key] = _const(+key, closureFns[key]);
+  return (owner, closureValues) => {
+    let instance = renderer(owner);
+    return ((instance.g = closureSignals), (instance.h = closureValues), instance);
+  };
+}
+function createCloneableHTML(html, ns) {
+  let { firstChild, lastChild } = parseHTML(html, ns),
+    parent = document.createElementNS(ns, "t");
+  return (
+    insertChildNodes(parent, null, firstChild, lastChild),
+    firstChild === lastChild && firstChild.nodeType < 8
+      ? (branch, walks) => {
+          walk((branch.S = branch.K = firstChild.cloneNode(!0)), walks, branch);
+        }
+      : (branch, walks) => {
+          let clone = parent.cloneNode(!0);
+          (walk(clone.firstChild, walks, branch),
+            (branch.S = clone.firstChild),
+            (branch.K = clone.lastChild));
+        }
+  );
+}
+function _to_text(value) {
+  return value || value === 0 ? value + "" : "";
+}
+function _attr(element, name, value) {
+  setAttribute(element, name, normalizeAttrValue(value));
+}
+function setAttribute(element, name, value) {
+  element.getAttribute(name) != value &&
+    (value === void 0 ? element.removeAttribute(name) : element.setAttribute(name, value));
+}
+function _attr_class(element, value) {
+  setAttribute(element, "class", toDelimitedString(value, " ", stringifyClassObject) || void 0);
+}
+function _attr_class_items(element, items) {
+  for (let key in items) _attr_class_item(element, key, items[key]);
+}
+function _attr_class_item(element, name, value) {
+  element.classList.toggle(name, !!value);
+}
+function _attr_style(element, value) {
+  setAttribute(element, "style", toDelimitedString(value, ";", stringifyStyleObject) || void 0);
+}
+function _attr_style_items(element, items) {
+  for (let key in items) _attr_style_item(element, key, items[key]);
+}
+function _attr_style_item(element, name, value) {
+  element.style.setProperty(name, _to_text(value));
+}
+function _style_shell(scope, nodeAccessor) {
+  let element = scope[nodeAccessor],
+    id = _id(scope);
+  (_attr_nonce(scope, nodeAccessor),
+    (element.className = id),
+    _text_content(element, "." + id + "~*{}"));
+}
+function _style_rule_item(element, name, value) {
+  let text = element.textContent,
+    decl = name + ":" + escapeStyleValue(_to_text(value)) + ";",
+    start = text.indexOf("{" + name + ":");
+  (~start || (start = text.indexOf(";" + name + ":")),
+    _text_content(
+      element,
+      ~start
+        ? text.slice(0, ++start) + decl + text.slice(text.indexOf(";", start) + 1)
+        : text.slice(0, -1) + decl + "}",
+    ));
+}
+function _attr_nonce(scope, nodeAccessor) {
+  _attr(scope[nodeAccessor], "nonce", scope.$.cspNonce);
+}
+function _text(node, value) {
+  let normalizedValue = _to_text(value);
+  node.data !== normalizedValue && (node.data = normalizedValue);
+}
+function _text_content(node, value) {
+  let normalizedValue = _to_text(value);
+  node.textContent !== normalizedValue && (node.textContent = normalizedValue);
+}
+function _attrs(scope, nodeAccessor, nextAttrs, controllable) {
+  let el = scope[nodeAccessor];
+  for (let i = el.attributes.length; i--;) {
+    let { name } = el.attributes.item(i);
+    (nextAttrs && (name in nextAttrs || hasAttrAlias(el, name, nextAttrs))) ||
+      el.removeAttribute(name);
+  }
+  attrsInternal(scope, nodeAccessor, nextAttrs, controllable);
+}
+function _attrs_content(scope, nodeAccessor, nextAttrs, controllable) {
+  (_attrs(scope, nodeAccessor, nextAttrs, controllable),
+    _attr_content(scope, nodeAccessor, nextAttrs?.content));
+}
+function hasAttrAlias(element, attr, nextAttrs) {
+  return attr === "checked" && element.tagName === "INPUT" && "checkedValue" in nextAttrs;
+}
+function _attrs_partial(scope, nodeAccessor, nextAttrs, skip, controllable) {
+  let el = scope[nodeAccessor],
+    partial = {};
+  for (let i = el.attributes.length; i--;) {
+    let { name } = el.attributes.item(i);
+    !skip[name] && !(nextAttrs && name in nextAttrs) && el.removeAttribute(name);
+  }
+  for (let name in nextAttrs) {
+    let key = isEventHandler(name) ? `on-${getEventHandlerName(name)}` : name;
+    skip[key] || (partial[key] = nextAttrs[name]);
+  }
+  attrsInternal(scope, nodeAccessor, partial, controllable);
+}
+function _attrs_partial_content(scope, nodeAccessor, nextAttrs, skip, controllable) {
+  (_attrs_partial(scope, nodeAccessor, nextAttrs, skip, controllable),
+    _attr_content(scope, nodeAccessor, nextAttrs?.content));
+}
+function attrsInternal(scope, nodeAccessor, nextAttrs, controllable) {
+  let el = scope[nodeAccessor],
+    events = scope["I" + nodeAccessor],
+    skip;
+  for (let name in events) events[name] = 0;
+  controllable &&
+    ((scope["F" + nodeAccessor] = 5),
+    (scope["E" + nodeAccessor] = 0),
+    nextAttrs && (skip = controllable(scope, nodeAccessor, nextAttrs)));
+  for (let name in nextAttrs) {
+    let value = nextAttrs[name];
+    switch (name) {
+      case "class":
+        _attr_class(el, value);
+        break;
+      case "style":
+        _attr_style(el, value);
+        break;
+      default:
+        isEventHandler(name)
+          ? ((events ||= scope["I" + nodeAccessor] = {})[getEventHandlerName(name)] = value)
+          : skip?.test(name) ||
+            (name === "content" && el.tagName !== "META") ||
+            _attr(el, name, value);
+        break;
+    }
+  }
+}
+function _attr_content(scope, nodeAccessor, value) {
+  let content = normalizeClientRender(value);
+  scope["D" + nodeAccessor] !== (scope["D" + nodeAccessor] = content?.a) &&
+    (setConditionalRenderer(scope, nodeAccessor, content, createAndSetupBranch),
+    content?.f && subscribeToScopeSet(content.e, content.f, scope["A" + nodeAccessor]));
+  for (let accessor in content?.g)
+    content.g[accessor](scope["A" + nodeAccessor], content.h[accessor]);
+}
+function _attrs_script(scope, nodeAccessor) {
+  let el = scope[nodeAccessor],
+    events = scope["I" + nodeAccessor];
+  controllableScripts[scope["F" + nodeAccessor]]?.(scope, nodeAccessor);
+  for (let name in events) _on(el, name, events[name]);
+}
+function _html(scope, value, accessor) {
+  let firstChild = scope[accessor],
+    parentNode = firstChild.parentNode,
+    lastChild = scope["H" + accessor] || firstChild,
+    newContent = parseHTML(_to_text(value), parentNode.namespaceURI);
+  (insertChildNodes(
+    parentNode,
+    firstChild,
+    (scope[accessor] = newContent.firstChild || newContent.appendChild(new Text())),
+    (scope["H" + accessor] = newContent.lastChild),
+  ),
+    removeChildNodes(firstChild, lastChild));
+}
+function normalizeClientRender(value) {
+  let renderer = normalizeDynamicRenderer(value);
+  if (renderer && renderer.a) return renderer;
+}
+function normalizeAttrValue(value) {
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
+}
+function _lifecycle(scope, thisObj, index = 0) {
+  let accessor = "K" + index,
+    instance = scope[accessor];
+  instance
+    ? (Object.assign(instance, thisObj), instance.onUpdate?.())
+    : ((scope[accessor] = thisObj),
+      Object.assign(thisObj, thisObj.onMount?.()),
+      ($signal(scope, accessor).onabort = () => thisObj.onDestroy?.()));
+}
+function removeChildNodes(startNode, endNode) {
+  let stop = endNode.nextSibling;
+  for (; startNode !== stop;) {
+    let next = startNode.nextSibling;
+    (startNode.remove(), (startNode = next));
+  }
+}
+function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
+  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+}
+function toInsertNode(startNode, endNode) {
+  if (startNode === endNode) return startNode;
+  let parent = new DocumentFragment(),
+    stop = endNode.nextSibling;
+  for (; startNode !== stop;) {
+    let next = startNode.nextSibling;
+    (parent.appendChild(startNode), (startNode = next));
+  }
+  return parent;
+}
+function resolveCursorPosition(inputType, initialPosition, initialValue, updatedValue) {
+  if (
+    (initialPosition || initialPosition === 0) &&
+    (initialPosition !== initialValue.length || /kw/.test(inputType))
+  ) {
+    let before = initialValue.slice(0, initialPosition),
+      after = initialValue.slice(initialPosition);
+    if (updatedValue.startsWith(before)) return initialPosition;
+    if (updatedValue.endsWith(after)) return updatedValue.length - after.length;
+    let count = before.replace(R, "").length,
+      pos = 0;
+    for (; count && updatedValue[pos];) updatedValue[pos++].replace(R, "") && count--;
+    return pos;
+  }
+  return -1;
 }
 function _attr_input_checked_default(scope, nodeAccessor, checked) {
   let el = scope[nodeAccessor],
@@ -1371,187 +1554,6 @@ function _controllable_open(scope, nodeAccessor, nextAttrs) {
       _attr_details_or_dialog_open(scope, nodeAccessor, nextAttrs.open, nextAttrs.openChange),
       /^open(?:Change)?$/
     );
-}
-function _to_text(value) {
-  return value || value === 0 ? value + "" : "";
-}
-function _attr(element, name, value) {
-  setAttribute(element, name, normalizeAttrValue(value));
-}
-function setAttribute(element, name, value) {
-  element.getAttribute(name) != value &&
-    (value === void 0 ? element.removeAttribute(name) : element.setAttribute(name, value));
-}
-function _attr_class(element, value) {
-  setAttribute(element, "class", toDelimitedString(value, " ", stringifyClassObject) || void 0);
-}
-function _attr_class_items(element, items) {
-  for (let key in items) _attr_class_item(element, key, items[key]);
-}
-function _attr_class_item(element, name, value) {
-  element.classList.toggle(name, !!value);
-}
-function _attr_style(element, value) {
-  setAttribute(element, "style", toDelimitedString(value, ";", stringifyStyleObject) || void 0);
-}
-function _attr_style_items(element, items) {
-  for (let key in items) _attr_style_item(element, key, items[key]);
-}
-function _attr_style_item(element, name, value) {
-  element.style.setProperty(name, _to_text(value));
-}
-function _style_shell(scope, nodeAccessor) {
-  let element = scope[nodeAccessor],
-    id = _id(scope);
-  (_attr_nonce(scope, nodeAccessor),
-    (element.className = id),
-    _text_content(element, "." + id + "~*{}"));
-}
-function _style_rule_item(element, name, value) {
-  let text = element.textContent,
-    decl = name + ":" + escapeStyleValue(_to_text(value)) + ";",
-    start = text.indexOf("{" + name + ":");
-  (~start || (start = text.indexOf(";" + name + ":")),
-    _text_content(
-      element,
-      ~start
-        ? text.slice(0, ++start) + decl + text.slice(text.indexOf(";", start) + 1)
-        : text.slice(0, -1) + decl + "}",
-    ));
-}
-function _attr_nonce(scope, nodeAccessor) {
-  _attr(scope[nodeAccessor], "nonce", scope.$.cspNonce);
-}
-function _text(node, value) {
-  let normalizedValue = _to_text(value);
-  node.data !== normalizedValue && (node.data = normalizedValue);
-}
-function _text_content(node, value) {
-  let normalizedValue = _to_text(value);
-  node.textContent !== normalizedValue && (node.textContent = normalizedValue);
-}
-function _attrs(scope, nodeAccessor, nextAttrs, controllable) {
-  let el = scope[nodeAccessor];
-  for (let i = el.attributes.length; i--;) {
-    let { name } = el.attributes.item(i);
-    (nextAttrs && (name in nextAttrs || hasAttrAlias(el, name, nextAttrs))) ||
-      el.removeAttribute(name);
-  }
-  attrsInternal(scope, nodeAccessor, nextAttrs, controllable);
-}
-function _attrs_content(scope, nodeAccessor, nextAttrs, controllable) {
-  (_attrs(scope, nodeAccessor, nextAttrs, controllable),
-    _attr_content(scope, nodeAccessor, nextAttrs?.content));
-}
-function hasAttrAlias(element, attr, nextAttrs) {
-  return attr === "checked" && element.tagName === "INPUT" && "checkedValue" in nextAttrs;
-}
-function _attrs_partial(scope, nodeAccessor, nextAttrs, skip, controllable) {
-  let el = scope[nodeAccessor],
-    partial = {};
-  for (let i = el.attributes.length; i--;) {
-    let { name } = el.attributes.item(i);
-    !skip[name] && !(nextAttrs && name in nextAttrs) && el.removeAttribute(name);
-  }
-  for (let name in nextAttrs) {
-    let key = isEventHandler(name) ? `on-${getEventHandlerName(name)}` : name;
-    skip[key] || (partial[key] = nextAttrs[name]);
-  }
-  attrsInternal(scope, nodeAccessor, partial, controllable);
-}
-function _attrs_partial_content(scope, nodeAccessor, nextAttrs, skip, controllable) {
-  (_attrs_partial(scope, nodeAccessor, nextAttrs, skip, controllable),
-    _attr_content(scope, nodeAccessor, nextAttrs?.content));
-}
-function attrsInternal(scope, nodeAccessor, nextAttrs, controllable) {
-  let el = scope[nodeAccessor],
-    events = scope["I" + nodeAccessor];
-  for (let name in events) events[name] = 0;
-  ((scope["F" + nodeAccessor] = 5), (scope["E" + nodeAccessor] = 0));
-  let skip =
-    nextAttrs &&
-    (controllable || controllableRenders[el.tagName])?.(scope, nodeAccessor, nextAttrs);
-  for (let name in nextAttrs) {
-    let value = nextAttrs[name];
-    switch (name) {
-      case "class":
-        _attr_class(el, value);
-        break;
-      case "style":
-        _attr_style(el, value);
-        break;
-      default:
-        isEventHandler(name)
-          ? ((events ||= scope["I" + nodeAccessor] = {})[getEventHandlerName(name)] = value)
-          : skip?.test(name) ||
-            (name === "content" && el.tagName !== "META") ||
-            _attr(el, name, value);
-        break;
-    }
-  }
-}
-function _attr_content(scope, nodeAccessor, value) {
-  let content = normalizeClientRender(value);
-  scope["D" + nodeAccessor] !== (scope["D" + nodeAccessor] = content?.a) &&
-    (setConditionalRenderer(scope, nodeAccessor, content, createAndSetupBranch),
-    content?.f && subscribeToScopeSet(content.e, content.f, scope["A" + nodeAccessor]));
-  for (let accessor in content?.g)
-    content.g[accessor](scope["A" + nodeAccessor], content.h[accessor]);
-}
-function _attrs_script(scope, nodeAccessor) {
-  let el = scope[nodeAccessor],
-    events = scope["I" + nodeAccessor];
-  controllableScripts[scope["F" + nodeAccessor]]?.(scope, nodeAccessor);
-  for (let name in events) _on(el, name, events[name]);
-}
-function _html(scope, value, accessor) {
-  let firstChild = scope[accessor],
-    parentNode = firstChild.parentNode,
-    lastChild = scope["H" + accessor] || firstChild,
-    newContent = parseHTML(_to_text(value), parentNode.namespaceURI);
-  (insertChildNodes(
-    parentNode,
-    firstChild,
-    (scope[accessor] = newContent.firstChild || newContent.appendChild(new Text())),
-    (scope["H" + accessor] = newContent.lastChild),
-  ),
-    removeChildNodes(firstChild, lastChild));
-}
-function normalizeClientRender(value) {
-  let renderer = normalizeDynamicRenderer(value);
-  if (renderer && renderer.a) return renderer;
-}
-function normalizeAttrValue(value) {
-  if (isNotVoid(value)) return value === !0 ? "" : value + "";
-}
-function _lifecycle(scope, thisObj, index = 0) {
-  let accessor = "K" + index,
-    instance = scope[accessor];
-  instance
-    ? (Object.assign(instance, thisObj), instance.onUpdate?.())
-    : ((scope[accessor] = thisObj),
-      Object.assign(thisObj, thisObj.onMount?.()),
-      ($signal(scope, accessor).onabort = () => thisObj.onDestroy?.()));
-}
-function removeChildNodes(startNode, endNode) {
-  let stop = endNode.nextSibling;
-  for (; startNode !== stop;) {
-    let next = startNode.nextSibling;
-    (startNode.remove(), (startNode = next));
-  }
-}
-function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
-  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
-}
-function toInsertNode(startNode, endNode) {
-  if (startNode === endNode) return startNode;
-  let parent = new DocumentFragment(),
-    stop = endNode.nextSibling;
-  for (; startNode !== stop;) {
-    let next = startNode.nextSibling;
-    (parent.appendChild(startNode), (startNode = next));
-  }
-  return parent;
 }
 function _await_promise(nodeAccessor, params) {
   nodeAccessor = decodeAccessor(nodeAccessor);

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -301,30 +301,6 @@ still reaches the options). Re-verify: server-render
 value=a>A${n}</option><option value=b>B</option></>` for `tag="div"` and
 `tag="select"` and diff the payloads.
 
-## Stop `attrsInternal` from clearing controlled slots the spread does not own
-
-`packages/runtime-tags/src/dom/dom.ts` › `attrsInternal` | 2026-07-23 | impact:high | effort:low
-
-`attrsInternal` unconditionally resets `scope[AccessorPrefix.ControlledType +
-nodeAccessor] = ControlledType.None` and `scope[AccessorPrefix.ControlledHandler
-
-- nodeAccessor] = 0`(dom.ts:264-265) before its tag switch, on the assumption
-that the spread owns the element's controllable. That is false for`_attrs_partial`(dom.ts:215): it filters every name present in`skip`out of`partial`, so when the controllable is declared as a static attribute alongside
-a spread (`<input ...rest value:=v/>`, which compiles to `_attrs_partial($scope,
-"#input/3", $scope.rest, { value: 1, valueChange: 1 })`), the switch never
-re-installs the handler and the reset wins. `_attr_input_value_script`/`_attr_input_checked*_script`/`_attr_select_value_script`in`dom/controllable.ts`all read the handler lazily out of that slot at
-interaction time, so the two-way binding is silently dead: typing into the input
-never calls`valueChange`, the state never updates, and the element is left
-holding the un-reverted user value. It fires on every CSR mount whose spread
-signal is ordered after the controllable's signal, and after any client re-run
-of the spread signal following SSR resume; the binding only revives if the
-controllable's own signal happens to re-run. The HTML runtime's `_attrs`never
-clears these slots, so this is a DOM-only asymmetry. Fix by giving`attrsInternal`a way to know the controllable is skipped (e.g.`_attrs_partial`suppressing the reset when the tag's controllable props appear in`skip`, or
-passing `skip`through). Re-verify: in`src/**tests**/fixtures/controllable-partial-spread`, add `<span>${v}</span>` to
-`template.marko` and change `config.steps` to `[{}, typeBound]` (dropping the
-`click` step, which currently masks the bug by re-running `$v`and reinstalling
-the handler) —`v`stays`"a"`while the input shows`"typed"`.
-
 ## Apply the `hasAttrAlias` guard in `_attrs_partial` so a `checkedValue` spread stops unchecking the box
 
 `packages/runtime-tags/src/dom/dom.ts` › `_attrs_partial` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62493,
-        "brotli": 19282
+        "min": 62489,
+        "brotli": 19301
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63781,
-        "brotli": 19858
+        "min": 63774,
+        "brotli": 19810
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63666,
-        "brotli": 19826
+        "min": 63663,
+        "brotli": 19849
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62493,
-        "brotli": 19282
+        "min": 62489,
+        "brotli": 19301
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63820,
-        "brotli": 19875
+        "min": 63815,
+        "brotli": 19860
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62391,
-        "brotli": 19265
+        "min": 62387,
+        "brotli": 19237
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62432,
-        "brotli": 19259
+        "min": 62428,
+        "brotli": 19261
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63768,
-        "brotli": 19843
+        "min": 63766,
+        "brotli": 19862
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63887,
-        "brotli": 19856
+        "min": 63885,
+        "brotli": 19858
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62544,
-        "brotli": 19295
+        "min": 62540,
+        "brotli": 19287
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64080,
-        "brotli": 19959
+        "min": 64072,
+        "brotli": 19991
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65318,
-        "brotli": 20301
+        "min": 65306,
+        "brotli": 20282
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63715,
-        "brotli": 19818
+        "min": 63712,
+        "brotli": 19804
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63781,
-        "brotli": 19844
+        "min": 63774,
+        "brotli": 19854
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62798,
-        "brotli": 19412
+        "min": 62794,
+        "brotli": 19416
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62470,
-        "brotli": 19286
+        "min": 62466,
+        "brotli": 19247
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64218,
-        "brotli": 20011
+        "min": 64215,
+        "brotli": 20014
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63723,
-        "brotli": 19817
+        "min": 63719,
+        "brotli": 19805
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63393,
-        "brotli": 19705
+        "min": 63389,
+        "brotli": 19715
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63889,
-        "brotli": 19874
+        "min": 63887,
+        "brotli": 19887
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63496,
-        "brotli": 19726
+        "min": 63488,
+        "brotli": 19722
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62852,
-        "brotli": 19412
+        "min": 62848,
+        "brotli": 19415
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64582,
-        "brotli": 20229
+        "min": 64576,
+        "brotli": 20208
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5942,
-      "brotli": 2728
+      "min": 5936,
+      "brotli": 2719
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7433,
-      "brotli": 3269
+      "brotli": 3267
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6190,
-      "brotli": 2808
+      "min": 6184,
+      "brotli": 2802
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8892,
+      "min": 8886,
       "brotli": 3855
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8869,
-        "brotli": 3828
+        "min": 8865,
+        "brotli": 3835
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3606,
-        "brotli": 1650
+        "min": 3600,
+        "brotli": 1649
       },
       "files": {
         "tags/hello/index.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3589,
-        "brotli": 1655
+        "min": 3583,
+        "brotli": 1659
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3589,
-        "brotli": 1653
+        "min": 3583,
+        "brotli": 1663
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9951,
-        "brotli": 4306
+        "min": 9925,
+        "brotli": 4296
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3765,
-      "brotli": 1713
+      "brotli": 1701
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10114,
-      "brotli": 4309
+      "min": 10108,
+      "brotli": 4308
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6812,
-      "brotli": 3084
+      "min": 6806,
+      "brotli": 3091
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6226,
-      "brotli": 2852
+      "min": 6220,
+      "brotli": 2845
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6915,
-      "brotli": 3123
+      "min": 6909,
+      "brotli": 3135
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7067,
-      "brotli": 3190
+      "min": 7061,
+      "brotli": 3186
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7112,
-      "brotli": 3202
+      "min": 7106,
+      "brotli": 3188
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7567,
-      "brotli": 3364
+      "brotli": 3368
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7103,
-      "brotli": 3177
+      "brotli": 3176
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9033,
-      "brotli": 3891
+      "min": 9027,
+      "brotli": 3886
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7053,
-      "brotli": 3140
+      "brotli": 3133
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7103,
-      "brotli": 3177
+      "brotli": 3176
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8879,
-      "brotli": 3838
+      "min": 8873,
+      "brotli": 3837
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8881,
-      "brotli": 3841
+      "min": 8875,
+      "brotli": 3838
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6235,
-      "brotli": 2838
+      "min": 6229,
+      "brotli": 2839
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6233,
-      "brotli": 2829
+      "min": 6227,
+      "brotli": 2831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6302,
-      "brotli": 2865
+      "min": 6296,
+      "brotli": 2864
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7582,
-        "brotli": 3471
+        "min": 7574,
+        "brotli": 3466
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9444,
-        "brotli": 4086
+        "min": 9440,
+        "brotli": 4082
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4643,
-      "brotli": 2137
+      "min": 4637,
+      "brotli": 2138
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6317,
-      "brotli": 2886
+      "min": 6311,
+      "brotli": 2877
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7119,
-      "brotli": 3254
+      "min": 7113,
+      "brotli": 3257
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7382,
-      "brotli": 3332
+      "min": 7376,
+      "brotli": 3333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6204,
-      "brotli": 2825
+      "min": 6198,
+      "brotli": 2834
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4691,
-        "brotli": 2179
+        "min": 4671,
+        "brotli": 2171
       },
       "files": {
         "tags/FancyButton.marko": 238,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2739,
-      "brotli": 1315
+      "min": 2745,
+      "brotli": 1325
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3680,
-      "brotli": 1748
+      "brotli": 1750
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4341,
-      "brotli": 2008
+      "brotli": 2013
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4222,
-      "brotli": 1963
+      "brotli": 1961
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4323,
-      "brotli": 1992
+      "min": 4329,
+      "brotli": 1998
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7193,
-      "brotli": 3257
+      "min": 7187,
+      "brotli": 3252
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7150,
-      "brotli": 3232
+      "min": 7144,
+      "brotli": 3233
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7150,
-      "brotli": 3232
+      "min": 7144,
+      "brotli": 3233
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7170,
-      "brotli": 3248
+      "min": 7164,
+      "brotli": 3242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6872,
+      "min": 6866,
       "brotli": 3105
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7825,
-        "brotli": 3570
+        "min": 7819,
+        "brotli": 3595
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7615,
-        "brotli": 3368
+        "min": 7609,
+        "brotli": 3370
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6169,
-      "brotli": 2817
+      "min": 6163,
+      "brotli": 2820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6350,
-        "brotli": 2897
+        "min": 6342,
+        "brotli": 2890
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8281,
-        "brotli": 3737
+        "min": 8275,
+        "brotli": 3735
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7775,
-        "brotli": 3554
+        "min": 7769,
+        "brotli": 3556
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7549,
-        "brotli": 3339
+        "min": 7543,
+        "brotli": 3338
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6151,
+      "min": 6145,
       "brotli": 2806
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6332,
-        "brotli": 2884
+        "min": 6324,
+        "brotli": 2877
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6232,
-      "brotli": 2831
+      "min": 6226,
+      "brotli": 2838
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11026,
-        "brotli": 4766
+        "min": 11022,
+        "brotli": 4769
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5940,
-      "brotli": 2723
+      "min": 5934,
+      "brotli": 2718
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3781
+      "min": 8495,
+      "brotli": 3798
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7345,
-        "brotli": 3002
+        "min": 7325,
+        "brotli": 2992
       },
       "files": {
         "tags/checkbox.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7406,
-      "brotli": 3044
+      "min": 7386,
+      "brotli": 3040
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4287,
-      "brotli": 1941
+      "brotli": 1939
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4668,
-      "brotli": 2053
+      "brotli": 2052
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4412,
-      "brotli": 1959
+      "brotli": 1970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7602,
-        "brotli": 3082
+        "min": 7582,
+        "brotli": 3070
       },
       "files": {
         "tags/radio.marko": 310,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4424,
-      "brotli": 1990
+      "brotli": 1992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7605,
-        "brotli": 3083
+        "min": 7585,
+        "brotli": 3071
       },
       "files": {
         "tags/checkbox.marko": 316,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4424,
-      "brotli": 1990
+      "brotli": 1992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3330,
-      "brotli": 1565
+      "brotli": 1569
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4716,
-        "brotli": 2143
+        "min": 4696,
+        "brotli": 2130
       },
       "files": {
         "tags/my-details.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2825,
-      "brotli": 1400
+      "brotli": 1406
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4951,
-      "brotli": 2262
+      "min": 4931,
+      "brotli": 2252
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6360,
-        "brotli": 2758
+        "min": 6340,
+        "brotli": 2748
       },
       "files": {
         "tags/my-dialog.marko": 293,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2825,
-      "brotli": 1400
+      "brotli": 1406
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8343,
-      "brotli": 3611
+      "min": 8337,
+      "brotli": 3609
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14276,
-      "brotli": 5553
+      "min": 14273,
+      "brotli": 5556
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13833,
-      "brotli": 5340
+      "min": 13830,
+      "brotli": 5354
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13707,
-      "brotli": 5285
+      "min": 13704,
+      "brotli": 5299
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4122,
-        "brotli": 1909
+        "min": 4128,
+        "brotli": 1898
       },
       "files": {
         "tags/custom-input.marko": 496,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4138,
-        "brotli": 1914
+        "min": 4144,
+        "brotli": 1905
       },
       "files": {
         "tags/my-input.marko": 507,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3852,
-      "brotli": 1796
+      "min": 3858,
+      "brotli": 1798
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7324,
-        "brotli": 2994
+        "min": 7304,
+        "brotli": 2986
       },
       "files": {
         "tags/my-input.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3824,
-      "brotli": 1786
+      "min": 3830,
+      "brotli": 1788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7362,
-      "brotli": 3034
+      "min": 7342,
+      "brotli": 3025
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// template.marko
+const $template = "<button>respread</button><input><div> </div>";
+const $walks = " b bD l";
+_enable_controllable_input();
+const $v = /*@__PURE__*/ _let("v/3", ($scope) => {
+	_attr_input_value($scope, "#input/1", $scope.v, $valueChange($scope));
+	_text($scope["#text/2"], $scope.v);
+});
+const $rest__script = _script("__tests__/template.marko_0_rest", ($scope) => _attrs_script($scope, "#input/1"));
+const $rest = /*@__PURE__*/ _let("rest/4", ($scope) => {
+	_attrs_partial($scope, "#input/1", $scope.rest, {
+		value: 1,
+		valueChange: 1
+	});
+	$rest__script($scope);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$rest($scope, { placeholder: "q" });
+	});
+	_attr_input_value_script($scope, "#input/1");
+});
+function $setup($scope) {
+	$v($scope, "a");
+	$rest($scope, { placeholder: "p" });
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return (_new_v) => {
+		$v($scope, _new_v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/dom.bundle.js
@@ -1,0 +1,26 @@
+// template.marko
+_enable_controllable_input();
+const $v = /*@__PURE__*/ _let(3, ($scope) => {
+	_attr_input_value($scope, "b", $scope.d, $valueChange($scope));
+	_text($scope.c, $scope.d);
+});
+const $rest__script = _script("a1", ($scope) => _attrs_script($scope, "b"));
+const $rest = /*@__PURE__*/ _let(4, ($scope) => {
+	_attrs_partial($scope, "b", $scope.e, {
+		value: 1,
+		valueChange: 1
+	});
+	$rest__script($scope);
+});
+const $setup__script = _script("a2", ($scope) => {
+	_on($scope.a, "click", function() {
+		$rest($scope, { placeholder: "q" });
+	});
+	_attr_input_value_script($scope, "b");
+});
+function $valueChange($scope) {
+	return (_new_v) => {
+		$v($scope, _new_v);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = "a";
+	let rest = { placeholder: "p" };
+	_html(`<button>respread</button>${_el_resume($scope0_id, "#button/0")}<input${_attr_input_value($scope0_id, "#input/1", v, _resume((_new_v) => {
+		v = _new_v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))}${_attrs_partial(rest, {
+		value: 1,
+		valueChange: 1
+	}, "#input/1", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/1")}<div>${_escape(v)}${_el_resume($scope0_id, "#text/2")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_rest");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { rest }, "__tests__/template.marko", 0, { rest: "2:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = "a";
+	let rest = { placeholder: "p" };
+	_html(`<button>respread</button>${_el_resume($scope0_id, "a")}<input${_attr_input_value($scope0_id, "b", v, _resume((_new_v) => {
+		v = _new_v;
+	}, "a0", $scope0_id))}${_attrs_partial(rest, {
+		value: 1,
+		valueChange: 1
+	}, "b", $scope0_id, "input")}>${_el_resume($scope0_id, "b")}<div>${_escape(v)}${_el_resume($scope0_id, "c")}</div>`);
+	_script($scope0_id, "a1");
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, { e: rest });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/render.debug.md
@@ -1,0 +1,85 @@
+# Render
+```html
+<button>
+  respread
+</button>
+<input
+  placeholder="p"
+  value="a"
+/>
+<div>
+  a
+</div>
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="p"
+  value="one"
+/>
+<div>
+  one
+</div>
+```
+## Change
+```
+UPDATE: div::text "a" => "one"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="q"
+  value="one"
+/>
+<div>
+  one
+</div>
+```
+## Change
+```
+UPDATE: input[placeholder] "p" => "q"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="q"
+  value="two"
+/>
+<div>
+  two
+</div>
+```
+## Change
+```
+UPDATE: div::text "one" => "two"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/render.md
@@ -1,0 +1,85 @@
+# Render
+```html
+<button>
+  respread
+</button>
+<input
+  placeholder="p"
+  value="a"
+/>
+<div>
+  a
+</div>
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="p"
+  value="one"
+/>
+<div>
+  one
+</div>
+```
+## Change
+```
+UPDATE: div::text "a" => "one"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="q"
+  value="one"
+/>
+<div>
+  one
+</div>
+```
+## Change
+```
+UPDATE: input[placeholder] "p" => "q"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<button>
+  respread
+</button>
+<input
+  default-value="a"
+  placeholder="q"
+  value="two"
+/>
+<div>
+  two
+</div>
+```
+## Change
+```
+UPDATE: div::text "one" => "two"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/writes.debug.html
@@ -1,0 +1,17 @@
+<button>respread</button><!--M_*1 #button/0--><input value=a
+  placeholder=p><!--M_*1 #input/1-->
+<div>a<!--M_*1 #text/2--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#input/1": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/template.marko_0/valueChange"
+        ),
+      rest: {
+        placeholder: "p"
+      }
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/template.marko_0_rest 1 packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>respread</button><!--M_*1 a--><input value=a placeholder=p><!--M_*1 b-->
+<div>a<!--M_*1 c--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Eb: _(1, "a0"),
+    e: {
+      placeholder: "p"
+    }
+  }], "a1 1 a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6229,
+      "brotli": 2695
+    }
+  },
+  "html": {
+    "min": 447,
+    "brotli": 292
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/template.marko
@@ -1,0 +1,5 @@
+<let/v = "a"/>
+<let/rest = { placeholder: "p" }/>
+<button onClick() { rest = { placeholder: "q" } }>respread</button>
+<input ...rest value:=v/>
+<div>${v}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/test.ts
@@ -1,0 +1,18 @@
+import type { TestConfig } from "../../main.test";
+
+function respread(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+function type(value: string) {
+  return (document: Document) => {
+    const input = document.querySelector("input")!;
+    const window = input.ownerDocument.defaultView!;
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  };
+}
+
+export const config: TestConfig = {
+  steps: [{}, type("one"), respread, type("two")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/__snapshots__/dom.bundle.debug.js
@@ -26,7 +26,7 @@ const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
 	_attrs_partial($scope, "#input/3", $scope.rest, {
 		value: 1,
 		valueChange: 1
-	}, _controllable_input);
+	});
 	$v__OR__rest($scope);
 	$rest__script($scope);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7378,
-      "brotli": 3038
+      "min": 7358,
+      "brotli": 3021
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4424,
-      "brotli": 1990
+      "brotli": 1992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13993,
-      "brotli": 5389
+      "min": 13990,
+      "brotli": 5399
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4528,
-      "brotli": 2005
+      "brotli": 2004
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9104,
-      "brotli": 3934
+      "min": 9096,
+      "brotli": 3938
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4435,
-      "brotli": 1972
+      "brotli": 1974
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9328,
-      "brotli": 4007
+      "min": 9320,
+      "brotli": 4009
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9008,
-        "brotli": 3658
+        "min": 8982,
+        "brotli": 3655
       },
       "files": {
         "tags/my-select.marko": 297,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4106,
-      "brotli": 1827
+      "brotli": 1828
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4106,
-      "brotli": 1827
+      "brotli": 1828
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4416,
-      "brotli": 1967
+      "brotli": 1965
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5656,
-        "brotli": 2485
+        "min": 5636,
+        "brotli": 2476
       },
       "files": {
         "tags/my-textarea.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3824,
-      "brotli": 1786
+      "min": 3830,
+      "brotli": 1788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8999,
-        "brotli": 3883
+        "min": 8995,
+        "brotli": 3884
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8985,
-        "brotli": 3869
+        "min": 8981,
+        "brotli": 3871
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8913,
+        "min": 8909,
         "brotli": 3848
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1002
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6414,
-      "brotli": 2910
+      "min": 6408,
+      "brotli": 2908
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8815,
-        "brotli": 3785
+        "min": 8811,
+        "brotli": 3790
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6680,
-      "brotli": 3041
+      "min": 6674,
+      "brotli": 3047
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6285,
-      "brotli": 2875
+      "min": 6279,
+      "brotli": 2882
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4732,
-        "brotli": 2178
+        "min": 4726,
+        "brotli": 2176
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7411,
-        "brotli": 3371
+        "min": 7403,
+        "brotli": 3372
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6127,
-      "brotli": 2781
+      "min": 6121,
+      "brotli": 2785
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5929,
-      "brotli": 2661
+      "min": 5923,
+      "brotli": 2660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8758,
-      "brotli": 3784
+      "min": 8754,
+      "brotli": 3783
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8645,
-      "brotli": 3737
+      "min": 8641,
+      "brotli": 3725
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9516,
-        "brotli": 4063
+        "min": 9512,
+        "brotli": 4064
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9595,
+        "min": 9591,
         "brotli": 4082
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9408,
-        "brotli": 4021
+        "min": 9404,
+        "brotli": 4022
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6407,
-        "brotli": 2907
+        "min": 6401,
+        "brotli": 2909
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9431,
-        "brotli": 4041
+        "min": 9427,
+        "brotli": 4029
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14573,
-        "brotli": 5618
+        "min": 14570,
+        "brotli": 5633
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13686,
-        "brotli": 5291
+        "min": 13683,
+        "brotli": 5307
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8547,
-      "brotli": 3288
+      "min": 8541,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9325,
-        "brotli": 4010
+        "min": 9322,
+        "brotli": 4011
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9453,
-        "brotli": 4039
+        "min": 9449,
+        "brotli": 4036
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8612,
-      "brotli": 3700
+      "min": 8608,
+      "brotli": 3699
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8547,
-      "brotli": 3288
+      "min": 8541,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4109,
-        "brotli": 1898
+        "min": 4103,
+        "brotli": 1905
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8874,
-        "brotli": 3802
+        "min": 8870,
+        "brotli": 3810
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6684,
-      "brotli": 3013
+      "min": 6678,
+      "brotli": 3018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7281,
-      "brotli": 3327
+      "min": 7275,
+      "brotli": 3333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7912,
-      "brotli": 3583
+      "min": 7906,
+      "brotli": 3608
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7377,
-      "brotli": 3343
+      "min": 7371,
+      "brotli": 3345
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7995,
-      "brotli": 3643
+      "min": 7989,
+      "brotli": 3614
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7484,
-      "brotli": 3353
+      "min": 7478,
+      "brotli": 3343
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7225,
-      "brotli": 3320
+      "min": 7219,
+      "brotli": 3302
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7027,
-      "brotli": 3231
+      "min": 7021,
+      "brotli": 3239
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7295,
-      "brotli": 3327
+      "min": 7289,
+      "brotli": 3349
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7304,
-      "brotli": 3334
+      "min": 7298,
+      "brotli": 3338
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8330,
-      "brotli": 3745
+      "min": 8324,
+      "brotli": 3716
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6513,
-      "brotli": 2952
+      "min": 6507,
+      "brotli": 2956
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8409,
-      "brotli": 3773
+      "min": 8403,
+      "brotli": 3777
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8156,
-      "brotli": 3673
+      "min": 8150,
+      "brotli": 3675
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6963,
-      "brotli": 3191
+      "min": 6957,
+      "brotli": 3204
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7692,
-        "brotli": 3523
+        "min": 7686,
+        "brotli": 3529
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8055,
-        "brotli": 3664
+        "min": 8049,
+        "brotli": 3667
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7042,
-      "brotli": 3205
+      "min": 7036,
+      "brotli": 3197
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7036,
-      "brotli": 3198
+      "min": 7030,
+      "brotli": 3194
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6820,
-      "brotli": 3147
+      "min": 6814,
+      "brotli": 3160
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7032,
-      "brotli": 3237
+      "min": 7026,
+      "brotli": 3242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7169,
-      "brotli": 3299
+      "min": 7163,
+      "brotli": 3294
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9256,
-        "brotli": 3939
+        "min": 9252,
+        "brotli": 3929
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9979,
-        "brotli": 4217
+        "min": 9975,
+        "brotli": 4201
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9064,
-        "brotli": 3864
+        "min": 9060,
+        "brotli": 3856
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6336,
-      "brotli": 2864
+      "min": 6330,
+      "brotli": 2878
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6325,
-      "brotli": 2854
+      "min": 6319,
+      "brotli": 2866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5922,
-      "brotli": 2713
+      "min": 5916,
+      "brotli": 2712
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6194,
-      "brotli": 2822
+      "min": 6188,
+      "brotli": 2827
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6063,
-      "brotli": 2768
+      "min": 6057,
+      "brotli": 2770
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6443,
-        "brotli": 2923
+        "min": 6437,
+        "brotli": 2939
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6604,
-        "brotli": 2982
+        "min": 6598,
+        "brotli": 2991
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6573,
-        "brotli": 2968
+        "min": 6567,
+        "brotli": 2972
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6123,
-        "brotli": 2813
+        "min": 6117,
+        "brotli": 2806
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7253,
-      "brotli": 2988
+      "min": 7233,
+      "brotli": 2972
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6471,
-      "brotli": 2949
+      "min": 6465,
+      "brotli": 2954
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7334,
-        "brotli": 2993
+        "min": 7314,
+        "brotli": 2988
       },
       "files": {
         "tags/my-input.marko": 401,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6409,
-        "brotli": 2911
+        "min": 6403,
+        "brotli": 2907
       },
       "files": {
         "tags/test.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 1975,
-        "brotli": 1014
+        "brotli": 1020
       },
       "files": {
         "tags/child.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7495,
-        "brotli": 3417
+        "min": 7489,
+        "brotli": 3405
       },
       "files": {
         "tags/inner/index.marko": 1000,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 117,
-      "brotli": 118
+      "brotli": 119
     },
     "template.marko.page.mjs": {
       "min": 1150,
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7783,
-      "brotli": 3476
+      "min": 7777,
+      "brotli": 3468
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -6,7 +6,7 @@
     },
     "template.marko.page.mjs": {
       "min": 1154,
-      "brotli": 635
+      "brotli": 637
     },
     "child.mjs": {
       "min": 296,
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7805,
-      "brotli": 3479
+      "min": 7799,
+      "brotli": 3471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 79,
-      "brotli": 74
+      "brotli": 75
     },
     "template.marko.page.mjs": {
-      "min": 1144,
-      "brotli": 640
+      "min": 1149,
+      "brotli": 638
     },
     "child.mjs": {
       "min": 221,
       "brotli": 152
     },
     "shared": {
-      "min": 11362,
-      "brotli": 4856
+      "min": 11358,
+      "brotli": 4862
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 79,
-      "brotli": 74
+      "brotli": 75
     },
     "template.marko.page.mjs": {
       "min": 1095,
-      "brotli": 617
+      "brotli": 620
     },
     "child.mjs": {
       "min": 223,
       "brotli": 158
     },
     "shared": {
-      "min": 11238,
-      "brotli": 4811
+      "min": 11240,
+      "brotli": 4818
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -6,15 +6,15 @@
     },
     "template.marko.page.mjs": {
       "min": 1069,
-      "brotli": 590
+      "brotli": 596
     },
     "child.mjs": {
       "min": 221,
       "brotli": 152
     },
     "shared": {
-      "min": 11031,
-      "brotli": 4731
+      "min": 11027,
+      "brotli": 4739
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -6,7 +6,7 @@
     },
     "template.marko.page.mjs": {
       "min": 1315,
-      "brotli": 704
+      "brotli": 710
     },
     "child.mjs": {
       "min": 177,
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7747,
-      "brotli": 3426
+      "min": 7741,
+      "brotli": 3418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -6,7 +6,7 @@
     },
     "template.marko.page.mjs": {
       "min": 1252,
-      "brotli": 681
+      "brotli": 682
     },
     "child.mjs": {
       "min": 177,
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7747,
-      "brotli": 3426
+      "min": 7741,
+      "brotli": 3418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 118
     },
     "template.marko.page.mjs": {
-      "min": 1201,
-      "brotli": 672
+      "min": 1206,
+      "brotli": 671
     },
     "child.mjs": {
       "min": 124,
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8153,
-      "brotli": 3587
+      "min": 8147,
+      "brotli": 3590
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -5,16 +5,16 @@
       "brotli": 74
     },
     "template.marko.page.mjs": {
-      "min": 193,
-      "brotli": 148
+      "min": 188,
+      "brotli": 145
     },
     "child.mjs": {
       "min": 69,
       "brotli": 69
     },
     "shared": {
-      "min": 6064,
-      "brotli": 2733
+      "min": 6058,
+      "brotli": 2735
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 74
     },
     "template.marko.page.mjs": {
-      "min": 1201,
-      "brotli": 672
+      "min": 1206,
+      "brotli": 671
     },
     "child.mjs": {
       "min": 145,
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8164,
-      "brotli": 3588
+      "min": 8158,
+      "brotli": 3591
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -6,15 +6,15 @@
     },
     "template.marko.page.mjs": {
       "min": 1139,
-      "brotli": 628
+      "brotli": 624
     },
     "child.mjs": {
       "min": 199,
       "brotli": 140
     },
     "shared": {
-      "min": 11089,
-      "brotli": 4783
+      "min": 11085,
+      "brotli": 4791
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6016,
-      "brotli": 2708
+      "min": 6010,
+      "brotli": 2714
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 117,
-      "brotli": 111
+      "brotli": 119
     },
     "template.marko.page.mjs": {
-      "min": 424,
-      "brotli": 285
+      "min": 429,
+      "brotli": 283
     },
     "v:child.marko.input_value.mjs": {
       "min": 78,
       "brotli": 74
     },
     "shared": {
-      "min": 7240,
-      "brotli": 3219
+      "min": 7234,
+      "brotli": 3224
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -5,16 +5,16 @@
       "brotli": 74
     },
     "template.marko.page.mjs": {
-      "min": 128,
-      "brotli": 106
+      "min": 123,
+      "brotli": 100
     },
     "child.mjs": {
       "min": 143,
       "brotli": 112
     },
     "shared": {
-      "min": 6690,
-      "brotli": 3003
+      "min": 6684,
+      "brotli": 3009
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 74
     },
     "template.marko.page.mjs": {
-      "min": 1354,
-      "brotli": 746
+      "min": 1359,
+      "brotli": 744
     },
     "child.mjs": {
       "min": 177,
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9338,
-      "brotli": 4010
+      "min": 9332,
+      "brotli": 4008
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7739,
-        "brotli": 3511
+        "min": 7735,
+        "brotli": 3513
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6389,
-        "brotli": 2875
+        "min": 6383,
+        "brotli": 2874
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6618,
-      "brotli": 2936
+      "min": 6612,
+      "brotli": 2932
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4083,
-      "brotli": 1913
+      "brotli": 1908
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9409,
-      "brotli": 4024
+      "min": 9405,
+      "brotli": 4020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4345,
-      "brotli": 2017
+      "min": 4325,
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2782,
-      "brotli": 1398
+      "brotli": 1392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9961,
-      "brotli": 4298
+      "min": 9935,
+      "brotli": 4316
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3520,
+        "min": 3514,
         "brotli": 1627
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 2739,
-        "brotli": 1367
+        "brotli": 1370
       },
       "files": {
         "tags/my-box.marko": 207,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3520,
+        "min": 3514,
         "brotli": 1627
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4259,
-        "brotli": 1963
+        "min": 4253,
+        "brotli": 1968
       },
       "files": {
         "tags/my-box.marko": 350,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9049,
-        "brotli": 3896
+        "min": 9045,
+        "brotli": 3886
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 2719,
-        "brotli": 1362
+        "brotli": 1360
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3587,
-      "brotli": 1641
+      "min": 3581,
+      "brotli": 1644
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4120,
-        "brotli": 1942
+        "min": 4102,
+        "brotli": 1929
       },
       "files": {
         "tags/my-img.marko": 233,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8007,
-      "brotli": 3609
+      "min": 7999,
+      "brotli": 3631
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 2011,
-        "brotli": 1032
+        "brotli": 1033
       },
       "files": {
         "tags/my-button.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7903,
-      "brotli": 3573
+      "min": 7897,
+      "brotli": 3574
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8632,
-        "brotli": 3900
+        "min": 8625,
+        "brotli": 3929
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7666,
-      "brotli": 3489
+      "min": 7660,
+      "brotli": 3522
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4096,
-      "brotli": 1861
+      "brotli": 1865
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4268,
-      "brotli": 2056
+      "brotli": 2057
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4463,
-      "brotli": 2133
+      "brotli": 2131
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4417,
-      "brotli": 2128
+      "brotli": 2127
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4335,
-      "brotli": 2082
+      "brotli": 2089
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4415,
-      "brotli": 2125
+      "brotli": 2123
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4285,
-      "brotli": 2062
+      "brotli": 2067
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4423,
-      "brotli": 2135
+      "brotli": 2136
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3211,
-        "brotli": 1492
+        "min": 3205,
+        "brotli": 1488
       },
       "files": {
         "tags/child.marko": 151,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2205,
-      "brotli": 1095
+      "brotli": 1097
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7293,
-      "brotli": 2989
+      "min": 7273,
+      "brotli": 2979
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4502,
-      "brotli": 2069
+      "min": 4482,
+      "brotli": 2056
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3548,
+        "min": 3542,
         "brotli": 1636
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3548,
-      "brotli": 1632
+      "min": 3542,
+      "brotli": 1645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3548,
-        "brotli": 1634
+        "min": 3542,
+        "brotli": 1630
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1951,
-      "brotli": 1004
+      "brotli": 1006
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15021,
-        "brotli": 5923
+        "min": 15016,
+        "brotli": 5937
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7045,
-        "brotli": 2716
+        "brotli": 2720
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2001,
-      "brotli": 1031
+      "brotli": 1029
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8955,
-        "brotli": 3852
+        "min": 8951,
+        "brotli": 3848
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6206,
-      "brotli": 2814
+      "min": 6200,
+      "brotli": 2817
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9817,
-        "brotli": 4160
+        "min": 9813,
+        "brotli": 4163
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9311,
-      "brotli": 4006
+      "min": 9307,
+      "brotli": 4004
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6122,
-        "brotli": 2789
+        "min": 6116,
+        "brotli": 2788
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6344,
-        "brotli": 2885
+        "min": 6338,
+        "brotli": 2890
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3132,
-      "brotli": 1557
+      "brotli": 1560
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3040,
-      "brotli": 1452
+      "brotli": 1456
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3251,
-      "brotli": 1605
+      "brotli": 1602
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6926,
-      "brotli": 3097
+      "min": 6920,
+      "brotli": 3099
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6926,
-      "brotli": 3097
+      "min": 6920,
+      "brotli": 3099
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7446,
-      "brotli": 3273
+      "min": 7440,
+      "brotli": 3279
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6598,
-        "brotli": 2994
+        "min": 6592,
+        "brotli": 2997
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9032,
-      "brotli": 3910
+      "min": 9024,
+      "brotli": 3912
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7140,
-      "brotli": 3208
+      "min": 7134,
+      "brotli": 3204
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6024,
-      "brotli": 2717
+      "min": 6018,
+      "brotli": 2723
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9405,
-      "brotli": 4066
+      "min": 9401,
+      "brotli": 4074
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4329,
-      "brotli": 1972
+      "brotli": 1967
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3512,
-      "brotli": 1652
+      "brotli": 1660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4323,
-      "brotli": 1961
+      "brotli": 1960
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3913,
-      "brotli": 1827
+      "brotli": 1836
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4282,
-      "brotli": 1909
+      "brotli": 1915
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4288,
-      "brotli": 1916
+      "brotli": 1919
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3955,
-      "brotli": 1839
+      "brotli": 1843
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9074,
-      "brotli": 3913
+      "min": 9070,
+      "brotli": 3910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 1982,
-      "brotli": 1021
+      "brotli": 1016
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -18,6 +18,7 @@ import {
   RendererProp,
   type Scope,
 } from "../common/types";
+import { controllableRenders } from "./controllable";
 import { _attrs, _attrs_content, _attrs_script } from "./dom";
 import {
   _enable_catch,
@@ -578,21 +579,17 @@ export let _dynamic_tag = function dynamicTag(
       const childScope = scope[childScopeAccessor] as Scope;
       const args = getInput?.();
       if (typeof normalizedRenderer === "string") {
+        const nodeAccessor = MARKO_DEBUG ? `#${normalizedRenderer}/0` : "a";
         (getContent ? _attrs : _attrs_content)(
           childScope,
-          MARKO_DEBUG ? `#${normalizedRenderer}/0` : "a",
+          nodeAccessor,
           (inputIsArgs ? args[0] : args) || {},
+          controllableRenders[(childScope[nodeAccessor] as Element).tagName],
         );
 
         if (
-          childScope[
-            AccessorPrefix.EventAttributes +
-              (MARKO_DEBUG ? `#${normalizedRenderer}/0` : "a")
-          ] ||
-          childScope[
-            AccessorPrefix.ControlledHandler +
-              (MARKO_DEBUG ? `#${normalizedRenderer}/0` : "a")
-          ]
+          childScope[AccessorPrefix.EventAttributes + nodeAccessor] ||
+          childScope[AccessorPrefix.ControlledHandler + nodeAccessor]
         ) {
           queueEffect(childScope, dynamicTagScript);
         }

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -24,11 +24,7 @@ import {
 } from "../common/types";
 import { $signal } from "./abort-signal";
 import { setConditionalRenderer } from "./control-flow";
-import {
-  type ControllableAttrs,
-  controllableRenders,
-  controllableScripts,
-} from "./controllable";
+import { type ControllableAttrs, controllableScripts } from "./controllable";
 import { _on } from "./event";
 import { parseHTML } from "./parse-html";
 import { createAndSetupBranch, type Renderer } from "./renderer";
@@ -256,18 +252,17 @@ function attrsInternal(
   let events = scope[AccessorPrefix.EventAttributes + nodeAccessor] as
     | undefined
     | Record<string, unknown>;
+  let skip: RegExp | void = undefined;
   for (const name in events) events[name] = 0;
-  scope[AccessorPrefix.ControlledType + nodeAccessor] = ControlledType.None;
-  scope[AccessorPrefix.ControlledHandler + nodeAccessor] = 0;
-  // A lone `null`/`undefined`/`false` spread reaches here unwrapped, and has no
-  // controlled attrs to claim; the attr loop below is a no-op on it.
-  const skip =
-    nextAttrs &&
-    (controllable || controllableRenders[el.tagName])?.(
-      scope,
-      nodeAccessor,
-      nextAttrs,
-    );
+  // Only a spread that claims the element's controllable may release it; one
+  // owned by a static attr is installed by a signal that does not re-run here.
+  if (controllable) {
+    scope[AccessorPrefix.ControlledType + nodeAccessor] = ControlledType.None;
+    scope[AccessorPrefix.ControlledHandler + nodeAccessor] = 0;
+    // A lone `null`/`undefined`/`false` spread reaches here unwrapped, and has
+    // no controlled attrs to claim; the attr loop below is a no-op on it.
+    if (nextAttrs) skip = controllable(scope, nodeAccessor, nextAttrs);
+  }
 
   // https://jsperf.com/object-keys-vs-for-in-with-closure/194
   for (const name in nextAttrs) {

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -931,7 +931,8 @@ export default {
           const staticName = name.isStringLiteral()
             ? name.node.value
             : undefined;
-          const controllable = controllableClaimFor(staticName);
+          const controllable =
+            !staticControllable && controllableClaimFor(staticName);
           if (skipExpression) {
             addStatement(
               "render",
@@ -1843,8 +1844,9 @@ function buildUndefined() {
   return t.unaryExpression("void", t.numericLiteral(0));
 }
 
-/** How a statically named tag claims its controlled attrs during render;
- * nothing for the many tags that control nothing. */
+/** How a spread claims its controlled attrs during render; nothing for the many
+ * tags that control nothing, and nothing when a static attr owns the
+ * controllable, since then the spread must leave the slots it wrote alone. */
 export function controllableClaimFor(tagName: string | undefined) {
   switch (tagName) {
     case "input":


### PR DESCRIPTION
`attrsInternal` reset `scope[#ControlledType]`/`scope[#ControlledHandler]` before claiming, on the assumption that the spread owns the element's controllable. `_attrs_partial` filters every name in `skip` out of `partial`, so when the controllable is declared as a static attribute beside a spread the claim never sees it, never re-installs the handler, and the reset stands:

```marko
<input ...rest value:=v/>
```

The two-way binding is then silently dead: typing calls no `valueChange`, the state never updates, and the element keeps the un-reverted user value. It fires on every CSR mount whose spread signal is ordered after the controllable's, and after any client re-run of the spread following resume.

The claim is now entirely compiler-chosen. `controllableClaimFor` returns nothing when `getUsedAttrs` reports a `staticControllable`, and the runtime resets only when it was handed a claim to re-install. The dynamic-tag renderer is the one caller that needs a run-time tag name, so it resolves its claim at its own call site; `controllableRenders` and its lookup then leave every statically named page. That is a net size win: −21 brotli on the full dom runtime, with 205 of 272 fixtures shrinking and 9 growing by at most 6 bytes.

The new `controllable-partial-spread-update` fixture covers typing before and after a spread re-run. Without the change its `csr` and `ssr` traces diverge — `csr` loses the binding from mount, `ssr` survives resume but loses it on the first spread re-run. The existing `controllable-partial-spread` passes either way, since its `<const/rest>` spread signal happens to be ordered before the controllable's.
