### PR TITLE
fix(runtime-tags): stop one call site's compat boundary mode deciding for the rest

### DIFF
--- a/.changeset/compat-boundary-mode-order.md
+++ b/.changeset/compat-boundary-mode-order.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"@marko/runtime-class": patch
+---
+
+Stop a Class-API component rendered at both an inert and an updating call site from inheriting the first call site's `"preserve"` boundary mode, which left the updating one serialized as a component that never re-renders in the browser.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1070,44 +1070,24 @@ callable. Type 'never' has no call signatures." `tags/html-script.d.marko` and
 HTMLStyleElement`. Re-verify: type-check `<html-comment/c>hi</html-comment>`
 followed by `<const/x=c()/>`; with the stub unchanged the call is TS2349.
 
-## Key the Class-API compat registration by boundary mode; the first call site's `preserve` decision currently wins for every other use of that component
+## Carry the Class-API compat boundary mode per call site instead of downgrading the whole program
 
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `pushCompatRegistration` | 2026-07-23 | impact:high | effort:med
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `pushCompatRegistration` | 2026-07-27 | impact:low | effort:med
 
-`pushCompatRegistration(key, statement)` (dynamic-tag.ts:95) dedupes on
-`classFile.metadata.marko.id`, but the statement it guards is NOT call-site
-invariant: `preserveBoundary` (`:335`) is `!tagsSerializeReason &&
-(classHydration === Descendant || (Self && hasComponentBrowser))`, and
-`tagsSerializeReason = getSerializeReason(tagSection, nodeBinding)` differs per
-tag. So when one template renders the same Class-API component at an inert call
-site (emits `s(id, Cmp, "preserve")`) and at a call site the Tags side can
-update (emits `s(id, Cmp)`), only the first-translated registration is emitted
-and BOTH call sites get that mode. This is not cosmetic: `register(id, renderer,
-boundaryMode)` does `boundaryModeByRenderer.set(renderer, boundaryMode || true)`
-(packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js:239),
-and `beginComponent` maps `"preserve"` to `isSplitComponent = true`, skipping
-`componentDef.___flags |= FLAG_WILL_RERENDER_IN_BROWSER`
-(packages/runtime-class/src/node_modules/@internal/components-beginComponent/index.js:42-70)
-— visible on the wire as the missing `"f": 1` in the `$MC` payload (compare
-`fixtures-interop/interop-reactive-split-tags-to-class/__snapshots__/writes.html`,
-which has it, with
-`interop-self-interactive-split-tags-to-class/__snapshots__/writes.html`, which
-does not). A stateful call site that inherits `"preserve"` is therefore
-serialized as a component that will never re-render in the browser, while in the
-opposite source order the inert call site loses its preserve optimization;
-because `boundaryModeByRenderer` is a per-renderer Map, the same clobbering
-happens across templates in one process (last module evaluated wins). Fix
-direction: move the boundary mode off the module-level `s()` registration onto
-the per-call-site `_dynamic_tag` invocation. Merely keying the dedupe on the
-mode and emitting both registration forms does not work — `boundaryModeByRenderer`
-is keyed by renderer, so the second `s()` call just overwrites the first.
-Re-verify: copy
-`fixtures-interop/interop-self-interactive-split-tags-to-class/components/split-counter`
-next to two templates that differ only in statement order — `<let/n=0/><button
-onClick(){n++}>${n}</button><split-counter/><split-counter count=n/>` vs. the
-two `split-counter` lines swapped — compile both with `-o html` using the
-interop translator and diff the `s(...)` line: one emits `"preserve"`, the other
-does not.
+`preserveBoundary` is a per-call-site decision (`!tagsSerializeReason && …`)
+but `s(id, renderer, mode)` is emitted once per renderer, and
+`boundaryModeByRenderer` in
+`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` is
+keyed by renderer as well. The order-dependence this caused is fixed — a call
+site that cannot preserve now drops the mode for the whole program, and
+`register` keeps a plain `true` sticky across modules — but the fix is a
+downgrade, so one updating call site costs every inert call site of that class
+its split-component optimization. Carrying the mode on the per-call-site
+`_dynamic_tag` invocation instead would keep both, at the cost of a parameter on
+a helper every dynamic tag pays for; measure before taking it. Re-verify: the
+`interop-mixed-boundary-split-tags-to-class` fixture emits `s(…, renderer)`
+with no `"preserve"`, while `interop-self-interactive-split-tags-to-class`,
+whose only call site is inert, still emits it.
 
 ## SSR silently drops `content=` on void and text-only native tags, and on any tag whose body is only Marko comments
 

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
@@ -235,7 +235,12 @@ exports.p = function (htmlCompat) {
   });
 
   return function register(id, renderer, boundaryMode) {
-    boundaryModeByRenderer.set(renderer, boundaryMode || true);
+    // A renderer registered without "preserve" by any module keeps that mode:
+    // preserving a call site that updates stops it re-rendering in the browser.
+    boundaryModeByRenderer.set(
+      renderer,
+      boundaryModeByRenderer.get(renderer) === true || boundaryMode || true,
+    );
     return htmlCompat.register(id, renderer);
   };
 };

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,61 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+var import_component_browser = /* @__PURE__ */ __toESM(require_component_browser());
+(0, import_components.register)("__tests__/components/split-counter/index.marko", import_component_browser.default);
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
+
+// components/split-counter/component-browser.js
+var require_component_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		handleClick() {
+			const el = this.getEl();
+			el.setAttribute("data-count", Number(el.getAttribute("data-count")) + 1);
+		}
+	};
+}));
+
+// components/split-counter/index.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_component_browser = /* @__PURE__ */ __toESM(require_component_browser());
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/components/split-counter/index.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => import_component_browser.default);
+const _marko_component = {};
+import_component_browser.default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", {
+		"id": "class-api",
+		"data-count": "0"
+	}, "0", _component, null, 0, { "onclick": _componentDef.d("click", "handleClick", false) });
+	out.t("click", _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	s: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+const $template = "<button id=bump> </button><!><!><!>";
+const $walks = " D l%b%c";
+_resume("__tests__/components/split-counter/index.marko", _marko_template);
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag("#text/3");
+const $n = /*@__PURE__*/ _let("n/4", ($scope) => {
+	_text($scope["#text/1"], $scope.n);
+	$dynamicTag2($scope, _marko_template, () => ({ count: $scope.n }));
+});
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/2");
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$dynamicTag($scope, _marko_template);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/dom.bundle.js
@@ -1,0 +1,50 @@
+// components/split-counter/component-browser.js
+var require_component_browser = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		handleClick() {
+			const el = this.getEl();
+			el.setAttribute("data-count", Number(el.getAttribute("data-count")) + 1);
+		}
+	};
+}));
+
+// components/split-counter/index.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_component_browser = /* @__PURE__ */ __toESM(require_component_browser());
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => import_component_browser.default);
+const _marko_component = {};
+import_component_browser.default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", {
+		"id": "class-api",
+		"data-count": "0"
+	}, "0", _component, null, 0, { "onclick": _componentDef.d("click", "handleClick", false) });
+	out.t("click", _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	s: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+_resume("b", _marko_template);
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(3);
+const $n = /*@__PURE__*/ _let(4, ($scope) => {
+	_text($scope.b, $scope.e);
+	$dynamicTag2($scope, _marko_template, () => ({ count: $scope.e }));
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, $scope.e + 1);
+}));
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+(0, import_components.register)("b", import_component_browser.default);
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,29 @@
+// components/split-counter/index.marko
+var import_html = require_html();
+var import_data_marko = /* @__PURE__ */ __toESM(require_data_marko());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/components/split-counter/index.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button${(0, import_data_marko.default)(out, _componentDef, { "onclick": _componentDef.d("click", "handleClick", false) })} id=class-api data-count=0>`);
+	out.w("click");
+	out.w("</button>");
+}, {
+	t: _marko_componentType,
+	s: true,
+	d: true
+}, _marko_component);
+
+// template.marko
+s("__tests__/components/split-counter/index.marko", _marko_template);
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=bump>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_dynamic_tag($scope0_id, "#text/2", _marko_template, {}, 0, 0, 0);
+	_dynamic_tag($scope0_id, "#text/3", _marko_template, { count: n });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "2:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/html.bundle.js
@@ -1,0 +1,25 @@
+// components/split-counter/index.marko
+var import_html = require_html();
+var import_data_marko = /* @__PURE__ */ __toESM(require_data_marko());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button${(0, import_data_marko.default)(out, _componentDef, { "onclick": _componentDef.d("click", "handleClick", false) })} id=class-api data-count=0>click</button>`);
+}, {
+	t: _marko_componentType,
+	s: true
+}, {});
+
+// template.marko
+s("b", _marko_template);
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=bump>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_dynamic_tag($scope0_id, "c", _marko_template, {}, 0, 0, 0);
+	_dynamic_tag($scope0_id, "d", _marko_template, { count: n });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: n });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/render.debug.md
@@ -1,0 +1,48 @@
+# Render
+```html
+<button
+  id="bump"
+>
+  0
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+```
+
+# Update
+```js
+(document.querySelector("#bump")).click();
+```
+```html
+<button
+  id="bump"
+>
+  1
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+```
+## Change
+```
+UPDATE: #bump::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/render.md
@@ -1,0 +1,48 @@
+# Render
+```html
+<button
+  id="bump"
+>
+  0
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+```
+
+# Update
+```js
+(document.querySelector("#bump")).click();
+```
+```html
+<button
+  id="bump"
+>
+  1
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+<button
+  data-count="0"
+  id="class-api"
+>
+  click
+</button>
+```
+## Change
+```
+UPDATE: #bump::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/writes.debug.html
@@ -1,0 +1,40 @@
+<button
+  id=bump>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><!--M#_0--><button
+  id=class-api data-count=0>click</button><!--M/--><!--M_[--><!--M#_1--><button
+  id=class-api data-count=0>click</button><!--M/--><!--M_]1 #text/3 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    "ConditionalRenderer:#text/3": _._[
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/index.marko"
+      ],
+    n: 0
+  }, {
+    m5c: "_0",
+    m5i: {}
+  }, {
+    m5c: "_1",
+    m5i: {
+      count: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }],
+      ["_1", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/index.marko"
+    ]
+  });
+  M._.r.push(
+    "$compat_setScope 2 3 packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/template.marko_0 1"
+    );
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/__snapshots__/writes.html
@@ -1,0 +1,33 @@
+<button id=bump>0<!--M_*1 b--></button><!--M_*1 a--><!--M#_0--><button
+  id=class-api data-count=0>click</button><!--M/--><!--M_[--><!--M#_1--><button
+  id=class-api data-count=0>click</button><!--M/--><!--M_]1 d 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Dd: _._.b,
+    e: 0
+  }, {
+    m5c: "_0",
+    m5i: {}
+  }, {
+    m5c: "_1",
+    m5i: {
+      count: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }],
+      ["_1", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 2 3 a0 1");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/component-browser.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/component-browser.js
@@ -1,0 +1,8 @@
+// Split component: browser-only logic, like ebay-button. It is stateless (no
+// re-render) and reacts to its own DOM events after attaching on hydration.
+module.exports = class {
+  handleClick() {
+    const el = this.getEl();
+    el.setAttribute("data-count", Number(el.getAttribute("data-count")) + 1);
+  }
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/components/split-counter/index.marko
@@ -1,0 +1,3 @@
+<button id="class-api" data-count="0" onClick("handleClick")>
+  click
+</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -1,0 +1,21 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 63996,
+        "brotli": 19935
+      },
+      "files": {
+        "components/split-counter/component-browser.js": 317,
+        "components/split-counter/index.marko": 1096,
+        "template.marko": 386,
+        "v:template.marko.hydrate-6.js": 110,
+        "v:template.marko.hydrate-5.js": 249
+      }
+    }
+  },
+  "html": {
+    "min": 695,
+    "brotli": 394
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/template.marko
@@ -1,0 +1,5 @@
+// use tags
+<let/n=0/>
+<button id="bump" onClick() { n++ }>${n}</button>
+<split-counter/>
+<split-counter count=n/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function bump(document: Document) {
+  (document.querySelector("#bump") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, bump],
+};

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -94,12 +94,15 @@ const importedDynamicTagResume = new WeakSet<t.Program>();
 const [getCompatRegistrations] = createProgramState<Set<string>>(
   () => new Set(),
 );
+const [getCompatBoundaryCalls] = createProgramState<
+  Map<string, t.CallExpression>
+>(() => new Map());
 function pushCompatRegistration(key: string, statement: t.Statement) {
   const keys = getCompatRegistrations();
-  if (!keys.has(key)) {
-    keys.add(key);
-    getProgram().node.body.push(statement);
-  }
+  if (keys.has(key)) return false;
+  keys.add(key);
+  getProgram().node.body.push(statement);
+  return true;
 }
 
 type ClassHydration = ClassHydration.Value;
@@ -336,41 +339,42 @@ export default {
             (classHydration === ClassHydration.Descendant ||
               (classHydration === ClassHydration.Self &&
                 !!classFile?.metadata.marko.hasComponentBrowser));
+          const classId = classFile!.metadata.marko.id;
+          const registration = isOutputHTML()
+            ? t.callExpression(
+                importNamed(tag.hub.file, getCompatRuntimeFile(), "s"),
+                [
+                  t.stringLiteral(classId),
+                  t.identifier((tagExpression as t.Identifier).name),
+                  ...(preserveBoundary ? [t.stringLiteral("preserve")] : []),
+                ],
+              )
+            : undefined;
           if (
             isOutputHTML() ? serializeReason || classHydration : serializeReason
           ) {
-            pushCompatRegistration(
-              classFile!.metadata.marko.id,
-              isOutputHTML()
-                ? t.markoScriptlet(
-                    [
-                      t.expressionStatement(
-                        t.callExpression(
-                          importNamed(
-                            tag.hub.file,
-                            getCompatRuntimeFile(),
-                            "s",
-                          ),
-                          [
-                            t.stringLiteral(classFile!.metadata.marko.id),
-                            t.identifier((tagExpression as t.Identifier).name),
-                            ...(preserveBoundary
-                              ? [t.stringLiteral("preserve")]
-                              : []),
-                          ],
-                        ),
-                      ),
-                    ],
-                    true,
-                  )
+            const pushed = pushCompatRegistration(
+              classId,
+              registration
+                ? t.markoScriptlet([t.expressionStatement(registration)], true)
                 : t.expressionStatement(
                     callRuntime(
                       "_resume",
-                      t.stringLiteral(classFile!.metadata.marko.id),
+                      t.stringLiteral(classId),
                       t.identifier((tagExpression as t.Identifier).name),
                     ),
                   ),
             );
+            if (pushed && registration) {
+              getCompatBoundaryCalls().set(classId, registration);
+            }
+          }
+
+          // The registration is per renderer but the mode is per call site, so
+          // one that cannot preserve drops it for every other use of the class.
+          if (!preserveBoundary) {
+            const emitted = getCompatBoundaryCalls().get(classId);
+            if (emitted) emitted.arguments.length = 2;
           }
         } else {
           const rendererName = (tagExpression as t.Identifier).name;


### PR DESCRIPTION
`preserveBoundary` is a per-call-site decision — it depends on `tagsSerializeReason`, which differs per tag — but `pushCompatRegistration` dedupes on the class file's id, so `s(id, renderer, mode)` is emitted once per renderer and `boundaryModeByRenderer` is keyed by renderer too. A class component rendered both at an inert call site and at one the Tags side can update therefore took whichever mode was translated first. Two templates differing only in statement order:

```marko
<split-counter/>          <split-counter count=n/>
<split-counter count=n/>  <split-counter/>
```

```js
s(…/split-counter/index.marko, _index.default, "preserve")   // left
s(…/split-counter/index.marko, _index.default)               // right
```

`"preserve"` is matched by `beginComponent` as `isSplitComponent`, which skips `FLAG_WILL_RERENDER_IN_BROWSER` — so in the first ordering the updating call site is serialized as a component that never re-renders in the browser. In the other, the inert call site loses its optimization. Because `boundaryModeByRenderer` is a per-renderer map, the same clobbering happens across templates in one process.

A call site that cannot preserve now drops the mode from the emitted registration for the whole program, and `register` keeps a plain `true` sticky so a later module cannot re-preserve a renderer either. `true` is the safe direction: only `"preserve"` suppresses the re-render flag.

This is a downgrade rather than a per-call-site mode, so one updating call site costs the class its split-component optimization program-wide. Carrying the mode on `_dynamic_tag` instead would keep both but adds a parameter every dynamic tag pays for; `agent-feedback` now records that trade rather than the original bug.

`interop-self-interactive-split-tags-to-class`, whose only call site is inert, still emits `"preserve"` unchanged. The new `interop-mixed-boundary-split-tags-to-class` fixture covers both call sites in one template and emits no `"preserve"`; against `main` it emits one.
