### PR TITLE
test(compiler): cover the require hook

### DIFF
--- a/packages/compiler/test/fixtures/register/other.marko
+++ b/packages/compiler/test/fixtures/register/other.marko
@@ -1,0 +1,1 @@
+<p>second ${input.n}</p>

--- a/packages/compiler/test/fixtures/register/run.cjs
+++ b/packages/compiler/test/fixtures/register/run.cjs
@@ -1,0 +1,27 @@
+const path = require("path");
+const register = require("@marko/compiler/register");
+register({ translator: require.resolve("@marko/runtime-tags/translator") });
+
+// Two templates: the first installs source-map-support, the second goes
+// through the reassigned recorder.
+const first = require(path.join(__dirname, "template.marko"));
+const second = require(path.join(__dirname, "other.marko"));
+const render = (m, input) => String((m.default || m).render(input));
+
+if (process.env.REGISTER_MODE === "throw") {
+  try {
+    render(first, {
+      name: {
+        toString() {
+          throw new Error("boom");
+        },
+      },
+    });
+  } catch (err) {
+    // Reading the stack is what asks source-map-support for the map.
+    process.stdout.write(/template\.marko/.test(err.stack) ? "mapped" : "raw");
+    process.exit(0);
+  }
+}
+
+process.stdout.write(render(first, { name: "world" }) + render(second, { n: 2 }));

--- a/packages/compiler/test/fixtures/register/template.marko
+++ b/packages/compiler/test/fixtures/register/template.marko
@@ -1,0 +1,1 @@
+<div>hello ${input.name}</div>

--- a/packages/compiler/test/register.test.js
+++ b/packages/compiler/test/register.test.js
@@ -1,0 +1,34 @@
+import assert from "assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const here = import.meta.dirname;
+const root = path.join(here, "..", "..", "..");
+const script = path.join(here, "fixtures", "register", "run.cjs");
+
+// In a child process on purpose: requiring the hook installs a `.marko`
+// handler onto the real `require.extensions`, which would outlive this test
+// and change how every other suite resolves a template.
+const run = (env) =>
+  execFileSync(process.execPath, ["-r", "~ts", script], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  }).trim();
+
+describe("compiler/register", () => {
+  it("compiles templates required through the hook", () => {
+    assert.equal(run(), "<div>hello world</div><p>second 2</p>");
+  });
+
+  it("maps a stack back to the template it came from", () => {
+    assert.equal(run({ REGISTER_MODE: "throw" }), "mapped");
+  });
+
+  it("compiles with source maps off", () => {
+    assert.equal(
+      run({ NODE_ENV: "production" }),
+      "<div>hello world</div><p>second 2</p>",
+    );
+  });
+});


### PR DESCRIPTION
`register.cjs` had no coverage at all — requiring it installs a `.marko` handler onto the real `require.extensions`, so exercising it in-process would outlive the test and change how every other suite resolves a template. It runs in a child process instead.

Three cases: two templates compiled through the hook, a thrown stack mapped back to the `.marko` it came from, and the same compile with source maps off. Takes the file from 0/21 statements to 21/21.