### PR TITLE
fix(runtime-tags): run cleanup queued by a destroy outside a render

### DIFF
--- a/.changeset/destroy-outside-render-cleanup.md
+++ b/.changeset/destroy-outside-render-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Run `<lifecycle>` `onDestroy` and abort in-flight `$signal` requests when a scope is destroyed outside a render, such as from a mounted template's `destroy()`.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26420,
-        "brotli": 9814
+        "min": 26428,
+        "brotli": 9840
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 119
       },
       "runtime": {
-        "min": 3904,
-        "brotli": 1733
+        "min": 3911,
+        "brotli": 1737
       },
       "total": {
-        "min": 4065,
-        "brotli": 1852
+        "min": 4072,
+        "brotli": 1856
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6429,
-        "brotli": 2826
+        "min": 6436,
+        "brotli": 2833
       },
       "total": {
-        "min": 7074,
-        "brotli": 3190
+        "min": 7081,
+        "brotli": 3197
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6429 (min) 2826 (brotli)
+// size: 6436 (min) 2833 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -520,7 +520,7 @@ function skipDestroyedRenders() {
 }
 function $signalReset(scope, id) {
   let ctrl = scope.A?.[id];
-  ctrl && (queueEffect(ctrl, abort), (scope.A[id] = void 0));
+  ctrl && ((scope.A[id] = void 0), rendering ? queueEffect(ctrl, abort) : abort(ctrl));
 }
 function abort(ctrl) {
   ctrl.abort();

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 3904 (min) 1733 (brotli)
+// size: 3911 (min) 1737 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -291,7 +291,7 @@ function runRenders() {
 }
 function $signalReset(scope, id) {
   let ctrl = scope.A?.[id];
-  ctrl && (queueEffect(ctrl, abort), (scope.A[id] = void 0));
+  ctrl && ((scope.A[id] = void 0), rendering ? queueEffect(ctrl, abort) : abort(ctrl));
 }
 function abort(ctrl) {
   ctrl.abort();

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26420 (min) 9814 (brotli)
+// size: 26428 (min) 9840 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -2124,7 +2124,7 @@ function _enable_catch() {
 }
 function $signalReset(scope, id) {
   let ctrl = scope.A?.[id];
-  ctrl && (queueEffect(ctrl, abort), (scope.A[id] = void 0));
+  ctrl && ((scope.A[id] = void 0), rendering ? queueEffect(ctrl, abort) : abort(ctrl));
 }
 function $signal(scope, id) {
   return (

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -430,37 +430,6 @@ with the tags translator, then group the collected bindings by `(section, id,
 type===dom)` — section 1 id 6 holds both `$foo` (alias, `pruned === false`) and
 `$bar`, and `bindingUtil.compare($foo, $bar)` returns `0`.
 
-## Flush queued cleanup effects when a scope is destroyed outside a render, so `destroy()` runs `<lifecycle> onDestroy` and aborts `$signal`
-
-`packages/runtime-tags/src/dom/abort-signal.ts` › `$signalReset` | 2026-07-23 | impact:high | effort:low
-
-`$signalReset` does not abort its `AbortController` directly — it defers via
-`queueEffect(ctrl, abort)` (abort-signal.ts:7) into the module-level
-`pendingEffects` array in `dom/queue.ts`, which is only drained by
-`run()`/`prepareEffects`. That is fine for destroys that happen inside a render,
-but three destroy entry points run outside one and never flush:
-`MountedTemplate.destroy()` in `dom/template.ts` › `mount`
-(`removeAndDestroyBranch(branch)` at template.ts:147), `initEmbedded`'s
-MutationObserver in `dom/resume.ts` (`destroyScope(scopes[id])` at
-resume.ts:90), and `compat.runComponentDestroy` in `dom/compat.ts:84`. Because
-`<lifecycle>` wires teardown through the same channel — `_lifecycle` ends with
-`$signal(scope, accessor).onabort = () => thisObj.onDestroy?.()`
-(`dom/dom.ts:494`) — destroying a mounted template removes the DOM but never
-runs `onDestroy` and never aborts in-flight `$signal` fetches; the stranded
-`(abort, ctrl)` pair then fires at an arbitrary later time if any unrelated
-`run()` ever happens, or never at all in an otherwise idle host. This leaks
-timers/subscriptions/observers for every embedder that mounts and unmounts Marko
-6 imperatively (micro-frontends, testing-library cleanup, Class-API interop).
-Fix direction: have `destroyScope`/`destroyBranch` (or each out-of-render
-destroy site) run the effects it queues, e.g. wrap the destroy in
-`runEffects(prepareEffects(() => removeAndDestroyBranch(branch)))`, or make
-`$signalReset` abort synchronously when `rendering` is falsy. Re-verify: in
-jsdom, build `_script('t_0', $s => _lifecycle($s, {
-onMount(){log.push('mount')}, onDestroy(){log.push('destroy')} }))` under a
-`_let`, `_template(...).mount({}, document.body, 'afterbegin')`, then call
-`instance.destroy()` — `log` is `["mount"]` and `pendingEffects.length` is 2; a
-subsequent bare `queue.run()` turns it into `["mount","destroy"]`.
-
 ## Reset the scheduler's `isScheduled` guard without depending on `requestAnimationFrame`
 
 `packages/runtime-tags/src/dom/schedule.ts` › `schedule` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62489,
-        "brotli": 19301
+        "min": 62501,
+        "brotli": 19297
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63774,
-        "brotli": 19810
+        "min": 63785,
+        "brotli": 19866
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63663,
-        "brotli": 19849
+        "min": 63672,
+        "brotli": 19800
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62489,
-        "brotli": 19301
+        "min": 62501,
+        "brotli": 19297
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63815,
-        "brotli": 19860
+        "min": 63824,
+        "brotli": 19857
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62387,
-        "brotli": 19237
+        "min": 62396,
+        "brotli": 19224
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62428,
-        "brotli": 19261
+        "min": 62437,
+        "brotli": 19265
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63766,
-        "brotli": 19862
+        "min": 63776,
+        "brotli": 19786
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63885,
-        "brotli": 19858
+        "min": 63894,
+        "brotli": 19895
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62540,
-        "brotli": 19287
+        "min": 62549,
+        "brotli": 19312
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64072,
-        "brotli": 19991
+        "min": 64081,
+        "brotli": 19984
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65306,
-        "brotli": 20282
+        "min": 65315,
+        "brotli": 20277
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63712,
-        "brotli": 19804
+        "min": 63721,
+        "brotli": 19774
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63774,
-        "brotli": 19854
+        "min": 63785,
+        "brotli": 19853
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62794,
-        "brotli": 19416
+        "min": 62806,
+        "brotli": 19446
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62466,
-        "brotli": 19247
+        "min": 62478,
+        "brotli": 19286
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64215,
-        "brotli": 20014
+        "min": 64224,
+        "brotli": 20032
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63719,
-        "brotli": 19805
+        "min": 63728,
+        "brotli": 19842
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63389,
-        "brotli": 19715
+        "min": 63398,
+        "brotli": 19705
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63887,
-        "brotli": 19887
+        "min": 63896,
+        "brotli": 19869
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63488,
-        "brotli": 19722
+        "min": 63497,
+        "brotli": 19716
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62848,
-        "brotli": 19415
+        "min": 62860,
+        "brotli": 19454
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64576,
-        "brotli": 20208
+        "min": 64585,
+        "brotli": 20233
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5936,
-      "brotli": 2719
+      "min": 5943,
+      "brotli": 2721
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7433,
-      "brotli": 3267
+      "min": 7442,
+      "brotli": 3273
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6184,
-      "brotli": 2802
+      "min": 6191,
+      "brotli": 2809
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8886,
-      "brotli": 3855
+      "min": 8894,
+      "brotli": 3860
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8865,
+        "min": 8872,
         "brotli": 3835
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9925,
+        "min": 9933,
         "brotli": 4296
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10108,
-      "brotli": 4308
+      "min": 10116,
+      "brotli": 4314
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6806,
-      "brotli": 3091
+      "min": 6815,
+      "brotli": 3088
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6220,
-      "brotli": 2845
+      "min": 6227,
+      "brotli": 2850
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6909,
-      "brotli": 3135
+      "min": 6918,
+      "brotli": 3139
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7061,
-      "brotli": 3186
+      "min": 7066,
+      "brotli": 3187
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7106,
-      "brotli": 3188
+      "min": 7111,
+      "brotli": 3192
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7567,
-      "brotli": 3368
+      "min": 7574,
+      "brotli": 3372
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7103,
-      "brotli": 3176
+      "min": 7110,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9027,
-      "brotli": 3886
+      "min": 9035,
+      "brotli": 3890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7053,
-      "brotli": 3133
+      "min": 7060,
+      "brotli": 3143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7103,
-      "brotli": 3176
+      "min": 7110,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8873,
-      "brotli": 3837
+      "min": 8881,
+      "brotli": 3848
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8875,
-      "brotli": 3838
+      "min": 8883,
+      "brotli": 3849
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6229,
-      "brotli": 2839
+      "min": 6236,
+      "brotli": 2841
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6227,
-      "brotli": 2831
+      "min": 6234,
+      "brotli": 2834
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6296,
-      "brotli": 2864
+      "min": 6303,
+      "brotli": 2869
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7574,
-        "brotli": 3466
+        "min": 7583,
+        "brotli": 3471
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9440,
-        "brotli": 4082
+        "min": 9448,
+        "brotli": 4084
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6311,
-      "brotli": 2877
+      "min": 6318,
+      "brotli": 2888
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7113,
-      "brotli": 3257
+      "min": 7120,
+      "brotli": 3279
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7376,
-      "brotli": 3333
+      "min": 7383,
+      "brotli": 3344
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6198,
-      "brotli": 2834
+      "min": 6205,
+      "brotli": 2836
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7187,
-      "brotli": 3252
+      "min": 7192,
+      "brotli": 3266
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7144,
-      "brotli": 3233
+      "min": 7149,
+      "brotli": 3237
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7144,
-      "brotli": 3233
+      "min": 7149,
+      "brotli": 3237
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7164,
-      "brotli": 3242
+      "min": 7169,
+      "brotli": 3251
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6866,
-      "brotli": 3105
+      "min": 6873,
+      "brotli": 3111
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7819,
-        "brotli": 3595
+        "min": 7826,
+        "brotli": 3574
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7609,
-        "brotli": 3370
+        "min": 7617,
+        "brotli": 3373
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6163,
-      "brotli": 2820
+      "min": 6168,
+      "brotli": 2819
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6342,
-        "brotli": 2890
+        "min": 6351,
+        "brotli": 2895
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8275,
-        "brotli": 3735
+        "min": 8283,
+        "brotli": 3740
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7769,
-        "brotli": 3556
+        "min": 7774,
+        "brotli": 3553
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7543,
-        "brotli": 3338
+        "min": 7551,
+        "brotli": 3347
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6145,
-      "brotli": 2806
+      "min": 6150,
+      "brotli": 2808
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6324,
-        "brotli": 2877
+        "min": 6333,
+        "brotli": 2880
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6226,
-      "brotli": 2838
+      "min": 6233,
+      "brotli": 2840
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11022,
-        "brotli": 4769
+        "min": 11030,
+        "brotli": 4772
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5934,
-      "brotli": 2718
+      "min": 5941,
+      "brotli": 2721
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8495,
-      "brotli": 3798
+      "min": 8503,
+      "brotli": 3794
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6340,
-        "brotli": 2748
+        "min": 6347,
+        "brotli": 2753
       },
       "files": {
         "tags/my-dialog.marko": 293,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8337,
-      "brotli": 3609
+      "min": 8344,
+      "brotli": 3620
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14273,
-      "brotli": 5556
+      "min": 14281,
+      "brotli": 5558
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13830,
-      "brotli": 5354
+      "min": 13838,
+      "brotli": 5361
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13704,
-      "brotli": 5299
+      "min": 13712,
+      "brotli": 5304
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13990,
-      "brotli": 5399
+      "min": 13998,
+      "brotli": 5416
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9096,
-      "brotli": 3938
+      "min": 9104,
+      "brotli": 3943
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9320,
-      "brotli": 4009
+      "min": 9328,
+      "brotli": 4010
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8982,
+        "min": 8989,
         "brotli": 3655
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8995,
-        "brotli": 3884
+        "min": 9003,
+        "brotli": 3880
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8981,
-        "brotli": 3871
+        "min": 8988,
+        "brotli": 3877
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8909,
-        "brotli": 3848
+        "min": 8916,
+        "brotli": 3853
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6408,
-      "brotli": 2908
+      "min": 6415,
+      "brotli": 2922
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8811,
-        "brotli": 3790
+        "min": 8818,
+        "brotli": 3793
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6674,
-      "brotli": 3047
+      "min": 6681,
+      "brotli": 3053
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6279,
-      "brotli": 2882
+      "min": 6284,
+      "brotli": 2887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7403,
-        "brotli": 3372
+        "min": 7412,
+        "brotli": 3375
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6121,
+      "min": 6128,
       "brotli": 2785
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5776,
-      "brotli": 2692
+      "min": 5783,
+      "brotli": 2698
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5923,
-      "brotli": 2660
+      "min": 5930,
+      "brotli": 2665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8754,
-      "brotli": 3783
+      "min": 8761,
+      "brotli": 3792
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8641,
-      "brotli": 3725
+      "min": 8648,
+      "brotli": 3737
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9512,
-        "brotli": 4064
+        "min": 9520,
+        "brotli": 4071
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9591,
-        "brotli": 4082
+        "min": 9599,
+        "brotli": 4087
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9404,
-        "brotli": 4022
+        "min": 9412,
+        "brotli": 4026
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6401,
-        "brotli": 2909
+        "min": 6408,
+        "brotli": 2918
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9427,
-        "brotli": 4029
+        "min": 9435,
+        "brotli": 4030
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14570,
-        "brotli": 5633
+        "min": 14578,
+        "brotli": 5639
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13683,
-        "brotli": 5307
+        "min": 13691,
+        "brotli": 5313
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9322,
-        "brotli": 4011
+        "min": 9329,
+        "brotli": 4012
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9449,
-        "brotli": 4036
+        "min": 9457,
+        "brotli": 4033
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8608,
-      "brotli": 3699
+      "min": 8615,
+      "brotli": 3713
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8870,
-        "brotli": 3810
+        "min": 8878,
+        "brotli": 3812
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6678,
-      "brotli": 3018
+      "min": 6685,
+      "brotli": 3026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3318,
-      "brotli": 1633
+      "min": 3325,
+      "brotli": 1637
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2762,
-      "brotli": 1352
+      "min": 2769,
+      "brotli": 1359
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7275,
-      "brotli": 3333
+      "min": 7282,
+      "brotli": 3336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7906,
-      "brotli": 3608
+      "min": 7911,
+      "brotli": 3589
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7371,
+      "min": 7378,
       "brotli": 3345
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7989,
-      "brotli": 3614
+      "min": 7996,
+      "brotli": 3618
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7478,
-      "brotli": 3343
+      "min": 7485,
+      "brotli": 3346
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7219,
-      "brotli": 3302
+      "min": 7226,
+      "brotli": 3304
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7021,
-      "brotli": 3239
+      "min": 7028,
+      "brotli": 3245
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7289,
-      "brotli": 3349
+      "min": 7296,
+      "brotli": 3336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7298,
-      "brotli": 3338
+      "min": 7305,
+      "brotli": 3358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8324,
-      "brotli": 3716
+      "min": 8333,
+      "brotli": 3723
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6507,
-      "brotli": 2956
+      "min": 6514,
+      "brotli": 2959
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8403,
-      "brotli": 3777
+      "min": 8408,
+      "brotli": 3780
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8150,
+      "min": 8157,
       "brotli": 3675
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6957,
-      "brotli": 3204
+      "min": 6964,
+      "brotli": 3202
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7686,
-        "brotli": 3529
+        "min": 7693,
+        "brotli": 3562
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8049,
-        "brotli": 3667
+        "min": 8056,
+        "brotli": 3699
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7036,
-      "brotli": 3197
+      "min": 7043,
+      "brotli": 3208
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7030,
-      "brotli": 3194
+      "min": 7037,
+      "brotli": 3205
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6814,
-      "brotli": 3160
+      "min": 6821,
+      "brotli": 3144
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7026,
-      "brotli": 3242
+      "min": 7033,
+      "brotli": 3250
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7163,
-      "brotli": 3294
+      "min": 7170,
+      "brotli": 3295
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9252,
-        "brotli": 3929
+        "min": 9260,
+        "brotli": 3943
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9975,
-        "brotli": 4201
+        "min": 9983,
+        "brotli": 4203
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9060,
-        "brotli": 3856
+        "min": 9068,
+        "brotli": 3857
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6330,
-      "brotli": 2878
+      "min": 6337,
+      "brotli": 2881
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6319,
-      "brotli": 2866
+      "min": 6326,
+      "brotli": 2874
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5916,
-      "brotli": 2712
+      "min": 5923,
+      "brotli": 2711
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6188,
-      "brotli": 2827
+      "min": 6197,
+      "brotli": 2834
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6057,
-      "brotli": 2770
+      "min": 6064,
+      "brotli": 2771
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6437,
-        "brotli": 2939
+        "min": 6442,
+        "brotli": 2936
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6598,
-        "brotli": 2991
+        "min": 6603,
+        "brotli": 2993
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6567,
-        "brotli": 2972
+        "min": 6572,
+        "brotli": 2979
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6117,
-        "brotli": 2806
+        "min": 6122,
+        "brotli": 2812
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6465,
-      "brotli": 2954
+      "min": 6472,
+      "brotli": 2956
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6403,
-        "brotli": 2907
+        "min": 6410,
+        "brotli": 2910
       },
       "files": {
         "tags/test.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7489,
-        "brotli": 3405
+        "min": 7496,
+        "brotli": 3409
       },
       "files": {
         "tags/inner/index.marko": 1000,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7777,
-      "brotli": 3468
+      "min": 7786,
+      "brotli": 3467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7799,
-      "brotli": 3471
+      "min": 7808,
+      "brotli": 3470
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11358,
-      "brotli": 4862
+      "min": 11366,
+      "brotli": 4868
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 11240,
-      "brotli": 4818
+      "min": 11248,
+      "brotli": 4814
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11027,
-      "brotli": 4739
+      "min": 11035,
+      "brotli": 4745
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7741,
-      "brotli": 3418
+      "min": 7750,
+      "brotli": 3417
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7741,
-      "brotli": 3418
+      "min": 7750,
+      "brotli": 3417
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8147,
-      "brotli": 3590
+      "min": 8155,
+      "brotli": 3587
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 6058,
-      "brotli": 2735
+      "min": 6077,
+      "brotli": 2746
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8158,
-      "brotli": 3591
+      "min": 8166,
+      "brotli": 3588
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 140
     },
     "shared": {
-      "min": 11085,
-      "brotli": 4791
+      "min": 11093,
+      "brotli": 4797
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6010,
-      "brotli": 2714
+      "min": 6029,
+      "brotli": 2729
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 74
     },
     "shared": {
-      "min": 7234,
-      "brotli": 3224
+      "min": 7241,
+      "brotli": 3220
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 112
     },
     "shared": {
-      "min": 6684,
-      "brotli": 3009
+      "min": 6689,
+      "brotli": 3007
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9332,
-      "brotli": 4008
+      "min": 9340,
+      "brotli": 4007
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7735,
-        "brotli": 3513
+        "min": 7742,
+        "brotli": 3533
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6383,
-        "brotli": 2874
+        "min": 6390,
+        "brotli": 2880
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6612,
+      "min": 6617,
       "brotli": 2932
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9405,
-      "brotli": 4020
+      "min": 9413,
+      "brotli": 4026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9935,
-      "brotli": 4316
+      "min": 9943,
+      "brotli": 4296
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9045,
-        "brotli": 3886
+        "min": 9053,
+        "brotli": 3896
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7999,
-      "brotli": 3631
+      "min": 8008,
+      "brotli": 3618
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7897,
+      "min": 7902,
       "brotli": 3574
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8625,
-        "brotli": 3929
+        "min": 8633,
+        "brotli": 3910
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7660,
-      "brotli": 3522
+      "min": 7667,
+      "brotli": 3495
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15016,
-        "brotli": 5937
+        "min": 15024,
+        "brotli": 5930
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8951,
-        "brotli": 3848
+        "min": 8958,
+        "brotli": 3857
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6200,
-      "brotli": 2817
+      "min": 6207,
+      "brotli": 2824
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9813,
+        "min": 9821,
         "brotli": 4163
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9307,
+      "min": 9314,
       "brotli": 4004
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6116,
-        "brotli": 2788
+        "min": 6123,
+        "brotli": 2791
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6338,
-        "brotli": 2890
+        "min": 6345,
+        "brotli": 2891
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6920,
-      "brotli": 3099
+      "min": 6927,
+      "brotli": 3103
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6920,
-      "brotli": 3099
+      "min": 6927,
+      "brotli": 3103
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7440,
-      "brotli": 3279
+      "min": 7447,
+      "brotli": 3285
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6592,
-        "brotli": 2997
+        "min": 6599,
+        "brotli": 2994
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9024,
-      "brotli": 3912
+      "min": 9034,
+      "brotli": 3919
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7134,
-      "brotli": 3204
+      "min": 7139,
+      "brotli": 3206
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6018,
-      "brotli": 2723
+      "min": 6037,
+      "brotli": 2736
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9401,
-      "brotli": 4074
+      "min": 9409,
+      "brotli": 4076
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9070,
-      "brotli": 3910
+      "min": 9078,
+      "brotli": 3914
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/mounted-template.test.ts
+++ b/packages/runtime-tags/src/__tests__/mounted-template.test.ts
@@ -1,0 +1,55 @@
+import assert from "assert/strict";
+import path from "path";
+
+import type { Template } from "@marko/runtime-tags/common/types";
+
+import * as tagsTranslator from "../translator";
+import { createServerRunner } from "./utils/bundle";
+import createBrowser from "./utils/create-browser";
+
+const dir = path.join(import.meta.dirname, "mounted-template");
+
+describe("runtime-tags/dom mounted template", () => {
+  let clientRunner: (ctx: any) => Promise<{ template: Template }>;
+  let disposeServer: () => void;
+
+  before(async function () {
+    this.timeout(60000);
+    const runner = await createServerRunner(
+      dir,
+      { lifecycle: "./lifecycle.marko" },
+      {
+        translator: tagsTranslator as any,
+        optimize: false,
+        babelConfig: {
+          babelrc: false,
+          configFile: false,
+          browserslistConfigFile: false,
+        },
+      },
+    );
+    clientRunner = runner.clientRunner!;
+    disposeServer = runner.disposeServer;
+  });
+
+  after(() => disposeServer?.());
+
+  it("runs cleanup queued outside a render when destroyed", async () => {
+    const browser = createBrowser();
+    const { window } = browser;
+    const log: string[] = ((window as any).log = []);
+    const { template } = await clientRunner(browser.ctx);
+    const instance = template.mount({}, window.document.body, "afterbegin");
+    const signal = (window as any).signal as AbortSignal;
+
+    assert.deepEqual(log, ["mount"]);
+    assert.equal(signal.aborted, false);
+    assert.equal(window.document.getElementById("out")?.textContent, "mounted");
+
+    instance.destroy();
+
+    assert.equal(window.document.getElementById("out"), null);
+    assert.deepEqual(log, ["mount", "destroy"]);
+    assert.equal(signal.aborted, true);
+  });
+});

--- a/packages/runtime-tags/src/__tests__/mounted-template/lifecycle.marko
+++ b/packages/runtime-tags/src/__tests__/mounted-template/lifecycle.marko
@@ -1,0 +1,8 @@
+<lifecycle
+  onMount() { window.log.push("mount"); }
+  onDestroy() { window.log.push("destroy"); }
+/>
+<script>
+  window.signal = $signal;
+</script>
+<div#out>mounted</div>

--- a/packages/runtime-tags/src/dom/abort-signal.ts
+++ b/packages/runtime-tags/src/dom/abort-signal.ts
@@ -1,11 +1,14 @@
 import { AccessorProp, type Scope } from "../common/types";
-import { queueEffect } from "./queue";
+import { queueEffect, rendering } from "./queue";
 
 export function $signalReset(scope: Scope, id: string | number) {
   const ctrl = scope[AccessorProp.AbortControllers]?.[id];
   if (ctrl) {
-    queueEffect(ctrl as any, abort as any);
     scope[AccessorProp.AbortControllers]![id] = undefined;
+    // Deferred so `onabort` cannot run user code mid render; a destroy from
+    // outside a render has no effect flush to defer to.
+    if (rendering) queueEffect(ctrl as any, abort as any);
+    else abort(ctrl as AbortController);
   }
 }
 


### PR DESCRIPTION
`$signalReset` never aborts its `AbortController` directly — it defers through `queueEffect`, and that queue is only drained by a render's effect flush. Three destroy entry points run outside a render and never flush: `MountedTemplate.destroy()`, `initEmbedded`'s MutationObserver, and `compat.runComponentDestroy`.

Since `<lifecycle>` wires teardown through the same channel (`_lifecycle` ends with `$signal(scope, accessor).onabort = () => thisObj.onDestroy?.()`), destroying a mounted template removed the DOM but never ran `onDestroy` and never aborted in-flight `$signal` fetches. The stranded pair then fired at an arbitrary later time if any unrelated render happened, or never at all on an otherwise idle page — leaking timers, subscriptions and observers for every embedder that mounts and unmounts imperatively.

The deferral exists so `onabort` cannot run user code mid render. A destroy from outside a render has no such hazard and no flush to defer to, so it now aborts synchronously. Costs 26 brotli bytes on the dom runtime; flushing at the three destroy sites instead measured 34 and would leave a fourth such site to reintroduce the bug.

`mounted-template.test.ts` is new, covering the `mount()`/`destroy()` API that previously had none. Without the change its template renders and logs `mount`, then `destroy()` removes the DOM while `onDestroy` never runs and the signal stays unaborted.
