### PR TITLE
fix(runtime-tags): drop an unreferenced `<define>` from the dom translation too

### DIFF
--- a/.changeset/define-unreferenced-with-body.md
+++ b/.changeset/define-unreferenced-with-body.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a DOM compile of a template containing a `<define>` with body content whose tag variable is never referenced failing with `Marko internal error: analysis marked this template's setup export as empty but translation produced statements for it.`

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -838,37 +838,6 @@ value:=val/></define><Wrap a=n aChange(v){ n = v }/>` and observe the
 destructuring-key error pointing at the `<define>` tag; deleting `value:=val`
 makes it compile.
 
-## Stop the DOM compile from failing with an internal error on an unreferenced `<define>` that has body content
-
-`packages/runtime-tags/src/translator/core/define.ts` › `analyze` | 2026-07-23 | impact:med | effort:low
-
-A `<define>` with body content whose tag variable is never referenced aborts the
-`dom` compile with `Marko internal error: analysis marked this template's setup
-export as empty but translation produced statements for it. Please open an issue
-with a reproduction.` (thrown at `visitors/program/dom.ts:170-177`), while the
-same template compiles fine for `html` — so SSR-only checks pass and only the
-client build breaks, with an error that tells the user to file an issue. Cause:
-in `analyze`, when `babelBinding.referencePaths` is empty the loop never runs,
-`allDirectReferences` stays `true`, and the `if (allDirectReferences)` branch
-(define.ts:86-94) returns early, skipping `setBindingDownstream(varBinding,
-tagExtra)`; that call is the only thing that eventually reaches
-`finalizeReferences`' `addSetupStatement(expr.section)`
-(`util/references.ts:918-926`), because `core/define.ts` never calls
-`addSetupExpr`/`addSetupStatement` itself (contrast `core/await.ts:124`).
-`translate.exit` nevertheless still runs `addValue(section, …,
-initValue(tag.get("var").node!.extra!.binding!)!, propsToExpression(...))`
-(define.ts:172-177), which lands in the setup signal and contradicts the
-`setupEmpty` proof. The fix should make an unreferenced `<define>` emit nothing
-at all (the same shape as the existing `!varBinding` and
-`allDirectReferences`+refs paths, both of which drop the tag) rather than merely
-recording a setup statement — note that when the template has other setup work
-the current code compiles but emits dead `(/* Foo */{});` in `$setup`.
-Re-verify: `pnpm run compile -- -o dom` on a file containing exactly
-`<define/Foo>content</define>` and `<div>hi</div>` throws the internal error in
-both debug and optimize, while `-o html` succeeds; adding `<let/n=0/>` plus a
-`<button onClick(){n++}>` to the same file makes it compile and emit the dead
-`{}` instead.
-
 ## Flush pending HTML before the `<debug>`/`<log>` statement so SSR keeps the tag's source position
 
 `packages/runtime-tags/src/translator/core/debug.ts` › `translate.exit` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,5 @@
+// template.marko
+const $template = "<span>only this</span>";
+const $walks = "b";
+const $setup = () => {};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const Unused = { content: _content("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_html("<div>never rendered</div>");
+	}) };
+	_html("<span>only this</span>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/html.bundle.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	_content("a0", () => {
+		_scope_id();
+		_scope_reason();
+		_html("<div>never rendered</div>");
+	});
+	_html("<span>only this</span>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/render.debug.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<span>
+  only this
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/render.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<span>
+  only this
+</span>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+<span>only this</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+<span>only this</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 22,
+    "brotli": 26
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/template.marko
@@ -1,0 +1,4 @@
+<define/Unused>
+  <div>never rendered</div>
+</define>
+<span>only this</span>

--- a/packages/runtime-tags/src/translator/core/define.ts
+++ b/packages/runtime-tags/src/translator/core/define.ts
@@ -140,20 +140,22 @@ export default {
             }
           }
 
-          if (hasDirectReferences) {
+          // Matches the analysis, which drops the tag whenever every reference
+          // is direct — including a `<define>` with no references at all.
+          if (allDirectReferences) {
             const bodySection = getSectionForBody(tag.get("body"));
             if (bodySection) {
-              const signal = getSignal(bodySection, undefined);
-              signal.build = () => {
-                if (signalHasStatements(signal)) {
-                  return callRuntime("_child_setup", getSignalFn(signal));
-                }
-              };
-
-              if (allDirectReferences) {
-                tag.remove();
-                return;
+              if (hasDirectReferences) {
+                const signal = getSignal(bodySection, undefined);
+                signal.build = () => {
+                  if (signalHasStatements(signal)) {
+                    return callRuntime("_child_setup", getSignalFn(signal));
+                  }
+                };
               }
+
+              tag.remove();
+              return;
             }
           }
         }


### PR DESCRIPTION
`analyze` returns early and drops the tag whenever every reference to a `<define>`'s variable is direct — which is vacuously true when there are no references at all. `translate.exit` instead gated removal on there being at least one direct reference, so an unreferenced `<define>` with body content fell through to `addValue` and produced setup statements the analysis had already proven empty:

```
> 1 | <define/Unused>
    | ^ Marko internal error: analysis marked this template's setup export as empty
      but translation produced statements for it. Please open an issue with a reproduction.
```

`-o html` compiles the same template fine, so SSR-only checks pass and only the client build breaks — with an error that names no cause and asks the user to file an issue.

Translation now removes the tag on the same condition the analysis drops it, and builds the body signal only when a reference actually needs one.

| | before | after |
|---|---|---|
| unreferenced, with body | internal error | compiles, emits nothing |
| unreferenced, alongside other setup work | dead `(/* Foo */{})` in `$setup` | dead code gone |
| referenced | unchanged | unchanged |

A var-less-body `<define/Unused/>` still emits an empty object; it has no body section, so it never reaches this path and the analysis does not drop it either. Left alone as pre-existing and inert.

The new `define-unreferenced-with-body` fixture is the first case above; against `main` it fails with the internal error in every mode.
