### PR TITLE
test(compiler): cover translator detection and config overrides

### DIFF
--- a/packages/compiler/test/config.test.js
+++ b/packages/compiler/test/config.test.js
@@ -1,0 +1,56 @@
+import assert from "assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const fixtures = path.join(import.meta.dirname, "fixtures", "config");
+const script = path.join(fixtures, "print.mjs");
+
+// The translator is chosen once, while the module loads, from the package.json
+// nearest the working directory -- so each case needs its own process.
+const read = (dir, env) =>
+  JSON.parse(
+    execFileSync(process.execPath, ["-r", "~ts", script], {
+      cwd: path.join(fixtures, dir),
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    }),
+  );
+
+describe("compiler/config", () => {
+  describe("translator", () => {
+    it("prefers the class-tags interop when it is depended on", () =>
+      assert.equal(
+        read("interop").translator,
+        "@marko/translator-interop-class-tags",
+      ));
+
+    it("takes a runtime from dependencies", () =>
+      assert.equal(read("dep").translator, "marko-runtime-example/translator"));
+
+    it("takes a runtime from peerDependencies", () =>
+      assert.equal(
+        read("peer").translator,
+        "@marko/runtime-example/translator",
+      ));
+
+    it("takes a runtime from devDependencies", () =>
+      assert.equal(read("dev").translator, "marko-runtime-example/translator"));
+
+    // Two runtimes and no way to choose, so it declines rather than guessing --
+    // which also means the `marko/translator` fallback is not reached.
+    for (const [dir, where] of [
+      ["conflict", "dependencies"],
+      ["conflict-peer", "peerDependencies"],
+      ["conflict-dev", "devDependencies"],
+    ]) {
+      it(`chooses none when two runtimes disagree in ${where}`, () =>
+        assert.equal(read(dir).translator, undefined));
+    }
+  });
+
+  it("applies MARKO_CONFIG over the defaults", () =>
+    assert.equal(
+      read("dep", { MARKO_CONFIG: '{"output":"dom"}' }).output,
+      "dom",
+    ));
+});

--- a/packages/compiler/test/fixtures/config/conflict-dev/package.json
+++ b/packages/compiler/test/fixtures/config/conflict-dev/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-conflict-dev", "devDependencies": { "marko-runtime-one": "*", "marko-runtime-two": "*" } }

--- a/packages/compiler/test/fixtures/config/conflict-peer/package.json
+++ b/packages/compiler/test/fixtures/config/conflict-peer/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-conflict-peer", "peerDependencies": { "marko-runtime-one": "*", "marko-runtime-two": "*" } }

--- a/packages/compiler/test/fixtures/config/conflict/package.json
+++ b/packages/compiler/test/fixtures/config/conflict/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-conflict", "dependencies": { "marko-runtime-one": "*", "marko-runtime-two": "*" } }

--- a/packages/compiler/test/fixtures/config/dep/package.json
+++ b/packages/compiler/test/fixtures/config/dep/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-dep-fixture", "dependencies": { "marko-runtime-example": "*" } }

--- a/packages/compiler/test/fixtures/config/dev/package.json
+++ b/packages/compiler/test/fixtures/config/dev/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-dev", "devDependencies": { "marko-runtime-example": "*" } }

--- a/packages/compiler/test/fixtures/config/interop/package.json
+++ b/packages/compiler/test/fixtures/config/interop/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-interop", "dependencies": { "@marko/translator-interop-class-tags": "*" } }

--- a/packages/compiler/test/fixtures/config/peer/package.json
+++ b/packages/compiler/test/fixtures/config/peer/package.json
@@ -1,0 +1,1 @@
+{ "name": "config-peer", "peerDependencies": { "@marko/runtime-example": "*" } }

--- a/packages/compiler/test/fixtures/config/print.mjs
+++ b/packages/compiler/test/fixtures/config/print.mjs
@@ -1,0 +1,2 @@
+import config from "@marko/compiler/config";
+process.stdout.write(JSON.stringify({ translator: config.translator, output: config.output }));


### PR DESCRIPTION
The translator is chosen once while `config.js` loads, by reading the package.json nearest the working directory — so none of that detection had ever run under test. Each case needs its own process and cwd, so they run as child processes against fixture package files.

Covers picking the class-tags interop, a runtime from each of `dependencies`, `peerDependencies` and `devDependencies`, declining when two runtimes disagree in any of the three, and `MARKO_CONFIG` overriding a default. `config.js` goes from 13/27 statements to 27/27, branches 12/33 to 30/33.