### PR TITLE
fix(runtime-tags): copy a lone-spread attribute tag's attrs before the runtime writes to them

### DIFF
--- a/.changeset/attr-tag-lone-spread-copy.md
+++ b/.changeset/attr-tag-lone-spread-copy.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Stop an attribute tag whose attributes are a lone spread (`<@item ...obj/>`) from mutating the spread object itself, which added `Symbol.iterator` and an internal symbol to the caller's own data and threw on a frozen object.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -122,37 +122,6 @@ attributes, which is about type-check messaging for `onKeydown` vs `onKeyDown`.
 Re-verify: compile `<div onX() { console.log(1) }>hi</div>` — it fails today;
 `<div on-x() { … }>` and `<div onXy() { … }>` both succeed.
 
-## Stop `attrTag`/`attrTags` from mutating a user object when an attribute tag's attrs are a lone spread
-
-`packages/runtime-tags/src/common/attr-tag.ts` › `attrTag` | 2026-07-23 | impact:high | effort:med
-
-`attrTag(attrs)` mutates its argument in place (`attrs[Symbol.iterator] =
-attrTagIterator; attrs[rest] = empty`), and `attrTags` then writes sibling attr
-tags into `first[rest]`. That is safe only while the argument is a
-compiler-built object literal — but `propsToExpression`
-(`packages/runtime-tags/src/translator/util/translate-attrs.ts`) returns the
-spread argument itself when the property list is a single `SpreadElement`, so
-`<@item ...obj/>` compiles to `attrTag(obj)` on the user's own binding.
-Consequences on a plain `<let>`/`input` object: it silently gains
-`Symbol.iterator` plus the internal `Symbol(Attribute Tag)` (both copied by
-`{...obj}`), `[...obj]` starts yielding the object and its attr-tag siblings,
-`Object.freeze`d objects throw `TypeError: Cannot add property
-Symbol(Symbol.iterator), object is not extensible` at render, and the HTML
-serializer's `writeMaybeIterableProps` switches the object to its iterable form,
-dragging an unrelated sibling attr tag's data into the resume payload. The
-`<for|row| of=input.rows><my-tag><@item ...row/></my-tag></for>` shape mutates
-every row of the caller's data. Fix at the translator: give the four
-`attrTag`/`attrTags` call sites (`translate-attrs.ts` ~105/113/208/221 and
-`packages/runtime-tags/src/translator/util/known-tag.ts` ~940/947/999/1006) a
-variant of `propsToExpression` that always emits `t.objectExpression(props)`, so
-the runtime always receives a fresh object; `propsToExpression`'s unwrapping
-stays correct for ordinary tag input. No fixture covers a lone-spread attribute
-tag today (`grep -rn '<@' packages/runtime-tags/src/__tests__/fixtures
---include=template.marko | grep '\.\.\.'` returns nothing), so add one.
-Re-verify: compile `<let/obj={label:'a'}/><my-tag><@item ...obj/></my-tag>` and
-confirm the output contains `_attrTag($scope.obj)` rather than
-`_attrTag({...})`.
-
 ## Validate (or coerce) `from`/`step` in `forTo`/`forUntil`; a string `from` silently produces concatenated indices
 
 `packages/runtime-tags/src/common/for.ts` › `forTo` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $Row_content__walks = "D l", $Row_content__template = "<div> </div>";
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div>added=<!></div>`)($Row_content__template);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&Db%l`)($Row_content__walks);
+const $setup = () => {};
+const $Row_content__input_cell_label = ($scope, input_cell_label) => _text($scope["#text/0"], input_cell_label);
+const $Row_content__$params = ($scope, $params2) => $Row_content__input($scope, $params2[0]);
+const $Row_content__input = ($scope, input) => $Row_content__input_cell($scope, input.cell);
+const $Row_content__input_cell = ($scope, input_cell) => $Row_content__input_cell_label($scope, input_cell?.label);
+const $input_obj_label = ($scope, input_obj_label) => $Row_content__input_cell_label($scope["#childScope/0"], input_obj_label);
+const $input_obj = ($scope, input_obj) => {
+	_text($scope["#text/1"], Object.getOwnPropertySymbols(input_obj).length);
+	$input_obj_label($scope, input_obj?.label);
+};
+const $input = ($scope, input) => $input_obj($scope, input.obj);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_obj = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const Row = { content: _content("__tests__/template.marko_1_content", (input) => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _scope_reason();
+		_html(`<div>${_escape(input.cell.label)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}</div>`);
+		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
+	}) };
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
+	Row.content({ cell: attrTag({ ...input.obj }) });
+	_html(`<div>added=${_sep($sg__input_obj)}${_escape(Object.getOwnPropertySymbols(input.obj).length)}${_el_resume($scope0_id, "#text/1", $sg__input_obj)}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { "#childScope/0": _serialize_if($scope0_reason, 1) && _existing_scope($childScope) }, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.js
@@ -1,0 +1,16 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_obj = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const Row = { content: _content("a0", (input) => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _scope_reason();
+		_html(`<div>${_escape(input.cell.label)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}</div>`);
+		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
+	}) };
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1));
+	const $childScope = _peek_scope_id();
+	Row.content({ cell: attrTag({ ...input.obj }) });
+	_html(`<div>added=${_sep($sg__input_obj)}${_escape(Object.getOwnPropertySymbols(input.obj).length)}${_el_resume($scope0_id, "b", $sg__input_obj)}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, { a: _serialize_if($scope0_reason, 1) && _existing_scope($childScope) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/render.debug.md
@@ -1,0 +1,9 @@
+# Render `{"obj":{"label":"a"}}`
+```html
+<div>
+  a
+</div>
+<div>
+  added=0
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/render.md
@@ -1,0 +1,9 @@
+# Render `{"obj":{"label":"a"}}`
+```html
+<div>
+  a
+</div>
+<div>
+  added=0
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/writes.debug.html
@@ -1,0 +1,2 @@
+<div>a</div>
+<div>added=0</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/writes.html
@@ -1,0 +1,2 @@
+<div>a</div>
+<div>added=0</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 30,
+    "brotli": 34
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/template.marko
@@ -1,0 +1,5 @@
+<define/Row|input|>
+  <div>${input.cell.label}</div>
+</define>
+<Row><@cell ...input.obj/></Row>
+<div>added=${Object.getOwnPropertySymbols(input.obj).length}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ obj: { label: "a" } }],
+};

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -918,6 +918,7 @@ function applyAttrObject(
   }
 
   if (isAttributeTag(tag)) {
+    translatedProps = t.objectExpression(translatedAttrs.properties);
     const attrTagName = getTagName(tag);
     const parentTag = tag.parentPath as t.NodePath<t.MarkoTag>;
     const repeated = analyzeAttributeTags(parentTag)?.[attrTagName]?.repeated;
@@ -977,7 +978,9 @@ function translateAttrTag(
   statements: t.Statement[],
 ) {
   const translatedAttrs = translateAttrs(tag, true, undefined, statements);
-  let translatedProps = propsToExpression(translatedAttrs.properties);
+  let translatedProps: t.Expression = t.objectExpression(
+    translatedAttrs.properties,
+  );
   const attrTagName = getTagName(tag);
   const parentTag = tag.parentPath as t.NodePath<t.MarkoTag>;
 

--- a/packages/runtime-tags/src/translator/util/translate-attrs.ts
+++ b/packages/runtime-tags/src/translator/util/translate-attrs.ts
@@ -102,7 +102,7 @@ export function translateAttrs(
               prevProp.value = callRuntime(
                 "attrTags",
                 prevProp.value as t.Expression,
-                propsToExpression(translatedAttrTag.properties),
+                t.objectExpression(translatedAttrTag.properties),
               );
             } else {
               contentProperties.push(
@@ -110,7 +110,7 @@ export function translateAttrs(
                   attrTagMeta.name,
                   callRuntime(
                     "attrTag",
-                    propsToExpression(translatedAttrTag.properties),
+                    t.objectExpression(translatedAttrTag.properties),
                   ),
                 ),
               );
@@ -205,7 +205,7 @@ export function addDynamicAttrTagStatements(
                 callRuntime(
                   "attrTags",
                   getAttrTagIdentifier(attrTagMeta),
-                  propsToExpression(translatedAttrTag.properties),
+                  t.objectExpression(translatedAttrTag.properties),
                 ),
               ),
             ),
@@ -218,7 +218,7 @@ export function addDynamicAttrTagStatements(
                 getAttrTagIdentifier(attrTagMeta),
                 callRuntime(
                   "attrTag",
-                  propsToExpression(translatedAttrTag.properties),
+                  t.objectExpression(translatedAttrTag.properties),
                 ),
               ),
             ),
@@ -254,6 +254,8 @@ export function addDynamicAttrTagStatements(
   return index;
 }
 
+/** Unwraps a lone spread to the spread argument itself, so the result may alias
+ * a caller binding; anything the runtime writes to needs its own object. */
 export function propsToExpression(
   props: t.ObjectExpression["properties"],
 ): t.Expression {


### PR DESCRIPTION
`attrTag(attrs)` mutates its argument in place — it installs `Symbol.iterator` and the internal attr-tag symbol — and `attrTags` writes sibling attr tags into the same object. That is safe while the argument is a compiler-built object literal, but `propsToExpression` returns the spread argument itself when the property list is a single `SpreadElement`, so `<@item ...obj/>` compiled to `attrTag(obj)` on the caller's own binding:

```marko
<Row><@cell ...input.obj/></Row>
```

The caller's object then silently gained `Symbol(Symbol.iterator)` and `Symbol(Attribute Tag)` — both copied on by `{...obj}` — started yielding itself and its attr-tag siblings from `[...obj]`, had its iterable form picked up by the HTML serializer's `writeMaybeIterableProps` (dragging an unrelated sibling attr tag's data into the resume payload), and threw `TypeError: Cannot add property Symbol(Symbol.iterator), object is not extensible` at render when frozen. A `<for|row| of=input.rows>` around the tag mutated every row of the caller's data.

The six attr tag call sites in `translate-attrs.ts` and `known-tag.ts` now build a fresh object. `propsToExpression`'s unwrapping is unchanged for ordinary tag input, which the runtime never writes to.

No fixture covered a lone-spread attribute tag, which is why this went unnoticed; the new `attr-tag-lone-spread` fixture renders the caller object's own-symbol count, which is `2` against `main` and `0` here. No existing fixture's output or size changed, confirming the shape was genuinely uncovered.
