### PR TITLE
fix(runtime-tags): reject a show whose hidden wrapper the parser would discard

### DIFF
--- a/.changeset/show-table-context-error.md
+++ b/.changeset/show-table-context-error.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Report a compile error when a `<show>` is a direct child of a table or select element, where its hidden-content wrapper was discarded by the HTML parser and the content rendered instead of being hidden.

--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -18,7 +18,7 @@ While working on any task, record anything a future contributor should act on:
 2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering your analysis. Never reference "my earlier analysis" or conversation context.
 3. **Cite by stable symbol, not line number.** Line numbers rot with the next edit; anchor the primary citation to the nearest enclosing stable symbol (exported function, class, variable, or a heading for docs). A line number may appear in the body as a secondary hint.
 4. **Append to the end** of the category file.
-5. Entries are **removed when resolved** (delete, don't mark done; git history is the archive).
+5. Entries are **removed when resolved** (delete, don't mark done; git history is the archive), in **the same PR as the fix** — never a follow-up PR. A partial fix rewrites the entry to what remains.
 6. **Verify before recording.** A guess is not feedback.
 
 ## Resolving a "won't fix" item

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -516,31 +516,11 @@ ch.length; ... }`). Re-verify: `resolveCursorPosition("", 5, "(𠮷𠮸𠮹) x",
 𠮸𠮹y")` returns 10 (end of value) where 8 is correct, while the all-BMP
 `resolveCursorPosition("", 5, "(5405) 810-9227", "(540) 581-0922")` returns 7.
 
-## Make the hidden `<show>` wrapper legal in table/select insertion contexts; `<t hidden>` is foster-parented and the hidden content renders
+## Give a hidden `<show>` a wrapper legal in table/select insertion contexts, instead of rejecting it
 
-`packages/runtime-tags/src/html/writer.ts` › `_show_start` | 2026-07-23 | impact:high | effort:med
+`packages/runtime-tags/src/html/writer.ts` › `_show_start` | 2026-07-28 | impact:med | effort:high
 
-`_show_start` writes a literal `<t hidden>` (and `_show_end` the matching
-`</t>`) around a non-displayed `<show>` range, with the same wrapper emitted
-statically at `translator/core/show.ts` (`writer.writeTo(tag)`<t hidden>``).
-`<t>` is an unknown element, so the HTML parser's "in table"/"in table body"
-insertion mode foster-parents it out of the table while its `<tr>` children are
-still inserted into the table, and "in select" mode ignores the `<t>` token
-entirely while keeping its `<option>` children — in both cases the content the
-author asked to hide is rendered and interactive after SSR, and the
-`BranchEndSingleNode` resume comment no longer bounds the nodes it names, so
-resume/toggle is wrong too. This is a plain SSR/CSR divergence (CSR moves the
-range into a detached fragment and correctly hides it), and it hits exactly the
-usage the docs recommend — website `docs/reference/core-tag.md` `## <show>`
-promotes `<show>` for form fields and bulky markup with no note about table or
-select ancestors. Direction: the translator knows the static ancestor tag at the
-`<show>` site, so pick a wrapper legal in that insertion context (or reject the
-construct with a compile-time diagnostic as a cheap first step) instead of
-always emitting `<t>`. Re-verify by adding a fixture
-`<table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>` with
-`show=false` and running `pnpm test -- --grep "runtime-tags/translator
-show-tag-in-table "`: `render.md` will show the row inside the table (visible)
-and an empty `<t hidden>` before the table.
+A `<show>` directly inside `<table>`/`<thead>`/`<tbody>`/`<tfoot>`/`<tr>`/`<colgroup>`/`<select>`/`<optgroup>` is now a compile error (`assertLegalHiddenContext` in `translator/core/show.ts`), because `_show_start` wraps non-displayed content in `<t hidden>` and those insertion modes discard the unknown element while keeping its children — so the content the author asked to hide rendered, visible and interactive, with a `<option>` even coming back `selected` and a `<col>` escaping into a second `<colgroup>`. The same hazard applies to the `<t hidden>` that `Chunk.flushScript` wraps reordered content in (`html/writer.ts`), which is the subject of its own entry; the shared predicate for these insertion modes is `translator/util/insertion-context.ts` › `discardsWrapperChildren`. That diagnostic only stops the silent mis-render; it does not make the construct work, and the docs still recommend `<show>` for bulky markup that may well be a table body. The blocker for a real fix is that no ordinary element is legal in both contexts: `<tbody>` accepts only `<tr>`, `<template>`, `<script>` and `<style>`, and `<select>` only `<option>`, `<optgroup>`, `<hr>`, `<script>` and `<template>`. `<template>` is the sole universal candidate and is semantically apt (its children park in a `DocumentFragment`, which is exactly the runtime's hidden representation), but its children are not in the normal tree — `firstChild` is null and the content sits on `.content` — so the resume walker and `_show`'s `<t>`-dissolve path both need to reach through it before it can be adopted. A narrower alternative is to set `hidden` on each top-level node of the body when the parent is one of these tags, which needs no wrapper at all but only works when those nodes are statically known elements. Re-verify by deleting the `assertLegalHiddenContext` call and running `pnpm run test:update -- --grep "runtime-tags/translator error-show-tag-in-table "`: `render.debug.md` shows the row inside the table despite `show=false`.
 
 ## Wrap reordered out-of-order content in a parser-context-legal container; table rows streamed after a `@placeholder` are destroyed
 

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko:2:19
+      1 | <let/show=false/>
+    > 2 | <table><colgroup><show=show><col span="2"/></show></colgroup></table>
+        |                   ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<colgroup>`: hidden content is wrapped in an element that `<colgroup>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko:2:19
+      1 | <let/show=false/>
+    > 2 | <table><colgroup><show=show><col span="2"/></show></colgroup></table>
+        |                   ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<colgroup>`: hidden content is wrapped in an element that `<colgroup>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko:2:19
+      1 | <let/show=false/>
+    > 2 | <table><colgroup><show=show><col span="2"/></show></colgroup></table>
+        |                   ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<colgroup>`: hidden content is wrapped in an element that `<colgroup>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko:2:19
+      1 | <let/show=false/>
+    > 2 | <table><colgroup><show=show><col span="2"/></show></colgroup></table>
+        |                   ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<colgroup>`: hidden content is wrapped in an element that `<colgroup>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/template.marko
@@ -1,0 +1,2 @@
+<let/show=false/>
+<table><colgroup><show=show><col span="2"/></show></colgroup></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-colgroup/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko:2:10
+      1 | <let/show=false/>
+    > 2 | <select><show=show><option value="a">a</option></show></select>
+        |          ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<select>`: hidden content is wrapped in an element that `<select>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko:2:10
+      1 | <let/show=false/>
+    > 2 | <select><show=show><option value="a">a</option></show></select>
+        |          ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<select>`: hidden content is wrapped in an element that `<select>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko:2:10
+      1 | <let/show=false/>
+    > 2 | <select><show=show><option value="a">a</option></show></select>
+        |          ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<select>`: hidden content is wrapped in an element that `<select>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko:2:10
+      1 | <let/show=false/>
+    > 2 | <select><show=show><option value="a">a</option></show></select>
+        |          ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<select>`: hidden content is wrapped in an element that `<select>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/template.marko
@@ -1,0 +1,2 @@
+<let/show=false/>
+<select><show=show><option value="a">a</option></show></select>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-select/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko:2:16
+      1 | <let/show=false/>
+    > 2 | <table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>
+        |                ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<tbody>`: hidden content is wrapped in an element that `<tbody>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko:2:16
+      1 | <let/show=false/>
+    > 2 | <table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>
+        |                ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<tbody>`: hidden content is wrapped in an element that `<tbody>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko:2:16
+      1 | <let/show=false/>
+    > 2 | <table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>
+        |                ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<tbody>`: hidden content is wrapped in an element that `<tbody>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko:2:16
+      1 | <let/show=false/>
+    > 2 | <table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>
+        |                ^^^^ A [`<show>` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of `<tbody>`: hidden content is wrapped in an element that `<tbody>` discards, which would render the content instead of hiding it. Move the `<show>` inside the row or option, or use [`<if>`](https://markojs.com/docs/reference/core-tag#if).
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/template.marko
@@ -1,0 +1,2 @@
+<let/show=false/>
+<table><tbody><show=show><tr><td>row</td></tr></show></tbody></table>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-show-tag-in-table/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/show.ts
+++ b/packages/runtime-tags/src/translator/core/show.ts
@@ -12,6 +12,7 @@ import evaluate from "../util/evaluate";
 import { generateUidIdentifier } from "../util/generate-uid";
 import { getParentTag } from "../util/get-parent-tag";
 import { getTagName } from "../util/get-tag-name";
+import { discardsWrapperChildren } from "../util/insertion-context";
 import {
   getOnlyChildParentTagName,
   getOptimizedOnlyChildNodeBinding,
@@ -84,6 +85,8 @@ export default {
       }
 
       if (tagExtra[kStaticDisplay] === true) return;
+
+      assertLegalHiddenContext(tag);
 
       const tagSection = getOrCreateSection(tag);
 
@@ -342,6 +345,20 @@ function assertValidShow(tag: t.NodePath<t.MarkoTag>) {
   assertNoSpreadAttrs(tag);
   assertHasBody(tag);
   assertHasValueAttribute(tag);
+}
+
+function assertLegalHiddenContext(tag: t.NodePath<t.MarkoTag>) {
+  const parentName = getParentTag(tag)?.node.name;
+  if (
+    t.isStringLiteral(parentName) &&
+    discardsWrapperChildren(parentName.value)
+  ) {
+    throw tag
+      .get("name")
+      .buildCodeFrameError(
+        `A [\`<${getTagName(tag)}>\` tag](https://markojs.com/docs/reference/core-tag#show) cannot be a direct child of \`<${parentName.value}>\`: hidden content is wrapped in an element that \`<${parentName.value}>\` discards, which would render the content instead of hiding it. Move the \`<${getTagName(tag)}>\` inside the row or option, or use [\`<if>\`](https://markojs.com/docs/reference/core-tag#if).`,
+      );
+  }
 }
 
 function assertHasBody(tag: t.NodePath<t.MarkoTag>) {

--- a/packages/runtime-tags/src/translator/util/insertion-context.ts
+++ b/packages/runtime-tags/src/translator/util/insertion-context.ts
@@ -1,0 +1,17 @@
+// Insertion modes that drop an unknown element but keep processing its
+// children, so any wrapper injected around content inside one of these is
+// discarded and the content it was meant to contain ends up in the document.
+const discardsUnknownChildren = new Set([
+  "table",
+  "thead",
+  "tbody",
+  "tfoot",
+  "tr",
+  "colgroup",
+  "select",
+  "optgroup",
+]);
+
+export function discardsWrapperChildren(tagName: string) {
+  return discardsUnknownChildren.has(tagName);
+}


### PR DESCRIPTION
A `<show>` directly inside a table, colgroup or select element had its `<t hidden>` wrapper dropped by the HTML parser while its children stayed in place, so content the author asked to hide rendered visibly — an `<option>` came back `selected` and a `<col>` escaped into a second `<colgroup>`.

It is now a compile error rather than a silent mis-render. The insertion-mode predicate lives in a shared util so the reorder wrapper can reuse it. Also notes in the agent-feedback README that a fix removes its own entry.