### PR TITLE
fix(runtime-tags): reject an `<import>`/`<export>` line holding several statements

### DIFF
--- a/.changeset/import-export-multiple-statements.md
+++ b/.changeset/import-export-multiple-statements.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Report a compile error when an `<import>`/`<export>` line holds more than one statement. Every statement after the first was silently discarded, leaving the template referencing an undefined binding at render.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -858,29 +858,6 @@ value:=val/></define><Wrap a=n aChange(v){ n = v }/>` and observe the
 destructuring-key error pointing at the `<define>` tag; deleting `value:=val`
 makes it compile.
 
-## Emit every statement parsed from an `<import>`/`<export>` tag, not just the first
-
-`packages/runtime-tags/src/translator/core/import.ts` › `parse` | 2026-07-23 | impact:med | effort:low
-
-`parse` replaces the tag with `parseStatements(tag.hub.file, node.rawValue!,
-node.start!, node.end!)[0]` (import.ts:7) and discards every statement after the
-first; `packages/runtime-tags/src/translator/core/export.ts` › `parse` (:7) is
-byte-identical in this respect. `rawValue` is the whole raw open tag, so one
-source line can legitimately parse to several statements: a template beginning
-`import { a } from "./a"; import { b } from "./b"` compiles to a module
-containing only the first import while the body still references `b`, yielding
-generated code with a free identifier and no compile error, warning, or
-`meta.diagnostics` entry — the failure surfaces later as a render-time
-`ReferenceError` (or an unresolved global after bundling). `export const p = 1;
-export const q = 2` drops `q` the same way. The sibling statement tags already
-handle this correctly: `core/static.ts`, `core/server.ts`, and `core/client.ts`
-keep the full `parseStatements` result and wrap it in a `markoScriptlet`, so the
-fix is either `tag.replaceWithMultiple(parseStatements(...))` or a
-`buildCodeFrameError` when more than one statement comes back. Re-verify:
-compile a template whose first line is `import { a } from "./a"; import { b }
-from "./b"` followed by `<div>${a} ${b}</div>` and confirm the output contains
-only `import { a } from "./a";` while the render body still escapes a bare `b`.
-
 ## Stop the DOM compile from failing with an internal error on an unreferenced `<define>` that has body content
 
 `packages/runtime-tags/src/translator/core/define.ts` › `analyze` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko:1:21
+    > 1 | export const p = 1; export const q = 2
+        |                     ^^^^^^^^^^^^^^^^^^ The `<export>` tag takes a single export statement.
+      2 | <div>${p}${q}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko:1:21
+    > 1 | export const p = 1; export const q = 2
+        |                     ^^^^^^^^^^^^^^^^^^ The `<export>` tag takes a single export statement.
+      2 | <div>${p}${q}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko:1:21
+    > 1 | export const p = 1; export const q = 2
+        |                     ^^^^^^^^^^^^^^^^^^ The `<export>` tag takes a single export statement.
+      2 | <div>${p}${q}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko:1:21
+    > 1 | export const p = 1; export const q = 2
+        |                     ^^^^^^^^^^^^^^^^^^ The `<export>` tag takes a single export statement.
+      2 | <div>${p}${q}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/template.marko
@@ -1,0 +1,2 @@
+export const p = 1; export const q = 2
+<div>${p}${q}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-multiple-statements/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
+    > 1 | import { a } from "./a.js"; import { b } from "./b.js"
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+      2 | <div>${a}${b}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
+    > 1 | import { a } from "./a.js"; import { b } from "./b.js"
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+      2 | <div>${a}${b}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
+    > 1 | import { a } from "./a.js"; import { b } from "./b.js"
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+      2 | <div>${a}${b}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
+    > 1 | import { a } from "./a.js"; import { b } from "./b.js"
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+      2 | <div>${a}${b}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/a.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/a.js
@@ -1,0 +1,1 @@
+export const a = "A";

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/b.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/b.js
@@ -1,0 +1,1 @@
+export const b = "B";

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko
@@ -1,0 +1,2 @@
+import { a } from "./a.js"; import { b } from "./b.js"
+<div>${a}${b}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/export.ts
+++ b/packages/runtime-tags/src/translator/core/export.ts
@@ -3,9 +3,21 @@ import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
 export default {
   parse(tag) {
     const { node } = tag;
-    tag.replaceWith(
-      parseStatements(tag.hub.file, node.rawValue!, node.start!, node.end!)[0],
+    const statements = parseStatements(
+      tag.hub.file,
+      node.rawValue!,
+      node.start!,
+      node.end!,
     );
+
+    if (statements.length > 1) {
+      throw tag.hub.buildError(
+        statements[1],
+        "The `<export>` tag takes a single export statement.",
+      );
+    }
+
+    tag.replaceWith(statements[0]);
   },
   parseOptions: {
     statement: true,

--- a/packages/runtime-tags/src/translator/core/import.ts
+++ b/packages/runtime-tags/src/translator/core/import.ts
@@ -3,9 +3,21 @@ import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
 export default {
   parse(tag) {
     const { node } = tag;
-    tag.replaceWith(
-      parseStatements(tag.hub.file, node.rawValue!, node.start!, node.end!)[0],
+    const statements = parseStatements(
+      tag.hub.file,
+      node.rawValue!,
+      node.start!,
+      node.end!,
     );
+
+    if (statements.length > 1) {
+      throw tag.hub.buildError(
+        statements[1],
+        "The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.",
+      );
+    }
+
+    tag.replaceWith(statements[0]);
   },
   parseOptions: {
     statement: true,


### PR DESCRIPTION
`<import>` and `<export>` replaced themselves with `parseStatements(…)[0]` and discarded everything after the first statement. `rawValue` is the whole raw open tag, so one line can parse to several:

```marko
import { a } from "./a.js"; import { b } from "./b.js"
<div>${a} ${b}</div>
```

compiled to a module importing only `a`, while the body still referenced `b` — a free identifier in the generated code, with no compile error, warning or `meta.diagnostics` entry, surfacing as a `ReferenceError` at render or an unresolved global after bundling. `export const p = 1; export const q = 2` dropped `q` the same way.

Each tag takes one statement, so a second one is now a source-level error anchored at its own start rather than at the whole line:

```
> 1 | import { a } from "./a.js"; import { b } from "./b.js"
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The `<import>` tag takes a single import statement.
```

Two error fixtures cover it. Against `main` the same templates compile clean and fail at render with `ReferenceError: b is not defined`.
