### PR TITLE
fix(runtime-tags): keep a `<textarea>` value's leading newline through SSR

### DIFF
--- a/.changeset/textarea-leading-newline.md
+++ b/.changeset/textarea-leading-newline.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Keep a `<textarea>` value's leading newline through an SSR render. The HTML parser discards one newline directly after the start tag, so the first line of the value was silently dropped on the server while the client kept it.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -173,28 +173,20 @@ under `node -r ~ts`,
 `""` while `require('.../src/dom/dom.ts')._attrs({a: el},'a',{className:null})`
 throws.
 
-## Compensate for the HTML parser dropping a `<textarea>`'s leading newline in `_textarea_value`
+## Escape a carriage return in a `<textarea>` body so SSR and CSR agree
 
-`packages/runtime-tags/src/html/attrs.ts` › `_textarea_value` | 2026-07-23 | impact:med | effort:low
+`packages/runtime-tags/src/html/attrs.ts` › `_textarea_value` | 2026-07-27 | impact:low | effort:low
 
-`_textarea_value` (attrs.ts:133) writes the textarea's value straight into the
-element body as `_escape(normalizeStrAttrValue(value))`, so a value beginning
-with a newline serializes as `<textarea>\nhello</textarea>`. The HTML tokenizer
-discards the first newline after a `<textarea>` start tag, so the browser parses
-that back as `"hello"` — the leading blank line is silently lost on every SSR
-render, while CSR keeps it (`dom.ts:42` aliases `_attr_textarea_value` to
-`_attr_input_value`, whose `_attr_input_value_default` in `dom/controllable.ts`
-assigns `el.defaultValue = value` verbatim). It affects all three authoring
-forms (`value=`, `value:=`, and a `${}` body), and for the controlled form it
-also corrupts resume: `_attr_input_value_script` seeds
-`AccessorPrefix.ControlledValue` from `el.defaultValue`, so the client's
-controlled value starts one character behind the server's. Fix as React does —
-have `_textarea_value` prepend a `\n` when the escaped string starts with `\n`
-or `\r` (all of `\n`, `\r\n`, `\r` leads lose the newline). Re-verify:
-SSR-render `<textarea value=input.v/>` with `v = "\nhello"`, confirm the emitted
-HTML is `<textarea>\nhello</textarea>`, parse it with jsdom and observe
-`el.value === "hello"`, versus `el.defaultValue = "\nhello"` giving `el.value
-=== "\nhello"` on the client.
+`_textarea_value` writes the value as element text, and the HTML tokenizer
+normalizes every CR and CRLF in text to a single LF, so a `\r` anywhere in the
+value — not just at the start — is lost on SSR: `"a\rb"` and `"a\r\nb"` both
+parse back as `"a\nb"`. CSR keeps them, since `_attr_input_value_default`
+assigns `el.defaultValue` verbatim, so the two halves disagree and a controlled
+`<textarea>` resumes with a value the server never rendered. Writing `\r` as
+`&#13;` survives, because character references are decoded after newline
+normalization. Weigh that against the bytes it costs every textarea, since a
+lone CR in user input is rare. Re-verify: SSR-render `<textarea value=input.v/>`
+with `v = "a\rb"` and parse the output — the value is `"a\nb"`.
 
 ## Don't emit the "no matching `<option>`" dev error when a controlled `<select>`'s options render asynchronously
 

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<textarea id=attr></textarea><textarea id=bound></textarea><textarea id=body></textarea>";
+const $walks = " b b b";
+const $bound = /*@__PURE__*/ _let("bound/6", ($scope) => _attr_input_value($scope, "#textarea/1", $scope.bound, $valueChange($scope)));
+const $input_v = /*@__PURE__*/ _const("input_v", ($scope) => {
+	_attr_input_value_default($scope, "#textarea/0", $scope.input_v);
+	_attr_input_value_default($scope, "#textarea/2", $scope.input_v);
+	$bound($scope, $scope.input_v);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#textarea/1"));
+const $setup = $setup__script;
+const $input = ($scope, input) => $input_v($scope, input.v);
+function $valueChange($scope) {
+	return (_new_bound) => {
+		$bound($scope, _new_bound);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $bound = /*@__PURE__*/ _let(6, ($scope) => _attr_input_value($scope, "b", $scope.g, $valueChange($scope)));
+const $setup__script = _script("a1", ($scope) => _attr_input_value_script($scope, "b"));
+function $valueChange($scope) {
+	return (_new_bound) => {
+		$bound($scope, _new_bound);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_v = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let bound = input.v;
+	_html(`<textarea id=attr>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/0", $sg__input_v)}<textarea id=bound>${_attr_textarea_value($scope0_id, "#textarea/1", bound, _resume((_new_bound) => {
+		bound = _new_bound;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))}</textarea>${_el_resume($scope0_id, "#textarea/1")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/2", $sg__input_v)}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $sg__input_v = _serialize_guard(_scope_reason(), 0);
+	const $scope0_id = _scope_id();
+	let bound = input.v;
+	_html(`<textarea id=attr>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "a", $sg__input_v)}<textarea id=bound>${_attr_textarea_value($scope0_id, "b", bound, _resume((_new_bound) => {
+		bound = _new_bound;
+	}, "a0", $scope0_id))}</textarea>${_el_resume($scope0_id, "b")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "c", $sg__input_v)}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.debug.md
@@ -1,0 +1,21 @@
+# Render `{"v":"\nkept"}`
+```html
+<textarea
+  id="attr"
+>
+  
+kept
+</textarea>
+<textarea
+  id="bound"
+>
+  
+kept
+</textarea>
+<textarea
+  id="body"
+>
+  
+kept
+</textarea>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.md
@@ -1,0 +1,21 @@
+# Render `{"v":"\nkept"}`
+```html
+<textarea
+  id="attr"
+>
+  
+kept
+</textarea>
+<textarea
+  id="bound"
+>
+  
+kept
+</textarea>
+<textarea
+  id="body"
+>
+  
+kept
+</textarea>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<textarea id=attr>
+
+kept</textarea><textarea id=bound>
+
+kept</textarea><!--M_*1 #textarea/1--><textarea id=body>
+
+kept</textarea>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#textarea/1": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<textarea id=attr>
+
+kept</textarea><textarea id=bound>
+
+kept</textarea><!--M_*1 b--><textarea id=body>
+
+kept</textarea>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Eb: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3729,
+      "brotli": 1750
+    }
+  },
+  "html": {
+    "min": 436,
+    "brotli": 274
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko
@@ -1,0 +1,4 @@
+<let/bound=input.v/>
+<textarea id="attr" value=input.v/>
+<textarea id="bound" value:=bound/>
+<textarea id="body">${input.v}</textarea>

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{ v: "\nkept" }],
+};

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -131,7 +131,10 @@ export function _attr_textarea_value(
 // A textarea renders its value as text content, but coerces it like the `value=`
 // attribute (and like `<input>`/the client) so SSR and CSR agree on non-strings.
 export function _textarea_value(value: unknown) {
-  return _escape(normalizeStrAttrValue(value));
+  const escaped = _escape(normalizeStrAttrValue(value));
+  // The tokenizer drops one newline directly after the start tag, so a value
+  // beginning with one needs a second to survive the round trip.
+  return escaped[0] === "\n" || escaped[0] === "\r" ? "\n" + escaped : escaped;
 }
 
 export function _attr_input_value(


### PR DESCRIPTION
`_textarea_value` writes the value straight into the element body, so a value beginning with a newline serializes as `<textarea>\nhello</textarea>`. The HTML tokenizer discards one newline directly after a `<textarea>` start tag, so the browser parses that back as `"hello"`:

```
serialized "\nhello" -> parsed value "hello"
serialized "\n\nkeep" -> parsed value "\nkeep"
```

The first line is therefore lost on every SSR render, while CSR keeps it — `_attr_input_value_default` assigns `el.defaultValue` verbatim. For the controlled form it also skews resume, since `_attr_input_value_script` seeds the controlled value from `el.defaultValue`, so the client starts a character behind the server.

A value starting with a newline now gets a second one for the parser to consume, which is what React does for the same reason. It affects `value=`, `value:=` and a `${}` body alike, so the new `textarea-leading-newline` fixture covers all three; against `main` its `ssr`, `csr` and `html` cases fail.

Carriage returns are a separate matter and left alone: the tokenizer normalizes every CR and CRLF in text to LF regardless of position, so `"a\rb"` loses it mid-string too. Fixing that means escaping `\r` as `&#13;` on every textarea, which is recorded in `agent-feedback` with the size trade rather than bundled here.
