### PR TITLE
fix(runtime-tags): keep repeat references inline when a cycle assignment is pending

### DIFF
--- a/.changeset/serializer-pending-assign-inline.md
+++ b/.changeset/serializer-pending-assign-inline.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix serializing a repeated reference to a value that already has a deferred cycle assignment: Map/Set members resumed as missing and a generator return emitted unparsable output.

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,37 @@
+// template.marko
+const $template = "<button id=go>go</button><div id=out> </div>";
+const $walks = " bD l";
+function buildGraph() {
+	const a = { id: 1 };
+	const b = { id: 2 };
+	a.next = b;
+	b.prev = a;
+	return {
+		current: a,
+		byId: new Map([[1, a], [2, b]]),
+		all: new Set([a, b])
+	};
+}
+const $graph = /*@__PURE__*/ _let("graph/2", ($scope) => {
+	$graph_byId($scope, $scope.graph?.byId);
+	$graph_current($scope, $scope.graph?.current);
+	$graph_all($scope, $scope.graph?.all);
+});
+const $graph_byId__OR__graph_current__OR__graph_all__script = _script("__tests__/template.marko_0_graph_byId_graph_current_graph_all", ($scope) => _on($scope["#button/0"], "click", function() {
+	$result($scope, [
+		$scope.graph_byId.get(1) === $scope.graph_current,
+		$scope.graph_byId.get(2) === $scope.graph_current.next,
+		$scope.graph_all.has($scope.graph_current),
+		$scope.graph_current.next.prev === $scope.graph_current
+	].join(","));
+}));
+const $graph_byId__OR__graph_current__OR__graph_all = /*@__PURE__*/ _or(6, $graph_byId__OR__graph_current__OR__graph_all__script, 2);
+const $graph_byId = /*@__PURE__*/ _const("graph_byId", $graph_byId__OR__graph_current__OR__graph_all);
+const $graph_current = /*@__PURE__*/ _const("graph_current", $graph_byId__OR__graph_current__OR__graph_all);
+const $graph_all = /*@__PURE__*/ _const("graph_all", $graph_byId__OR__graph_current__OR__graph_all);
+const $result = /*@__PURE__*/ _let("result/7", ($scope) => _text($scope["#text/1"], $scope.result));
+function $setup($scope) {
+	$graph($scope, buildGraph());
+	$result($scope, "pending");
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $graph_byId__OR__graph_current__OR__graph_all = /*@__PURE__*/ _or(6, _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$result($scope, [
+		$scope.d.get(1) === $scope.e,
+		$scope.d.get(2) === $scope.e.next,
+		$scope.f.has($scope.e),
+		$scope.e.next.prev === $scope.e
+	].join(","));
+})), 2);
+const $result = /*@__PURE__*/ _let(7, ($scope) => _text($scope.b, $scope.h));

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+function buildGraph() {
+	const a = { id: 1 };
+	const b = { id: 2 };
+	a.next = b;
+	b.prev = a;
+	return {
+		current: a,
+		byId: new Map([[1, a], [2, b]]),
+		all: new Set([a, b])
+	};
+}
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let graph = buildGraph();
+	let result = "pending";
+	_html(`<button id=go>go</button>${_el_resume($scope0_id, "#button/0")}<div id=out>${_escape(result)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_graph_byId_graph_current_graph_all");
+	writeScope($scope0_id, {
+		graph_byId: graph?.byId,
+		graph_current: graph?.current,
+		graph_all: graph?.all
+	}, "__tests__/template.marko", 0, {
+		graph_byId: ["graph.byId", "9:6"],
+		graph_current: ["graph.current", "9:6"],
+		graph_all: ["graph.all", "9:6"]
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/html.bundle.js
@@ -1,0 +1,25 @@
+// template.marko
+function buildGraph() {
+	const a = { id: 1 };
+	const b = { id: 2 };
+	a.next = b;
+	b.prev = a;
+	return {
+		current: a,
+		byId: /* @__PURE__ */ new Map([[1, a], [2, b]]),
+		all: /* @__PURE__ */ new Set([a, b])
+	};
+}
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let graph = buildGraph();
+	_html(`<button id=go>go</button>${_el_resume($scope0_id, "a")}<div id=out>${_escape("pending")}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		d: graph?.byId,
+		e: graph?.current,
+		f: graph?.all
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/render.debug.md
@@ -1,0 +1,34 @@
+# Render
+```html
+<button
+  id="go"
+>
+  go
+</button>
+<div
+  id="out"
+>
+  pending
+</div>
+```
+
+# Update
+```js
+document.getElementById("go").click();
+```
+```html
+<button
+  id="go"
+>
+  go
+</button>
+<div
+  id="out"
+>
+  true,true,true,true
+</div>
+```
+## Change
+```
+UPDATE: #out::text "pending" => "true,true,true,true"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/render.md
@@ -1,0 +1,34 @@
+# Render
+```html
+<button
+  id="go"
+>
+  go
+</button>
+<div
+  id="out"
+>
+  pending
+</div>
+```
+
+# Update
+```js
+document.getElementById("go").click();
+```
+```html
+<button
+  id="go"
+>
+  go
+</button>
+<div
+  id="out"
+>
+  true,true,true,true
+</div>
+```
+## Change
+```
+UPDATE: #out::text "pending" => "true,true,true,true"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/writes.debug.html
@@ -1,0 +1,21 @@
+<button id=go>go</button><!--M_*1 #button/0-->
+<div id=out>pending<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => (_([1, {
+      graph_byId: new Map(_.a = [
+        [1, _.b = {
+          id: 1,
+          next: _.c = {
+            id: 2
+          }
+        }],
+        [2, _.c]
+      ]),
+      graph_current: _.b,
+      graph_all: new Set(_.d = [_.b, _.c])
+    }]), _.c.prev = _.b, 0),
+    "packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/template.marko_0_graph_byId_graph_current_graph_all 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/__snapshots__/writes.html
@@ -1,0 +1,19 @@
+<button id=go>go</button><!--M_*1 a-->
+<div id=out>pending<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => (_([1, {
+    d: new Map(_.a = [
+      [1, _.b = {
+        id: 1,
+        next: _.c = {
+          id: 2
+        }
+      }],
+      [2, _.c]
+    ]),
+    e: _.b,
+    f: new Set(_.d = [_.b, _.c])
+  }]), _.c.prev = _.b, 0), "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2682,
+      "brotli": 1358
+    }
+  },
+  "html": {
+    "min": 487,
+    "brotli": 324
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/template.marko
@@ -1,0 +1,19 @@
+static function buildGraph() {
+  const a = { id: 1 };
+  const b = { id: 2 };
+  a.next = b;
+  b.prev = a;
+  return { current: a, byId: new Map([[1, a], [2, b]]), all: new Set([a, b]) };
+}
+
+<let/graph = buildGraph()/>
+<let/result = "pending"/>
+<button id="go" onClick() {
+  result = [
+    graph.byId.get(1) === graph.current,
+    graph.byId.get(2) === graph.current.next,
+    graph.all.has(graph.current),
+    graph.current.next.prev === graph.current,
+  ].join(",");
+}>go</button>
+<div id="out">${result}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.getElementById("go")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -412,7 +412,7 @@ describe("serializer", () => {
       const rt = deserialize({ x, gen });
       const iter = rt.gen as Generator;
       assert.deepEqual(iter.next(), { value: 1, done: false });
-      assert.equal(iter.next().value, rt.x);
+      assert.deepEqual(iter.next(), { value: rt.x, done: true });
       assert.equal(rt.x.self, rt.x);
     });
   });

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -374,6 +374,49 @@ describe("serializer", () => {
     });
   });
 
+  describe("repeat references to a value with a pending cycle assignment", () => {
+    it("keeps a Map entry inline", () => {
+      const a: any = { id: 1 };
+      const b: any = { id: 2 };
+      a.next = b;
+      b.prev = a;
+      const rt = deserialize({
+        current: a,
+        byId: new Map([
+          [1, a],
+          [2, b],
+        ]),
+      });
+      assert.equal(rt.byId.get(1), rt.current);
+      assert.equal(rt.byId.get(2), rt.current.next);
+      assert.equal(rt.current.next.prev, rt.current);
+    });
+
+    it("keeps a Set member inline", () => {
+      const a: any = { id: 1 };
+      const b: any = { id: 2 };
+      a.next = b;
+      b.prev = a;
+      const rt = deserialize({ current: a, all: new Set([a, b]) });
+      assert.ok(rt.all.has(rt.current));
+      assert.ok(rt.all.has(rt.current.next));
+    });
+
+    it("keeps a generator return inline", () => {
+      const x: any = {};
+      x.self = x;
+      const gen = (function* () {
+        yield 1;
+        return x;
+      })();
+      const rt = deserialize({ x, gen });
+      const iter = rt.gen as Generator;
+      assert.deepEqual(iter.next(), { value: 1, done: false });
+      assert.equal(iter.next().value, rt.x);
+      assert.equal(rt.x.self, rt.x);
+    });
+  });
+
   describe("object", () => {
     it("empty", () => assertStringify({}, `{}`));
     it("nested", () => assertStringify({ a: { b: 1 } }, `{a:{b:1}}`));

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -677,16 +677,11 @@ function writeReferenceOr(
       return false;
     }
 
-    if (parent) {
-      if (ref.assigns) {
-        addAssignment(ref, accessId(state, parent) + toAccess(accessor));
-        return false;
-      } else if (isCircular(parent, ref)) {
-        ensureId(state, ref);
-        state.assigned.add(ref);
-        addAssignment(ref, accessId(state, parent) + toAccess(accessor));
-        return false;
-      }
+    if (parent && isCircular(parent, ref)) {
+      ensureId(state, ref);
+      state.assigned.add(ref);
+      addAssignment(ref, accessId(state, parent) + toAccess(accessor));
+      return false;
     }
 
     state.buf.push(ensureId(state, ref));


### PR DESCRIPTION
`writeReferenceOr` short-circuited on `ref.assigns` before reaching the `isCircular` test, so once a value had a single deferred assignment queued, every later occurrence of it in that flush became a post-fill assignment instead of the inline `_.a` reference it already had a binding for.

Two containers are built eagerly and never see the fill: `writeMap`/`writeSet` construct from a bound array, so the trailing patch lands after `new Map(...)` already copied it (the entry resumes as `undefined`), and `writeGenerator`'s non-held return emits `_.b.=_.a` — a SyntaxError that stops the entire inline resume script from parsing, so nothing on the page hydrates. Both are reachable from ordinary source with no diagnostic.

Removing the short-circuit is safe because the value's `_.a=` binding is emitted at its own earlier buffer position; the genuine ordering hazard is exactly what `isCircular` already covers.