### PR TITLE
test(runtime-tags): size every chunk a fixture ships

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 44,
     "brotli": 42

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/explicit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/explicit/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-only-show/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-only-show/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 5,
     "brotli": 9

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 1734,
       "brotli": 858
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 366,
       "brotli": 227
+    },
+    "shared": {
+      "min": 48926,
+      "brotli": 14358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-event/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 1983,
       "brotli": 945
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 366,
       "brotli": 227
+    },
+    "shared": {
+      "min": 48926,
+      "brotli": 14358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-idle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-idle/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 1937,
       "brotli": 929
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 366,
       "brotli": 227
+    },
+    "shared": {
+      "min": 48926,
+      "brotli": 14358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-media/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-media/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 1982,
       "brotli": 955
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 366,
       "brotli": 227
+    },
+    "shared": {
+      "min": 48926,
+      "brotli": 14358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-no-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-no-rerender/sizes.json
@@ -1,5 +1,13 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 47,
+      "brotli": 51
+    },
+    "template.marko.page.mjs": {
+      "min": 505,
+      "brotli": 308
+    },
     "child.mjs": {
       "min": 49016,
       "brotli": 14419

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-value-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child-value-ref/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 68,
     "brotli": 50

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-child/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 1751,
       "brotli": 860
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 366,
       "brotli": 227
+    },
+    "shared": {
+      "min": 48926,
+      "brotli": 14358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-head/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/lazy-class-head/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 921,
+      "brotli": 453
+    }
+  },
   "html": {
     "min": 108,
     "brotli": 65

--- a/packages/runtime-tags/src/__tests__/fixtures/abort-signal-render-phase-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/abort-signal-render-phase-error/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 1525,
     "brotli": 639

--- a/packages/runtime-tags/src/__tests__/fixtures/async-nested-resolve-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-nested-resolve-in-order/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 13,
     "brotli": 17

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-isolated-boundaries/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 989,
     "brotli": 566

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reorder-nested-batched-resolve/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 1301,
     "brotli": 627

--- a/packages/runtime-tags/src/__tests__/fixtures/async-resolve-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-resolve-in-order/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 5,
     "brotli": 9

--- a/packages/runtime-tags/src/__tests__/fixtures/async-resolve-out-of-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-resolve-out-of-order/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 5,
     "brotli": 9

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 17,
     "brotli": 21

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 341,
     "brotli": 248

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 119,
     "brotli": 71

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 314,
     "brotli": 222

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 10,
     "brotli": 14

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 4,
     "brotli": 8

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 15,
     "brotli": 16

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 66,
     "brotli": 70

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 240,
     "brotli": 67

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-escape/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 63,
     "brotli": 48

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-falsey/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-falsey/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 19,
     "brotli": 23

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-object-prototype-names/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-object-prototype-names/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 80,
     "brotli": 71

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 274,
     "brotli": 73

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 308,
     "brotli": 217

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 29,
     "brotli": 33

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 919,
     "brotli": 544

--- a/packages/runtime-tags/src/__tests__/fixtures/await-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-in-for/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 29,
     "brotli": 33

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 49,
     "brotli": 44

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-and-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-and-async/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 21,
     "brotli": 25

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-in-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-in-try/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 354,
     "brotli": 256

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-no-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-no-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 30,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 10,
     "brotli": 14

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-chain/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 12,
     "brotli": 16

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 1,
     "brotli": 5

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 32,
     "brotli": 35

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-export/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-export/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 14,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-flush-here/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 35,
     "brotli": 39

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-layout/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-layout/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 33,
     "brotli": 37

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-static/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 25,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-empty-reject-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-empty-reject-async/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 852,
     "brotli": 516

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 868,
     "brotli": 523

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-async/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 362,
     "brotli": 262

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-success-sync/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 335,
     "brotli": 247

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 340,
     "brotli": 251

--- a/packages/runtime-tags/src/__tests__/fixtures/comments/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/comments/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 86,
     "brotli": 86

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 32,
     "brotli": 36

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-attr-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-attr-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 186,
     "brotli": 112

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 54,
     "brotli": 44

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 13,
     "brotli": 17

--- a/packages/runtime-tags/src/__tests__/fixtures/controlled-select-undefined-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controlled-select-undefined-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 105,
     "brotli": 58

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 23,
     "brotli": 27

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 68,
     "brotli": 55

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-child-analyze/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-child-analyze/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 15

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 4,
     "brotli": 8

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-render-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-render-body/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 29,
     "brotli": 26

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 12,
     "brotli": 16

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 30,
     "brotli": 34

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 30,
     "brotli": 34

--- a/packages/runtime-tags/src/__tests__/fixtures/define-destructured-var-with-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-destructured-var-with-body/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 14,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-circular/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-circular/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 8,
     "brotli": 12

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-no-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-no-content/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 68,
     "brotli": 58

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 4,
     "brotli": 8

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 315,
     "brotli": 228

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/doctype/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/doctype/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 123,
     "brotli": 61

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-default/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 27,
     "brotli": 20

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 310,
     "brotli": 95

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 26,
     "brotli": 30

--- a/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 11

--- a/packages/runtime-tags/src/__tests__/fixtures/entities/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/entities/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 105,
     "brotli": 89

--- a/packages/runtime-tags/src/__tests__/fixtures/error-async-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-async-placeholder/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-async/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-const-mutation/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 25,
     "brotli": 29

--- a/packages/runtime-tags/src/__tests__/fixtures/error-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-sync/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/escape-html-strings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/escape-html-strings/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 56,
     "brotli": 54

--- a/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/flatten-text-if-tag-param-ref/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 36,
     "brotli": 30

--- a/packages/runtime-tags/src/__tests__/fixtures/for-of-member-signal-collapse/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-of-member-signal-collapse/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 44,
     "brotli": 48

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 11

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 68,
     "brotli": 45

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 106,
     "brotli": 49

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 68,
     "brotli": 45

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 106,
     "brotli": 49

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 106,
     "brotli": 49

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 67,
     "brotli": 35

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-siblings/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 105,
     "brotli": 50

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 491,
     "brotli": 122

--- a/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 33,
     "brotli": 33

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-placeholder/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 13,
     "brotli": 17

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-static-unsafe/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-static-unsafe/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 46,
     "brotli": 44

--- a/packages/runtime-tags/src/__tests__/fixtures/html-entity/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-entity/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 22,
     "brotli": 26

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 67,
     "brotli": 62

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 39,
     "brotli": 43

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 70,
     "brotli": 71

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 47,
     "brotli": 46

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/if-flatten-else-if-space-syntax/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-flatten-else-if-space-syntax/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 12,
     "brotli": 16

--- a/packages/runtime-tags/src/__tests__/fixtures/if-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 22,
     "brotli": 26

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-conflict/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-conflict/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 3,
     "brotli": 7

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 22,
     "brotli": 14

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 14,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 34,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/import-types/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-types/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 19,
     "brotli": 23

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 2,
     "brotli": 6

--- a/packages/runtime-tags/src/__tests__/fixtures/input-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-destructure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 3,
     "brotli": 7

--- a/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 5,
     "brotli": 9

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 15

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 48,
     "brotli": 31

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 8,
     "brotli": 12

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-chained/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-chained/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 80,
+      "brotli": 73
+    },
     "child.mjs": {
       "min": 129,
       "brotli": 104
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
+    "template.marko.page.mjs": {
+      "min": 62,
+      "brotli": 61
+    },
     "child.mjs": {
       "min": 199,
       "brotli": 143
+    },
+    "shared": {
+      "min": 3262,
+      "brotli": 1608
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 68
+    },
     "template.marko.page.mjs": {
       "min": 362,
       "brotli": 247
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 122,
       "brotli": 100
+    },
+    "shared": {
+      "min": 2904,
+      "brotli": 1463
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 117,
+      "brotli": 118
+    },
     "template.marko.page.mjs": {
       "min": 1151,
       "brotli": 638
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 77,
       "brotli": 80
+    },
+    "shared": {
+      "min": 7783,
+      "brotli": 3473
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1155,
       "brotli": 636
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 95,
       "brotli": 81
+    },
+    "shared": {
+      "min": 7805,
+      "brotli": 3476
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1148,
       "brotli": 644
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 221,
       "brotli": 152
+    },
+    "shared": {
+      "min": 16218,
+      "brotli": 6320
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1099,
       "brotli": 622
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 223,
       "brotli": 158
+    },
+    "shared": {
+      "min": 16099,
+      "brotli": 6271
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1069,
       "brotli": 590
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 221,
       "brotli": 152
+    },
+    "shared": {
+      "min": 15880,
+      "brotli": 6180
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 104
+    },
     "template.marko.page.mjs": {
       "min": 545,
       "brotli": 323
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 71,
       "brotli": 67
+    },
+    "shared": {
+      "min": 2846,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1316,
       "brotli": 705
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 87,
       "brotli": 75
+    },
+    "shared": {
+      "min": 7747,
+      "brotli": 3423
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/sizes.json
@@ -1,5 +1,18 @@
 {
-  "dom": {},
+  "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 106
+    },
+    "template.marko.page.mjs": {
+      "min": 49,
+      "brotli": 50
+    },
+    "shared": {
+      "min": 497,
+      "brotli": 299
+    }
+  },
   "html": {
     "min": 161,
     "brotli": 89

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 104
+    },
     "template.marko.page.mjs": {
       "min": 479,
       "brotli": 298
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 71,
       "brotli": 67
+    },
+    "shared": {
+      "min": 2846,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1253,
       "brotli": 682
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 87,
       "brotli": 75
+    },
+    "shared": {
+      "min": 7747,
+      "brotli": 3423
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 117,
+      "brotli": 118
+    },
     "template.marko.page.mjs": {
       "min": 1207,
       "brotli": 674
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 74,
       "brotli": 69
+    },
+    "shared": {
+      "min": 8153,
+      "brotli": 3584
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-event-handler/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
     "template.marko.page.mjs": {
       "min": 247,
       "brotli": 164
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 147,
       "brotli": 114
+    },
+    "shared": {
+      "min": 2791,
+      "brotli": 1398
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 198,
       "brotli": 151
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 69,
       "brotli": 69
+    },
+    "shared": {
+      "min": 6064,
+      "brotli": 2732
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1207,
       "brotli": 674
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 87,
       "brotli": 75
+    },
+    "shared": {
+      "min": 8164,
+      "brotli": 3585
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1139,
       "brotli": 628
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 199,
       "brotli": 140
+    },
+    "shared": {
+      "min": 15938,
+      "brotli": 6232
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 104
+    },
     "template.marko.page.mjs": {
       "min": 837,
       "brotli": 426
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 71,
       "brotli": 67
+    },
+    "shared": {
+      "min": 2846,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 104
+    },
     "template.marko.page.mjs": {
       "min": 825,
       "brotli": 435
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 71,
       "brotli": 67
+    },
+    "shared": {
+      "min": 2846,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/sizes.json
@@ -1,5 +1,13 @@
 {
   "dom": {
+    "child-a.marko.load.mjs": {
+      "min": 74,
+      "brotli": 68
+    },
+    "child-b.marko.load.mjs": {
+      "min": 74,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "min": 430,
       "brotli": 262
@@ -11,6 +19,10 @@
     "child-b.mjs": {
       "min": 126,
       "brotli": 103
+    },
+    "shared": {
+      "min": 2966,
+      "brotli": 1518
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
@@ -1,5 +1,17 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
+    "grand-child.marko.load.mjs": {
+      "min": 85,
+      "brotli": 75
+    },
+    "template.marko.page.mjs": {
+      "min": 67,
+      "brotli": 66
+    },
     "child.mjs": {
       "min": 419,
       "brotli": 280
@@ -7,6 +19,10 @@
     "grand-child.mjs": {
       "min": 214,
       "brotli": 153
+    },
+    "shared": {
+      "min": 3383,
+      "brotli": 1680
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
@@ -1,5 +1,17 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 68
+    },
+    "grand-child.marko.load.mjs": {
+      "min": 78,
+      "brotli": 82
+    },
+    "template.marko.page.mjs": {
+      "min": 60,
+      "brotli": 62
+    },
     "child.mjs": {
       "min": 402,
       "brotli": 278
@@ -7,6 +19,10 @@
     "grand-child.mjs": {
       "min": 211,
       "brotli": 160
+    },
+    "shared": {
+      "min": 2995,
+      "brotli": 1497
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
@@ -1,5 +1,17 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 68
+    },
+    "grand-child.marko.load.mjs": {
+      "min": 78,
+      "brotli": 82
+    },
+    "template.marko.page.mjs": {
+      "min": 60,
+      "brotli": 62
+    },
     "child.mjs": {
       "min": 402,
       "brotli": 278
@@ -7,6 +19,10 @@
     "grand-child.mjs": {
       "min": 211,
       "brotli": 160
+    },
+    "shared": {
+      "min": 2995,
+      "brotli": 1497
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
@@ -1,5 +1,17 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 68
+    },
+    "grand-child.marko.load.mjs": {
+      "min": 78,
+      "brotli": 82
+    },
+    "template.marko.page.mjs": {
+      "min": 60,
+      "brotli": 62
+    },
     "child.mjs": {
       "min": 402,
       "brotli": 278
@@ -7,6 +19,10 @@
     "grand-child.mjs": {
       "min": 211,
       "brotli": 160
+    },
+    "shared": {
+      "min": 2995,
+      "brotli": 1497
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/sizes.json
@@ -1,8 +1,24 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "grand-child.marko.load.mjs": {
+      "min": 78,
+      "brotli": 82
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "grand-child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 68
+    },
     "template.marko.page.mjs": {
       "min": 384,
       "brotli": 261
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 182,
       "brotli": 147
+    },
+    "shared": {
+      "min": 2904,
+      "brotli": 1463
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 110,
       "brotli": 89
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 107,
       "brotli": 87
+    },
+    "shared": {
+      "min": 6016,
+      "brotli": 2707
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 117,
+      "brotli": 111
+    },
     "template.marko.page.mjs": {
       "min": 428,
       "brotli": 288
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 78,
       "brotli": 74
+    },
+    "shared": {
+      "min": 7240,
+      "brotli": 3220
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 132,
       "brotli": 109
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 143,
       "brotli": 112
+    },
+    "shared": {
+      "min": 6690,
+      "brotli": 3004
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 63,
+      "brotli": 66
+    },
     "child.mjs": {
       "min": 129,
       "brotli": 102
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 107,
       "brotli": 93
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 111,
       "brotli": 85
+    },
+    "shared": {
+      "min": 1976,
+      "brotli": 1039
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 143,
       "brotli": 109
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 69
+    },
     "template.marko.page.mjs": {
       "total": {
         "min": 474,
@@ -14,6 +18,10 @@
     "child.mjs": {
       "min": 122,
       "brotli": 100
+    },
+    "shared": {
+      "min": 2904,
+      "brotli": 1463
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-sibling-binding/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-sibling-binding/sizes.json
@@ -1,5 +1,13 @@
 {
   "dom": {
+    "child-b.marko.load.mjs": {
+      "min": 74,
+      "brotli": 78
+    },
+    "child-s.marko.load.mjs": {
+      "min": 74,
+      "brotli": 78
+    },
     "template.marko.page.mjs": {
       "min": 324,
       "brotli": 194
@@ -11,6 +19,10 @@
     "child-s.mjs": {
       "min": 140,
       "brotli": 108
+    },
+    "shared": {
+      "min": 2791,
+      "brotli": 1398
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-twice/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-twice/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 129,
       "brotli": 104
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 79,
+      "brotli": 74
+    },
     "template.marko.page.mjs": {
       "min": 1361,
       "brotli": 745
@@ -11,6 +15,10 @@
     "v:child.marko.setup.mjs": {
       "min": 87,
       "brotli": 75
+    },
+    "shared": {
+      "min": 9306,
+      "brotli": 3997
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 110,
+      "brotli": 104
+    },
     "template.marko.page.mjs": {
       "min": 600,
       "brotli": 359
@@ -7,6 +11,10 @@
     "v:child.marko.input_value.mjs": {
       "min": 71,
       "brotli": 67
+    },
+    "shared": {
+      "min": 2846,
+      "brotli": 1411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-parent-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-parent-resume/sizes.json
@@ -1,5 +1,9 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
     "template.marko.page.mjs": {
       "min": 159,
       "brotli": 121
@@ -7,6 +11,10 @@
     "child.mjs": {
       "min": 129,
       "brotli": 102
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 65,
       "brotli": 63
+    },
+    "shared": {
+      "min": 1835,
+      "brotli": 969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag/sizes.json
@@ -1,8 +1,20 @@
 {
   "dom": {
+    "child.marko.load.mjs": {
+      "min": 72,
+      "brotli": 76
+    },
+    "template.marko.page.mjs": {
+      "min": 55,
+      "brotli": 59
+    },
     "child.mjs": {
       "min": 129,
       "brotli": 103
+    },
+    "shared": {
+      "min": 2784,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/log-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/log-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 0,
     "brotli": 1

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-input/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 25,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-out-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-out-global/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 25,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 14,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 3,
     "brotli": 7

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 6,
     "brotli": 10

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-name/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-name/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 35,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 3,
     "brotli": 7

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 3,
     "brotli": 7

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 168,
     "brotli": 50

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 50,
     "brotli": 48

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-single/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 905,
     "brotli": 542

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-skipped/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 337,
     "brotli": 249

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders-nested/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 1052,
     "brotli": 573

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 236,
     "brotli": 137

--- a/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 14,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/render-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/render-effect/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 0,
     "brotli": 1

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-state/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 37,
     "brotli": 41

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 18,
     "brotli": 22

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 20,
     "brotli": 18

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 0,
     "brotli": 1

--- a/packages/runtime-tags/src/__tests__/fixtures/select-uncontrolled-empty-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-uncontrolled-empty-option/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 70,
     "brotli": 51

--- a/packages/runtime-tags/src/__tests__/fixtures/server-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/server-client/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 1500,
+      "brotli": 818
+    }
+  },
   "html": {
     "min": 25,
     "brotli": 24

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-static/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 55,
     "brotli": 53

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 76,
     "brotli": 44

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 200,
     "brotli": 76

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 242,
     "brotli": 83

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 110,
     "brotli": 46

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 26,
     "brotli": 28

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 28,
     "brotli": 30

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 183,
     "brotli": 68

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 76,
     "brotli": 44

--- a/packages/runtime-tags/src/__tests__/fixtures/static-function-invoked-render-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-function-invoked-render-reference/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 13,
     "brotli": 17

--- a/packages/runtime-tags/src/__tests__/fixtures/static-function-self-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-function-self-reference/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 16,
     "brotli": 20

--- a/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 54,
     "brotli": 35

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 11

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 87,
     "brotli": 70

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-injection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-injection/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 145,
     "brotli": 104

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-multi/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-multi/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 116,
     "brotli": 86

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-selectors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-selectors/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 111,
     "brotli": 90

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-static-mix/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-static-mix/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 82,
     "brotli": 84

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 133,
     "brotli": 102

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 78,
     "brotli": 76

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-default/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-modules-destructured/sizes.json
@@ -1,3 +1,8 @@
 {
-  "dom": {}
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-type/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-type/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 30,
     "brotli": 29

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 30,
     "brotli": 29

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 35,
     "brotli": 16

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure-rest-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure-rest-chain/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 133,
     "brotli": 69

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 53,
     "brotli": 49

--- a/packages/runtime-tags/src/__tests__/fixtures/text-escape-coverage/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-escape-coverage/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 60,
     "brotli": 60

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-value-leading-newline/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-value-leading-newline/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 26,
     "brotli": 19

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-value-template-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-value-template-escape/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 33,
     "brotli": 37

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 55,
     "brotli": 39

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 11,
     "brotli": 11

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 349,
     "brotli": 253

--- a/packages/runtime-tags/src/__tests__/fixtures/try-tag-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-tag-closure/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 325,
     "brotli": 239

--- a/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 5,
     "brotli": 9

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 104,
     "brotli": 50

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-coercion/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-coercion/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 21,
     "brotli": 15

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 26,
     "brotli": 19

--- a/packages/runtime-tags/src/__tests__/fixtures/update-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-attr/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 19,
     "brotli": 23

--- a/packages/runtime-tags/src/__tests__/fixtures/update-html/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-html/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 45,
     "brotli": 43

--- a/packages/runtime-tags/src/__tests__/fixtures/update-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-text/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 16,
     "brotli": 20

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/sizes.json
@@ -1,5 +1,10 @@
 {
-  "dom": {},
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
   "html": {
     "min": 49,
     "brotli": 43

--- a/packages/runtime-tags/src/__tests__/utils/bundle.ts
+++ b/packages/runtime-tags/src/__tests__/utils/bundle.ts
@@ -23,6 +23,10 @@ const virtualFilePrefix = "v:";
 const virtualRe = /(?:^|\/)v:/;
 // Test-only helpers (utils/resolve) are excluded from the measured bundle.
 const testUtilRe = /[\\/]__tests__[\\/]utils[\\/]/;
+const testUtilChunkName = "test-utils";
+// Totals every chunk that holds only shared runtime, under one stable key
+// (chunk file names for those follow the module graph and would churn).
+const sharedChunkKey = "shared";
 
 interface Diagnostic {
   type: string;
@@ -202,7 +206,8 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
       chunkFileNames: "[name].mjs",
       // Split test-only helpers into their own chunk: still imported at runtime
       // (same realm, so behavior is unchanged) but skipped by buildSnapshot.
-      manualChunks: (id) => (testUtilRe.test(id) ? "test-utils" : undefined),
+      manualChunks: (id) =>
+        testUtilRe.test(id) ? testUtilChunkName : undefined,
     },
   });
   domBuiltBox.promise = domBuilt;
@@ -332,6 +337,7 @@ async function buildSnapshot(
   const sizes: Record<string, ChunkSizes | Sizes> | undefined = includeSizes
     ? {}
     : undefined;
+  let shared: Sizes | undefined;
   for (const chunk of result.output) {
     if (!("code" in chunk) || !chunk.code) continue;
     const { modules } = chunk;
@@ -348,7 +354,25 @@ async function buildSnapshot(
       fixtureCode += `// ${relId}\n${modCode}`;
       if (sizes) files[relId] = renderedLength;
     }
-    if (!fixtureCode) continue;
+    // A chunk with no fixture module has no snapshot, but it is still
+    // shipped: runtime that moves between a shared chunk and an entry would
+    // otherwise read as a size change with no total to check it against.
+    if (!fixtureCode) {
+      if (sizes && chunk.name !== testUtilChunkName) {
+        const chunkSizes = await getMinifiedSizes(chunk.code);
+        if (chunk.isEntry) {
+          sizes[chunk.fileName] = chunkSizes;
+        } else {
+          shared = shared
+            ? {
+                min: shared.min + chunkSizes.min,
+                brotli: shared.brotli + chunkSizes.brotli,
+              }
+            : chunkSizes;
+        }
+      }
+      continue;
+    }
     parts.push(fixtureCode);
     if (sizes) {
       const total = await getMinifiedSizes(chunk.code);
@@ -356,6 +380,7 @@ async function buildSnapshot(
         Object.keys(files).length === 1 ? total : { total, files };
     }
   }
+  if (sizes && shared) sizes[sharedChunkKey] = shared;
   return { snapshot: parts.length ? `${parts.join("\n\n")}\n` : "", sizes };
 }
 


### PR DESCRIPTION
`buildSnapshot` skipped any chunk whose modules were all runtime, so `sizes.json` measured a subset of what a fixture actually ships: 174 fixtures recorded `"dom": {}` while shipping a real entry chunk, and every lazy fixture's shared runtime chunk went unmeasured.

That blind spot hides moves. Runtime shifting between a shared chunk and an entry chunk reads as an entry-size change with no total to check it against — I chased a "+2 kB regression" on the lazy-tag fixtures that was really 1.9 kB moving out of an unreported shared chunk into the reported entry, for +152 B min overall.

Entry chunks are now keyed by file name whether or not they carry fixture code; chunks holding only shared runtime total under one `shared` key, since their file names follow the module graph and would churn. The regenerated snapshots are additions only — no existing number moves.
