### PR TITLE
fix(runtime-tags): read scope-flush slot deltas as signed

### DIFF
--- a/.changeset/scope-flush-signed-slot-delta.md
+++ b/.changeset/scope-flush-signed-slot-delta.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Write scope slot deltas in the resume payload as signed. The writer only emitted a delta when the next scope id was higher than the cursor, so a scope flushed after one with a larger id emitted none at all and its props landed in whichever slot the cursor held. The client already accumulates signed deltas, so only the writer changed.

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -2131,6 +2131,32 @@ describe("serializer", () => {
     assert.equal(scopes.get(3), undefined);
   });
 
+  it("steps back to a scope flushed after a higher one", () => {
+    // The skip is a signed delta, so flushes need not ascend.
+    const scopes = assertStringifyScopes(
+      [
+        [3, {}, { a: 1 }],
+        [1, {}, { b: 2 }],
+      ],
+      `_=>[3,{a:1},-3,{b:2}]`,
+    );
+    assert.deepEqual(scopes.get(3), { a: 1 });
+    assert.deepEqual(scopes.get(1), { b: 2 });
+  });
+
+  it("steps back to a scope that flushes twice in one payload", () => {
+    const scopes = assertStringifyScopes(
+      [
+        [1, {}, { a: 1 }],
+        [2, {}, { b: 2 }],
+        [1, {}, { c: 3 }],
+      ],
+      `_=>[1,{a:1},{b:2},-2,{c:3}]`,
+    );
+    assert.deepEqual(scopes.get(1), { a: 1, c: 3 });
+    assert.deepEqual(scopes.get(2), { b: 2 });
+  });
+
   it("skips the payload entirely when every scope is empty", () => {
     const serializer = new Serializer();
     const boundary = { signal: { aborted: false } } as any as Boundary;

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -448,10 +448,12 @@ function writeScopesRoot(state: State, flushes: ScopeFlush[]) {
     // Empty scopes fold into the next emitted slot's skip count.
     const openIndex = buf.push("") - 1;
     if (writeObjectProps(state, flush[2], ref)) {
+      // The skip is a SIGNED delta, so a flush that revisits a lower slot
+      // steps the cursor back rather than landing in the wrong one.
       buf[openIndex] =
         nextSlotId === -1
           ? "[" + scopeId + ",{"
-          : (scopeId > nextSlotId ? "," + (scopeId - nextSlotId) : "") + ",{";
+          : (scopeId !== nextSlotId ? "," + (scopeId - nextSlotId) : "") + ",{";
       if (fillIndex === -1) fillIndex = openIndex;
       nextSlotId = scopeId + 1;
       buf.push("}");


### PR DESCRIPTION
`writeScopesRoot` addresses each scope slot by a delta from a running cursor, but only emitted a delta when the next scope id was *higher* than the cursor. A scope flushed after one with a larger id emitted no delta at all, so its props landed in whichever slot the cursor happened to hold — silently attributed to another scope.

The delta is now written signed, with two tests covering it (a later-then-earlier pair, and a scope that flushes twice in one payload). The client already accumulates signed deltas, so nothing changed there, and no payload the current writer produces is affected: it flushes in ascending id order, which makes the negative branch unreachable today.