### PR TITLE
fix(runtime-tags): lower a logical assignment to a tag variable

### DIFF
--- a/.changeset/logical-assign-tag-variable.md
+++ b/.changeset/logical-assign-tag-variable.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `x ||= …`, `x &&= …` and `x ??= …` on a tag variable crashing the DOM compile with an internal Babel error, and skip the assignment entirely when the operator short circuits.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -673,32 +673,20 @@ onClick(){a++;b++;a_b++}>x</button><script>{console.log(a,b)}</script><script>{c
 with `npm run compile -- -o dom` and observe two `_script("<same hash>", …)`
 registrations.
 
-## Lower `||=` / `&&=` / `??=` on a tag variable — they crash the DOM translator with an internal Babel error
+## Apply `ToNumeric` when lowering `++`/`--` on a tag variable
 
-`packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-23 | impact:med | effort:low
+`packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-27 | impact:med | effort:med
 
-In `replaceAssignedNode`'s `AssignmentExpression` → `Identifier` case, a
-compound assignment is lowered with `t.binaryExpression(node.operator.slice(0,
--1) as t.BinaryExpression["operator"], …)` (signals.ts ~:1564). For the logical
-assignment operators the sliced operator is `||`, `&&` or `??`, which are
-`LogicalExpression` operators, not binary ones — the `as` cast hides this from
-TypeScript and Babel's validator throws `Property operator expected value to be
-one of ["+","-",…] but got "||"` with no code frame, from inside `writeSignals`
-→ `traverseReplace`. So `<let/x=1/><button onClick(){ x ||= 5 }>` is a hard
-build failure for any Marko 6 app: `-o html` compiles fine (the handler body is
-registered, not serialized) and only `-o dom` dies, so the error surfaces as an
-opaque internal TypeError rather than a source-level diagnostic. Fix by emitting
-`t.logicalExpression` for `||`/`&&`/`??` (and ideally preserving short-circuit
-assignment semantics — the current shape would call the setter unconditionally,
-which matters for a `<let>` with `valueChange`, whose `_let_change` invokes the
-parent's change handler on every call). Separately, the `UpdateExpression` case
-just above lowers `x++` to `$x(scope, scope.x + 1) - 1`, which is `x = x + 1`
-rather than JS's `ToNumeric(x) + 1`: for `<let/x="5"/>` an `x++` sets `x` to
-`"51"` and yields `50` instead of setting `6` and yielding `5`, and for a bigint
-`<let>` it throws "Cannot mix BigInt and other types". Re-verify: `npm run
-compile -- -o dom -d f.marko` on `<let/x=1/><button onClick(){ x ??= 5
-}>x</button>${x}` throws the Babel operator TypeError; the same file with `x +=
-5` compiles.
+The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix
+subtracting 1 from the result), which is `x = x + 1` rather than JS's
+`x = ToNumeric(x) + 1`. For `<let/x="5"/>` an `x++` therefore sets `x` to `"51"`
+and yields `50`, instead of setting `6` and yielding `5`. A `<let>` holding a
+bigint is worse: `1n + 1` throws `Cannot mix BigInt and other types`. Writing
+the read as `+scope.x` fixes the string case but breaks bigint, since unary plus
+throws on one, so the lowering needs a form that coerces the way `ToNumeric`
+does — or the operators need rejecting on a tag variable whose type is not
+known numeric. Re-verify: compile `<let/x="5"/><button onClick(){ x++ }>${x}</button>`
+with `-o dom`; the handler emits `$x($scope, $scope.x + 1)`.
 
 ## Lower (or reject) `for (x of …)` / `for (x in …)` writes to a tag variable — they bypass the signal
 

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,37 @@
+// template.marko
+const $template = "<button id=or>or</button><button id=and>and</button><button id=nullish>nullish</button><div>value=<!> changes=<!></div>";
+const $walks = " b b bDb%c%l";
+const $x = /*@__PURE__*/ _let_change("x/8");
+const $changes__OR__value = /*@__PURE__*/ _or(7, ($scope) => $x($scope, $scope.value, $valueChange($scope)));
+const $changes = /*@__PURE__*/ _let("changes/5", ($scope) => {
+	_text($scope["#text/4"], $scope.changes);
+	$changes__OR__value($scope);
+});
+const $value = /*@__PURE__*/ _let("value/6", ($scope) => {
+	_text($scope["#text/3"], $scope.value);
+	$changes__OR__value($scope);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$scope.x || $x($scope, 5);
+	});
+	_on($scope["#button/1"], "click", function() {
+		$scope.x && $x($scope, 6);
+	});
+	_on($scope["#button/2"], "click", function() {
+		$scope.x ?? $x($scope, 7);
+	});
+});
+function $setup($scope) {
+	$changes($scope, 0);
+	$value($scope, 1);
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+		$changes($scope, $scope.changes + 1);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/dom.bundle.js
@@ -1,0 +1,29 @@
+// template.marko
+const $x = /*@__PURE__*/ _let_change(8);
+const $changes__OR__value = /*@__PURE__*/ _or(7, ($scope) => $x($scope, $scope.g, $valueChange($scope)));
+const $changes = /*@__PURE__*/ _let(5, ($scope) => {
+	_text($scope.e, $scope.f);
+	$changes__OR__value($scope);
+});
+const $value = /*@__PURE__*/ _let(6, ($scope) => {
+	_text($scope.d, $scope.g);
+	$changes__OR__value($scope);
+});
+const $setup__script = _script("a1", ($scope) => {
+	_on($scope.a, "click", function() {
+		$scope.i || $x($scope, 5);
+	});
+	_on($scope.b, "click", function() {
+		$scope.i && $x($scope, 6);
+	});
+	_on($scope.c, "click", function() {
+		$scope.i ?? $x($scope, 7);
+	});
+});
+function $valueChange($scope) {
+	return function(v) {
+		$value($scope, v);
+		$changes($scope, $scope.f + 1);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,24 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let changes = 0;
+	let value = 1;
+	let x = value;
+	_html(`<button id=or>or</button>${_el_resume($scope0_id, "#button/0")}<button id=and>and</button>${_el_resume($scope0_id, "#button/1")}<button id=nullish>nullish</button>${_el_resume($scope0_id, "#button/2")}<div>value=<!>${_escape(value)}${_el_resume($scope0_id, "#text/3")} changes=<!>${_escape(changes)}${_el_resume($scope0_id, "#text/4")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		changes,
+		value,
+		x,
+		"TagVariableChange:x": _resume(function(v) {
+			value = v;
+			changes++;
+		}, "__tests__/template.marko_0/valueChange", $scope0_id) || void 0
+	}, "__tests__/template.marko", 0, {
+		changes: "1:6",
+		value: "2:6",
+		x: "3:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.js
@@ -1,0 +1,20 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let changes = 0;
+	let value = 1;
+	let x = value;
+	_html(`<button id=or>or</button>${_el_resume($scope0_id, "a")}<button id=and>and</button>${_el_resume($scope0_id, "b")}<button id=nullish>nullish</button>${_el_resume($scope0_id, "c")}<div>value=<!>${_escape(value)}${_el_resume($scope0_id, "d")} changes=<!>${_escape(changes)}${_el_resume($scope0_id, "e")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		f: changes,
+		g: value,
+		i: x,
+		j: _resume(function(v) {
+			value = v;
+			changes++;
+		}, "a0", $scope0_id) || void 0
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/render.debug.md
@@ -1,0 +1,61 @@
+# Render
+```html
+<button
+  id="or"
+>
+  or
+</button>
+<button
+  id="and"
+>
+  and
+</button>
+<button
+  id="nullish"
+>
+  nullish
+</button>
+<div>
+  value=1 changes=0
+</div>
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```
+```html
+<button
+  id="or"
+>
+  or
+</button>
+<button
+  id="and"
+>
+  and
+</button>
+<button
+  id="nullish"
+>
+  nullish
+</button>
+<div>
+  value=6 changes=1
+</div>
+```
+## Change
+```
+UPDATE: div::text@16 "0" => "1"
+UPDATE: div::text@6 "1" => "6"
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/render.md
@@ -1,0 +1,61 @@
+# Render
+```html
+<button
+  id="or"
+>
+  or
+</button>
+<button
+  id="and"
+>
+  and
+</button>
+<button
+  id="nullish"
+>
+  nullish
+</button>
+<div>
+  value=1 changes=0
+</div>
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```
+```html
+<button
+  id="or"
+>
+  or
+</button>
+<button
+  id="and"
+>
+  and
+</button>
+<button
+  id="nullish"
+>
+  nullish
+</button>
+<div>
+  value=6 changes=1
+</div>
+```
+## Change
+```
+UPDATE: div::text@16 "0" => "1"
+UPDATE: div::text@6 "1" => "6"
+```
+
+# Update
+```js
+(document.querySelector(`#${id}`)).click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<button id=or>or</button><!--M_*1 #button/0--><button
+  id=and>and</button><!--M_*1 #button/1--><button
+  id=nullish>nullish</button><!--M_*1 #button/2-->
+<div>value=<!>1<!--M_*1 #text/3--> changes=<!>0<!--M_*1 #text/4--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      changes: 0,
+      value: 1,
+      x: 1,
+      "TagVariableChange:x": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<button id=or>or</button><!--M_*1 a--><button
+  id=and>and</button><!--M_*1 b--><button
+  id=nullish>nullish</button><!--M_*1 c-->
+<div>value=<!>1<!--M_*1 d--> changes=<!>0<!--M_*1 e--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    f: 0,
+    g: 1,
+    i: 1,
+    j: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3064,
+      "brotli": 1493
+    }
+  },
+  "html": {
+    "min": 514,
+    "brotli": 307
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/template.marko
@@ -1,0 +1,10 @@
+<let/changes=0>
+<let/value=1>
+<let/x=value valueChange(v) {
+  value = v;
+  changes++;
+}>
+<button id="or" onClick() { x ||= 5 }>or</button>
+<button id="and" onClick() { x &&= 6 }>and</button>
+<button id="nullish" onClick() { x ??= 7 }>nullish</button>
+<div>value=${value} changes=${changes}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (id: string) => (document: Document) =>
+  (document.querySelector(`#${id}`) as HTMLButtonElement).click();
+
+export const config: TestConfig = {
+  steps: [{}, click("or"), click("and"), click("nullish")],
+};

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -1588,26 +1588,39 @@ function replaceAssignedNode(node: t.Node): t.Node | undefined {
       switch (node.left.type) {
         case "Identifier": {
           const { extra } = node.left;
+          if (isAssignedBindingExtra(extra)) {
+            const { operator } = node;
+            const shortCircuits =
+              operator === "||=" || operator === "&&=" || operator === "??=";
+            const readAssigned = () =>
+              createScopeReadExpression(extra.assignment, extra.section);
+            const builtAssignment = getBuildAssignment(extra)?.(
+              extra.section,
+              operator === "=" || shortCircuits
+                ? node.right
+                : t.binaryExpression(
+                    operator.slice(0, -1) as t.BinaryExpression["operator"],
+                    readAssigned(),
+                    node.right,
+                  ),
+            );
+
+            if (builtAssignment) {
+              // Short circuits as the source does, so the setter — and any
+              // `valueChange` it calls — is skipped when the read decides.
+              return shortCircuits
+                ? t.logicalExpression(
+                    operator.slice(0, -1) as t.LogicalExpression["operator"],
+                    readAssigned(),
+                    builtAssignment,
+                  )
+                : builtAssignment;
+            }
+          }
+
           return (
-            (isAssignedBindingExtra(extra) &&
-              getBuildAssignment(extra)?.(
-                extra.section,
-                node.operator === "="
-                  ? node.right
-                  : t.binaryExpression(
-                      node.operator.slice(
-                        0,
-                        -1,
-                      ) as t.BinaryExpression["operator"],
-                      createScopeReadExpression(
-                        extra.assignment,
-                        extra.section,
-                      ),
-                      node.right,
-                    ),
-              )) ||
-            (extra?.assignment &&
-              withLeadingComment(node.right, getDebugName(extra.assignment)))
+            extra?.assignment &&
+            withLeadingComment(node.right, getDebugName(extra.assignment))
           );
         }
         case "ArrayPattern":


### PR DESCRIPTION
`replaceAssignedNode` lowers a compound assignment by slicing the operator into a `t.binaryExpression`. For `||=`, `&&=` and `??=` the sliced operator is `||`, `&&` or `??`, which belong to `LogicalExpression` — the `as` cast hid that from TypeScript, so Babel's validator threw from inside `writeSignals`:

```
Property operator expected value to be one of ["+","-",…] but got "||"
```

`-o html` compiles fine, since the handler body is registered rather than serialized, so `<let/x=1/><button onClick(){ x ||= 5 }>` was a hard DOM build failure surfacing as an internal error with no code frame.

The three now build a logical expression with the assignment as its right operand, which also restores the short circuit the source has:

```js
$scope.x || $x($scope, 5)
```

That matters beyond the crash: the previous shape would have called the setter unconditionally, and `_let_change` invokes the parent's change handler on every call, so a `<let>` with `valueChange` would report a change even when the operator did not assign.

The new `logical-assign-to-let` fixture binds a `<let>` through a `valueChange` that counts calls, so the trace shows both the value and whether the setter ran:

```
value=1 changes=0     initial
value=1 changes=0     after x ||= 5   (truthy, skipped)
value=6 changes=1     after x &&= 6   (assigned)
value=6 changes=1     after x ??= 7   (not nullish, skipped)
```

The `UpdateExpression` case above lowers `x++` as `x + 1` rather than `ToNumeric(x) + 1`, which mishandles a string or bigint `<let>`. That is a separate defect with its own fix, so it stays in `agent-feedback` rather than riding this change.
