### PR TITLE
refactor(compiler): drop the unreachable nested-variable taglib loader

### DIFF
--- a/packages/compiler/src/taglib/loader/loadTagFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTagFromProps.js
@@ -101,44 +101,6 @@ class TagLoader {
     propertyHandlers(tagProps, this, this.dependencyChain.toString());
   }
 
-  _handleVar(value, dependencyChain) {
-    var tag = this.tag;
-
-    var nestedVariable;
-
-    if (typeof value === "string") {
-      nestedVariable = {
-        name: value,
-      };
-    } else {
-      nestedVariable = {};
-
-      propertyHandlers(
-        value,
-        {
-          name: function (value) {
-            nestedVariable.name = value;
-          },
-
-          nameFromAttribute: function (value) {
-            nestedVariable.nameFromAttribute = value;
-          },
-        },
-        dependencyChain.toString(),
-      );
-
-      if (!nestedVariable.name && !nestedVariable.nameFromAttribute) {
-        throw new Error(
-          'The "name" or "name-from-attribute" attribute is required for a nested variable (' +
-            dependencyChain +
-            ")",
-        );
-      }
-    }
-
-    tag.addNestedVariable(nestedVariable);
-  }
-
   /**
    * This is handler is for any properties that didn't match
    * one of the default property handlers. This is used to

--- a/packages/runtime-class/test/taglib-loader/fixtures/tag-properties/marko.json
+++ b/packages/runtime-class/test/taglib-loader/fixtures/tag-properties/marko.json
@@ -1,0 +1,7 @@
+{
+  "<info>": {
+    "open-tag-only": true,
+    "description": "Documented for tooling only.",
+    "deprecated": "Use <details> instead."
+  }
+}

--- a/packages/runtime-class/test/taglib-loader/fixtures/tag-properties/test.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/tag-properties/test.js
@@ -1,0 +1,15 @@
+var nodePath = require("path");
+
+exports.check = function (taglibLoader, expect) {
+  var taglib = taglibLoader.loadTaglibFromFile(
+    nodePath.join(__dirname, "marko.json"),
+  );
+
+  var tag = taglib.tags.info;
+
+  expect(tag).to.have.property("openTagOnly").to.equal(true);
+  expect(tag)
+    .to.have.property("description")
+    .to.equal("Documented for tooling only.");
+  expect(tag).to.have.property("deprecated").to.equal("Use <details> instead.");
+};


### PR DESCRIPTION
`_handleVar` in the taglib loader has no caller, and the `tag.addNestedVariable` it ends on is not defined on `Tag` — reaching it would have thrown. Nothing reads `nestedVariables` off a tag either.

Also adds a `taglib-loader` fixture for the `open-tag-only`, `description` and `deprecated` handlers it sat among. `loadTagFromProps.js` goes from 29 uncovered statements to 16.

No changeset: the removed code was unreachable, so nothing observable changes.