### PR TITLE
fix(runtime-tags): serialize a generator that returns one of its ancestors

### DIFF
--- a/.changeset/serializer-generator-ancestor-return.md
+++ b/.changeset/serializer-generator-ancestor-return.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a `SyntaxError` in the resume payload when a serialized generator returns one of its own ancestors, which emitted an assignment with no property to assign to and broke the whole page's resume.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -644,29 +644,6 @@ precedes an `<await>` whose body contains `<footer id=footer>` — the first
 flushed chunk contains `…document.querySelector("#footer")||l()… ` while
 `<footer id=footer>` only appears in the next chunk.
 
-## Emit a circular generator return value lazily instead of a deferred assignment that produces invalid JS
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeGenerator` | 2026-07-23 | impact:high | effort:med
-
-`writeGenerator` serializes a generator's return value with `writeProp(state,
-returnValue, ref, "")` (serializer.ts:1627) — an empty accessor, because the
-return value has no property path off the generator. When that value is
-already-referenced and circular relative to the generator (it is the generator
-itself, or any ancestor on the write tree), `writeReferenceOr` takes the
-deferred-assignment branch and builds `accessId(state, parent) + toAccess("")`.
-`toAccess("")` (serializer.ts:1941) reads `accessor[0]` as `undefined` and falls
-through to the `"." + accessor` branch, yielding a bare `"."`, so the extras
-section emits `_.b.=_.a` — a SyntaxError. Because the whole flush is written as
-one `<script>` (`M._.r=[...]` in html/writer.ts), the parse failure kills the
-entire page's resume payload, not just that value, and nothing warns even under
-MARKO_DEBUG. Since the generator body is lazily evaluated, the fix is to emit
-the circular return inside the body (`(function*(a){yield*a;return _.a})([1])`)
-rather than as an eager argument plus a post-hoc assignment; failing that,
-detect the empty accessor and abort loudly. Re-verify: serialize `const obj =
-{}; function* g(){ yield 1; return obj; } obj.g = g();` through
-`Serializer#stringifyScopes([[1, {}, { value: obj }]], boundary)` and `eval` the
-result — it currently throws `SyntaxError: Unexpected token '='`.
-
 ## Look up `debug.vars` with the raw accessor, not the escaped object key
 
 `packages/runtime-tags/src/html/serializer.ts` › `throwUnserializable` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -1341,6 +1341,18 @@ describe("serializer", () => {
       serializer.assertStringify({ c: shared }, `{c:_.a}`);
     });
 
+    it("returns an ancestor", () => {
+      const parent: any = { name: "p" };
+      parent.gen = (function* () {
+        yield 1;
+        return parent;
+      })();
+      const rt = deserialize(parent);
+      const iter = rt.gen as Generator;
+      assert.deepEqual(iter.next(), { value: 1, done: false });
+      assert.deepEqual(iter.next(), { value: rt, done: true });
+    });
+
     it("partially consumed resumes as an exhausted sync generator", () => {
       const gen = (function* () {
         yield 1;

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1745,12 +1745,19 @@ function writeGenerator(state: State, iter: Generator, ref: Reference) {
     return true;
   }
 
+  // A return value that is an ancestor has no accessor path of its own to be
+  // assigned into later, so it is read back out of a holder that does.
+  const heldReturn =
+    returnValue !== undefined && isAncestorMember(state, ref, returnValue);
+
   // Yield/return values live in eagerly evaluated arguments — the body only
   // runs when iterated, so values written there would break reference dedup.
   state.buf.push(
     returnValue === undefined
       ? "(function*(a){yield*a})("
-      : "(function*(a,r){yield*a;return r})(",
+      : heldReturn
+        ? "(function*(a,r){yield*a;return r.v})("
+        : "(function*(a,r){yield*a;return r})(",
   );
   if (needsId) {
     const arrayRef = new Reference(
@@ -1770,7 +1777,17 @@ function writeGenerator(state: State, iter: Generator, ref: Reference) {
     );
   }
 
-  if (returnValue !== undefined) {
+  if (heldReturn) {
+    const holder = new Reference(
+      ref,
+      null,
+      state.flush,
+      null,
+      nextRefAccess(state),
+    );
+    state.buf.push("," + holder.id + "={}");
+    writeProp(state, returnValue, holder, "v");
+  } else if (returnValue !== undefined) {
     const sepIndex = state.buf.push(",") - 1;
     if (
       writeProp(state, returnValue, ref, "") &&


### PR DESCRIPTION
A generator's yield and return values ride eagerly evaluated arguments, since the body only runs when iterated and values written there would break reference dedup. A return value that is one of the generator's own ancestors has no id yet at that point, so it took the deferred-assignment path — but it was written with an empty accessor, and `toAccess("")` yields `"."`:

```js
_=>(_([1,{value:_.a={g:_.b=(function*(a,r){yield*a;return r})([1],)}}]),_.b.=_.a,0)
//                                                                      ^^^^^
```

`SyntaxError: Unexpected token '='`. That aborts the entire resume payload, so every scope on the page fails to resume, not just the generator. The return value was dropped as well — the call closed as `([1],)`.

The ancestor case is now detected up front with `isAncestorMember`, the same predicate a `Map`/`Set` member referencing an ancestor already uses, and the value is passed in a holder read back as `r.v`, which gives the deferred assignment a property to target:

```js
_=>(_([1,{value:_.b={g:(function*(a,r){yield*a;return r.v})([1],_.a={})}}]),_.a.v=_.b,0)
```

Generators without a return value, and with a non-ancestor one, keep their existing shape and payload.

The new `returns an ancestor` test round-trips through `deserialize` and asserts the resumed generator yields `1` and then returns the resumed object itself; against `main` it fails with the `SyntaxError` above.
