### PR TITLE
test(runtime-tags): cover the server render result API

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1511,3 +1511,9 @@ input change, assignment has no meaningful reactive semantics; a compile
 error in `trackAssignment` when `binding.type === BindingType.local` would
 be cheap and clear. Re-verify: compile the template above with
 `pnpm run compile -o dom -d` and inspect the emitted assignment.
+
+## Declare `pipe`, `catch` and `finally` on `RenderedTemplate`
+
+`packages/runtime-tags/src/common/types.ts` › `RenderedTemplate` | 2026-07-27 | impact:med | effort:low
+
+`RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> & { toReadable() }`, but `ServerRendered` in `html/template.ts` also implements `pipe`, `catch`, `finally` and a synchronous `toString`. `PromiseLike` supplies only `then`, so TypeScript rejects `result.catch(...)` and `result.finally(...)`, and `pipe` — the Node streaming entry point — is not on the type at all: `template.render(input).pipe(res)` fails to compile with TS2339 and callers have to cast. `__tests__/render-result.test.ts` carries a local `ServerResult` intersection for exactly this reason, and it should be deleted once the public type is widened. Widening is safe: the DOM build's `render` only throws (`dom/template.ts` line 35), so `RenderedTemplate` is only ever produced by the HTML build. Re-verify: `const r = template.render({}); r.pipe(process.stdout);` in a `.ts` file, then `pnpm run build:types`.

--- a/packages/runtime-tags/src/__tests__/render-result.test.ts
+++ b/packages/runtime-tags/src/__tests__/render-result.test.ts
@@ -1,0 +1,263 @@
+import assert from "assert/strict";
+import path from "path";
+
+import type {
+  RenderedTemplate,
+  Template,
+} from "@marko/runtime-tags/common/types";
+
+import * as tagsTranslator from "../translator";
+import { createServerRunner } from "./utils/bundle";
+
+type PipeTarget = {
+  write(chunk: string): void;
+  end(): void;
+  flush?(): void;
+  emit?(name: PropertyKey, ...args: unknown[]): unknown;
+};
+
+// `RenderedTemplate` declares `then`, async iteration and `toReadable` only,
+// while the server result also implements these — see agent-feedback/bugs.md.
+type ServerResult = RenderedTemplate & {
+  pipe(stream: PipeTarget): void;
+  catch<T>(onrejected: (reason: unknown) => T): Promise<string | T>;
+  finally(onfinally: () => void): Promise<string>;
+};
+
+const dir = path.join(import.meta.dirname, "render-result");
+const CONSUMED = /consumed render result/;
+const HELLO = "<h1>Hello world</h1>";
+// The bundle injects a module script ahead of the body; these assertions are
+// about how a result is consumed, not about what the bundler emits.
+const assertBody = (html: string, expected = HELLO) =>
+  assert.ok(
+    html.endsWith(expected),
+    `expected html ending in ${expected}, got ${html}`,
+  );
+const iterate = (result: RenderedTemplate) =>
+  result[Symbol.asyncIterator]() as Required<AsyncIterator<string>>;
+
+describe("runtime-tags/html render result", () => {
+  let sync: Template;
+  let async: Template;
+  const renderSync = () => sync.render({ name: "world" }) as ServerResult;
+  const renderAsync = (value: Promise<string>) =>
+    async.render({ value }) as ServerResult;
+  let disposeServer: () => void;
+
+  before(async function () {
+    this.timeout(60000);
+    const runner = await createServerRunner(
+      dir,
+      { sync: "./sync.marko", async: "./async.marko" },
+      {
+        translator: tagsTranslator as any,
+        optimize: false,
+        babelConfig: {
+          babelrc: false,
+          configFile: false,
+          browserslistConfigFile: false,
+        },
+      },
+    );
+    ({ sync, async } = await runner.runServer());
+    disposeServer = runner.disposeServer;
+  });
+
+  after(() => disposeServer?.());
+
+  describe("toString", () => {
+    it("returns the html of a synchronous render", () => {
+      assertBody(renderSync().toString());
+    });
+
+    it("throws once the result has been consumed", () => {
+      const result = renderSync();
+      result.toString();
+      assert.throws(() => result.toString(), CONSUMED);
+    });
+
+    it("throws rather than truncate an asynchronous render", () => {
+      assert.throws(
+        () => renderAsync(Promise.resolve("a")).toString(),
+        /Cannot consume asynchronous render/,
+      );
+    });
+  });
+
+  describe("promise interface", () => {
+    it("resolves to the rendered html", async () => {
+      assertBody(await renderSync());
+    });
+
+    it("awaits asynchronous content", async () => {
+      const html = await renderAsync(Promise.resolve("a"));
+      assert.match(html, /<p>a<\/p>/);
+    });
+
+    it("rejects through catch when the render aborts", async () => {
+      const reason = new Error("boom");
+      const caught = await renderAsync(Promise.reject(reason)).catch(
+        (err) => err,
+      );
+      assert.equal(caught, reason);
+    });
+
+    it("rejects when the result has already been consumed", async () => {
+      const result = renderSync();
+      result.toString();
+      await assert.rejects(async () => {
+        await result;
+      }, CONSUMED);
+    });
+
+    it("runs finally on success", async () => {
+      let ran = false;
+      await renderSync().finally(() => {
+        ran = true;
+      });
+      assert.equal(ran, true);
+    });
+
+    it("caches the promise so a second read does not re-consume", async () => {
+      const result = renderSync();
+      assert.equal(await result, await result);
+    });
+  });
+
+  describe("pipe", () => {
+    const mockStream = () => {
+      const written: string[] = [];
+      const events: [PropertyKey, unknown][] = [];
+      let onEvent: (() => void) | undefined;
+      // Resolved by the first `emit`, so the abort assertion never races a timer.
+      const nextEvent = new Promise<void>((resolve) => (onEvent = resolve));
+      return {
+        written,
+        events,
+        nextEvent,
+        ended: false,
+        flushes: 0,
+        write(chunk: string) {
+          written.push(chunk);
+        },
+        end() {
+          this.ended = true;
+        },
+        flush() {
+          this.flushes++;
+        },
+        emit(name: PropertyKey, ...args: unknown[]) {
+          events.push([name, args[0]]);
+          onEvent?.();
+          return true;
+        },
+      };
+    };
+
+    it("writes the html and ends the stream", () => {
+      const stream = mockStream();
+      renderSync().pipe(stream);
+      assertBody(stream.written.join(""));
+      assert.equal(stream.ended, true);
+    });
+
+    it("flushes after each chunk so buffering transforms stream", () => {
+      const stream = mockStream();
+      renderSync().pipe(stream);
+      assert.ok(stream.flushes > 0);
+    });
+
+    it("emits an error rather than throwing when the render aborts", async () => {
+      const reason = new Error("boom");
+      const stream = mockStream();
+      renderAsync(Promise.reject(reason)).pipe(stream);
+      await stream.nextEvent;
+      assert.deepEqual(stream.events, [["error", reason]]);
+      assert.equal(stream.ended, false);
+    });
+
+    it("reports a consumed result through the error path", () => {
+      const result = renderSync();
+      result.toString();
+      const stream = mockStream();
+      result.pipe(stream);
+      assert.equal(stream.events.length, 1);
+      assert.match(String((stream.events[0][1] as Error).message), CONSUMED);
+    });
+  });
+
+  describe("toReadable", () => {
+    it("streams the same html a string render produces", async () => {
+      const expected = renderSync().toString();
+      const stream = renderSync().toReadable();
+      assert.equal(await new Response(stream).text(), expected);
+    });
+
+    it("does not start rendering until the stream is read", async () => {
+      const result = renderSync();
+      const stream = result.toReadable();
+      // Untouched, so the render has not been consumed and toString still works.
+      assertBody(result.toString());
+      await stream.cancel();
+    });
+
+    it("errors the stream when the render aborts", async () => {
+      const reason = new Error("boom");
+      const stream = renderAsync(Promise.reject(reason)).toReadable();
+      await assert.rejects(() => new Response(stream).text(), /boom/);
+    });
+
+    it("aborts the render when the reader cancels", async () => {
+      const stream = renderAsync(Promise.resolve("a")).toReadable();
+      const reader = stream.getReader();
+      await reader.read();
+      await reader.cancel(new Error("done here"));
+      assert.deepEqual(await reader.read(), { value: undefined, done: true });
+    });
+  });
+
+  describe("async iterator", () => {
+    it("yields the html in chunks", async () => {
+      const chunks: string[] = [];
+      for await (const chunk of renderSync()) chunks.push(chunk);
+      assertBody(chunks.join(""));
+    });
+
+    it("stops after the first chunk when the consumer breaks early", async () => {
+      const chunks: string[] = [];
+      for await (const chunk of renderAsync(Promise.resolve("a"))) {
+        chunks.push(chunk);
+        break;
+      }
+      assert.equal(chunks.length, 1);
+    });
+
+    it("reports done when the consumer returns early", async () => {
+      const result = renderAsync(Promise.resolve("a"));
+      const iterator = iterate(result);
+      await iterator.next();
+      assert.deepEqual(await iterator.return("stopped"), {
+        value: "stopped",
+        done: true,
+      });
+    });
+
+    it("aborts the render when the consumer throws in", async () => {
+      const result = renderAsync(Promise.resolve("a"));
+      const iterator = iterate(result);
+      await iterator.next();
+      assert.deepEqual(await iterator.throw(new Error("boom")), {
+        value: "",
+        done: true,
+      });
+    });
+
+    it("rejects when the result has already been consumed", async () => {
+      const result = renderSync();
+      result.toString();
+      const iterator = iterate(result);
+      await assert.rejects(() => iterator.next(), CONSUMED);
+    });
+  });
+});

--- a/packages/runtime-tags/src/__tests__/render-result/async.marko
+++ b/packages/runtime-tags/src/__tests__/render-result/async.marko
@@ -1,0 +1,3 @@
+<await|v|=input.value>
+  <p>${v}</p>
+</await>

--- a/packages/runtime-tags/src/__tests__/render-result/sync.marko
+++ b/packages/runtime-tags/src/__tests__/render-result/sync.marko
@@ -1,0 +1,1 @@
+<h1>Hello ${input.name}</h1>


### PR DESCRIPTION
`html/template.ts` had 38 of its 51 functions never called: `pipe`, `toReadable`, `catch`/`finally`, the synchronous `toString`, and the async iterator's `throw`/`return` were entirely untested, along with the consumed-result and abort paths of each. This adds 22 tests over a sync and an async fixture, taking that file from 58% to 92% of statements and 13/51 to 32/51 functions.

Repo-wide that is 91.72% → 92.01% statements and 89.14% → 89.81% functions.

Writing them surfaced a type gap, recorded in `agent-feedback/bugs.md` rather than fixed here: `RenderedTemplate` declares only `then`, async iteration and `toReadable`, so `pipe`/`catch`/`finally` do not type-check and the test file carries a local intersection to compensate.