### PR TITLE
test(runtime-tags): compare built-in contents in the serializer round-trip gate

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -828,32 +828,6 @@ of=input.words>constructor</for></div>` for dom and mount it with `{ words:
 ["a"] }` — it throws before rendering, while the same template with body text
 `x` renders fine.
 
-## Make `assertIsDeepSubset` compare Map/Set/Headers/Date contents instead of only the constructor name
-
-`packages/runtime-tags/src/__tests__/serializer.test.ts` › `assertIsDeepSubset` | 2026-07-23 | impact:high | effort:low
-
-`assertIsDeepSubset` is the round-trip correctness gate behind every
-`assertStringify` call in serializer.test.ts, but after the constructor-name
-check it walks `Reflect.ownKeys(subset)` — which is `[]` for `Map`, `Set`,
-`Date`, `URL`, `URLSearchParams`, `Headers`, `FormData`, `ArrayBuffer`,
-`Promise`, `Request` and `Response`, because their state is internal. Its `case
-Symbol.iterator:` arm never fires for those types either (their iterator lives
-on the prototype, not as an own key; it only fires for the
-plain-object-with-own-iterator attr-tag shape exercised by the `Symbol.iterator
-inline` tests), so for every built-in the deep check silently degenerates to
-"same constructor name". That is exactly the hole the already-filed
-`writeMap`/`writeSet` ancestor-reference data-loss bug slipped through: the
-payload string still looks plausible, so the string assertion passes, and the
-value check accepts a `Set` that round-tripped to `size === 0`. Fix by
-dispatching on the classified constructor — compare
-`[...map]`/`[...set]`/`[...headers]`/`[...formData]`/`[...searchParams]`
-entrywise and `+date`/`String(url)` for the opaque scalars — before falling back
-to the own-key walk. Re-verify: `assertIsDeepSubset(new Set(), new Set(["a"]))`
-currently returns without throwing, and round-tripping `const parent={name:'p'};
-const s=new Set(); s.add(parent); parent.set=s;` through
-`Serializer#stringifyScopes` yields a value whose `set.size` is 0 while
-`assertIsDeepSubset(result, parent)` still passes.
-
 ## Key the bound-attribute change-handler cache by refining function, not just the binding
 
 `packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandler` | 2026-07-23 | impact:med | effort:low
@@ -1358,34 +1332,6 @@ fixture `<svg><${"linearGradient"} onClick(){ … }><stop offset="0%"/></></svg>
 with a click step and run it in debug SSR-resume mode — it throws inside
 `_attrs_script` because `scope["#linearGradient/0"]` is undefined, while the
 same template renders fine in CSR-only mode.
-
-## Escape `<script>`/`<style>` raw-text bodies once per element, not once per interpolation
-
-`packages/runtime-tags/src/html/content.ts` › `_escape_script` | 2026-07-23 | impact:high | effort:med
-
-`_escape_script` (content.ts:36) and `_escape_style` (content.ts:47) neutralize
-multi-character tokens (`</script`, `<script`, `<!--`, `</style`), but the html
-`translate.exit` for text-only native tags in
-`packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` (the
-`isTextOnly` loop, ~:664-670) applies them per placeholder, so a token that
-straddles two adjacent interpolations is never seen by either call.
-`<html-script>${a}${b}${c}</html-script>` with `a='<'`, `b='/script>'`, `c='<img
-src=x onerror=alert(1)>'` emits `<script></script><img src=x
-onerror=alert(1)></script>` — a real breakout — and
-`<html-style>${a}${b}</html-style>` with `a='<'`, `b='/style><img src=x
-onerror=alert(1)>'` breaks out identically; the same value passed as a single
-expression (`${a+b+c}`) is escaped correctly to `\x3C/script>`. Static template
-text ending in `<` immediately before a placeholder has the same straddle.
-`_escape` (used for `<title>`/`<textarea>`) and `_escape_comment` are
-single-character escapers and are immune, which is why only the script/style
-helpers are affected. Fix direction: build one expression for the whole
-text-only body (as `bodyToTextLiteral` in
-`translator/util/body-to-text-literal.ts` already does for the DOM path) and
-wrap that single expression in `getTextOnlyEscapeHelper(tagName)`, so the
-concatenation — including static text boundaries — is escaped as one string.
-Re-verify: render `<html-script>${a}${b}${c}</html-script>` with those three
-values and parse the output with parse5 `parseFragment`; today the tree contains
-`img` with `onerror`, and after the fix it must contain only `script`.
 
 ## Stop double-escaping character references in a static `<textarea>` body
 

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -2183,6 +2183,34 @@ describe("serializer", () => {
   });
 });
 
+// The round-trip gate every `assertStringify` leans on: a built-in that lost
+// or changed its contents must not pass as the value that went in.
+describe("assertIsDeepSubset", () => {
+  const rejects = (subset: unknown, superset: unknown) =>
+    assert.throws(() => assertIsDeepSubset(subset, superset));
+
+  it("compares collection contents, not just the constructor", () => {
+    rejects(new Set(), new Set(["a"]));
+    rejects(new Set(["b"]), new Set(["a"]));
+    rejects(new Map(), new Map([["a", 1]]));
+    rejects(new Map([["a", 2]]), new Map([["a", 1]]));
+    rejects(new URLSearchParams(), new URLSearchParams("a=1"));
+    rejects(new Headers(), new Headers({ a: "1" }));
+    assertIsDeepSubset(new Set(["a"]), new Set(["a"]));
+    assertIsDeepSubset(new Map([["a", 1]]), new Map([["a", 1]]));
+  });
+
+  it("compares the opaque scalars by value", () => {
+    rejects(new Date(0), new Date(1));
+    rejects(new URL("https://a.example/"), new URL("https://b.example/"));
+    assertIsDeepSubset(new Date(1), new Date(1));
+    assertIsDeepSubset(
+      new URL("https://a.example/"),
+      new URL("https://a.example/"),
+    );
+  });
+});
+
 // Minimal stand-in for the browser's per render serialize context: a
 // callable that resolves scopes by id (optionally invoking a registered
 // factory), applies fill arrays with adopt-or-merge semantics, and carries
@@ -2408,6 +2436,39 @@ function assertIsDeepSubset(
 
   if (aConstructor === "Promise") {
     (subset as Promise<unknown>).catch(() => {});
+  }
+
+  // These keep their state internal, so `Reflect.ownKeys` is empty for them
+  // and the walk below would accept any two values of the same class.
+  switch (aConstructor) {
+    case "Map":
+    case "Set":
+    case "Headers":
+    case "FormData":
+    case "URLSearchParams": {
+      const subsetEntries = [...(subset as Iterable<unknown>)];
+      const supersetEntries = [...(superset as Iterable<unknown>)];
+      assertEqualAtAccessor(
+        subsetEntries.length,
+        supersetEntries.length,
+        `${accessor} size`,
+      );
+      for (let i = 0; i < subsetEntries.length; i++) {
+        assertIsDeepSubset(
+          subsetEntries[i],
+          supersetEntries[i],
+          `${accessor}[${i}]`,
+          seen,
+        );
+      }
+      return;
+    }
+    case "Date":
+      assertEqualAtAccessor(+(subset as Date), +(superset as Date), accessor);
+      return;
+    case "URL":
+      assertEqualAtAccessor(String(subset), String(superset), accessor);
+      return;
   }
 
   for (const key of Reflect.ownKeys(subset)) {


### PR DESCRIPTION
`assertIsDeepSubset` is the round-trip correctness gate behind every `assertStringify` call, but after classifying by constructor name it walked `Reflect.ownKeys(subset)` — which is `[]` for `Map`, `Set`, `Date`, `URL`, `Headers`, `FormData` and `URLSearchParams`, since their state is internal. Its `Symbol.iterator` arm never fired for them either, because that lives on the prototype rather than as an own key. For every built-in the deep check therefore degenerated to "same constructor name": `assertIsDeepSubset(new Set(), new Set(["a"]))` passed, as did `new Date(0)` against `new Date(1)`.

That is the hole the `writeMap`/`writeSet` ancestor-reference data loss slipped through — the payload string still looked plausible, so the string assertion passed and the value check accepted a `Set` that had round-tripped to `size === 0`.

Those types now compare entrywise, and `Date`/`URL` by value, before the own-key walk. Sizes must match rather than following the `length <=` leniency arrays get; the whole suite passes that way, so nothing depended on the looser rule. The 63 built-in round-trips already in this file are unchanged, which is the evidence the serializer is genuinely correct for them today rather than merely unmeasured.

Two `agent-feedback` entries are dropped: this one, and the raw-text escaping entry already fixed in 77230ef44e.
