### PR TITLE
fix(changeset): name the runtime-class package as it is in the workspace

### DIFF
--- a/.changeset/compat-boundary-mode-order.md
+++ b/.changeset/compat-boundary-mode-order.md
@@ -1,6 +1,6 @@
 ---
 "@marko/runtime-tags": patch
-"@marko/runtime-class": patch
+"marko": patch
 ---
 
 Stop a Class-API component rendered at both an inert and an updating call site from inheriting the first call site's `"preserve"` boundary mode, which left the updating one serialized as a component that never re-renders in the browser.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,8 @@ pnpm run change                                           # add a changeset (req
 
 `pnpm run compile` is the fastest way to inspect what the translator generates. (Pass `-t class` for the Marko 5 translator; `-t` also accepts a full translator module id.)
 
+`pnpm run change` prompts, so write `.changeset/<name>.md` directly. Name a workspace package — `@marko/compiler`, `@marko/runtime-tags` or `marko` (`packages/runtime-class`) — then check it with `pnpm exec changeset status`; a wrong name passes review and breaks the release on `main`.
+
 ## Repo invariants
 
 - **Babel is patched.** `patches/` (applied by pnpm patchedDependencies on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping a `@babel/*` version requires regenerating its patch.


### PR DESCRIPTION
The release job on `main` has been failing since `fe76065063`: `changeset version` throws `Found changeset compat-boundary-mode-order for package @marko/runtime-class which is not in the workspace`, so nothing has been released since — including the fixes already merged behind it.

`packages/runtime-class` is named `marko`, which is what the other 436 changesets in this repo's history use; `@marko/runtime-class` is only a publish alias. Renaming the entry lets `changeset status` resolve again.

Also notes in AGENTS.md that `pnpm run change` prompts and so stalls without a terminal, which is why changesets get written by hand, and that `pnpm exec changeset status` is the check that catches a name no package answers to.