### PR TITLE
fix(runtime-tags): reject `content=` on a void or text-only native tag

### DIFF
--- a/.changeset/content-attr-unsupported-tags.md
+++ b/.changeset/content-attr-unsupported-tags.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Report a compile error for a `content` attribute on a void or text-only native tag. `<input content=x>` and `<textarea content=x/>` previously compiled, emitting the content for the client and silently dropping it on the server, and neither could render it.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -1133,33 +1133,6 @@ a helper every dynamic tag pays for; measure before taking it. Re-verify: the
 with no `"preserve"`, while `interop-self-interactive-split-tags-to-class`,
 whose only call site is inert, still emits it.
 
-## SSR silently drops `content=` on void and text-only native tags, and on any tag whose body is only Marko comments
-
-`packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `translate.html.enter` | 2026-07-23 | impact:med | effort:low
-
-The native-tag `content=` attribute has two silent-drop paths. (1) In the HTML
-translate `enter`, the write-close chain tests `if (isOpenOnly || isTextOnly)
-write`>`` before `else if (staticContentAttr)` (native-tag.ts:560-579), so
-`content` is never rendered for a void (`openTagOnly`) or text-only tag; the DOM
-`enter` has no such guard and emits `_attr_content` unconditionally (:956-972),
-so `<textarea content=input.x/>` and `<input content=input.y>` compile to
-`_attr_content($scope, "#textarea/0", input_x)` for CSR but to plain
-`<textarea></textarea><input>` with no `_attr_content` for SSR — a CSR/SSR
-divergence with no diagnostic (`<div content=input.z/>` in the same file does
-emit `_attr_content` in both). (2) The analyze guard `attr.name === "content" &&
-tag.node.body.body.length` (:132-142, mirrored in `getUsedAttrs` at :1166)
-counts `MarkoComment` nodes as body content, so `<div content=input.x><!-- note
---></div>` renders an empty `<div>` in both outputs — the comment is stripped
-and the content attribute was dropped because of it.
-`translator/util/is-only-child-in-parent.ts` already filters `node.type !==
-"MarkoComment"` for exactly this kind of body-length test, so the same filter
-belongs here. For (1), either handle `content` consistently or raise a compile
-error saying `content` is not supported on void/text-only elements. Re-verify:
-`pnpm run compile -o dom -d` and `-o html -d` on a file containing `<div
-content=input.z/><textarea content=input.x/><input content=input.y>` and diff
-which tags get `_attr_content`; then compile `<div content=input.x><!-- hi
---></div>` and observe `<div></div>` with no `_attr_content` in either output.
-
 ## Enable branch machinery for spread `content=` branches; `_attr_content` creates branches without it
 
 `packages/runtime-tags/src/dom/dom.ts` › `_attr_content` | 2026-07-23 | impact:low | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,9 @@
+// template.marko
+const $template = "<div id=plain></div><div id=commented></div><div id=withBody>body wins</div>";
+const $walks = " d";
+const $Note_content = /*@__PURE__*/ _content("__tests__/template.marko_1_content", "<span>note</span>");
+const $Note = ($scope, Note) => _attr_content($scope, "#div/0", Note);
+function $setup($scope) {
+	$Note($scope, { content: $Note_content($scope) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " d", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const Note = { content: _content("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_html("<span>note</span>");
+	}) };
+	_html("<div id=plain>");
+	_attr_content("#div/0", $scope0_id, Note, 0);
+	_html("</div><div id=commented></div><div id=withBody>body wins</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/html.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const Note = { content: _content("a0", () => {
+		_scope_id();
+		_scope_reason();
+		_html("<span>note</span>");
+	}) };
+	_html("<div id=plain>");
+	_attr_content("a", $scope0_id, Note, 0);
+	_html("</div><div id=commented></div><div id=withBody>body wins</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/render.debug.md
@@ -1,0 +1,18 @@
+# Render
+```html
+<div
+  id="plain"
+>
+  <span>
+    note
+  </span>
+</div>
+<div
+  id="commented"
+/>
+<div
+  id="withBody"
+>
+  body wins
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/render.md
@@ -1,0 +1,18 @@
+# Render
+```html
+<div
+  id="plain"
+>
+  <span>
+    note
+  </span>
+</div>
+<div
+  id="commented"
+/>
+<div
+  id="withBody"
+>
+  body wins
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/writes.debug.html
@@ -1,0 +1,3 @@
+<div id=plain><span>note</span></div>
+<div id=commented></div>
+<div id=withBody>body wins</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/__snapshots__/writes.html
@@ -1,0 +1,3 @@
+<div id=plain><span>note</span></div>
+<div id=commented></div>
+<div id=withBody>body wins</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 93,
+    "brotli": 55
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-body-precedence/template.marko
@@ -1,0 +1,6 @@
+<define/Note>
+  <span>note</span>
+</define>
+<div id="plain" content=Note/>
+<div id="commented" content=Note><!-- a note --></div>
+<div id="withBody" content=Note>body wins</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko:4:11
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <textarea content=Note/>
+        |           ^^^^^^^^^^^^ The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko:4:11
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <textarea content=Note/>
+        |           ^^^^^^^^^^^^ The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko:4:11
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <textarea content=Note/>
+        |           ^^^^^^^^^^^^ The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko:4:11
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <textarea content=Note/>
+        |           ^^^^^^^^^^^^ The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/template.marko
@@ -1,0 +1,4 @@
+<define/Note>
+  <span>note</span>
+</define>
+<textarea content=Note/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-text-only-tag/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko:4:8
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <input content=Note>
+        |        ^^^^^^^^^^^^ The `<input>` tag cannot have content, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko:4:8
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <input content=Note>
+        |        ^^^^^^^^^^^^ The `<input>` tag cannot have content, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko:4:8
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <input content=Note>
+        |        ^^^^^^^^^^^^ The `<input>` tag cannot have content, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko:4:8
+      2 |   <span>note</span>
+      3 | </define>
+    > 4 | <input content=Note>
+        |        ^^^^^^^^^^^^ The `<input>` tag cannot have content, so it does not support the `content` attribute.
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/template.marko
@@ -1,0 +1,4 @@
+<define/Note>
+  <span>note</span>
+</define>
+<input content=Note>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-content-attr-void-tag/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -203,6 +203,22 @@ export default {
         throw tag.get("name").buildCodeFrameError(msg);
       });
 
+      if (seen.content) {
+        if (getTagDef(tag)?.parseOptions?.openTagOnly) {
+          throw tag.hub.buildError(
+            seen.content,
+            `The \`<${tagName}>\` tag cannot have content, so it does not support the \`content\` attribute.`,
+          );
+        }
+
+        if (isTextOnly) {
+          throw tag.hub.buildError(
+            seen.content,
+            `The \`<${tagName}>\` tag takes its content from its body as text, so it does not support the \`content\` attribute.`,
+          );
+        }
+      }
+
       let textPlaceholders: undefined | t.Node[];
       if (isTextOnly) {
         for (const child of tag.node.body.body) {


### PR DESCRIPTION
The html translate wrote `>` for a void or text-only tag before it considered a static `content` attribute, while the dom translate emitted `_attr_content` unconditionally. So these compiled, emitting content for the client and nothing for the server, with no diagnostic either way:

```marko
<input content=Note>
<textarea content=Note/>
```

Making the server match the client is not the fix, because neither side can render it. A void element takes no children — appending one leaves `innerHTML` empty and it serializes back as `<input>` — and a text-only element already takes its content from its body as text. Both are now a source-level error naming the tag and the reason:

```
> 4 | <input content=Note>
    |        ^^^^^^^^^^^^ The `<input>` tag cannot have content, so it does not support the `content` attribute.

> 4 | <textarea content=Note/>
    |           ^^^^^^^^^^^^ The `<textarea>` tag takes its content from its body as text, so it does not support the `content` attribute.
```

No existing fixture used the attribute on either kind of tag.

Also included is the `content-attr-body-precedence` fixture, which pins how body content overrides the attribute — including a body of only a Marko comment, which is stripped and so renders the element empty. That case had been filed in `agent-feedback` as a dropped attribute; it is the intended rule, and the fixture keeps it visible.
