### PR TITLE
fix(runtime-tags): detect the deprecated Marko 6 core tags

### DIFF
--- a/.changeset/interop-marko6-core-tag-markers.md
+++ b/.changeset/interop-marko6-core-tag-markers.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Detect `<attrs>` and `<effect>` as Tags-API markers, so a template whose only Marko 6 signal is one of them is no longer translated as Class API, where the tag is not defined.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -988,52 +988,6 @@ contains no markup between the`<debug>`tags, so a fixture with a`<log>`/`<debug>
 compile -- -o html -d`on`<div>a</div>`/`<log="x"/>`/`<div>b</div>`currently yields`console.log("x"); _html("<div>a</div><div>b</div>");`, versus
 `-o dom` which keeps the call between the two text writes.
 
-## Treat `<attrs>`/`<effect>` as tags-API markers in interop feature detection
-
-`packages/runtime-tags/src/translator/interop/feature-detection.ts` › `getFeatureTypeFromCoreTagName` | 2026-07-27 | impact:med | effort:low
-
-`getFeatureTypeFromCoreTagName` lists `const`/`let`/`lifecycle`/`try` and friends
-as `FeatureType.Tags`, but not the deprecated core tags `attrs` and `effect`.
-A template whose only tags-API signal is one of those two — e.g. a file whose
-whole body is `<effect() { … }/>` — is therefore detected as class API, so the
-tags-side migrator that would rewrite it to `<script>` never runs (`mergeVisit`
-dispatches on `isTagsAPI()`), and the merged `<effect>` tag definition's
-`attributes: {}` then rejects the method shorthand with `<effect> does not
-support the "value" attribute.` The same body compiles under
-`@marko/runtime-tags/translator`, which has no such dispatch. `<attrs/{ a }/>`
-only escapes this because its tag variable is itself a marker; a var-less
-`<attrs/>` fails the same way, as `Unable to find entry point for custom tag
-<attrs>.` Re-verify: compile a template whose entire body is `<effect() {
-console.log(1) }/>` with `marko/translator` and with
-`@marko/runtime-tags/translator` — the first errors, the second migrates.
-
-## Classify `<html-script>`/`<html-style>` as Tags-API markers in interop feature detection
-
-`packages/runtime-tags/src/translator/interop/feature-detection.ts` › `getFeatureTypeFromCoreTagName` | 2026-07-23 | impact:med | effort:low
-
-`getFeatureTypeFromCoreTagName` enumerates the core tag names that identify a
-file as Class API or Tags API, but four Marko 6-only core tags registered in
-`translator/core/index.ts` appear in neither list: `<html-script>`,
-`<html-style>`, `<attrs>` and `<effect>` (the Marko 5 core taglib,
-`packages/runtime-class/src/translator/taglib/core/index.js`, defines none of
-them). A template outside a `tags/` directory — any file in a Marko 5 project,
-e.g. under `components/` or a route folder — whose only Marko 6 marker is
-`<html-style>` therefore falls through to `FeatureType.Class` and is translated
-by the Marko 5 translator, which has no such tag: the emitted server code
-contains a literal `out.w("<html-style>")`, so the stylesheet silently renders
-as an unknown element with no error, warning, or diagnostic in any mode.
-`<html-script>` behaves identically; `<attrs>`/`<effect>` crash first for an
-unrelated reason (separate entry). Both are current, documented core tags
-(website `docs/reference/core-tag.md` § `<html-script>` & `<html-style>`), so
-add them to the `FeatureType.Tags` case — or better, derive the two lists from
-the difference between the runtime-tags and runtime-class core taglibs so a
-future Marko 6-only tag cannot be forgotten. Re-verify: compile a template whose
-entire body is `<html-style>\n .a { color: red }\n</html-style>` from a
-directory that is not under `tags/`, using `marko/translator`; `meta.api` is
-`class` and the output contains `out.w("<html-style>")`, whereas prepending
-`<!-- use tags -->` flips `meta.api` to `tags` and emits
-`<style${_attr_nonce()}>`.
-
 ## Drop escaped placeholders that confidently render an empty string, so the DOM walk does not gain a step for a node that is never written
 
 `packages/runtime-tags/src/translator/util/static-text.ts` › `isStaticText` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/diagnostics.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/diagnostics.md
@@ -1,0 +1,3 @@
+# Diagnostics
+
+- `template.marko` deprecation: The 'effect' tag has been replaced by the 'script' tag.

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,6 @@
+// template.marko
+const $template = "<div id=out></div>";
+const $walks = "b";
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => document.getElementById("out").textContent = "ran");
+const $setup = $setup__script;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/dom.bundle.js
@@ -1,0 +1,2 @@
+// template.marko
+const $setup__script = _script("a0", ($scope) => document.getElementById("out").textContent = "ran");

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div id=out></div>");
+	_script($scope0_id, "__tests__/template.marko_0");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div id=out></div>");
+	_script($scope0_id, "a0");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/render.debug.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<div
+  id="out"
+>
+  ran
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/render.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<div
+  id="out"
+>
+  ran
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/writes.debug.html
@@ -1,0 +1,8 @@
+<div id=out></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/__snapshots__/writes.html
@@ -1,0 +1,6 @@
+<div id=out></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = ["a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2206,
+      "brotli": 1089
+    }
+  },
+  "html": {
+    "min": 313,
+    "brotli": 228
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-feature-detection/template.marko
@@ -1,0 +1,2 @@
+<effect() { document.getElementById("out")!.textContent = "ran" }/>
+<div#out/>

--- a/packages/runtime-tags/src/translator/interop/feature-detection.ts
+++ b/packages/runtime-tags/src/translator/interop/feature-detection.ts
@@ -184,9 +184,11 @@ function getFeatureTypeFromCoreTagName(
     case "module-code":
     case "while":
       return FeatureType.Class;
+    case "attrs":
     case "const":
     case "debug":
     case "define":
+    case "effect":
     case "id":
     case "let":
     case "lifecycle":
@@ -196,6 +198,8 @@ function getFeatureTypeFromCoreTagName(
     case "try":
       return FeatureType.Tags;
     default:
+      // `<html-script>`/`<html-style>` fall through on purpose: they are being
+      // backported to Marko 5, so they identify neither API.
       return undefined;
   }
 }


### PR DESCRIPTION
`getFeatureTypeFromCoreTagName` enumerates the core tag names that identify a file as Class API or Tags API, but `<attrs>` and `<effect>` appeared in neither list, though the Marko 5 core taglib defines neither.

A template outside a `tags/` directory whose only Marko 6 marker is one of those therefore fell through to `FeatureType.Class` and was translated by the Marko 5 translator, which has no such tag. The taglib-merge crash fixed in #3627 was masking this: those tags threw before detection mattered.

`<html-script>` and `<html-style>` are deliberately not markers, since they are being backported to Marko 5 and will identify neither API. The fall-through carries a comment so they are not added later by the same reasoning that applies to the other two.

The new `interop-deprecated-core-tag-feature-detection` fixture has `<effect>` as its only Tags-API signal; compiled against `main` it fails with `<effect> does not support the "value" attribute`, and detects `tags` here.
