### PR TITLE
test(compiler): cover taglib registration and optional taglibs

### DIFF
--- a/packages/compiler/test/fixtures/taglib/local/marko.json
+++ b/packages/compiler/test/fixtures/taglib/local/marko.json
@@ -1,0 +1,6 @@
+{
+  "taglib-id": "taglib-fixture-local",
+  "<probe-local>": {
+    "@message": "string"
+  }
+}

--- a/packages/compiler/test/fixtures/taglib/package.json
+++ b/packages/compiler/test/fixtures/taglib/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "taglib-fixture",
+  "dependencies": { "marko-missing-taglib": "*" }
+}

--- a/packages/compiler/test/fixtures/taglib/run.mjs
+++ b/packages/compiler/test/fixtures/taglib/run.mjs
@@ -1,0 +1,44 @@
+import { taglib } from "@marko/compiler";
+
+// Empty on both halves of what a translator owes the lookup, so what comes
+// back is only what `register` put there.
+const emptyTranslator = { taglibs: [], tagDiscoveryDirs: [] };
+const write = (value) => process.stdout.write(JSON.stringify(value));
+const message = (fn) => {
+  try {
+    fn();
+    return null;
+  } catch (err) {
+    return err.message;
+  }
+};
+
+const cases = {
+  "invalid-translator": () =>
+    write(message(() => taglib.buildLookup(process.cwd(), {}))),
+
+  "register-by-path": () => {
+    taglib.register("./local/marko.json");
+    write(!!taglib.buildLookup(process.cwd(), emptyTranslator).getTag("probe-local"));
+  },
+
+  "register-by-module": () => {
+    taglib.register("@marko/compiler/test/fixtures/taglib/local/marko.json");
+    write(!!taglib.buildLookup(process.cwd(), emptyTranslator).getTag("probe-local"));
+  },
+
+  "optional-undeclared": () => write(taglib.resolveOptionalTaglibs(["marko-undeclared-taglib"])),
+
+  "optional-throws": () =>
+    write(message(() => taglib.resolveOptionalTaglibs(["marko-missing-taglib"]))),
+
+  "optional-onerror": () => {
+    const errors = [];
+    const resolved = taglib.resolveOptionalTaglibs(["marko-missing-taglib"], (err) =>
+      errors.push(err.message),
+    );
+    write({ resolved, errors });
+  },
+};
+
+cases[process.env.CASE]();

--- a/packages/compiler/test/taglib.test.js
+++ b/packages/compiler/test/taglib.test.js
@@ -1,0 +1,47 @@
+import assert from "assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const fixture = path.join(import.meta.dirname, "fixtures", "taglib");
+const script = path.join(fixture, "run.mjs");
+
+// `register` appends to a module-level list and taglib ids resolve from the
+// package nearest the working directory, so each case needs its own process.
+const run = (env) =>
+  JSON.parse(
+    execFileSync(process.execPath, ["-r", "~ts", script], {
+      cwd: fixture,
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+    }),
+  );
+
+describe("compiler/taglib", () => {
+  it("refuses a translator that brings no taglibs", () =>
+    assert.match(run({ CASE: "invalid-translator" }), /Invalid translator/));
+
+  describe("register", () => {
+    it("takes a taglib by relative path", () =>
+      assert.equal(run({ CASE: "register-by-path" }), true));
+
+    it("takes a taglib by module id", () =>
+      assert.equal(run({ CASE: "register-by-module" }), true));
+  });
+
+  describe("optional taglibs", () => {
+    it("skips one the root package does not depend on", () =>
+      assert.deepEqual(run({ CASE: "optional-undeclared" }), []));
+
+    it("throws when a declared one cannot be resolved", () =>
+      assert.match(
+        run({ CASE: "optional-throws" }),
+        /Cannot find module 'marko-missing-taglib\/marko\.json'/,
+      ));
+
+    it("hands that failure to onError instead, and keeps going", () => {
+      const { resolved, errors } = run({ CASE: "optional-onerror" });
+      assert.deepEqual(resolved, []);
+      assert.match(errors[0], /Cannot find module 'marko-missing-taglib/);
+    });
+  });
+});


### PR DESCRIPTION
`taglib.register(id)` with one argument and `taglib.resolveOptionalTaglibs` had never run — so neither had `resolveTaglib`, which is the whole id-to-module step, nor the `onError` path that lets a missing optional taglib be reported instead of thrown. Optional taglibs are declared as `marko-widgets` and `@marko/compat-v4`, neither a dependency of this repo, so nothing here reaches them.

A fixture package declaring an unresolvable optional taglib covers the failure both ways, and a local `marko.json` registered by path and by module id covers the two resolution shapes. `taglib/index.js` goes from 48/65 statements and 20/30 branches to 65/65 and 30/30.

Each case runs in its own process: `register` appends to a module-level list, and ids resolve from the package nearest the working directory.