### PR TITLE
fix(compiler): import kleur by name so browser bundles keep their code frames

### DIFF
--- a/.changeset/kleur-named-import.md
+++ b/.changeset/kleur-named-import.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix compile errors surfacing as `TypeError: cyan is not a function` when the compiler is bundled for the browser, so the diagnostic renders instead.

--- a/packages/compiler/src/util/build-code-frame.js
+++ b/packages/compiler/src/util/build-code-frame.js
@@ -2,7 +2,9 @@ import path from "path";
 
 import { codeFrameColumns } from "@marko/compiler/internal/babel";
 import { cwd } from "@marko/compiler/modules";
-import color from "kleur";
+// Imported by name: a default import compiles to a `__toESM(mod, 1)` wrapper
+// that double-wraps once a bundler resolves kleur through its ESM entry.
+import { cyan, yellow } from "kleur/colors";
 
 import { stripAnsi } from "./strip-ansi";
 const indent = "    ";
@@ -103,10 +105,8 @@ function buildMessage(code, loc, message) {
 }
 
 function buildFileName(filename, loc) {
-  return `${color.cyan(path.relative(cwd, filename))}${
-    loc
-      ? `:${color.yellow(loc.start.line)}:${color.yellow(loc.start.column + 1)}`
-      : ""
+  return `${cyan(path.relative(cwd, filename))}${
+    loc ? `:${yellow(loc.start.line)}:${yellow(loc.start.column + 1)}` : ""
   }`;
 }
 


### PR DESCRIPTION
`build-code-frame.js` imported kleur with a default import, which the rolldown bundle compiles to `__toESM(kleur, 1)`. That `isNodeMode` argument skips the `__esModule` check babel's old interop performed, so once a bundler resolves kleur through its ESM entry the module is double-wrapped, `color.cyan` is undefined, and every compile error surfaces as `TypeError: cyan is not a function` instead of the diagnostic. This is why the Marko playground showed that error for all compile failures in production.

Importing `cyan`/`yellow` from `kleur/colors` emits a bare `require()` with no interop wrapper, and both of kleur's builds expose those as real named exports, so it resolves under either module format. Terminal output and `$.enabled` behavior are unchanged.

Verified by bundling the built `dist` through vite for the browser: the diagnostic renders where the stock 5.41.10 build throws.

kleur is the only dependency affected. Breaking this way needs an ESM entry that exposes its members solely under `export default`, and nothing else the compiler requires has one — `jsesc`, `lasso-package-root`, `raptor-regexp` and `raptor-util` ship no ESM entry, `@marko/compiler/modules` is our own CJS file, and the node builtins resolve to polyfills that re-export by name beside the default.