### PR TITLE
fix(compiler): stop consuming a taglib's shared props while loading it

### DIFF
--- a/.changeset/taglib-props-not-consumed.md
+++ b/.changeset/taglib-props-not-consumed.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix taglib attribute definitions being lost when a taglib is loaded a second time, which left `clearCaches()` (used by hot reload) with untyped attributes.

--- a/packages/compiler/src/taglib/loader/loadTagFromProps.js
+++ b/packages/compiler/src/taglib/loader/loadTagFromProps.js
@@ -144,6 +144,9 @@ class TagLoader {
     var k;
 
     if (value != null && typeof value === "object") {
+      // Split into a copy: a taglib's props are shared module state that can be
+      // loaded again (after `clearCaches`), and consuming them empties it.
+      value = Object.assign({}, value);
       for (k in value) {
         if (hasOwnProperty.call(value, k)) {
           if (k.startsWith("@") || k.startsWith("<")) {


### PR DESCRIPTION
The shorthand tag/attribute handler in `loadTagFromProps` moved properties onto its own objects by deleting them from the caller's props, but a taglib's props are shared module state. The first load worked and emptied them, so any later load built attributes with no `type`.

That second load happens whenever `clearCaches()` runs — which hot reload does on every reload. It also made serial `pnpm test` fail on `taglib-lookup > core-attributes`; CI missed it because `test:parallel` shards those specs apart.