### PR TITLE
test(compiler): cover the array and script-lang taglib properties

### DIFF
--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/marko.json
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/marko.json
@@ -1,0 +1,6 @@
+{
+  "script-lang": "ts",
+  "tags-dir": ["./tags-a", "./tags-b"],
+  "transform": ["./transform-one.js", "./transform-two.js"],
+  "migrate": ["./migrate-one.js", "./migrate-two.js"]
+}

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/migrate-one.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/migrate-one.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/migrate-two.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/migrate-two.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/tags-a/alpha/index.marko
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/tags-a/alpha/index.marko
@@ -1,0 +1,1 @@
+<div>alpha</div>

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/tags-b/beta/index.marko
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/tags-b/beta/index.marko
@@ -1,0 +1,1 @@
+<div>beta</div>

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/test.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/test.js
@@ -1,0 +1,12 @@
+var nodePath = require("path");
+
+exports.check = function (taglibLoader, expect) {
+  var taglib = taglibLoader.loadTaglibFromFile(
+    nodePath.join(__dirname, "marko.json"),
+  );
+
+  expect(taglib.scriptLang).to.equal("ts");
+  expect(Object.keys(taglib.tags).sort()).to.deep.equal(["alpha", "beta"]);
+  expect(taglib.transformers).to.have.lengthOf(2);
+  expect(taglib.migrators).to.have.lengthOf(2);
+};

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/transform-one.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/transform-one.js
@@ -1,0 +1,1 @@
+module.exports = function () {};

--- a/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/transform-two.js
+++ b/packages/runtime-class/test/taglib-loader/fixtures/taglib-properties/transform-two.js
@@ -1,0 +1,1 @@
+module.exports = function () {};


### PR DESCRIPTION
`script-lang`, and the array forms of `tags-dir`, `transform` and `migrate`, had no fixture — every existing one passes a single string. Adds a taglib that uses all four, with a tag discovered from each of two directories.

`loadTaglibFromProps.js` goes from 112/129 statements to 117/129.