### PR TITLE
test(runtime-tags): guard the DurationFormat case on the global existing

### DIFF
--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -10,6 +10,7 @@ const [major, minor] = process.version
   .split(".")
   .map((v) => parseInt(v));
 const hasTemporal = "Temporal" in globalThis;
+const hasDurationFormat = "DurationFormat" in Intl;
 const shouldTestRequestAndResponse =
   major > 24 || (major === 24 && minor >= 14);
 
@@ -985,10 +986,11 @@ describe("serializer", () => {
         [...s.segment("hi there")].map((x) => x.segment).join("|"),
       ));
 
-    it("DurationFormat", () =>
-      roundTrips(new Intl.DurationFormat("en", { style: "long" }), (f) =>
-        f.format({ hours: 1, minutes: 2 }),
-      ));
+    hasDurationFormat &&
+      it("DurationFormat", () =>
+        roundTrips(new Intl.DurationFormat("en", { style: "long" }), (f) =>
+          f.format({ hours: 1, minutes: 2 }),
+        ));
 
     it("a long option string reused elsewhere resumes", () => {
       // The options object is temporary, so any reference recorded against it


### PR DESCRIPTION
`Intl.DurationFormat` ships in neither Node 22 nor Node 24, but the `DurationFormat` case added with the rest of the serializer value coverage constructs it unconditionally. `test: node@22` has failed on main since that commit:

```
TypeError: Intl.DurationFormat is not a constructor
  at packages/runtime-tags/src/__tests__/serializer.test.ts:989:18
```

The serializer itself already treats the type as optional — it is typed `DurationFormat?` and dispatched through `(globalThis.Intl as IntlWithDurationFormat)?.DurationFormat` — so only the test assumed the global. It now sits behind a feature check, matching the `hasTemporal` guard a few lines below it.

Verified by deleting `Intl.DurationFormat` before the suite loads: main's version reproduces the CI error exactly, this one passes, and the case still runs where the global exists.
