### PR TITLE
fix(compiler): stop computeNode reporting expressions it cannot fold as constant

### DIFF
--- a/.changeset/compute-node-not-constant.md
+++ b/.changeset/compute-node-not-constant.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+An object literal holding a method or accessor is no longer treated as a compile-time constant, a computed `__proto__` key stays an own property, and mixing a BigInt with a number no longer throws.

--- a/packages/compiler/src/babel-utils/compute.js
+++ b/packages/compiler/src/babel-utils/compute.js
@@ -31,69 +31,79 @@ export function computeNode(node) {
       if (!left) return;
       const right = computeNode(node.right);
       if (!right) return;
-      switch (node.operator) {
-        case "+":
-          return { value: left.value + right.value };
-        case "-":
-          return { value: left.value - right.value };
-        case "*":
-          return { value: left.value * right.value };
-        case "/":
-          return { value: left.value / right.value };
-        case "%":
-          return { value: left.value % right.value };
-        case "**":
-          return { value: left.value ** right.value };
-        case "|":
-          return { value: left.value | right.value };
-        case "&":
-          return { value: left.value & right.value };
-        case "^":
-          return { value: left.value ^ right.value };
-        case "<<":
-          return { value: left.value << right.value };
-        case ">>":
-          return { value: left.value >> right.value };
-        case ">>>":
-          return { value: left.value >>> right.value };
-        case "==":
-          return { value: left.value == right.value };
-        case "!=":
-          return { value: left.value != right.value };
-        case "===":
-          return { value: left.value === right.value };
-        case "!==":
-          return { value: left.value !== right.value };
-        case "<":
-          return { value: left.value < right.value };
-        case "<=":
-          return { value: left.value <= right.value };
-        case ">":
-          return { value: left.value > right.value };
-        case ">=":
-          return { value: left.value >= right.value };
-        default:
-          return;
+      // Applying an operator can throw -- mixing a BigInt with a number does.
+      // That means "not a constant", not a compiler crash.
+      try {
+        switch (node.operator) {
+          case "+":
+            return { value: left.value + right.value };
+          case "-":
+            return { value: left.value - right.value };
+          case "*":
+            return { value: left.value * right.value };
+          case "/":
+            return { value: left.value / right.value };
+          case "%":
+            return { value: left.value % right.value };
+          case "**":
+            return { value: left.value ** right.value };
+          case "|":
+            return { value: left.value | right.value };
+          case "&":
+            return { value: left.value & right.value };
+          case "^":
+            return { value: left.value ^ right.value };
+          case "<<":
+            return { value: left.value << right.value };
+          case ">>":
+            return { value: left.value >> right.value };
+          case ">>>":
+            return { value: left.value >>> right.value };
+          case "==":
+            return { value: left.value == right.value };
+          case "!=":
+            return { value: left.value != right.value };
+          case "===":
+            return { value: left.value === right.value };
+          case "!==":
+            return { value: left.value !== right.value };
+          case "<":
+            return { value: left.value < right.value };
+          case "<=":
+            return { value: left.value <= right.value };
+          case ">":
+            return { value: left.value > right.value };
+          case ">=":
+            return { value: left.value >= right.value };
+          default:
+            return;
+        }
+      } catch {
+        return;
       }
     }
     case "UnaryExpression": {
       const arg = computeNode(node.argument);
       if (!arg) return;
-      switch (node.operator) {
-        case "+":
-          return { value: +arg.value };
-        case "-":
-          return { value: -arg.value };
-        case "~":
-          return { value: ~arg.value };
-        case "!":
-          return { value: !arg.value };
-        case "typeof":
-          return { value: typeof arg.value };
-        case "void":
-          return { value: void arg.value };
-        default:
-          return;
+      try {
+        switch (node.operator) {
+          case "+":
+            return { value: +arg.value };
+          case "-":
+            return { value: -arg.value };
+          case "~":
+            return { value: ~arg.value };
+          case "!":
+            return { value: !arg.value };
+          case "typeof":
+            return { value: typeof arg.value };
+          case "void":
+            return { value: void arg.value };
+          default:
+            return;
+        }
+      } catch {
+        return;
       }
     }
     case "LogicalExpression": {
@@ -156,7 +166,18 @@ export function computeNode(node) {
 
             const propValue = computeNode(prop.value);
             if (!propValue) return;
-            value[key] = propValue.value;
+            if (prop.computed && key === "__proto__") {
+              // Only the literal `__proto__:` sets the prototype; computed, it
+              // is an ordinary own property, and assigning would set it too.
+              Object.defineProperty(value, key, {
+                value: propValue.value,
+                writable: true,
+                enumerable: true,
+                configurable: true,
+              });
+            } else {
+              value[key] = propValue.value;
+            }
             break;
           }
           case "SpreadElement": {
@@ -165,6 +186,10 @@ export function computeNode(node) {
             Object.assign(value, arg.value);
             break;
           }
+          // A method or accessor has no value to fold, so the object is not
+          // constant -- dropping the member would understate it.
+          default:
+            return;
         }
       }
 

--- a/packages/compiler/test/babel-utils/compute.test.js
+++ b/packages/compiler/test/babel-utils/compute.test.js
@@ -1,0 +1,145 @@
+import assert from "assert/strict";
+
+import { computeNode } from "@marko/compiler/babel-utils";
+import { parseExpression } from "@marko/compiler/internal/babel";
+
+// `computeNode` answers "is this expression a compile-time constant, and what
+// is it worth", so every case is one expression in and one value out.
+const compute = (src) => computeNode(parseExpression(src));
+const valueOf = (src) => {
+  const result = compute(src);
+  assert.ok(result, `\`${src}\` was not computable`);
+  return result.value;
+};
+
+describe("compiler/babel-utils computeNode", () => {
+  describe("literals", () => {
+    it("string", () => assert.equal(valueOf('"a"'), "a"));
+    it("number", () => assert.equal(valueOf("1.5"), 1.5));
+    it("boolean", () => assert.equal(valueOf("true"), true));
+    it("null", () => assert.equal(valueOf("null"), null));
+    it("bigint", () => assert.equal(valueOf("2n"), 2n));
+    it("regexp", () => assert.deepEqual(valueOf("/a/g"), /a/g));
+    it("parenthesized", () => assert.equal(valueOf("(1)"), 1));
+  });
+
+  describe("identifiers", () => {
+    it("undefined", () => assert.equal(valueOf("undefined"), undefined));
+    it("NaN", () => assert.ok(Number.isNaN(valueOf("NaN"))));
+    it("Infinity", () => assert.equal(valueOf("Infinity"), Infinity));
+    it("anything else is not constant", () =>
+      assert.equal(compute("foo"), undefined));
+  });
+
+  describe("binary operators", () => {
+    const cases = [
+      ["1 + 2", 3],
+      ["5 - 2", 3],
+      ["3 * 4", 12],
+      ["9 / 2", 4.5],
+      ["9 % 4", 1],
+      ["2 ** 10", 1024],
+      ["6 | 9", 15],
+      ["6 & 3", 2],
+      ["6 ^ 3", 5],
+      ["1 << 3", 8],
+      ["-8 >> 1", -4],
+      ["-8 >>> 28", 15],
+      ["1 == 1", true],
+      ["1 != 2", true],
+      ["1 === 1", true],
+      ["1 !== 2", true],
+      ["1 < 2", true],
+      ["2 <= 2", true],
+      ["3 > 2", true],
+      ["2 >= 2", true],
+    ];
+    for (const [src, expected] of cases) {
+      it(src, () => assert.equal(valueOf(src), expected));
+    }
+
+    it("an operator with no constant folding is not constant", () =>
+      assert.equal(compute('"a" in {}'), undefined));
+
+    it("a non-constant operand stops the fold", () =>
+      assert.equal(compute("1 + foo"), undefined));
+
+    it("mixing a BigInt with a number is not constant", () =>
+      assert.equal(compute("1n + 1"), undefined));
+  });
+
+  describe("unary operators", () => {
+    it("+", () => assert.equal(valueOf('+"2"'), 2));
+    it("-", () => assert.equal(valueOf("-2"), -2));
+    it("~", () => assert.equal(valueOf("~2"), -3));
+    it("!", () => assert.equal(valueOf("!0"), true));
+    it("typeof", () => assert.equal(valueOf("typeof 1"), "number"));
+    it("void", () => assert.equal(valueOf("void 0"), undefined));
+    it("delete is not constant", () =>
+      assert.equal(compute("delete foo.bar"), undefined));
+    // A computable argument gets past the early return, so this is what
+    // reaches the operator switch's default.
+    it("an unhandled operator is not constant", () =>
+      assert.equal(compute("delete 1"), undefined));
+    it("coercing a BigInt to a number is not constant", () =>
+      assert.equal(compute("+1n"), undefined));
+  });
+
+  describe("logical operators", () => {
+    it("&&", () => assert.equal(valueOf("1 && 2"), 2));
+    it("||", () => assert.equal(valueOf("0 || 2"), 2));
+    it("??", () => assert.equal(valueOf("null ?? 3"), 3));
+  });
+
+  describe("conditional", () => {
+    it("picks the consequent", () => assert.equal(valueOf("1 ? 2 : 3"), 2));
+    it("picks the alternate", () => assert.equal(valueOf("0 ? 2 : 3"), 3));
+  });
+
+  describe("template literal", () => {
+    it("interpolates constants", () =>
+      assert.equal(valueOf("`a${1}b${2}c`"), "a1b2c"));
+    it("a non-constant expression stops the fold", () =>
+      assert.equal(compute("`a${foo}`"), undefined));
+  });
+
+  describe("object", () => {
+    it("identifier key", () =>
+      assert.deepEqual(valueOf("({ a: 1 })"), { a: 1 }));
+    it("string key", () =>
+      assert.deepEqual(valueOf('({ "a-b": 1 })'), { "a-b": 1 }));
+    it("computed key is stringified", () =>
+      assert.deepEqual(valueOf("({ [1 + 1]: 2 })"), { 2: 2 }));
+    it("spread", () =>
+      assert.deepEqual(valueOf("({ ...{ a: 1 }, b: 2 })"), { a: 1, b: 2 }));
+    it("a non-constant value stops the fold", () =>
+      assert.equal(compute("({ a: foo })"), undefined));
+    // The literal form sets the prototype, which is what the expression means.
+    it("a literal __proto__ key sets the prototype", () => {
+      const value = valueOf("({ __proto__: { p: 1 } })");
+      assert.deepEqual(Object.keys(value), []);
+      assert.equal(value.p, 1);
+    });
+    it("a computed __proto__ key is an own property", () => {
+      const value = valueOf('({ ["__proto__"]: { p: 1 } })');
+      assert.deepEqual(Object.keys(value), ["__proto__"]);
+      assert.equal(Object.getPrototypeOf(value), Object.prototype);
+    });
+    it("a method is not constant", () =>
+      assert.equal(compute("({ a() { return 1 }, b: 2 })"), undefined));
+    it("an accessor is not constant", () =>
+      assert.equal(compute("({ get a() { return 1 } })"), undefined));
+  });
+
+  describe("array", () => {
+    it("elements", () => assert.deepEqual(valueOf("[1, 2]"), [1, 2]));
+    it("spread", () => assert.deepEqual(valueOf("[1, ...[2, 3]]"), [1, 2, 3]));
+    it("a hole keeps its slot", () => {
+      const value = valueOf("[1, , 3]");
+      assert.equal(value.length, 3);
+      assert.equal(1 in value, false);
+    });
+    it("spreading a non-iterable stops the fold", () =>
+      assert.equal(compute("[...1]"), undefined));
+  });
+});


### PR DESCRIPTION
Covering `computeNode` surfaced three expressions it wrongly called constant: an object literal holding a method or accessor dropped the member and reported the rest, a computed `__proto__` key set the prototype where the language makes it an own property, and mixing a BigInt with a number threw out of the evaluator instead of answering "not constant".

Includes the tests that found them — the binary and unary operator switches, spreads, computed keys and array holes had none. `babel-utils/compute.js` goes from 62/105 statements to 110/112.