### PR TITLE
test(runtime-tags): cover a void element as a dynamic tag

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+const $template = "<div><!><select><option value=a>a</option></select><button>Swap</button></div>";
+const $walks = "D%b b l";
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $tag = /*@__PURE__*/ _let("tag/3", ($scope) => $dynamicTag($scope, $scope.tag));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_attr_select_value_script($scope, "#select/1");
+	_on($scope["#button/2"], "click", function() {
+		$tag($scope, $scope.tag === "input" ? "br" : "input");
+	});
+});
+function $setup($scope) {
+	_attr_select_value($scope, "#select/1", void 0, $valueChange($scope));
+	$tag($scope, "input");
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(next) {
+		$tag($scope, next);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/dom.bundle.js
@@ -1,0 +1,15 @@
+// template.marko
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
+const $tag = /*@__PURE__*/ _let(3, ($scope) => $dynamicTag($scope, $scope.d));
+const $setup__script = _script("a1", ($scope) => {
+	_attr_select_value_script($scope, "b");
+	_on($scope.c, "click", function() {
+		$tag($scope, $scope.d === "input" ? "br" : "input");
+	});
+});
+function $valueChange($scope) {
+	return function(next) {
+		$tag($scope, next);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let tag = "input";
+	_html("<div>");
+	_dynamic_tag($scope0_id, "#text/0", tag, {});
+	_attr_select_value($scope0_id, "#select/1", void 0, _resume(function(next) {
+		tag = next;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("a")}>a</option></select>`);
+	});
+	_html(`${_el_resume($scope0_id, "#select/1")}<button>Swap</button>${_el_resume($scope0_id, "#button/2")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { tag }, "__tests__/template.marko", 0, { tag: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let tag = "input";
+	_html("<div>");
+	_dynamic_tag($scope0_id, "a", tag, {});
+	_attr_select_value($scope0_id, "b", void 0, _resume(function(next) {
+		tag = next;
+	}, "a0", $scope0_id), () => {
+		_html(`<select><option${_attr_option_value("a")}>a</option></select>`);
+	});
+	_html(`${_el_resume($scope0_id, "b")}<button>Swap</button>${_el_resume($scope0_id, "c")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, { d: tag });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-csr.debug.md
@@ -1,0 +1,43 @@
+# Render
+```html
+<div>
+  <input />
+  <select>
+    <option
+      selected=""
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("button")).click();
+```
+```html
+<div>
+  <br />
+  <select>
+    <option
+      selected=""
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+## Change
+```
+INSERT: div > br
+REMOVE: div > br + input
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,44 @@
+# Render
+```html
+<div>
+  <input />
+  <select>
+    <option
+      selected=""
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("button")).click();
+```
+```html
+<div>
+  <input />
+  <select>
+    <option
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+## Change
+```
+INSERT: div > a
+REMOVE: a + input
+INSERT: div > input
+REMOVE: div > input + a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/render-ssr.md
@@ -1,0 +1,44 @@
+# Render
+```html
+<div>
+  <input />
+  <select>
+    <option
+      selected=""
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("button")).click();
+```
+```html
+<div>
+  <input />
+  <select>
+    <option
+      value="a"
+    >
+      a
+    </option>
+  </select>
+  <button>
+    Swap
+  </button>
+</div>
+```
+## Change
+```
+INSERT: div > a
+REMOVE: a + input
+INSERT: div > input
+REMOVE: div > input + a
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<div><input><!--M_'1 #text/0 2--><select>
+    <option value=a>a</option>
+  </select><!--M_*1 #select/1--><button>Swap</button><!--M_*1 #button/2--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ConditionalRenderer:#text/0": "input",
+      "ControlledHandler:#select/1": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/template.marko_0/valueChange"
+        ),
+      tag: "input"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<div><input><!--M_'1 a 2--><select>
+    <option value=a>a</option>
+  </select><!--M_*1 b--><button>Swap</button><!--M_*1 c--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Da: "input",
+    Eb: _(1, "a0"),
+    d: "input"
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8646,
+      "brotli": 3675
+    }
+  },
+  "html": {
+    "min": 461,
+    "brotli": 296
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/template.marko
@@ -1,0 +1,8 @@
+<let/tag="input"/>
+<div>
+  <${tag}/>
+  <${"select"} valueChange(next) { tag = next }>
+    <option value="a">a</option>
+  </>
+  <button onClick() { tag = tag === "input" ? "br" : "input" }>Swap</button>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  (document.querySelector("button") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, click],
+};


### PR DESCRIPTION
None of the 36 existing dynamic-tag fixtures render a void element or a dynamic tag with no attributes, so `_dynamic_tag`'s void-element path and its empty-input fallback never ran. This adds a fixture that renders `<${tag}/>` with `tag` swapping between `input` and `br`.

Small on its own — two branch paths and one statement in `html/dynamic-tag.ts`. Worth knowing before anyone targets that file for coverage: 22 of its 34 remaining branch misses sit on `MARKO_DEBUG` lines, which the bundler constant-folds away (`define: { MARKO_DEBUG: String(!optimize) }`), so they are not reachable from a debug-only run.