### PR TITLE
docs(runtime-tags): correct which latches may be marked pure

### DIFF
--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -21,10 +21,14 @@ export type HTMLRuntimeHelpers = keyof typeof import("../../html");
 
 // Marked `@__PURE__` (see callRuntime) so a bundler may drop a call whose
 // result is unused, despite call-time side effects: `_resume` registration
-// (`_template`, `_dynamic_tag`) and the `_enable_catch()`/`enableBranches()`
-// latches. This is sound because registration only matters when the value is
-// referenced by a serialized register id (which keeps it in the module graph),
-// and the latches are re-triggered by whichever construct survives shaking.
+// (`_template`, `_dynamic_tag`). This is sound because registration only
+// matters when the value is referenced by a serialized register id, which
+// keeps it in the module graph.
+//
+// A latch belongs here only if a surviving runtime construct re-triggers it.
+// `_enable_catch` does not qualify: `_try` never calls it, so a `<try>` with
+// no `<await>` or lazy child has the program-scope call as its only trigger
+// and dropping it leaves the boundary unable to catch.
 const pureDOMFunctions = new Set<string>([
   "_await_promise",
   "_await_content",


### PR DESCRIPTION
The note above `pureDOMFunctions` says the `@__PURE__` marking covers "the `_enable_catch()`/`enableBranches()` latches", and justifies it with "the latches are re-triggered by whichever construct survives shaking". That does not hold for `_enable_catch`: the only runtime callers are `_await_promise` and the two in `dom/load.ts`, and `_try` itself never calls it — so a `<try>` with no `<await>` and no lazy child has the program-scope call `core/try.ts` emits as its only trigger.

Adding `_enable_catch` to the set to check: 210 tests fail, six with `Error: ERROR!` escaping an uncaught boundary. The code was right and the comment was wrong, so this states the condition a latch has to meet.
