### PR TITLE
fix(compiler): hoist a comment preceding an attribute tag

### DIFF
--- a/.changeset/attr-tag-leading-comment.md
+++ b/.changeset/attr-tag-leading-comment.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Move a comment that directly precedes an `@attributeTag` into the attribute tags with it, rather than leaving it behind in the body.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -77,14 +77,17 @@ export function parseMarko(file) {
         );
       }
 
-      let previousSiblingIndex = currentBody.length;
+      // `currentBody` is the body's own path, so the siblings are the paths
+      // it holds rather than anything indexable off it directly.
+      const siblings = currentBody.get("body");
+      let previousSiblingIndex = siblings.length;
       while (previousSiblingIndex) {
-        let previousSibling = currentBody[--previousSiblingIndex];
-        if (!t.isMarkoComment(previousSibling)) {
+        const previousSibling = siblings[--previousSiblingIndex];
+        if (!t.isMarkoComment(previousSibling.node)) {
           break;
         }
         currentTag.pushContainer("attributeTags", previousSibling.node);
-        currentBody.get("body").get(previousSiblingIndex).remove();
+        previousSibling.remove();
       }
 
       currentTag = currentTag.pushContainer("attributeTags", node)[0];

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,21 @@
+// tags/box/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $for_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $for_content__content = $for_content__dynamicTag;
+const $for_content__$params = ($scope, $params2) => $for_content__content($scope, ($params2?.[0]).content);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<div class=item><!></div>", "D%", 0, $for_content__$params);
+const $input_item = ($scope, input_item) => $for($scope, [input_item]);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var box_default = /*@__PURE__*/ _template("__tests__/tags/box/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $item_content2 = /*@__PURE__*/ _content("__tests__/template.marko_3_content", "two");
+const $item_content = /*@__PURE__*/ _content("__tests__/template.marko_2_content", "one");
+function $setup($scope) {
+	$input_item($scope["#childScope/0"], attrTags(attrTag({ content: $item_content($scope) }), { content: $item_content2($scope) }));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,28 @@
+// tags/box/index.marko
+var box_default = _template("__tests__/tags/box/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0), $si__input_item = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, ({ content }) => {
+		const $scope1_id = _scope_id();
+		_html("<div class=item>");
+		_dynamic_tag($scope1_id, "#text/0", content, {}, 0, 0, $sg__input_item);
+		_html("</div>");
+		$si__input_item && writeScope($scope1_id, {}, "__tests__/tags/box/index.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	$si__input_item && writeScope($scope0_id, {}, "__tests__/tags/box/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	box_default({ item: attrTags(attrTag({ content: _content("__tests__/template.marko_2_content", () => {
+		_scope_reason();
+		const $scope2_id = _scope_id();
+		_html("one");
+	}) }), { content: _content("__tests__/template.marko_3_content", () => {
+		_scope_reason();
+		const $scope3_id = _scope_id();
+		_html("two");
+	}) }) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/html.bundle.js
@@ -1,0 +1,28 @@
+// tags/box/index.marko
+var box_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_item = _serialize_guard($scope0_reason, 0), $si__input_item = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.item, ({ content }) => {
+		const $scope1_id = _scope_id();
+		_html("<div class=item>");
+		_dynamic_tag($scope1_id, "a", content, {}, 0, 0, $sg__input_item);
+		_html("</div>");
+		$si__input_item && writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
+	$si__input_item && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	box_default({ item: attrTags(attrTag({ content: _content("a0", () => {
+		_scope_reason();
+		_scope_id();
+		_html("one");
+	}) }), { content: _content("a1", () => {
+		_scope_reason();
+		_scope_id();
+		_html("two");
+	}) }) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/render.debug.md
@@ -1,0 +1,13 @@
+# Render
+```html
+<div
+  class="item"
+>
+  one
+</div>
+<div
+  class="item"
+>
+  two
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/render.md
@@ -1,0 +1,13 @@
+# Render
+```html
+<div
+  class="item"
+>
+  one
+</div>
+<div
+  class="item"
+>
+  two
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/writes.debug.html
@@ -1,0 +1,2 @@
+<div class=item>one</div>
+<div class=item>two</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/writes.html
@@ -1,0 +1,2 @@
+<div class=item>one</div>
+<div class=item>two</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 50,
+    "brotli": 37
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/tags/box/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/tags/box/index.marko
@@ -1,0 +1,3 @@
+<for|{ content }| of=input.item>
+  <div.item><${content}/></div>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/template.marko
@@ -1,0 +1,6 @@
+<box>
+  <div>body content first</div>
+  <!-- a comment between body content and the attribute tags -->
+  <@item>one</@item>
+  <@item>two</@item>
+</box>


### PR DESCRIPTION
The loop that moves a comment sitting directly before an `@attributeTag` in with the attribute tags read `.length` off `currentBody`. That is the body's own path, which has no `length`, so the `while` condition was always `undefined` and the loop never ran — the comment stayed in the body instead.

Reads the sibling paths instead, and adds the fixture that exercises it. No existing snapshot changes, since none had that shape.