### PR TITLE
test(runtime-tags): cover the dom mount API

### DIFF
--- a/packages/runtime-tags/src/__tests__/mounted-template-value/value.marko
+++ b/packages/runtime-tags/src/__tests__/mounted-template-value/value.marko
@@ -1,0 +1,3 @@
+<let/count=0>
+<return:=count>
+<div#out>${count}</div>

--- a/packages/runtime-tags/src/__tests__/mounted-template.test.ts
+++ b/packages/runtime-tags/src/__tests__/mounted-template.test.ts
@@ -8,6 +8,9 @@ import { createServerRunner } from "./utils/bundle";
 import createBrowser from "./utils/create-browser";
 
 const dir = path.join(import.meta.dirname, "mounted-template");
+// Each runner writes its own bundle into `<dir>/dist`, so a second fixture
+// needs its own directory rather than sharing and clobbering the first.
+const valueDir = path.join(import.meta.dirname, "mounted-template-value");
 
 describe("runtime-tags/dom mounted template", () => {
   let clientRunner: (ctx: any) => Promise<{ template: Template }>;
@@ -51,5 +54,118 @@ describe("runtime-tags/dom mounted template", () => {
     assert.equal(window.document.getElementById("out"), null);
     assert.deepEqual(log, ["mount", "destroy"]);
     assert.equal(signal.aborted, true);
+  });
+
+  it("ignores an update for a template that takes no input", async () => {
+    const browser = createBrowser();
+    const { window } = browser;
+    (window as any).log = [];
+    const { template } = await clientRunner(browser.ctx);
+    const instance = template.mount({}, window.document.body, "afterbegin");
+
+    instance.update({ ignored: true });
+
+    assert.equal(window.document.getElementById("out")?.textContent, "mounted");
+  });
+
+  it("refuses to render a template compiled for the DOM", async () => {
+    const browser = createBrowser();
+    (browser.window as any).log = [];
+    const { template } = await clientRunner(browser.ctx);
+    assert.throws(
+      () => template.render({}),
+      /render\(\) is not implemented for the DOM compilation/,
+    );
+  });
+
+  for (const key of ["runtimeId", "renderId"]) {
+    it(`rejects a ${key} that is not an identifier`, async () => {
+      const browser = createBrowser();
+      const { window } = browser;
+      (window as any).log = [];
+      const { template } = await clientRunner(browser.ctx);
+      assert.throws(
+        () =>
+          template.mount(
+            { $global: { [key]: "1-bad" } },
+            window.document.body,
+            "afterbegin",
+          ),
+        new RegExp(`Invalid ${key}`),
+      );
+    });
+  }
+
+  // `beforebegin`/`afterend` insert relative to the reference's parent, so the
+  // reference needs one of its own rather than being the body.
+  for (const [position, relation] of [
+    ["beforebegin", "preceding"],
+    ["afterend", "following"],
+  ] as const) {
+    it(`inserts ${relation} the reference for ${position}`, async () => {
+      const browser = createBrowser();
+      const { window } = browser;
+      (window as any).log = [];
+      const anchor = window.document.createElement("div");
+      window.document.body.appendChild(anchor);
+      const { template } = await clientRunner(browser.ctx);
+
+      template.mount({}, anchor, position);
+
+      const out = window.document.getElementById("out")!;
+      assert.ok(out, "template did not mount");
+      const mask =
+        relation === "preceding"
+          ? 2 /* DOCUMENT_POSITION_PRECEDING */
+          : 4; /* DOCUMENT_POSITION_FOLLOWING */
+      assert.ok(
+        anchor.compareDocumentPosition(out) & mask,
+        `expected the mounted output ${relation} the reference`,
+      );
+    });
+  }
+});
+
+describe("runtime-tags/dom mounted template value", () => {
+  let clientRunner: (ctx: any) => Promise<{ template: Template }>;
+  let disposeServer: () => void;
+
+  before(async function () {
+    this.timeout(60000);
+    const runner = await createServerRunner(
+      valueDir,
+      { value: "./value.marko" },
+      {
+        translator: tagsTranslator as any,
+        optimize: false,
+        babelConfig: {
+          babelrc: false,
+          configFile: false,
+          browserslistConfigFile: false,
+        },
+      },
+    );
+    clientRunner = runner.clientRunner!;
+    disposeServer = runner.disposeServer;
+  });
+
+  after(() => disposeServer?.());
+
+  it("exposes the tag variable and writes back through it", async () => {
+    const browser = createBrowser();
+    const { window } = browser;
+    const { template } = await clientRunner(browser.ctx);
+    const instance = template.mount({}, window.document.body, "afterbegin");
+
+    assert.equal(instance.value, 0);
+    assert.equal(window.document.getElementById("out")?.textContent, "0");
+
+    instance.value = 7;
+    // The write is queued as a microtask, so the read back settles on the
+    // next one rather than after any particular delay.
+    await Promise.resolve();
+
+    assert.equal(instance.value, 7);
+    assert.equal(window.document.getElementById("out")?.textContent, "7");
   });
 });


### PR DESCRIPTION
`dom/template.ts` had 5 of its 11 functions and 12 of 45 statements untested. The gaps were all in the `mount()` surface: `render()` refusing to run on a DOM build, the `runtimeId`/`renderId` validation, the `beforebegin` and `afterend` insert positions, an update for a template that takes no input, and the returned handle's `value` accessors.

Seven tests added to the existing `mounted-template` suite, taking the file to 45/45 statements and 11/11 branches. The one function still reported uncovered is a duplicate record from source-map remapping, not dead code — the real arrow on that line is covered.

The tag-variable fixture gets its own directory: two runners over one directory both write to `<dir>/dist` and the second clobbers the first, which left a bundle missing at report time.