### PR TITLE
fix(compiler): compile a file without a config, and cover the entry points

### DIFF
--- a/.changeset/compile-file-without-config.md
+++ b/.changeset/compile-file-without-config.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix `compileFile` and `compileFileSync` throwing a `TypeError` when called without a config, instead of falling back to the configured file system.

--- a/packages/compiler/src/index.js
+++ b/packages/compiler/src/index.js
@@ -184,7 +184,7 @@ export function _clearDefaults() {
 }
 
 function getFs(config) {
-  return config.fileSystem || globalConfig.fileSystem;
+  return config?.fileSystem || globalConfig.fileSystem;
 }
 
 function isTranslatedOutput(output) {

--- a/packages/compiler/test/compile.test.js
+++ b/packages/compiler/test/compile.test.js
@@ -1,0 +1,82 @@
+import assert from "assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+import {
+  compile,
+  compileFile,
+  compileFileSync,
+  getRuntimeEntryFiles,
+  getRuntimeVersion,
+} from "@marko/compiler";
+
+const template = path.join(
+  import.meta.dirname,
+  "fixtures",
+  "register",
+  "template.marko",
+);
+
+// Enough of an fs to read one template, standing in for the virtual one a
+// bundler hands over.
+const fromMemory = (src) => ({
+  ...fs,
+  readFile: (_file, _encoding, cb) => cb(null, src),
+  readFileSync: () => src,
+});
+
+describe("compiler/compile", () => {
+  describe("compileFile", () => {
+    it("reads with the default file system when given no config", async () => {
+      const { code } = await compileFile(template);
+      assert.ok(code.length);
+    });
+
+    it("reads through a file system from the config", async () => {
+      const { code } = await compileFile(template, {
+        fileSystem: fromMemory("<div>from config</div>"),
+      });
+      assert.match(code, /from config/);
+    });
+
+    it("rejects when the file cannot be read", () =>
+      assert.rejects(() => compileFile(template + ".missing"), {
+        code: "ENOENT",
+      }));
+  });
+
+  describe("compileFileSync", () => {
+    it("reads with the default file system when given no config", () =>
+      assert.ok(compileFileSync(template).code.length));
+
+    it("reads through a file system from the config", () =>
+      assert.match(
+        compileFileSync(template, {
+          fileSystem: fromMemory("<div>from config</div>"),
+        }).code,
+        /from config/,
+      ));
+  });
+
+  describe("getRuntimeEntryFiles", () => {
+    it("asks the translator", () =>
+      assert.ok(getRuntimeEntryFiles("html").length));
+
+    it("is empty for a translator that offers none", () =>
+      assert.deepEqual(getRuntimeEntryFiles("html", {}), []));
+  });
+
+  describe("getRuntimeVersion", () => {
+    it("reports the translator's version", () =>
+      assert.match(getRuntimeVersion(), /^\d+\.\d+\.\d+/));
+
+    it("falls back for a translator that has no version", () =>
+      assert.equal(getRuntimeVersion({}), "0.0.0"));
+  });
+
+  it("keeps the compile error when compiling asynchronously", () =>
+    assert.rejects(
+      () => compile("<div", template),
+      /EOF reached while parsing/,
+    ));
+});


### PR DESCRIPTION
`compileFile` and `compileFileSync` both declare `config` optional and both threw a `TypeError` when it was omitted — `getFs` read `config.fileSystem` before it could fall back to the configured one. Nothing in the repo called them without a config, so nothing caught it.

Tests cover that path plus the rest of the untested public entry points: reading through a `fileSystem` handed over in the config, the rejection when a file cannot be read, `getRuntimeEntryFiles`, `getRuntimeVersion`, and the async compile's error path. `compiler/src/index.js` goes from 47/58 statements and 24/32 branches to 57/57 and 42/49.