### PR TITLE
fix(runtime-tags): allow `content=` on a void tag that declares the attribute

### DIFF
--- a/.changeset/meta-content-attribute.md
+++ b/.changeset/meta-content-attribute.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `<meta content=x>` failing to compile. `content` is a real html attribute on `<meta>`, so the check for a `content` attribute on a void tag now only rejects tags that do not declare one.

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+const $template = "<meta property=og:image:width content=1200><meta property=og:image:height><button>resize</button>";
+const $walks = "b b b";
+const $height = /*@__PURE__*/ _let("height/2", ($scope) => _attr($scope["#meta/0"], "content", $scope.height));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$height($scope, 1080);
+}));
+function $setup($scope) {
+	$height($scope, 630);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $height = /*@__PURE__*/ _let(2, ($scope) => _attr($scope.a, "content", $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$height($scope, 1080);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let height = 630;
+	_html(`<meta property=og:image:width content=1200><meta property=og:image:height${_attr("content", height)}>${_el_resume($scope0_id, "#meta/0")}<button>resize</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/html.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<meta property=og:image:width content=1200><meta property=og:image:height${_attr("content", 630)}>${_el_resume($scope0_id, "a")}<button>resize</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/render.debug.md
@@ -1,0 +1,36 @@
+# Render
+```html
+<meta
+  content="1200"
+  property="og:image:width"
+/>
+<meta
+  content="630"
+  property="og:image:height"
+/>
+<button>
+  resize
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<meta
+  content="1200"
+  property="og:image:width"
+/>
+<meta
+  content="1080"
+  property="og:image:height"
+/>
+<button>
+  resize
+</button>
+```
+## Change
+```
+UPDATE: meta:nth-of-type(2)[content] "630" => "1080"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/render.md
@@ -1,0 +1,36 @@
+# Render
+```html
+<meta
+  content="1200"
+  property="og:image:width"
+/>
+<meta
+  content="630"
+  property="og:image:height"
+/>
+<button>
+  resize
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<meta
+  content="1200"
+  property="og:image:width"
+/>
+<meta
+  content="1080"
+  property="og:image:height"
+/>
+<button>
+  resize
+</button>
+```
+## Change
+```
+UPDATE: meta:nth-of-type(2)[content] "630" => "1080"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<meta property=og:image:width content=1200>
+<meta property=og:image:height content=630>
+<!--M_*1 #meta/0--><button>resize</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [
+    "packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<meta property=og:image:width content=1200>
+<meta property=og:image:height content=630>
+<!--M_*1 a--><button>resize</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = ["a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2730,
+      "brotli": 1368
+    }
+  },
+  "html": {
+    "min": 430,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/template.marko
@@ -1,0 +1,6 @@
+<let/height = 630/>
+
+<meta property="og:image:width" content="1200">
+<meta property="og:image:height" content=height>
+
+<button onClick() { height = 1080 }>resize</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -204,7 +204,9 @@ export default {
       });
 
       if (seen.content) {
-        if (getTagDef(tag)?.parseOptions?.openTagOnly) {
+        const tagDef = getTagDef(tag);
+        // `<meta content=x>` is a real html attribute, not renderable content.
+        if (tagDef?.parseOptions?.openTagOnly && !tagDef.attributes?.content) {
           throw tag.hub.buildError(
             seen.content,
             `The \`<${tagName}>\` tag cannot have content, so it does not support the \`content\` attribute.`,


### PR DESCRIPTION
The void-tag guard added for `<input content=x>` rejects `content=` on every `openTagOnly` tag, but `content` is a real html attribute on `<meta>` — `<meta property="og:image:width" content="1200">` compiled correctly through 6.3.26 and stopped compiling in 6.3.27. That breaks any page carrying og or twitter meta tags; markojs.com itself no longer builds.

`marko-html.json` already draws the distinction: `<meta>` declares `@content`, while `<input>`, `<link>`, `<br>` and `<area>` do not. The guard now fires only when the tag definition declares no `content` attribute, so the unrenderable cases the original change targeted still error with the same message.

Verified that static and dynamic `<meta content=>` both survive: html output emits the attribute, and dom output sets it through `_attr` rather than dropping it. New `content-attr-meta` fixture covers both plus a client update.