### PR TITLE
fix(runtime-tags): scope attribute tag uids to the current translate

### DIFF
--- a/.changeset/attr-tag-uid-per-translate.md
+++ b/.changeset/attr-tag-uid-per-translate.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix attribute tag variable names leaking from an HTML compile into a later DOM compile of the same file, which made output order-dependent and could shadow a generated binding or fail the build with `Duplicate declaration`.

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,31 @@
+// tags/child/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $for_content__s_a = ($scope, s_a) => _text($scope["#text/0"], s_a);
+const $for_content__$params = ($scope, $params2) => $for_content__s_a($scope, $params2[0]?.a);
+const $for = /*@__PURE__*/ _for_of("#text/0", " ", " ", 0, $for_content__$params);
+const $input_scope = ($scope, input_scope) => $for($scope, [input_scope]);
+const $input = ($scope, input) => $input_scope($scope, input.scope);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&b`)("b%c");
+const $cond = /*@__PURE__*/ _let("cond/2", ($scope) => {
+	let $scope2;
+	if ($scope.cond) {
+		$scope2 = attrTag({ a: 1 });
+	} else {
+		$scope2 = attrTag({ a: 2 });
+	}
+	$input_scope($scope["#childScope/1"], $scope2);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$cond($scope, !$scope.cond);
+}));
+function $setup($scope) {
+	$cond($scope, true);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.js
@@ -1,0 +1,16 @@
+// tags/child/index.marko
+const $for_content__s_a = ($scope, s_a) => _text($scope.a, s_a);
+const $for_content__$params = ($scope, $params2) => $for_content__s_a($scope, $params2[0]?.a);
+const $for = /*@__PURE__*/ _for_of(0, " ", " ", 0, $for_content__$params);
+const $input_scope = ($scope, input_scope) => $for($scope, [input_scope]);
+
+// template.marko
+const $cond = /*@__PURE__*/ _let(2, ($scope) => {
+	let $scope2;
+	if ($scope.c) $scope2 = attrTag({ a: 1 });
+	else $scope2 = attrTag({ a: 2 });
+	$input_scope($scope.b, $scope2);
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$cond($scope, !$scope.c);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/child/index.marko
+var child_default = _template("__tests__/tags/child/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_scope = _serialize_guard($scope0_reason, 0), $si__input_scope = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.scope, (s) => {
+		const $scope1_id = _scope_id();
+		_html(`${_escape(s.a)}${_el_resume($scope1_id, "#text/0", $sg__input_scope)}`);
+		$si__input_scope && writeScope($scope1_id, {}, "__tests__/tags/child/index.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_scope, $sg__input_scope, $sg__input_scope, 0, 1);
+	$si__input_scope && writeScope($scope0_id, {}, "__tests__/tags/child/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let cond = true;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	let $scope;
+	if (cond) {
+		$scope = attrTag({ a: 1 });
+	} else {
+		$scope = attrTag({ a: 2 });
+	}
+	const $childScope = _peek_scope_id();
+	child_default({ scope: $scope });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		cond,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { cond: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// tags/child/index.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_scope = _serialize_guard($scope0_reason, 0), $si__input_scope = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_of(input.scope, (s) => {
+		const $scope1_id = _scope_id();
+		_html(`${_escape(s.a)}${_el_resume($scope1_id, "a", $sg__input_scope)}`);
+		$si__input_scope && writeScope($scope1_id, {});
+	}, 0, $scope0_id, "a", $sg__input_scope, $sg__input_scope, $sg__input_scope, 0, 1);
+	$si__input_scope && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let cond = true;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	let $scope;
+	$scope = attrTag({ a: 1 });
+	const $childScope = _peek_scope_id();
+	child_default({ scope: $scope });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: cond,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/render.debug.md
@@ -1,0 +1,22 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+1
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+2
+```
+## Change
+```
+UPDATE: ::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/render.md
@@ -1,0 +1,22 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+1
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+2
+```
+## Change
+```
+UPDATE: ::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/writes.debug.html
@@ -1,0 +1,11 @@
+<button>toggle</button><!--M_*1 #button/0-->1<!--M_*3 #text/0--><!--M_|2 #text/0 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      cond: !0,
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<button>toggle</button><!--M_*1 a-->1<!--M_*3 a--><!--M_|2 a 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: !0,
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 7212,
+        "brotli": 3311
+      },
+      "files": {
+        "tags/child/index.marko": 356,
+        "template.marko": 336
+      }
+    }
+  },
+  "html": {
+    "min": 381,
+    "brotli": 262
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/tags/child/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/tags/child/index.marko
@@ -1,0 +1,1 @@
+<for|s| of=input.scope>${s.a}</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/template.marko
@@ -1,0 +1,10 @@
+<let/cond = true/>
+<button onClick() { cond = !cond }>toggle</button>
+<child>
+  <if=cond>
+    <@scope a=1/>
+  </if>
+  <else>
+    <@scope a=2/>
+  </else>
+</child>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
@@ -34,16 +34,16 @@ var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", 
 const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)($walks$1);
 const $cond = /*@__PURE__*/ _let("cond/2", ($scope) => {
-	let $cond;
+	let $cond2;
 	if ($scope.cond) {
-		$cond = attrTag({ a: 1 });
+		$cond2 = attrTag({ a: 1 });
 	} else {
-		$cond = attrTag({ a: 2 });
+		$cond2 = attrTag({ a: 2 });
 	}
 	$rest($scope["#childScope/1"], {
 		row: attrTags(attrTag({ x: 1 }), { x: 2 }),
 		other: attrTag({ y: 1 }),
-		cond: $cond
+		cond: $cond2
 	});
 });
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.js
@@ -18,13 +18,13 @@ const $rest = ($scope, rest) => $input_stuff($scope.b, rest);
 
 // template.marko
 const $cond = /*@__PURE__*/ _let(2, ($scope) => {
-	let $cond;
-	if ($scope.c) $cond = attrTag({ a: 1 });
-	else $cond = attrTag({ a: 2 });
+	let $cond2;
+	if ($scope.c) $cond2 = attrTag({ a: 1 });
+	else $cond2 = attrTag({ a: 2 });
 	$rest($scope.b, {
 		row: attrTags(attrTag({ x: 1 }), { x: 2 }),
 		other: attrTag({ y: 1 }),
-		cond: $cond
+		cond: $cond2
 	});
 });
 const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -8,7 +8,7 @@
       "files": {
         "tags/inner/index.marko": 1000,
         "tags/child/index.marko": 108,
-        "template.marko": 408
+        "template.marko": 412
       }
     }
   },

--- a/packages/runtime-tags/src/translator/util/nested-attribute-tags.ts
+++ b/packages/runtime-tags/src/translator/util/nested-attribute-tags.ts
@@ -5,6 +5,7 @@ import { generateUid } from "./generate-uid";
 import { getParentTag } from "./get-parent-tag";
 import { getTagName } from "./get-tag-name";
 import { isConditionTag } from "./is-core-tag";
+import { createProgramState } from "./state";
 
 export interface AttrTagMeta {
   name: string;
@@ -24,14 +25,18 @@ declare module "@marko/compiler/dist/types" {
   }
 }
 
-const attrTagToIdentifierLookup = new WeakMap<AttrTagLookup[string], string>();
+// Per program because the analyze-owned meta outlives the per-output AST
+// clone, and each translate mints its own uids from its own counters.
+const [getAttrTagIdentifiers] = createProgramState(
+  () => new WeakMap<AttrTagLookup[string], string>(),
+);
 export function getAttrTagIdentifier(
   meta: AttrTagLookup[string],
 ): t.Identifier {
-  let name = attrTagToIdentifierLookup.get(meta);
+  const identifiers = getAttrTagIdentifiers();
+  let name = identifiers.get(meta);
   if (!name) {
-    name = generateUid(meta.name);
-    attrTagToIdentifierLookup.set(meta, name);
+    identifiers.set(meta, (name = generateUid(meta.name)));
   }
 
   return t.identifier(name);


### PR DESCRIPTION
`getAttrTagIdentifier` memoized its translate-time `generateUid` result on the `AttrTagMeta` that analyze stored on `tag.node.extra`. That meta object survives the per-output AST clone (`t.cloneNode(file.ast, true)` deep-clones nodes but shallow-copies `extra`), so a name minted during the HTML translate was handed straight back to a later DOM translate of the same file — without consuming a DOM counter, so the same name was then minted again for something else. Since the compiler shares one module-level cache across compiles, SSR-then-CSR is the default path.

Fixed by keying the memo to the current `BabelFile`, matching how `generate-uid.ts` scopes its counters.

The checked-in `known-tag-attr-tags-rest` DOM snapshot was already carrying the poisoned name — `let $cond` shadowing the module-level `const $cond` signal — and now regenerates as `$cond2`. The new `at-tags-name-shadows-generated-uid` fixture covers the loud case: an attribute tag named `<@scope>` aborts the DOM build with `Duplicate declaration "$scope"` without this fix. The leak also made output order-dependent byte-for-byte, defeating any content-hash caching over the compiler.