### PR TITLE
perf(runtime-tags): narrow nullability of `??` and `||` to the right operand

### DIFF
--- a/.changeset/nullable-logical-right-operand.md
+++ b/.changeset/nullable-logical-right-operand.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Stop treating `x ?? default` and `x || default` as possibly-nullish. The left operand can only be the result when it is non-nullish (`??`) or truthy (`||`), so the common default idiom `<const/opts = input.opts ?? { … }/>` no longer compiles every member read to an optional chain plus a runtime nullish check. `&&`/`&&=` keep the wider check, since their left operand can be the result.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -268,28 +268,6 @@ A binding read across a section boundary builds a `_closure_get`/dynamic `_closu
 
 `WalkCode` (`common/constants/walk-code.ts`) reserves char codes 67..91 for `next` walks (`Next=67`, `NextEnd=91`, a 25-code span the `// 67 through 91` comment even documents), and `dom/walker.ts` already bounds the decode branch at `value < WalkCode.NextEnd + 1` (≤91), but `WalkRangeSize.Next` is 20, so `toCharString` (`translator/util/walks.ts`) only ever emits remainder codes 67..86 and codes 87..91 are dead — unlike Over/Out/Multiplier, each fully packed at size 10 (97..106, 107..116, 117..126). As a result a consecutive `next` run of 20-24 nodes emits a redundant Multiplier char (2 chars where 1 suffices), and runs of 200-249 emit 3 where 2 would do; walk strings ship in every compiled DOM template and bundle size is a tracked feature here. Setting `WalkRangeSize.Next = 25` uses the whole range: encoder and decoder both read the enum so the change is coordinated, the widest emitted `next` char becomes 91 (remainder 24), still below the reserved backslash 92, and the decoder's `WalkRangeSize.Next * currentMultiplier + value - WalkCode.Next` reconstruction stays exact. Re-verify: mirror `toCharString` and the walker's `next` branch in node with `rangeSize=25` and confirm n=20..24 each encode to one char with max charCode 91 and decode back to 20..24 (I saw 0 roundtrip mismatches and 0 reserved-code emissions over n=0..600), then flip the enum and run `npm run test:update` plus the size hook to confirm affected DOM fixtures shrink rather than break.
 
-## Narrow `isNullableExpr` for `||`/`??` (and `||=`/`??=`) to the right operand so `x ?? default` stops emitting optional chaining
-
-`packages/runtime-tags/src/translator/util/evaluate.ts` › `isNullableExpr` | 2026-07-23 | impact:med | effort:low
-
-`isNullableExpr` returns `isNullableExpr(right) || isNullableExpr(left)` for
-`LogicalExpression` `||`/`??` and for `AssignmentExpression` `||=`/`??=`, but in
-all four the left operand can only be the result when it is truthy (`||`) or
-non-nullish (`??`) — so the result's nullability depends solely on the right
-operand. The over-approximation flows through `core/const.ts` (`if
-(!valueExtra.nullable) binding.nullable = false`) into
-`getDeclaredBindingExpression` and `util/signals.ts`'s `toMemberExpression(...,
-alias.nullable)`, so the extremely common default idiom `<const/opts =
-input.opts ?? { … }/>` compiles (optimize `-o dom`) to `$opts($scope, opts) => {
-$opts_title($scope, opts?.title); $opts_n($scope, opts?.n); }` — one needless
-`?.` and one needless runtime nullish check per property read, on a value that
-is provably never nullish. Only `&&`/`&&=` need the current `left || right`
-form. Bundle size is a tracked feature here, and this is a two-line change in
-one switch. Re-verify: compile `<const/a = input.o ?? { y: 1 }/><const/b =
-input.o || { y: 2 }/><const/c = input.o && { y: 3 }/><const/d = { y: 4
-}/><div>${a.y} ${b.y} ${c.y} ${d.y}</div>` with `-o dom -d`; today it emits
-`a?.y`, `b?.y`, `c?.y`, `d.y` — after the fix only `c?.y` should keep the `?.`.
-
 ## Cache the resolved lazy-module signal in `_load_signal` so the first post-load input update isn't deferred a tick
 
 `packages/runtime-tags/src/dom/load.ts` › `_load_signal` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// template.marko
+const $template = "<div><!>/<!> <!>/<!> <!></div>";
+const $walks = "D%c%c%c%c%l";
+const $setup = () => {};
+const $nullish = ($scope, nullish) => {
+	$nullish_label($scope, nullish.label);
+	$nullish_size($scope, nullish.size);
+};
+const $nullish_label = ($scope, nullish_label) => _text($scope["#text/0"], nullish_label);
+const $nullish_size = ($scope, nullish_size) => _text($scope["#text/1"], nullish_size);
+const $falsy = ($scope, falsy) => {
+	$falsy_label($scope, falsy.label);
+	$falsy_size($scope, falsy.size);
+};
+const $guarded = ($scope, guarded) => $guarded_label($scope, guarded?.label);
+const $input_opts = ($scope, input_opts) => {
+	$nullish($scope, input_opts ?? {
+		label: "nullish",
+		size: 1
+	});
+	$falsy($scope, input_opts || {
+		label: "falsy",
+		size: 2
+	});
+	$guarded($scope, input_opts && {
+		label: "guarded",
+		size: 3
+	});
+};
+const $falsy_label = ($scope, falsy_label) => _text($scope["#text/2"], falsy_label);
+const $falsy_size = ($scope, falsy_size) => _text($scope["#text/3"], falsy_size);
+const $guarded_label = ($scope, guarded_label) => _text($scope["#text/4"], guarded_label);
+const $input = ($scope, input) => $input_opts($scope, input.opts);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_opts = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const nullish = input.opts ?? {
+		label: "nullish",
+		size: 1
+	};
+	const falsy = input.opts || {
+		label: "falsy",
+		size: 2
+	};
+	const guarded = input.opts && {
+		label: "guarded",
+		size: 3
+	};
+	_html(`<div>${_escape(nullish.label)}${_el_resume($scope0_id, "#text/0", $sg__input_opts)}/${_sep($sg__input_opts)}${_escape(nullish.size)}${_el_resume($scope0_id, "#text/1", $sg__input_opts)} ${_sep($sg__input_opts)}${_escape(falsy.label)}${_el_resume($scope0_id, "#text/2", $sg__input_opts)}/${_sep($sg__input_opts)}${_escape(falsy.size)}${_el_resume($scope0_id, "#text/3", $sg__input_opts)} ${_sep($sg__input_opts)}${_escape(guarded?.label)}${_el_resume($scope0_id, "#text/4", $sg__input_opts)}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/html.bundle.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_opts = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const nullish = input.opts ?? {
+		label: "nullish",
+		size: 1
+	};
+	const falsy = input.opts || {
+		label: "falsy",
+		size: 2
+	};
+	const guarded = input.opts && {
+		label: "guarded",
+		size: 3
+	};
+	_html(`<div>${_escape(nullish.label)}${_el_resume($scope0_id, "a", $sg__input_opts)}/${_sep($sg__input_opts)}${_escape(nullish.size)}${_el_resume($scope0_id, "b", $sg__input_opts)} ${_sep($sg__input_opts)}${_escape(falsy.label)}${_el_resume($scope0_id, "c", $sg__input_opts)}/${_sep($sg__input_opts)}${_escape(falsy.size)}${_el_resume($scope0_id, "d", $sg__input_opts)} ${_sep($sg__input_opts)}${_escape(guarded?.label)}${_el_resume($scope0_id, "e", $sg__input_opts)}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-csr.debug.md
@@ -1,0 +1,21 @@
+# Render
+```html
+<div>
+  nullish/1 falsy/2 
+</div>
+```
+
+# Update `{"opts":{"label":"given","size":9}}`
+```html
+<div>
+  given/9 given/9 guarded
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "nullish" => "given"
+UPDATE: div::text@6 "1" => "9"
+UPDATE: div::text@8 "falsy" => "given"
+UPDATE: div::text@14 "2" => "9"
+UPDATE: div::text@16 "" => "guarded"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<div>
+  nullish/1 falsy/2 
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/render-ssr.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<div>
+  nullish/1 falsy/2 
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+<div>nullish/1 falsy/2 </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+<div>nullish/1 falsy/2 </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 29,
+    "brotli": 33
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/template.marko
@@ -1,0 +1,4 @@
+<const/nullish = input.opts ?? { label: "nullish", size: 1 }/>
+<const/falsy = input.opts || { label: "falsy", size: 2 }/>
+<const/guarded = input.opts && { label: "guarded", size: 3 }/>
+<div>${nullish.label}/${nullish.size} ${falsy.label}/${falsy.size} ${guarded?.label}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+// `??`/`||` defaults cannot be nullish, so their members read directly; `&&`
+// still can, and keeps its optional chain. Both inputs run so the falsy
+// branch proves the `&&` value is still guarded.
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, { opts: { label: "given", size: 9 } }],
+};

--- a/packages/runtime-tags/src/translator/util/evaluate.ts
+++ b/packages/runtime-tags/src/translator/util/evaluate.ts
@@ -72,10 +72,9 @@ function isNullableExpr(expr: t.Expression): boolean {
           return false;
         case "||=":
         case "??=":
-          return (
-            isNullableExpr(expr.right) ||
-            isNullableExpr(expr.left as t.Expression)
-          );
+          // The left operand can only be the result when it is truthy
+          // (`||=`) or non-nullish (`??=`), so only the right can be nullish.
+          return isNullableExpr(expr.right);
         case "&&=":
           return (
             isNullableExpr(expr.left as t.Expression) ||
@@ -92,7 +91,9 @@ function isNullableExpr(expr: t.Expression): boolean {
       switch (expr.operator) {
         case "||":
         case "??":
-          return isNullableExpr(expr.right) || isNullableExpr(expr.left);
+          // The left operand can only be the result when it is truthy (`||`)
+          // or non-nullish (`??`), so only the right can be nullish.
+          return isNullableExpr(expr.right);
         case "&&":
           return isNullableExpr(expr.left) || isNullableExpr(expr.right);
         default:


### PR DESCRIPTION
`isNullableExpr` returned `right || left` for `||`/`??` and `||=`/`??=`, but the left operand can only be the result when it is truthy or non-nullish. So the default idiom `<const/opts = input.opts ?? { … }/>` compiled every member read to `opts?.title` plus a runtime nullish check on a value that is provably never nullish. `&&`/`&&=` keep the wider form.

No fixture covered the idiom, so the suite showed no diff at all; `const-defaulted-input` now pins all three operators against a falsy and a present input.
