### PR TITLE
fix(runtime-tags): keep array-form tag hooks through the interop taglib merge

### DIFF
--- a/.changeset/interop-array-migrate-hooks.md
+++ b/.changeset/interop-array-migrate-hooks.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a `TypeError: Cannot read properties of undefined (reading 'default')` when compiling a template containing `<attrs>` or `<effect>` through `marko/translator`, whose taglib merge dropped the array-form `migrate` hooks those tags declare.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1014,37 +1014,24 @@ contains no markup between the`<debug>`tags, so a fixture with a`<log>`/`<debug>
 compile -- -o html -d`on`<div>a</div>`/`<log="x"/>`/`<div>b</div>`currently yields`console.log("x"); _html("<div>a</div><div>b</div>");`, versus
 `-o dom` which keeps the call between the two text writes.
 
-## Handle array-form tag `migrate` hooks in the interop taglib merge — `<attrs>`/`<effect>` crash every interop compile
+## Treat `<attrs>`/`<effect>` as tags-API markers in interop feature detection
 
-`packages/runtime-tags/src/translator/interop/index.ts` › `mergeTagDef` | 2026-07-23 | impact:high | effort:low
+`packages/runtime-tags/src/translator/interop/feature-detection.ts` › `getFeatureTypeFromCoreTagName` | 2026-07-27 | impact:med | effort:low
 
-`mergeTagDef` routes a tag definition's `migrate` key through
-`mergeVisit(normalizeVisit(value5), normalizeVisit(value6))`, but
-`normalizeVisit` only recognises a function or a `{enter,exit}`/`{default}`
-object. `translator/core/attrs.ts` and `translator/core/effect.ts` declare
-`migrate: [fn]` — an array, which the compiler's taglib loader natively supports
-(`loadTagFromProps.migrate` recurses over arrays) — so
-`getVisitorEnter`/`getVisitorExit` both see `undefined` and `mergeVisit` returns
-`undefined`. `mergeObjects` still writes the key, so the merged `marko-core`
-taglib ends up with `"<attrs>".migrate === undefined`; the loader then pushes `{
-hook: undefined }` and `addMigrators`
-(`packages/compiler/src/babel-plugin/plugins/migrate.js:49`) dereferences
-`migrator.hook.default`, throwing `TypeError: Cannot read properties of
-undefined (reading 'default')` with no filename, line, or code frame. Every
-compile through `marko/translator` of a template containing `<attrs>` or
-`<effect>` fails this way, including inside a `tags/` directory, while the
-identical template compiles under `@marko/runtime-tags/translator` and merely
-emits the deprecation diagnostic that would have auto-rewritten it; `<attrs>`
-still appears in 10+ `src/__tests__/fixtures/` templates but in zero
-`fixtures-interop/` ones, which is why it is untested. Fix
-`normalizeVisit`/`mergeVisit` to flatten array-form hooks and make
-`mergeObjects` omit keys whose merged value is `undefined` so a dropped hook can
-never reach the loader as a null hook, then add a `fixtures-interop/` fixture.
-Re-verify: `node -r ~ts -e 'const
-core=require("./packages/runtime-class/src/translator.js").taglibs.find(([id])=>id==="marko-core")[1];console.log("migrate"
-in core["<attrs>"], core["<attrs>"].migrate)'` prints `true undefined`, and
-compiling a template whose body is `<attrs/{ a }/>\n<div>${a}</div>` with
-`marko/translator` throws the TypeError above.
+`getFeatureTypeFromCoreTagName` lists `const`/`let`/`lifecycle`/`try` and friends
+as `FeatureType.Tags`, but not the deprecated core tags `attrs` and `effect`.
+A template whose only tags-API signal is one of those two — e.g. a file whose
+whole body is `<effect() { … }/>` — is therefore detected as class API, so the
+tags-side migrator that would rewrite it to `<script>` never runs (`mergeVisit`
+dispatches on `isTagsAPI()`), and the merged `<effect>` tag definition's
+`attributes: {}` then rejects the method shorthand with `<effect> does not
+support the "value" attribute.` The same body compiles under
+`@marko/runtime-tags/translator`, which has no such dispatch. `<attrs/{ a }/>`
+only escapes this because its tag variable is itself a marker; a var-less
+`<attrs/>` fails the same way, as `Unable to find entry point for custom tag
+<attrs>.` Re-verify: compile a template whose entire body is `<effect() {
+console.log(1) }/>` with `marko/translator` and with
+`@marko/runtime-tags/translator` — the first errors, the second migrates.
 
 ## Classify `<html-script>`/`<html-style>` as Tags-API markers in interop feature detection
 

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/diagnostics.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/diagnostics.md
@@ -1,0 +1,4 @@
+# Diagnostics
+
+- `template.marko` deprecation: The 'effect' tag has been replaced by the 'script' tag.
+- `template.marko` deprecation: The `attrs` tag is deprecated, prefer destructuring `input` via the `const` tag.

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<button id=inc>inc</button><div id=out></div>";
+const $walks = " c";
+const $input_greeting__OR__count__script = _script("__tests__/template.marko_0_greeting_count", ($scope) => document.getElementById("out").textContent = `${$scope.greeting} ${$scope.count}`);
+const $input_greeting__OR__count = /*@__PURE__*/ _or(5, $input_greeting__OR__count__script);
+const $count = /*@__PURE__*/ _let("count/4", $input_greeting__OR__count);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $greeting = /*@__PURE__*/ _const("greeting", $input_greeting__OR__count);
+const $input = ($scope, input) => $greeting($scope, input.greeting);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $input_greeting__OR__count = /*@__PURE__*/ _or(5, _script("a0", ($scope) => document.getElementById("out").textContent = `${$scope.d} ${$scope.e}`));
+const $count = /*@__PURE__*/ _let(4, $input_greeting__OR__count);
+const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.e + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const { greeting } = input;
+	let count = 0;
+	_html(`<button id=inc>inc</button>${_el_resume($scope0_id, "#button/0")}<div id=out></div>`);
+	_script($scope0_id, "__tests__/template.marko_0_greeting_count");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		greeting,
+		count
+	}, "__tests__/template.marko", 0, {
+		greeting: "1:10",
+		count: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/html.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const { greeting } = input;
+	let count = 0;
+	_html(`<button id=inc>inc</button>${_el_resume($scope0_id, "a")}<div id=out></div>`);
+	_script($scope0_id, "a0");
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		d: greeting,
+		e: count
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/render.debug.md
@@ -1,0 +1,35 @@
+# Render `{"greeting":"hi"}`
+```html
+<button
+  id="inc"
+>
+  inc
+</button>
+<div
+  id="out"
+>
+  hi 0
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#inc")).click();
+```
+```html
+<button
+  id="inc"
+>
+  inc
+</button>
+<div
+  id="out"
+>
+  hi 1
+</div>
+```
+## Change
+```
+REMOVE: #out::text("hi 0")
+INSERT: #out::text("hi 1")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/render.md
@@ -1,0 +1,35 @@
+# Render `{"greeting":"hi"}`
+```html
+<button
+  id="inc"
+>
+  inc
+</button>
+<div
+  id="out"
+>
+  hi 0
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#inc")).click();
+```
+```html
+<button
+  id="inc"
+>
+  inc
+</button>
+<div
+  id="out"
+>
+  hi 1
+</div>
+```
+## Change
+```
+REMOVE: #out::text("hi 0")
+INSERT: #out::text("hi 1")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button id=inc>inc</button><!--M_*1 #button/0-->
+<div id=out></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      greeting: "hi",
+      count: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/template.marko_0_greeting_count 1 packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button id=inc>inc</button><!--M_*1 a-->
+<div id=out></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: "hi",
+    e: 0
+  }], "a0 1 a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3233,
+      "brotli": 1573
+    }
+  },
+  "html": {
+    "min": 378,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/template.marko
@@ -1,0 +1,5 @@
+<attrs/{ greeting }/>
+<let/count = 0/>
+<button id="inc" onClick() { count++ }>inc</button>
+<effect() { document.getElementById("out")!.textContent = `${greeting} ${count}` }/>
+<div#out/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function inc(document: Document) {
+  (document.querySelector("#inc") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{ greeting: "hi" }, inc],
+};

--- a/packages/runtime-tags/src/translator/interop/index.ts
+++ b/packages/runtime-tags/src/translator/interop/index.ts
@@ -265,26 +265,32 @@ function mergeObjects<A, B, K extends keyof (B & {}) | keyof (A & {}), R>(
   ) => R,
 ): Record<K, R> {
   const merged: any = {};
+  // The taglib loader dispatches on key presence, so a key that merged to
+  // nothing is omitted rather than handed over as a hook it cannot call.
+  const assign = (key: unknown, aValue: unknown, bValue: unknown) => {
+    const value = (cb as any)(key, aValue, bValue);
+    if (value !== undefined) merged[key as string] = value;
+  };
 
   if (a) {
     if (b) {
       for (const key in a) {
-        merged[key] = (cb as any)(key, a[key], (b as any)[key]);
+        assign(key, a[key], (b as any)[key]);
       }
 
       for (const key in b) {
         if (!(key in (a as any))) {
-          merged[key] = (cb as any)(key, undefined, b[key]);
+          assign(key, undefined, b[key]);
         }
       }
     } else {
       for (const key in a) {
-        merged[key] = (cb as any)(key, a[key], undefined);
+        assign(key, a[key], undefined);
       }
     }
   } else if (b) {
     for (const key in b) {
-      merged[key] = (cb as any)(key, undefined, b[key]);
+      assign(key, undefined, b[key]);
     }
   }
 
@@ -331,7 +337,47 @@ function normalizeVisitor(visitor: any): t.Visitor | undefined {
 }
 
 function normalizeVisit(visitor: any): t.VisitNode<any, t.Node> | undefined {
+  if (Array.isArray(visitor)) {
+    // `migrate`/`transform` take a list of hooks, but the merge yields one
+    // hook per key, so the list has to run behind a single visit.
+    let merged: t.VisitNode<any, t.Node> | undefined;
+    for (const entry of visitor) {
+      merged = sequenceVisit(merged, normalizeVisit(entry));
+    }
+    return merged;
+  }
+
   return typeof visitor === "function" ? visitor : normalizeVisitor(visitor);
+}
+
+function sequenceVisit(
+  first: undefined | t.VisitNode<unknown, any>,
+  second: undefined | t.VisitNode<unknown, any>,
+): undefined | t.VisitNode<unknown, t.Node> {
+  if (!first || !second) return first || second;
+
+  const enterFirst = getVisitorEnter(first);
+  const enterSecond = getVisitorEnter(second);
+  const enter: undefined | t.VisitNode<unknown, t.Node> =
+    (enterFirst || enterSecond) &&
+    function enter(path, state) {
+      const { node } = path;
+      enterFirst?.call(this, path, state);
+      // Matches the hook loops these replace, which stop once one swaps the node.
+      if (path.node === node) enterSecond?.call(this, path, state);
+    };
+
+  const exitFirst = getVisitorExit(first);
+  const exitSecond = getVisitorExit(second);
+  const exit: undefined | t.VisitNode<unknown, t.Node> =
+    (exitFirst || exitSecond) &&
+    function exit(path, state) {
+      const { node } = path;
+      exitFirst?.call(this, path, state);
+      if (path.node === node) exitSecond?.call(this, path, state);
+    };
+
+  return exit ? (enter ? { enter, exit } : { exit }) : enter;
 }
 
 function getVisitorEnter<A, B extends t.Node>(


### PR DESCRIPTION
`normalizeVisit` recognised a hook that is a function or an `{enter,exit}` object, but not the array form the taglib loader also accepts (`loadTagFromProps` recurses over arrays for `migrate` and `transform`). `<attrs>` and `<effect>` both declare `migrate: [fn]`, so `mergeVisit` saw no enter and no exit and returned `undefined`, while `mergeObjects` still wrote the key — leaving `"<attrs>".migrate === undefined` in the merged `marko-core` taglib. The loader then pushed `{ hook: undefined }` and the migrate plugin dereferenced `migrator.hook.default`:

```
TypeError: Cannot read properties of undefined (reading 'default')
```

with no filename, line or code frame, on every compile through `marko/translator` of a template containing either tag. The same template compiles under `@marko/runtime-tags/translator` and merely emits the deprecation that would have rewritten it.

An array now runs behind a single visit, stopping when a hook replaces the node exactly as the migrate and transform loops it stands in for do, and `mergeObjects` omits a key whose merged value is `undefined` so a dropped hook can never reach the loader as a null hook.

The new `interop-deprecated-core-tag-migrate` fixture covers both tags; without the change it fails with the `TypeError` above. `<attrs>` appeared in 10+ `fixtures/` templates but zero `fixtures-interop/` ones, which is why this was untested.
