### PR TITLE
test(runtime-tags): cover the keyed for-in server path

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,25 @@
+// template.marko
+const $template = "<div><!><button>Change</button></div>";
+const $walks = "D%b l";
+const $for_content__key = ($scope, key) => _text($scope["#text/0"], key);
+const $for_content__value = ($scope, value) => _text($scope["#text/1"], value);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__key($scope, $params2[0]);
+	$for_content__value($scope, $params2[1]);
+};
+const $for = /*@__PURE__*/ _for_in("#text/0", "<p><!>:<!></p>", "D%c%", 0, $for_content__$params);
+const $entries = /*@__PURE__*/ _let("entries/2", ($scope) => $for($scope, [$scope.entries, (key) => key]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$entries($scope, {
+		b: 2,
+		c: 3
+	});
+}));
+function $setup($scope) {
+	$entries($scope, {
+		a: 1,
+		b: 2
+	});
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/dom.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+const $for_content__key = ($scope, key) => _text($scope.a, key);
+const $for_content__value = ($scope, value) => _text($scope.b, value);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__key($scope, $params2[0]);
+	$for_content__value($scope, $params2[1]);
+};
+const $for = /*@__PURE__*/ _for_in(0, "<p><!>:<!></p>", "D%c%", 0, $for_content__$params);
+const $entries = /*@__PURE__*/ _let(2, ($scope) => $for($scope, [$scope.c, (key) => key]));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$entries($scope, {
+		b: 2,
+		c: 3
+	});
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let entries = {
+		a: 1,
+		b: 2
+	};
+	_html("<div>");
+	_for_in(entries, (key, value) => {
+		const $scope1_id = _scope_id();
+		_html(`<p>${_escape(key)}${_el_resume($scope1_id, "#text/0")}:<!>${_escape(value)}${_el_resume($scope1_id, "#text/1")}</p>`);
+		writeScope($scope1_id, {}, "__tests__/template.marko", "4:4");
+	}, (key) => key, $scope0_id, "#text/0", 1, 1, 1, 0, 1);
+	_html(`<button>Change</button>${_el_resume($scope0_id, "#button/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/html.bundle.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let entries = {
+		a: 1,
+		b: 2
+	};
+	_html("<div>");
+	_for_in(entries, (key, value) => {
+		const $scope1_id = _scope_id();
+		_html(`<p>${_escape(key)}${_el_resume($scope1_id, "a")}:<!>${_escape(value)}${_el_resume($scope1_id, "b")}</p>`);
+		writeScope($scope1_id, {});
+	}, (key) => key, $scope0_id, "a", 1, 1, 1, 0, 1);
+	_html(`<button>Change</button>${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/render.debug.md
@@ -1,0 +1,37 @@
+# Render
+```html
+<div>
+  <p>
+    a:1
+  </p>
+  <p>
+    b:2
+  </p>
+  <button>
+    Change
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("button")).click();
+```
+```html
+<div>
+  <p>
+    b:2
+  </p>
+  <p>
+    c:3
+  </p>
+  <button>
+    Change
+  </button>
+</div>
+```
+## Change
+```
+REMOVE: div > p
+INSERT: div > p:nth-of-type(1) + p
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/render.md
@@ -1,0 +1,37 @@
+# Render
+```html
+<div>
+  <p>
+    a:1
+  </p>
+  <p>
+    b:2
+  </p>
+  <button>
+    Change
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("button")).click();
+```
+```html
+<div>
+  <p>
+    b:2
+  </p>
+  <p>
+    c:3
+  </p>
+  <button>
+    Change
+  </button>
+</div>
+```
+## Change
+```
+REMOVE: div > p
+INSERT: div > p:nth-of-type(1) + p
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<div>
+  <p>a<!--M_*2 #text/0-->:<!>1<!--M_*2 #text/1--></p>
+  <p>b<!--M_*3 #text/0-->:<!>2<!--M_*3 #text/1--></p>
+  <!--M_|1 #text/0 3 2--><button>Change</button><!--M_*1 #button/1-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      "#LoopKey": "a"
+    }, {
+      "#LoopKey": "b"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-in-by/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<div>
+  <p>a<!--M_*2 a-->:<!>1<!--M_*2 b--></p>
+  <p>b<!--M_*3 a-->:<!>2<!--M_*3 b--></p>
+  <!--M_|1 a 3 2--><button>Change</button><!--M_*1 b-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    M: "a"
+  }, {
+    M: "b"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7035,
+      "brotli": 3242
+    }
+  },
+  "html": {
+    "min": 460,
+    "brotli": 290
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/template.marko
@@ -1,0 +1,9 @@
+<div>
+  <let/entries={ a: 1, b: 2 }/>
+
+  <for|key, value| in=entries by=(key) => key>
+    <p>${key}:${value}</p>
+  </for>
+
+  <button onClick() { entries = { b: 2, c: 3 }; }>Change</button>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  (document.querySelector("button") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};


### PR DESCRIPTION
`<for in>` with a `by` key had no working fixture anywhere — the only `for-in-by` fixture is an error case that rejects a string `by`, so the keyed arm of `_for_of`'s `for...in` sibling in `html/writer.ts` never ran server-side. `_for_in` itself was called four times across the suite, always through the unkeyed path.

Adds a fixture that renders a keyed `for...in` and then adds and removes a key, taking those two functions from 0 to 4 calls. The serialized output shows the loop keys (`M_*2 a`) rather than positional indices, which is the behaviour the keyed path exists for.