### PR TITLE
fix: resolve package tag entries by package name

### DIFF
--- a/.changeset/tag-entry-package-identity.md
+++ b/.changeset/tag-entry-package-identity.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Resolve custom tags from installed packages by their package name instead of a realpath (eg pnpm's virtual store) that bundlers may not treat as a dependency.

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -709,7 +709,7 @@ function isRenderContent({ node }) {
 function resolveRelativeTagEntry(file, tagDef) {
   // TODO: support transform and other entries.
   const entry = tagDef.template || tagDef.renderer;
-  return entry && resolveRelativePath(file, entry);
+  return entry && resolveRelativePath(file, entry, tagDef);
 }
 
 function getClassHydrationMode(file, visited = new Set()) {

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/marko.json
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/marko.json
@@ -1,0 +1,10 @@
+{
+    "tags": {
+        "imported-foo": {
+            "renderer": "./renderer.js",
+            "attributes": {
+                "name": "string"
+            }
+        }
+    }
+}

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/package.json
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "imported-foo",
+    "version": "1.0.0"
+}

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/renderer.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/.store/imported-foo/node_modules/imported-foo/renderer.js
@@ -1,0 +1,3 @@
+exports.renderer = function (input, out) {
+    out.write("[imported-foo] Name: " + input.name);
+};

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/imported-foo
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/node_modules/imported-foo
@@ -1,0 +1,1 @@
+.store/imported-foo/node_modules/imported-foo

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/package.json
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/package.json
@@ -1,0 +1,5 @@
+{
+    "dependencies": {
+        "imported-foo": "^1.0.0"
+    }
+}

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/cjs-expected.js
@@ -1,0 +1,22 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+var _index = require("marko/src/runtime/html/index.js");
+var _renderer = _interopRequireDefault(require("imported-foo/renderer.js"));
+var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
+var _renderer2 = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = exports.default = _marko_template;
+const _marko_component = {};
+_marko_template._ = (0, _renderer2.default)(function (input, out, _componentDef, _component, state, $global) {
+  (0, _renderTag.default)(_renderer.default, {
+    "name": "John"
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/generated-expected.marko
@@ -1,0 +1,1 @@
+<imported-foo name="John"/>

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/html-expected.js
@@ -1,0 +1,17 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _importedFoo from "imported-foo/renderer.js";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_importedFoo, {
+    "name": "John"
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/htmlProduction-expected.js
@@ -1,0 +1,16 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "$sW$MRt",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _importedFoo from "imported-foo/renderer.js";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_importedFoo, {
+    "name": "John"
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/vdom-expected.js
@@ -1,0 +1,21 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _importedFoo from "imported-foo/renderer.js";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_importedFoo, {
+    "name": "John"
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/snapshots/vdomProduction-expected.js
@@ -1,0 +1,20 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "$sW$MRt",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _importedFoo from "imported-foo/renderer.js";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  _marko_tag(_importedFoo, {
+    "name": "John"
+  }, out, _componentDef, "0");
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/tag-from-package-virtual-store/template.marko
@@ -1,0 +1,1 @@
+<imported-foo name="John"/>


### PR DESCRIPTION
Marko 5's `resolveRelativeTagEntry` never forwarded the `tagDef` to `resolveRelativePath`, so `packageImportPath` (added in #3501) could not run for the ordinary custom-tag path. Tag entries fell back to `relativeImportPath`, whose `node_modules` heuristic refuses segments starting with `.`, `-` or `_` — so a hoisted layout accidentally produced the right bare specifier while pnpm produced a relative path into `.pnpm`.

Bundlers then don't treat that tag as a dependency. Under Vite the imported subtree skips `optimizeDeps`, and any CommonJS companion file it pulls in (eg `@ebay/ebayui-core`'s `component-browser.js`) is served without interop, failing with *does not provide an export named 'default'*.

Passing the `tagDef` through makes pnpm emit the same package specifier a hoisted install already gets. Added a translator fixture using a pnpm-shaped virtual store to cover it.

Resolves #3572.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.