### PR TITLE
test(runtime-class): poll for the async state render instead of racing it

### DIFF
--- a/packages/runtime-class/test/components-browser/fixtures/state-watch-null-async/test.js
+++ b/packages/runtime-class/test/components-browser/fixtures/state-watch-null-async/test.js
@@ -1,15 +1,30 @@
 // see https://github.com/marko-js/marko/issues/556
 var expect = require("chai").expect;
 
-module.exports = function (helpers, done) {
+module.exports = function (helpers) {
   var component = helpers.mount(require.resolve("./index"), {});
 
   expect(component.el.innerHTML).to.not.contain("FATAL ERROR");
 
   helpers.triggerEvent(component.getEl(), "submit");
 
-  setTimeout(function () {
-    expect(component.el.innerHTML).to.contain("FATAL ERROR");
-    done();
-  }, 100);
+  // The component sets its state on a timer, so poll for the render instead
+  // of asserting on a deadline a loaded machine can miss.
+  return new Promise(function (resolve, reject) {
+    var deadline = Date.now() + 5000;
+    (function check() {
+      if (component.el.innerHTML.indexOf("FATAL ERROR") !== -1) {
+        resolve();
+      } else if (Date.now() > deadline) {
+        try {
+          expect(component.el.innerHTML).to.contain("FATAL ERROR");
+          resolve();
+        } catch (err) {
+          reject(err);
+        }
+      } else {
+        setTimeout(check, 10);
+      }
+    })();
+  });
 };


### PR DESCRIPTION
`state-watch-null-async` asserts 100ms after submit, but the component sets its state on a 50ms timer — a 50ms margin that a loaded runner misses. It failed `expected '' to include 'FATAL ERROR'` on node@22 in CI while 24 and 26 passed the same commit, and passed on re-run.

The runner already supports promise-returning fixtures, so the test now polls for the render (10ms interval, 5s cap). Verified it still fails the same way if the render never happens, by commenting out the component's state assignment.
