### PR TITLE
docs(runtime-tags): record why a loop branch always writes its scope

### DIFF
--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -414,32 +414,6 @@ onClick(){n++}>add</button><ul><for|i| to=n><li>row</li></for></ul>` and compare
 the length of the single `<!--M_}…-->` comment against total page bytes before
 and after.
 
-## Stop materializing empty branch scopes — they cost ~1/3 of SSR time on a stateless list and emit zero payload bytes
-
-`packages/runtime-tags/src/html/writer.ts` › `writeScope` | 2026-07-23 | impact:high | effort:med
-
-Every loop branch reaches `writeScope` twice with an empty partial: once from
-the compiled section epilogue (`_scope($scopeN_id, {})`, emitted by
-`translator/util/signals.ts` `writeHTMLResumeStatements` whenever
-`sectionSerializeReason` is truthy even with zero serialized props) and once
-from `forBranches`, whose return value is unused when `resumeMarker` is set.
-Each call allocates a `{}`, inserts a canonical scope into `state.scopes` (never
-deleted for the life of the render), writes a `writeScopes` entry and sets
-`flushScopes`; `flushSerializer` (writer.ts:1584) then allocates an
-`Object.getOwnPropertyNames(props)` array per entry only to discard it. The
-naive "skip empty writes" fix is unsafe: an empty `writeScopes` entry is exactly
-what lets `writeScopePassive` props ride along — see the `_existing_scope`
-comment ("Lets passive props join an existing scope flush without forcing wire
-data") and the `passiveScopes` merge at the top of `flushSerializer` — so the
-opt-in must move to a separate flushable-id set with props materialized lazily.
-A cheap first step is dropping the redundant `forBranches` call in the
-`resumeMarker && (!resumeKeys || sameAsIndex)` case, but note it currently also
-supplies `state.needsMainRuntime = true`, which `state.mark` does not set.
-Re-verify: wrap `Object.getOwnPropertyNames` and
-`Serializer.prototype.stringifyScopes` around an SSR render of a large stateless
-`<for>` and compare the count of empty-props probes against the number of
-flushes actually serialized.
-
 ## Mark class/style item writes pure so a single-consumer derived binding is not forced into a `_const` wrapper and scope slot
 
 `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `translate.dom.enter` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -531,6 +531,8 @@ function forBranches(
 
     withBranchId(branchId, () => {
       render();
+      // Empty for an unkeyed branch, but the scope it returns is what the
+      // parent's branch list holds and what passive props flush through.
       const branchScope = writeScope(
         branchId,
         resumeKeys && !sameAsIndex ? { [AccessorProp.LoopKey]: itemKey } : {},


### PR DESCRIPTION
`agent-feedback/perf.md` claimed the empty branch-scope writes in `forBranches` cost ~1/3 of SSR time on a stateless list. Measuring it: a truly stateless loop never reaches that write at all (it takes the `serializeBranch === 0` path), and the shape that does produce them at scale — a 2000-row loop whose body has a branch — spends ~1.5 ms/render with 2000 empty writes, where skipping them moves the number by nothing outside noise.

They also aren't skippable there: `resumeMarker` is false in that shape, so the scope the write returns is what the parent's branch list holds, and its `writeScopes` entry is what lets passive props flush.

So the entry is resolved by a two-line note at the call site instead. No behavior change.
