### PR TITLE
fix(runtime-tags): register functions imported from another template

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Report a default export in a template as a compile error. The template is compiled into the module's default export, so a second one silently produced a module with two.

--- a/.changeset/tricky-doors-yawn.md
+++ b/.changeset/tricky-doors-yawn.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Support serializing functions imported from another template. A template that exports a function now reserves a register id for it, and templates that import it share a single generated module that registers it.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko:4:10
+      2 |   return message.toUpperCase();
+      3 | }
+    > 4 | export { shout as default };
+        |          ^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      5 |
+      6 | <div>hello</div>
+      7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko:4:10
+      2 |   return message.toUpperCase();
+      3 | }
+    > 4 | export { shout as default };
+        |          ^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      5 |
+      6 | <div>hello</div>
+      7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko:4:10
+      2 |   return message.toUpperCase();
+      3 | }
+    > 4 | export { shout as default };
+        |          ^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      5 |
+      6 | <div>hello</div>
+      7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko:4:10
+      2 |   return message.toUpperCase();
+      3 | }
+    > 4 | export { shout as default };
+        |          ^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      5 |
+      6 | <div>hello</div>
+      7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/template.marko
@@ -1,0 +1,6 @@
+export function shout(message: string) {
+  return message.toUpperCase();
+}
+export { shout as default };
+
+<div>hello</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-alias-default/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko:1:1
+    > 1 | export default function shout(message: string) { return message.toUpperCase(); }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      2 |
+      3 | <div>hello</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko:1:1
+    > 1 | export default function shout(message: string) { return message.toUpperCase(); }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      2 |
+      3 | <div>hello</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko:1:1
+    > 1 | export default function shout(message: string) { return message.toUpperCase(); }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      2 |
+      3 | <div>hello</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko:1:1
+    > 1 | export default function shout(message: string) { return message.toUpperCase(); }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ A template is already its own default export. Use a named export instead.
+      2 |
+      3 | <div>hello</div>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/template.marko
@@ -1,0 +1,3 @@
+export default function shout(message: string) { return message.toUpperCase(); }
+
+<div>hello</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-default/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-default/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+const $template = "<button>up</button><button>down</button><div> </div>";
+const $walks = " b bD l";
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const whisper = (message) => message.toLowerCase();
+const $loud = /*@__PURE__*/ _let("loud/3");
+const $quiet = /*@__PURE__*/ _let("quiet/4");
+const $message = /*@__PURE__*/ _let("message/5", ($scope) => _text($scope["#text/2"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$message($scope, $scope.loud($scope.message));
+	});
+	_on($scope["#button/1"], "click", function() {
+		$message($scope, $scope.quiet($scope.message));
+	});
+});
+function $setup($scope) {
+	$loud($scope, shout);
+	$quiet($scope, whisper);
+	$message($scope, "Hello");
+	$setup__script($scope);
+}
+_resume("__tests__/template.marko_0/export/shout", shout);
+_resume("__tests__/template.marko_0/export/whisper", whisper);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,16 @@
+// template.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const whisper = (message) => message.toLowerCase();
+const $message = /*@__PURE__*/ _let(5, ($scope) => _text($scope.c, $scope.f));
+const $setup__script = _script("a2", ($scope) => {
+	_on($scope.a, "click", function() {
+		$message($scope, $scope.d($scope.f));
+	});
+	_on($scope.b, "click", function() {
+		$message($scope, $scope.e($scope.f));
+	});
+});
+_resume("a0", shout);
+_resume("a1", whisper);

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,25 @@
+// template.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const whisper = _resume((message) => message.toLowerCase(), "__tests__/template.marko_0/export/whisper");
+_resume(shout, "__tests__/template.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = whisper;
+	let message = "Hello";
+	_html(`<button>up</button>${_el_resume($scope0_id, "#button/0")}<button>down</button>${_el_resume($scope0_id, "#button/1")}<div>${_escape(message)}${_el_resume($scope0_id, "#text/2")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		loud,
+		quiet,
+		message
+	}, "__tests__/template.marko", 0, {
+		loud: "4:6",
+		quiet: "5:6",
+		message: "6:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const whisper = _resume((message) => message.toLowerCase(), "a1");
+_resume(shout, "a0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = whisper;
+	let message = "Hello";
+	_html(`<button>up</button>${_el_resume($scope0_id, "a")}<button>down</button>${_el_resume($scope0_id, "b")}<div>${_escape(message)}${_el_resume($scope0_id, "c")}</div>`);
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, {
+		d: loud,
+		e: quiet,
+		f: message
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  hello!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "hello!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/render.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  up
+</button>
+<button>
+  down
+</button>
+<div>
+  hello!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "hello!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,17 @@
+<button>up</button><!--M_*1 #button/0--><button>down</button><!--M_*1 #button/1-->
+<div>Hello<!--M_*1 #text/2--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      loud: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/export-registered-function/template.marko_0/export/shout"
+        ],
+      quiet: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/export-registered-function/template.marko_0/export/whisper"
+        ],
+      message: "Hello"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/export-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>up</button><!--M_*1 a--><button>down</button><!--M_*1 b-->
+<div>Hello<!--M_*1 c--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: _._.a0,
+    e: _._.a1,
+    f: "Hello"
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2732,
+      "brotli": 1363
+    }
+  },
+  "html": {
+    "min": 427,
+    "brotli": 275
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/template.marko
@@ -1,0 +1,9 @@
+export function shout(message: string) { return message.toUpperCase() + "!"; }
+export const whisper = (message: string) => message.toLowerCase();
+
+<let/loud=shout/>
+<let/quiet=whisper/>
+<let/message="Hello"/>
+<button onClick() { message = loud(message) }>up</button>
+<button onClick() { message = quiet(message) }>down</button>
+<div>${message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickUp(document: Document) {
+  document.querySelectorAll("button")[0].click();
+}
+
+function clickDown(document: Document) {
+  document.querySelectorAll("button")[1].click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickUp, clickDown],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// tags/greeting.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const whisper = (message) => message.toLowerCase();
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", $setup$1, $input);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("__tests__/tags/greeting.marko_0/export/shout", shout);
+
+// tags/v:greeting.marko.register-whisper.js
+_resume("__tests__/tags/greeting.marko_0/export/whisper", whisper);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>shout</button><button>whisper</button>${_w0}`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b b/${_w0}&`)("D l");
+const $loud = /*@__PURE__*/ _let("loud/3");
+const $quiet = /*@__PURE__*/ _let("quiet/4");
+const $message = /*@__PURE__*/ _let("message/5", ($scope) => $input_message($scope["#childScope/2"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$message($scope, $scope.loud($scope.message));
+	});
+	_on($scope["#button/1"], "click", function() {
+		$message($scope, $scope.quiet($scope.message));
+	});
+});
+function $setup($scope) {
+	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
+	$loud($scope, shout);
+	$quiet($scope, whisper);
+	$message($scope, "Hello");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,23 @@
+// tags/greeting.marko
+const whisper = (message) => message.toLowerCase();
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("b1", shout);
+
+// tags/v:greeting.marko.register-whisper.js
+_resume("b0", whisper);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(5, ($scope) => $input_message($scope.c, $scope.f));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.a, "click", function() {
+		$message($scope, $scope.d($scope.f));
+	});
+	_on($scope.b, "click", function() {
+		$message($scope, $scope.e($scope.f));
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,38 @@
+// tags/greeting.marko
+const whisper = (message) => message.toLowerCase();
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("__tests__/tags/greeting.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/greeting.marko", 0);
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/greeting.marko_0/export/shout");
+_resume(whisper, "__tests__/tags/greeting.marko_0/export/whisper");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = whisper;
+	let message = "Hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}<button>whisper</button>${_el_resume($scope0_id, "#button/1")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		loud,
+		quiet,
+		message,
+		"#childScope/2": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, {
+		loud: "3:6",
+		quiet: "4:6",
+		message: "5:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,34 @@
+// tags/greeting.marko
+const whisper = (message) => message.toLowerCase();
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+_resume(shout, "b1");
+_resume(whisper, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = whisper;
+	let message = "Hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}<button>whisper</button>${_el_resume($scope0_id, "b")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		d: loud,
+		e: quiet,
+		f: message,
+		c: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  hello!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "hello!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/render.md
@@ -1,0 +1,52 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button")[0].click();
+```
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```
+
+# Update
+```js
+document.querySelectorAll("button")[1].click();
+```
+```html
+<button>
+  shout
+</button>
+<button>
+  whisper
+</button>
+<div>
+  hello!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "hello!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<button>shout</button><!--M_*1 #button/0--><button>whisper</button><!--M_*1 #button/1-->
+<div>Hello<!--M_*2 #text/0--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      loud: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/tags/greeting.marko_0/export/shout"
+        ],
+      quiet: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/tags/greeting.marko_0/export/whisper"
+        ],
+      message: "Hello",
+      "#childScope/2": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>shout</button><!--M_*1 a--><button>whisper</button><!--M_*1 b-->
+<div>Hello<!--M_*2 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: _._.b1,
+    e: _._.b0,
+    f: "Hello",
+    c: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/sizes.json
@@ -1,0 +1,20 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2762,
+        "brotli": 1372
+      },
+      "files": {
+        "tags/greeting.marko": 242,
+        "tags/v:greeting.marko.register-shout.js": 85,
+        "tags/v:greeting.marko.register-whisper.js": 89,
+        "template.marko": 345
+      }
+    }
+  },
+  "html": {
+    "min": 440,
+    "brotli": 289
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/tags/greeting.marko
@@ -1,0 +1,9 @@
+static const whisper = (message: string) => message.toLowerCase();
+
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}
+
+export { shout as yell, whisper };
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/template.marko
@@ -1,0 +1,8 @@
+import { yell, whisper } from "./tags/greeting.marko";
+
+<let/loud=yell/>
+<let/quiet=whisper/>
+<let/message="Hello"/>
+<button onClick() { message = loud(message) }>shout</button>
+<button onClick() { message = quiet(message) }>whisper</button>
+<greeting message=message/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function clickShout(document: Document) {
+  document.querySelectorAll("button")[0].click();
+}
+
+function clickWhisper(document: Document) {
+  document.querySelectorAll("button")[1].click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickShout, clickWhisper],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,49 @@
+// tags/extras.marko
+const $template$3 = "";
+const $walks$3 = "";
+const $setup$3 = () => {};
+function gamma(message) {
+	return message + "-g";
+}
+var extras_default = /*@__PURE__*/ _template("__tests__/tags/extras.marko", "", "", $setup$3);
+
+// tags/handlers.marko
+const $template$2 = "";
+const $walks$2 = "";
+const $setup$2 = () => {};
+function alpha(message) {
+	return message + "-a";
+}
+function beta(message) {
+	return message + "-b";
+}
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "", $setup$2);
+
+// tags/barrel.marko
+const $template$1 = "";
+const $walks$1 = "";
+const $setup$1 = () => {};
+var barrel_default = /*@__PURE__*/ _template("__tests__/tags/barrel.marko", "", "", $setup$1);
+
+// tags/v:handlers.marko.register-beta.js
+_resume("__tests__/tags/handlers.marko_0/export/beta", beta);
+
+// tags/v:extras.marko.register-gamma.js
+_resume("__tests__/tags/extras.marko_0/export/gamma", gamma);
+
+// template.marko
+const $template = "<button>go</button><div> </div>";
+const $walks = " bD l";
+const $first = /*@__PURE__*/ _let("first/2");
+const $second = /*@__PURE__*/ _let("second/3");
+const $message = /*@__PURE__*/ _let("message/4", ($scope) => _text($scope["#text/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.second($scope.first($scope.message)));
+}));
+function $setup($scope) {
+	$first($scope, beta);
+	$second($scope, gamma);
+	$message($scope, "start");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,21 @@
+// tags/extras.marko
+function gamma(message) {
+	return message + "-g";
+}
+
+// tags/handlers.marko
+function beta(message) {
+	return message + "-b";
+}
+
+// tags/v:handlers.marko.register-beta.js
+_resume("d1", beta);
+
+// tags/v:extras.marko.register-gamma.js
+_resume("c0", gamma);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(4, ($scope) => _text($scope.b, $scope.e));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.d($scope.c($scope.e)));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,49 @@
+// tags/extras.marko
+function gamma(message) {
+	return message + "-g";
+}
+var extras_default = _template("__tests__/tags/extras.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+});
+
+// tags/handlers.marko
+function alpha(message) {
+	return message + "-a";
+}
+function beta(message) {
+	return message + "-b";
+}
+var handlers_default = _template("__tests__/tags/handlers.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+});
+
+// tags/barrel.marko
+var barrel_default = _template("__tests__/tags/barrel.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+});
+
+// template.marko
+_resume(beta, "__tests__/tags/handlers.marko_0/export/beta");
+_resume(gamma, "__tests__/tags/extras.marko_0/export/gamma");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let first = beta;
+	let second = gamma;
+	let message = "start";
+	_html(`<button>go</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(message)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		first,
+		second,
+		message
+	}, "__tests__/template.marko", 0, {
+		first: "3:6",
+		second: "4:6",
+		message: "5:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,42 @@
+// tags/extras.marko
+function gamma(message) {
+	return message + "-g";
+}
+var extras_default = _template("c", (input) => {
+	_scope_reason();
+	_scope_id();
+});
+
+// tags/handlers.marko
+function beta(message) {
+	return message + "-b";
+}
+var handlers_default = _template("d", (input) => {
+	_scope_reason();
+	_scope_id();
+});
+
+// tags/barrel.marko
+var barrel_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+});
+
+// template.marko
+_resume(beta, "d1");
+_resume(gamma, "c0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let first = beta;
+	let second = gamma;
+	let message = "start";
+	_html(`<button>go</button>${_el_resume($scope0_id, "a")}<div>${_escape(message)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: first,
+		d: second,
+		e: message
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  start
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  start-b-g
+</div>
+```
+## Change
+```
+UPDATE: div::text "start" => "start-b-g"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  start
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  start-b-g
+</div>
+```
+## Change
+```
+UPDATE: div::text "start" => "start-b-g"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,17 @@
+<button>go</button><!--M_*1 #button/0-->
+<div>start<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      first: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/handlers.marko_0/export/beta"
+        ],
+      second: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/extras.marko_0/export/gamma"
+        ],
+      message: "start"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>go</button><!--M_*1 a-->
+<div>start<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: _._.d1,
+    d: _._.c0,
+    e: "start"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/sizes.json
@@ -1,0 +1,21 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2688,
+        "brotli": 1351
+      },
+      "files": {
+        "tags/extras.marko": 93,
+        "tags/handlers.marko": 94,
+        "tags/v:handlers.marko.register-beta.js": 83,
+        "tags/v:extras.marko.register-gamma.js": 83,
+        "template.marko": 256
+      }
+    }
+  },
+  "html": {
+    "min": 393,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/barrel.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/barrel.marko
@@ -1,0 +1,2 @@
+export * from "./extras.marko";
+export { alpha, beta } from "./handlers.marko";

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/extras.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/extras.marko
@@ -1,0 +1,1 @@
+export function gamma(message: string) { return message + "-g"; }

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/handlers.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/tags/handlers.marko
@@ -1,0 +1,2 @@
+export function alpha(message: string) { return message + "-a"; }
+export function beta(message: string) { return message + "-b"; }

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/template.marko
@@ -1,0 +1,7 @@
+import { beta, gamma } from "./tags/barrel.marko";
+
+<let/first=beta/>
+<let/second=gamma/>
+<let/message="start"/>
+<button onClick() { message = second(first(message)) }>go</button>
+<div>${message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// tags/chain-b.marko
+const $template$2 = "<div>b</div>";
+const $walks$2 = "b";
+const $setup$2 = () => {};
+function bFn(message) {
+	return message + "-b";
+}
+var chain_b_default = /*@__PURE__*/ _template("__tests__/tags/chain-b.marko", $template$2, "b", $setup$2);
+
+// tags/chain-a.marko
+const $template$1 = "<div>a</div>";
+const $walks$1 = "b";
+const $setup$1 = () => {};
+function aFn(message) {
+	return message + "-a";
+}
+var chain_a_default = /*@__PURE__*/ _template("__tests__/tags/chain-a.marko", $template$1, "b", $setup$1);
+
+// tags/v:chain-b.marko.register-bFn.js
+_resume("__tests__/tags/chain-b.marko_0/export/bFn", bFn);
+
+// tags/v:chain-a.marko.register-aFn.js
+_resume("__tests__/tags/chain-a.marko_0/export/aFn", aFn);
+
+// template.marko
+const $template = "<button>go</button><div> </div>";
+const $walks = " bD l";
+const $first = /*@__PURE__*/ _let("first/2");
+const $second = /*@__PURE__*/ _let("second/3");
+const $message = /*@__PURE__*/ _let("message/4", ($scope) => _text($scope["#text/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.second($scope.first($scope.message)));
+}));
+function $setup($scope) {
+	$first($scope, aFn);
+	$second($scope, bFn);
+	$message($scope, "start");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,21 @@
+// tags/chain-b.marko
+function bFn(message) {
+	return message + "-b";
+}
+
+// tags/chain-a.marko
+function aFn(message) {
+	return message + "-a";
+}
+
+// tags/v:chain-b.marko.register-bFn.js
+_resume("c0", bFn);
+
+// tags/v:chain-a.marko.register-aFn.js
+_resume("b0", aFn);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(4, ($scope) => _text($scope.b, $scope.e));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.d($scope.c($scope.e)));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// tags/chain-b.marko
+function bFn(message) {
+	return message + "-b";
+}
+var chain_b_default = _template("__tests__/tags/chain-b.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div>b</div>");
+});
+
+// tags/chain-a.marko
+function aFn(message) {
+	return message + "-a";
+}
+var chain_a_default = _template("__tests__/tags/chain-a.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div>a</div>");
+});
+
+// template.marko
+_resume(bFn, "__tests__/tags/chain-b.marko_0/export/bFn");
+_resume(aFn, "__tests__/tags/chain-a.marko_0/export/aFn");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let first = aFn;
+	let second = bFn;
+	let message = "start";
+	_html(`<button>go</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(message)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		first,
+		second,
+		message
+	}, "__tests__/template.marko", 0, {
+		first: "4:6",
+		second: "5:6",
+		message: "6:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,38 @@
+// tags/chain-b.marko
+function bFn(message) {
+	return message + "-b";
+}
+var chain_b_default = _template("c", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div>b</div>");
+});
+
+// tags/chain-a.marko
+function aFn(message) {
+	return message + "-a";
+}
+var chain_a_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div>a</div>");
+});
+
+// template.marko
+_resume(bFn, "c0");
+_resume(aFn, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let first = aFn;
+	let second = bFn;
+	let message = "start";
+	_html(`<button>go</button>${_el_resume($scope0_id, "a")}<div>${_escape(message)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: first,
+		d: second,
+		e: message
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  start
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  start-a-b
+</div>
+```
+## Change
+```
+UPDATE: div::text "start" => "start-a-b"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  start
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  start-a-b
+</div>
+```
+## Change
+```
+UPDATE: div::text "start" => "start-a-b"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,17 @@
+<button>go</button><!--M_*1 #button/0-->
+<div>start<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      first: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-a.marko_0/export/aFn"
+        ],
+      second: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-b.marko_0/export/bFn"
+        ],
+      message: "start"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>go</button><!--M_*1 a-->
+<div>start<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: _._.b0,
+    d: _._.c0,
+    e: "start"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/sizes.json
@@ -1,0 +1,21 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2688,
+        "brotli": 1348
+      },
+      "files": {
+        "tags/chain-b.marko": 92,
+        "tags/chain-a.marko": 92,
+        "tags/v:chain-b.marko.register-bFn.js": 80,
+        "tags/v:chain-a.marko.register-aFn.js": 80,
+        "template.marko": 256
+      }
+    }
+  },
+  "html": {
+    "min": 393,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-a.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-a.marko
@@ -1,0 +1,7 @@
+export { bFn } from "./chain-b.marko";
+
+export function aFn(message: string) {
+  return message + "-a";
+}
+
+<div>a</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-b.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/tags/chain-b.marko
@@ -1,0 +1,7 @@
+export { aFn } from "./chain-a.marko";
+
+export function bFn(message: string) {
+  return message + "-b";
+}
+
+<div>b</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/template.marko
@@ -1,0 +1,8 @@
+import { bFn } from "./tags/chain-a.marko";
+import { aFn } from "./tags/chain-b.marko";
+
+<let/first=aFn/>
+<let/second=bFn/>
+<let/message="start"/>
+<button onClick() { message = second(first(message)) }>go</button>
+<div>${message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,33 @@
+// tags/handlers.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", $template$1, "D l", $setup$1, $input);
+
+// tags/v:handlers.marko.register-shout.js
+_resume("__tests__/tags/handlers.marko_0/export/shout", shout);
+
+// template.marko
+const $template = "<button> </button><!><!>";
+const $walks = " D l%c";
+const $loud = /*@__PURE__*/ _let("loud/3");
+const $quiet = /*@__PURE__*/ _let("quiet/4");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/2");
+const $message = /*@__PURE__*/ _let("message/5", ($scope) => $dynamicTag($scope, handlers_default, () => ({ message: $scope.message })));
+const $label = ($scope, label) => _text($scope["#text/1"], label);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.loud($scope.quiet($scope.message)));
+}));
+function $setup($scope) {
+	$loud($scope, shout);
+	$quiet($scope, shout);
+	$message($scope, "Hello");
+	$label($scope, "static");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.js
@@ -1,0 +1,20 @@
+// tags/handlers.marko
+const $template = "<div> </div>";
+const $walks = "D l";
+const $setup = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var handlers_default = /*@__PURE__*/ _template("b", $template, "D l", $setup, $input);
+
+// tags/v:handlers.marko.register-shout.js
+_resume("b0", shout);
+
+// template.marko
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag(2);
+const $message = /*@__PURE__*/ _let(5, ($scope) => $dynamicTag($scope, handlers_default, () => ({ message: $scope.f })));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.d($scope.e($scope.f)));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/handlers.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var handlers_default = _template("__tests__/tags/handlers.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/handlers.marko", 0);
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/handlers.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = shout;
+	let message = "Hello";
+	const label = "static";
+	_html(`<button>${_escape(label)}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_dynamic_tag($scope0_id, "#text/2", handlers_default, { message });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		loud,
+		quiet,
+		message
+	}, "__tests__/template.marko", 0, {
+		loud: "6:6",
+		quiet: "7:6",
+		message: "8:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/html.bundle.js
@@ -1,0 +1,29 @@
+// tags/handlers.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var handlers_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+_resume(shout, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let loud = shout;
+	let quiet = shout;
+	let message = "Hello";
+	_html(`<button>${_escape("static")}</button>${_el_resume($scope0_id, "a")}`);
+	_dynamic_tag($scope0_id, "c", handlers_default, { message });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		d: loud,
+		e: quiet,
+		f: message
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  static
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  static
+</button>
+<div>
+  HELLO!!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  static
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  static
+</button>
+<div>
+  HELLO!!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<button>static</button><!--M_*1 #button/0--><!--M_[-->
+<div>Hello<!--M_*2 #text/0--></div><!--M_]1 #text/2 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ConditionalRenderer:#text/2": "packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/tags/handlers.marko",
+      loud: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/tags/handlers.marko_0/export/shout"
+        ],
+      quiet: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/tags/handlers.marko_0/export/shout"
+        ],
+      message: "Hello"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>static</button><!--M_*1 a--><!--M_[-->
+<div>Hello<!--M_*2 a--></div><!--M_]1 c 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Dc: "b",
+    d: _._.b0,
+    e: _._.b0,
+    f: "Hello"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 9521,
+        "brotli": 4057
+      },
+      "files": {
+        "tags/handlers.marko": 431,
+        "tags/v:handlers.marko.register-shout.js": 85,
+        "template.marko": 350
+      }
+    }
+  },
+  "html": {
+    "min": 429,
+    "brotli": 284
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/tags/handlers.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/tags/handlers.marko
@@ -1,0 +1,5 @@
+export type Message = string;
+
+export function shout(message: Message) { return message.toUpperCase() + "!"; }
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/template.marko
@@ -1,0 +1,11 @@
+import { shout, type Message } from "./tags/handlers.marko";
+import type { Message as Alias } from "./tags/handlers.marko";
+import { default as Handlers } from "./tags/handlers.marko";
+import { shout as alsoShout } from "./tags/handlers.marko";
+
+<let/loud=shout/>
+<let/quiet=alsoShout/>
+<let/message=("Hello" as Message)/>
+<const/label=("static" as Alias)/>
+<button onClick() { message = loud(quiet(message)) }>${label}</button>
+<Handlers message=message/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,23 @@
+// tags/greeting.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>add</button>${_w0}`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D l");
+const $message = /*@__PURE__*/ _let("message/2", ($scope) => $input_message($scope["#childScope/1"], shout($scope.message)));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.message + "!");
+}));
+function $setup($scope) {
+	$message($scope, "hello");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(2, ($scope) => $input_message($scope.b, shout($scope.c)));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.c + "!");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("__tests__/tags/greeting.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/greeting.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let message = "hello";
+	_html(`<button>add</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message: shout(message) });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		message,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { message: "3:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,27 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let message = "hello";
+	_html(`<button>add</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message: shout(message) });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: message,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  add
+</button>
+<div>
+  HELLO!
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  add
+</button>
+<div>
+  HELLO!!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "HELLO!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  add
+</button>
+<div>
+  HELLO!
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  add
+</button>
+<div>
+  HELLO!!
+</div>
+```
+## Change
+```
+UPDATE: div::text "HELLO!" => "HELLO!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button>add</button><!--M_*1 #button/0-->
+<div>HELLO!<!--M_*2 #text/0--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      message: "hello",
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button>add</button><!--M_*1 a-->
+<div>HELLO!<!--M_*2 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: "hello",
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2668,
+        "brotli": 1350
+      },
+      "files": {
+        "tags/greeting.marko": 190,
+        "template.marko": 258
+      }
+    }
+  },
+  "html": {
+    "min": 384,
+    "brotli": 267
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/tags/greeting.marko
@@ -1,0 +1,5 @@
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/template.marko
@@ -1,0 +1,5 @@
+import { shout } from "./tags/greeting.marko";
+
+<let/message="hello"/>
+<button onClick() { message += "!" }>add</button>
+<greeting message=shout(message)/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,44 @@
+// tags/greeting.marko
+const $template$2 = "<div> </div>";
+const $walks$2 = "D l";
+const $setup$2 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", $setup$2, $input);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("__tests__/tags/greeting.marko_0/export/shout", shout);
+
+// tags/panel.marko
+const $template$1 = /*@__PURE__*/ ((_w0) => `<button>panel</button>${_w0}`)($template$2);
+const $walks$1 = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D l");
+const $format$1 = /*@__PURE__*/ _let("format/2");
+const $message$1 = /*@__PURE__*/ _let("message/3", ($scope) => $input_message($scope["#childScope/1"], $scope.message));
+const $setup__script$1 = _script("__tests__/tags/panel.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message$1($scope, $scope.format($scope.message));
+}));
+function $setup$1($scope) {
+	$format$1($scope, shout);
+	$message$1($scope, "panel");
+	$setup__script$1($scope);
+}
+var panel_default = /*@__PURE__*/ _template("__tests__/tags/panel.marko", $template$1, $walks$1, $setup$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<button>page</button>${_w0}${_w1}`)($template$2, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => ` b/${_w0}&/${_w1}&`)("D l", $walks$1);
+const $format = /*@__PURE__*/ _let("format/3");
+const $message = /*@__PURE__*/ _let("message/4", ($scope) => $input_message($scope["#childScope/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.format($scope.message));
+}));
+function $setup($scope) {
+	$setup$1($scope["#childScope/2"]);
+	$format($scope, shout);
+	$message($scope, "page");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.js
@@ -1,0 +1,20 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("b0", shout);
+
+// tags/panel.marko
+const $message$1 = /*@__PURE__*/ _let(3, ($scope) => $input_message($scope.b, $scope.d));
+const $setup__script$1 = _script("c0", ($scope) => _on($scope.a, "click", function() {
+	$message$1($scope, $scope.c($scope.d));
+}));
+
+// template.marko
+const $message = /*@__PURE__*/ _let(4, ($scope) => $input_message($scope.b, $scope.e));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.d($scope.e));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,57 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("__tests__/tags/greeting.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/greeting.marko", 0);
+});
+
+// tags/panel.marko
+_resume(shout, "__tests__/tags/greeting.marko_0/export/shout");
+var panel_default = _template("__tests__/tags/panel.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "panel";
+	_html(`<button>panel</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "__tests__/tags/panel.marko_0");
+	writeScope($scope0_id, {
+		format,
+		message,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/tags/panel.marko", 0, {
+		format: "3:6",
+		message: "4:6"
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/greeting.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "page";
+	_html(`<button>page</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	panel_default({});
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		format,
+		message,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, {
+		format: "3:6",
+		message: "4:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.js
@@ -1,0 +1,51 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// tags/panel.marko
+_resume(shout, "b0");
+var panel_default = _template("c", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "panel";
+	_html(`<button>panel</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "c0");
+	writeScope($scope0_id, {
+		c: format,
+		d: message,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+_resume(shout, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "page";
+	_html(`<button>page</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	panel_default({});
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		d: format,
+		e: message,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/render.debug.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  page
+</button>
+<div>
+  page
+</div>
+<button>
+  panel
+</button>
+<div>
+  panel
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button").forEach((button) => button.click());
+```
+```html
+<button>
+  page
+</button>
+<div>
+  PAGE!
+</div>
+<button>
+  panel
+</button>
+<div>
+  PANEL!
+</div>
+```
+## Change
+```
+UPDATE: div:nth-of-type(1)::text "page" => "PAGE!"
+UPDATE: div:nth-of-type(2)::text "panel" => "PANEL!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/render.md
@@ -1,0 +1,39 @@
+# Render
+```html
+<button>
+  page
+</button>
+<div>
+  page
+</div>
+<button>
+  panel
+</button>
+<div>
+  panel
+</div>
+```
+
+# Update
+```js
+document.querySelectorAll("button").forEach((button) => button.click());
+```
+```html
+<button>
+  page
+</button>
+<div>
+  PAGE!
+</div>
+<button>
+  panel
+</button>
+<div>
+  PANEL!
+</div>
+```
+## Change
+```
+UPDATE: div:nth-of-type(1)::text "page" => "PAGE!"
+UPDATE: div:nth-of-type(2)::text "panel" => "PANEL!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<button>page</button><!--M_*1 #button/0-->
+<div>page<!--M_*2 #text/0--></div><button>panel</button><!--M_*3 #button/0-->
+<div>panel<!--M_*4 #text/0--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      format: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/greeting.marko_0/export/shout"
+        ],
+      message: "page",
+      "#childScope/1": _(2)
+    }, 1, {
+      format: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/greeting.marko_0/export/shout"
+        ],
+      message: "panel",
+      "#childScope/1": _(4)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/panel.marko_0 3 packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/writes.html
@@ -1,0 +1,16 @@
+<button>page</button><!--M_*1 a-->
+<div>page<!--M_*2 a--></div><button>panel</button><!--M_*3 a-->
+<div>panel<!--M_*4 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: _._.b0,
+    e: "page",
+    b: _(2)
+  }, 1, {
+    c: _._.b0,
+    d: "panel",
+    b: _(4)
+  }], "c0 3 a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/sizes.json
@@ -1,0 +1,20 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2761,
+        "brotli": 1370
+      },
+      "files": {
+        "tags/greeting.marko": 190,
+        "tags/v:greeting.marko.register-shout.js": 85,
+        "tags/panel.marko": 263,
+        "template.marko": 255
+      }
+    }
+  },
+  "html": {
+    "min": 490,
+    "brotli": 299
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/greeting.marko
@@ -1,0 +1,5 @@
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/panel.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/tags/panel.marko
@@ -1,0 +1,6 @@
+import { shout } from "./greeting.marko";
+
+<let/format=shout/>
+<let/message="panel"/>
+<button onClick() { message = format(message) }>panel</button>
+<greeting message=message/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/template.marko
@@ -1,0 +1,7 @@
+import { shout } from "./tags/greeting.marko";
+
+<let/format=shout/>
+<let/message="page"/>
+<button onClick() { message = format(message) }>page</button>
+<greeting message=message/>
+<panel/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function clickBoth(document: Document) {
+  document.querySelectorAll("button").forEach((button) => button.click());
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickBoth],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/handlers.marko
+const $template$2 = "";
+const $walks$2 = "";
+const $setup$2 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "", $setup$2);
+
+// tags/press.marko
+const $template$1 = "<button>press</button><div> </div>";
+const $walks$1 = " bD l";
+const $label = /*@__PURE__*/ _let("label/4", ($scope) => _text($scope["#text/1"], $scope.label));
+const $setup__script = _script("__tests__/tags/press.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$label($scope, $scope.input.format($scope.label));
+}));
+function $setup$1($scope) {
+	$label($scope, "quiet");
+	$setup__script($scope);
+}
+const $input = /*@__PURE__*/ _const("input");
+var press_default = /*@__PURE__*/ _template("__tests__/tags/press.marko", $template$1, $walks$1, $setup$1, $input);
+
+// tags/v:handlers.marko.register-shout.js
+_resume("__tests__/tags/handlers.marko_0/export/shout", shout);
+
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input($scope["#childScope/0"], { format: shout });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// tags/handlers.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+
+// tags/press.marko
+const $label = /*@__PURE__*/ _let(4, ($scope) => _text($scope.b, $scope.e));
+const $setup__script = _script("c0", ($scope) => _on($scope.a, "click", function() {
+	$label($scope, $scope.d.format($scope.e));
+}));
+
+// tags/v:handlers.marko.register-shout.js
+_resume("b0", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,33 @@
+// tags/handlers.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var handlers_default = _template("__tests__/tags/handlers.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+});
+
+// tags/press.marko
+var press_default = _template("__tests__/tags/press.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "quiet";
+	_html(`<button>press</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(label)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/tags/press.marko_0");
+	writeScope($scope0_id, {
+		input,
+		label
+	}, "__tests__/tags/press.marko", 0, {
+		input: 0,
+		label: "1:6"
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/handlers.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	press_default({ format: shout });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// tags/handlers.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var handlers_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+});
+
+// tags/press.marko
+var press_default = _template("c", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "quiet";
+	_html(`<button>press</button>${_el_resume($scope0_id, "a")}<div>${_escape(label)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "c0");
+	writeScope($scope0_id, {
+		d: input,
+		e: label
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+_resume(shout, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	press_default({ format: shout });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  press
+</button>
+<div>
+  quiet
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  press
+</button>
+<div>
+  QUIET!
+</div>
+```
+## Change
+```
+UPDATE: div::text "quiet" => "QUIET!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  press
+</button>
+<div>
+  quiet
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  press
+</button>
+<div>
+  QUIET!
+</div>
+```
+## Change
+```
+UPDATE: div::text "quiet" => "QUIET!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<button>press</button><!--M_*2 #button/0-->
+<div>quiet<!--M_*2 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      input: {
+        format: _._[
+          "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/handlers.marko_0/export/shout"
+          ]
+      },
+      label: "quiet"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/press.marko_0 2"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>press</button><!--M_*2 a-->
+<div>quiet<!--M_*2 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    d: {
+      format: _._.b0
+    },
+    e: "quiet"
+  }], "c0 2"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2665,
+        "brotli": 1344
+      },
+      "files": {
+        "tags/handlers.marko": 108,
+        "tags/press.marko": 251,
+        "tags/v:handlers.marko.register-shout.js": 85
+      }
+    }
+  },
+  "html": {
+    "min": 396,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/handlers.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/handlers.marko
@@ -1,0 +1,3 @@
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/press.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/tags/press.marko
@@ -1,0 +1,3 @@
+<let/label="quiet"/>
+<button onClick() { label = input.format(label) }>press</button>
+<div>${label}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/template.marko
@@ -1,0 +1,3 @@
+import { shout } from "./tags/handlers.marko";
+
+<press format=shout/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,28 @@
+// tags/greeting.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", $setup$1, $input);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("__tests__/tags/greeting.marko_0/export/shout", shout);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>shout</button>${_w0}`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D l");
+const $format = /*@__PURE__*/ _let("format/2");
+const $message = /*@__PURE__*/ _let("message/3", ($scope) => $input_message($scope["#childScope/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.format($scope.message));
+}));
+function $setup($scope) {
+	$format($scope, shout);
+	$message($scope, "hello");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,14 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("b0", shout);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(3, ($scope) => $input_message($scope.b, $scope.d));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.c($scope.d));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,33 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("__tests__/tags/greeting.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/greeting.marko", 0);
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/greeting.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		format,
+		message,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, {
+		format: "3:6",
+		message: "4:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+_resume(shout, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: format,
+		d: message,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<div>
+  hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  shout
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<div>
+  hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  shout
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<button>shout</button><!--M_*1 #button/0-->
+<div>hello<!--M_*2 #text/0--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      format: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/tags/greeting.marko_0/export/shout"
+        ],
+      message: "hello",
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>shout</button><!--M_*1 a-->
+<div>hello<!--M_*2 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: _._.b0,
+    d: "hello",
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2682,
+        "brotli": 1349
+      },
+      "files": {
+        "tags/greeting.marko": 190,
+        "tags/v:greeting.marko.register-shout.js": 85,
+        "template.marko": 255
+      }
+    }
+  },
+  "html": {
+    "min": 394,
+    "brotli": 272
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/tags/greeting.marko
@@ -1,0 +1,5 @@
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/template.marko
@@ -1,0 +1,6 @@
+import { shout } from "./tags/greeting.marko";
+
+<let/format=shout/>
+<let/message="hello"/>
+<button onClick() { message = format(message) }>shout</button>
+<greeting message=message/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/greeting.marko
+const $template$2 = "<div> </div>";
+const $walks$2 = "D l";
+const $setup$2 = () => {};
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
+const $input = ($scope, input) => $input_message($scope, input.message);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", $setup$2, $input);
+
+// tags/greetings.marko
+const $template$1 = "<div>greetings</div>";
+const $walks$1 = "b";
+const $setup$1 = () => {};
+var greetings_default = /*@__PURE__*/ _template("__tests__/tags/greetings.marko", $template$1, "b", $setup$1);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("__tests__/tags/greeting.marko_0/export/shout", shout);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>shout</button>${_w0}`)($template$2);
+const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D l");
+const $format = /*@__PURE__*/ _let("format/2");
+const $message = /*@__PURE__*/ _let("message/3", ($scope) => $input_message($scope["#childScope/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.format($scope.message));
+}));
+function $setup($scope) {
+	$format($scope, shout);
+	$message($scope, "hello");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,14 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+const $input_message = ($scope, input_message) => _text($scope.a, input_message);
+
+// tags/v:greeting.marko.register-shout.js
+_resume("b0", shout);
+
+// template.marko
+const $message = /*@__PURE__*/ _let(3, ($scope) => $input_message($scope.b, $scope.d));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.c($scope.d));
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,40 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("__tests__/tags/greeting.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/greeting.marko", 0);
+});
+
+// tags/greetings.marko
+var greetings_default = _template("__tests__/tags/greetings.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div>greetings</div>");
+});
+
+// template.marko
+_resume(shout, "__tests__/tags/greeting.marko_0/export/shout");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		format,
+		message,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, {
+		format: "3:6",
+		message: "4:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,37 @@
+// tags/greeting.marko
+function shout(message) {
+	return message.toUpperCase() + "!";
+}
+var greeting_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.message)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// tags/greetings.marko
+var greetings_default = _template("c", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div>greetings</div>");
+});
+
+// template.marko
+_resume(shout, "b0");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let format = shout;
+	let message = "hello";
+	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}`);
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	greeting_default({ message });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: format,
+		d: message,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<div>
+  hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  shout
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  shout
+</button>
+<div>
+  hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  shout
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<button>shout</button><!--M_*1 #button/0-->
+<div>hello<!--M_*2 #text/0--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      format: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/tags/greeting.marko_0/export/shout"
+        ],
+      message: "hello",
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>shout</button><!--M_*1 a-->
+<div>hello<!--M_*2 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: _._.b0,
+    d: "hello",
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2682,
+        "brotli": 1349
+      },
+      "files": {
+        "tags/greeting.marko": 190,
+        "tags/v:greeting.marko.register-shout.js": 85,
+        "template.marko": 255
+      }
+    }
+  },
+  "html": {
+    "min": 394,
+    "brotli": 272
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/tags/greeting.marko
@@ -1,0 +1,5 @@
+export function shout(message: string) {
+  return message.toUpperCase() + "!";
+}
+
+<div>${input.message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/tags/greetings.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/tags/greetings.marko
@@ -1,0 +1,3 @@
+export { shout } from "./greeting.marko";
+
+<div>greetings</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/template.marko
@@ -1,0 +1,6 @@
+import { shout } from "./tags/greetings.marko";
+
+<let/format=shout/>
+<let/message="hello"/>
+<button onClick() { message = format(message) }>shout</button>
+<greeting message=message/>

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,20 @@
+// template.marko
+const $template = "<button>go</button><div> </div>";
+const $walks = " bD l";
+const base = $base;
+const alias = base;
+const $fn = /*@__PURE__*/ _let("fn/2");
+const $message = /*@__PURE__*/ _let("message/3", ($scope) => _text($scope["#text/1"], $scope.message));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$message($scope, $scope.fn($scope.message));
+}));
+function $setup($scope) {
+	$fn($scope, alias);
+	$message($scope, "Hello");
+	$setup__script($scope);
+}
+function $base(message) {
+	return message.toUpperCase() + "!";
+}
+_resume("__tests__/template.marko_0/base", $base);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $message = /*@__PURE__*/ _let(3, ($scope) => _text($scope.b, $scope.d));
+const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$message($scope, $scope.c($scope.d));
+}));
+function $base(message) {
+	return message.toUpperCase() + "!";
+}
+_resume("a0", $base);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+function base(message) {
+	return message.toUpperCase() + "!";
+}
+_resume(base, "__tests__/template.marko_0/base");
+const alias = base;
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let fn = alias;
+	let message = "Hello";
+	_html(`<button>go</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(message)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		fn,
+		message
+	}, "__tests__/template.marko", 0, {
+		fn: "4:6",
+		message: "5:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/html.bundle.js
@@ -1,0 +1,19 @@
+// template.marko
+function base(message) {
+	return message.toUpperCase() + "!";
+}
+_resume(base, "a0");
+const alias = base;
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let fn = alias;
+	let message = "Hello";
+	_html(`<button>go</button>${_el_resume($scope0_id, "a")}<div>${_escape(message)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		c: fn,
+		d: message
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  go
+</button>
+<div>
+  Hello
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  go
+</button>
+<div>
+  HELLO!
+</div>
+```
+## Change
+```
+UPDATE: div::text "Hello" => "HELLO!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<button>go</button><!--M_*1 #button/0-->
+<div>Hello<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      fn: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/template.marko_0/base"
+        ],
+      message: "Hello"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button>go</button><!--M_*1 a-->
+<div>Hello<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: _._.a0,
+    d: "Hello"
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2658,
+      "brotli": 1335
+    }
+  },
+  "html": {
+    "min": 384,
+    "brotli": 264
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/template.marko
@@ -1,0 +1,7 @@
+static function base(message: string) { return message.toUpperCase() + "!"; }
+static const alias = base;
+
+<let/fn=alias/>
+<let/message="Hello"/>
+<button onClick() { message = fn(message) }>go</button>
+<div>${message}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/core/export.ts
+++ b/packages/runtime-tags/src/translator/core/export.ts
@@ -1,3 +1,4 @@
+import type { types as t } from "@marko/compiler";
 import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
 
 export default {
@@ -17,6 +18,16 @@ export default {
       );
     }
 
+    // The template is compiled into the default export, so a second one would
+    // leave the module with two.
+    const defaultExport = getDefaultExport(statements[0]);
+    if (defaultExport) {
+      throw tag.hub.buildError(
+        defaultExport,
+        "A template is already its own default export. Use a named export instead.",
+      );
+    }
+
     tag.replaceWith(statements[0]);
   },
   parseOptions: {
@@ -29,3 +40,22 @@ export default {
     },
   ],
 } as Tag;
+
+// `export * from` is not one: it never carries the source's default export.
+function getDefaultExport(statement: t.Statement) {
+  if (statement.type === "ExportDefaultDeclaration") return statement;
+  if (statement.type !== "ExportNamedDeclaration") return;
+
+  for (const specifier of statement.specifiers) {
+    const { exported } = specifier as
+      | t.ExportSpecifier
+      | t.ExportNamespaceSpecifier;
+    if (
+      exported &&
+      (exported.type === "Identifier" ? exported.name : exported.value) ===
+        "default"
+    ) {
+      return specifier;
+    }
+  }
+}

--- a/packages/runtime-tags/src/translator/util/module-registrations.ts
+++ b/packages/runtime-tags/src/translator/util/module-registrations.ts
@@ -1,0 +1,120 @@
+import path from "path";
+
+import { types as t } from "@marko/compiler";
+import { importDefault } from "@marko/compiler/babel-utils";
+
+import type { ResolvedExport } from "../visitors/function";
+import { getMarkoOpts, isOutputHTML } from "./marko-config";
+import { isRegisteredFnExtra } from "./references";
+import { callRuntime, getRuntimePath } from "./runtime";
+
+/**
+ * Writes the registrations for module scoped functions: the ones this template
+ * exports and registers itself, and the ones it imports from a template that
+ * reserved a register id without registering it.
+ */
+export function writeModuleRegistrations(program: t.NodePath<t.Program>) {
+  const { file } = program.hub;
+  const statements: t.Statement[] = [];
+  const seen = new Set<string>();
+
+  for (const child of program.node.body) {
+    const registeredImportedFns = child.extra?.registeredImportedFns;
+    if (registeredImportedFns) {
+      for (const importedFn of registeredImportedFns) {
+        if (seen.has(importedFn.registerId)) continue;
+        seen.add(importedFn.registerId);
+
+        // The dom output shares a module per function, so templates that import
+        // the same one do not each carry a copy of its registration into the
+        // bundle. The html output has no bundle to keep small.
+        if (isOutputHTML()) {
+          statements.push(
+            buildRegistration(importedFn.local, importedFn.registerId),
+          );
+        } else {
+          importDefault(file, resolveRegisterModule(file, importedFn));
+        }
+      }
+    } else if (child.type === "ExportNamedDeclaration") {
+      addExportRegistrations(child, seen, statements);
+    }
+  }
+
+  program.node.body.push(...statements);
+}
+
+// The exporting template registers itself inline: it is the only module that
+// can, and importing its own registration back would be a cycle through the
+// declaration it is registering.
+function addExportRegistrations(
+  node: t.ExportNamedDeclaration,
+  seen: Set<string>,
+  statements: t.Statement[],
+) {
+  const { declaration } = node;
+  if (!declaration) return;
+
+  const add = (local: string, registerId: string) => {
+    if (seen.has(registerId)) return;
+    seen.add(registerId);
+    statements.push(buildRegistration(local, registerId));
+  };
+
+  if (declaration.type === "FunctionDeclaration") {
+    if (isRegisteredFnExtra(declaration.extra)) {
+      add(declaration.id!.name, declaration.extra.registerId);
+    }
+    return;
+  }
+
+  // The html output registers exported function expressions where they are
+  // written, by replacing them with the `_resume` call that returns them.
+  if (isOutputHTML() || declaration.type !== "VariableDeclaration") return;
+
+  for (const declarator of declaration.declarations) {
+    const extra = declarator.init?.extra;
+    if (isRegisteredFnExtra(extra) && t.isIdentifier(declarator.id)) {
+      add(declarator.id.name, extra.registerId);
+    }
+  }
+}
+
+function buildRegistration(local: string, registerId: string) {
+  return t.expressionStatement(
+    isOutputHTML()
+      ? callRuntime("_resume", t.identifier(local), t.stringLiteral(registerId))
+      : callRuntime(
+          "_resume",
+          t.stringLiteral(registerId),
+          t.identifier(local),
+        ),
+  );
+}
+
+// Keyed by the declaring template and the export's canonical name, so every
+// template that imports the function resolves to the same module.
+function resolveRegisterModule(
+  file: t.BabelFile,
+  { filename, exportName, registerId }: ResolvedExport,
+) {
+  const importer = file.opts.filename as string;
+  return getMarkoOpts().resolveVirtualDependency!(importer, {
+    virtualPath: `${relativePath(importer, filename)}.register-${exportName}.js`,
+    code:
+      `import { ${exportName} } from "./${path.basename(filename)}";\n` +
+      `import { _resume } from "${getRuntimePath("dom")}";\n` +
+      `_resume(${JSON.stringify(registerId)}, ${exportName});\n`,
+  })!;
+}
+
+// The module is placed beside the template it registers, so that it can import
+// it as a sibling. `resolveRelativePath` would name a template in another
+// package by that package, which resolves somewhere else entirely.
+function relativePath(from: string, to: string) {
+  const relative = path
+    .relative(path.dirname(from), to)
+    .split(path.sep)
+    .join("/");
+  return relative.startsWith(".") ? relative : `./${relative}`;
+}

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -183,6 +183,9 @@ declare module "@marko/compiler/dist/types" {
     name?: string;
     registerId?: string;
     registerReason?: SerializeReason;
+    // Reserved for a function reachable through an export: importing templates
+    // resolve it to register the function without this template registering it.
+    exportRegisterId?: string;
   }
 
   export interface ArrowFunctionExpressionExtra extends FunctionExtra {}

--- a/packages/runtime-tags/src/translator/visitors/function.ts
+++ b/packages/runtime-tags/src/translator/visitors/function.ts
@@ -1,5 +1,10 @@
 import { types as t } from "@marko/compiler";
-import { getFile, getTemplateId } from "@marko/compiler/babel-utils";
+import {
+  getFile,
+  getProgram,
+  getTemplateId,
+  loadFileForImport,
+} from "@marko/compiler/babel-utils";
 
 import { generateUid } from "../util/generate-uid";
 import { getAttributeTagParent } from "../util/get-parent-tag";
@@ -26,10 +31,35 @@ import { createProgramState } from "../util/state";
 import analyzeTagNameType, { TagNameType } from "../util/tag-name-type";
 import type { TemplateVisitor } from "../util/visitors";
 
+declare module "@marko/compiler/dist/types" {
+  export interface ProgramExtra {
+    // Every name an export is reachable by -> its reserved registration.
+    registeredExports?: Map<string, ReservedExport>;
+  }
+}
+
+/** The canonical name a reserved register id is exported under, and its id. */
+export interface ReservedExport {
+  registerId: string;
+  exportName: string;
+}
+
+/** A reserved export, plus the template that declares it. */
+export interface ResolvedExport extends ReservedExport {
+  filename: string;
+}
+
+interface ImportedFn extends ResolvedExport {
+  node: t.ImportDeclaration;
+  local: string;
+}
+
 const [getReferencesByFn] = createProgramState(
   () => new Map<RegisteredFnExtra, Set<t.NodeExtra>>(),
 );
-
+const [getReferencesByImportedFn] = createProgramState(
+  () => new Map<ImportedFn, Set<t.NodeExtra>>(),
+);
 export default {
   analyze(fn) {
     // bail on closures
@@ -60,8 +90,10 @@ export default {
             ? node.key.name
             : "anonymous");
 
+    reserveExportRegisterId(fnExtra, fn, markoRoot);
+
     if (isStaticRoot(markoRoot)) {
-      const refs = getStaticDeclRefs(fnExtra, fn);
+      const refs = getStaticDeclRefs(fn);
       if (refs === true) {
         registerFunction(fnExtra, true);
       } else if (refs.size) {
@@ -77,18 +109,208 @@ export default {
 
 export function finalizeFunctionRegistry() {
   for (const [fnExtra, exprExtras] of getReferencesByFn()) {
-    let reason: undefined | SerializeReason;
-    for (const exprExtra of exprExtras) {
-      reason = mergeSerializeReasons(
-        reason,
-        getAllSerializeReasonsForExtra(getCanonicalExtra(exprExtra)),
-      );
-    }
-
+    const reason = resolveSerializeReason(exprExtras);
     if (reason) {
       registerFunction(fnExtra, reason);
     }
   }
+
+  for (const [importedFn, exprExtras] of getReferencesByImportedFn()) {
+    if (resolveSerializeReason(exprExtras)) {
+      registerImportedFn(importedFn);
+    }
+  }
+}
+
+/**
+ * Tracks a function imported from another template that reserved a register id.
+ * The importing template registers it (under the reserved id) when its own
+ * references reach something serialized.
+ */
+export function trackImportedFn(
+  importDecl: t.NodePath<t.ImportDeclaration>,
+  local: string,
+  resolved: ResolvedExport,
+) {
+  const binding = importDecl.scope.getBinding(local);
+  if (!binding) return;
+
+  const importedFn: ImportedFn = { ...resolved, node: importDecl.node, local };
+  const refs = new Set<t.NodeExtra>();
+  if (addBindingRefs(binding, refs, new Set()) === true) {
+    registerImportedFn(importedFn);
+  } else if (refs.size) {
+    getReferencesByImportedFn().set(importedFn, refs);
+  }
+}
+
+/**
+ * Finds the id reserved for an export, following `export ... from` hops. Each
+ * template only records the exports it declares, so this resolves on demand:
+ * a template in an import cycle is read while it is still analyzing, and would
+ * hand out an incomplete map if the ids were pushed ahead of time.
+ */
+export function resolveRegisteredExport(
+  file: t.BabelFile,
+  exportName: string,
+  seen = new Set<string>(),
+): ResolvedExport | undefined {
+  const filename = file.opts.filename as string;
+  const key = `${filename}\0${exportName}`;
+  if (seen.has(key)) return;
+  seen.add(key);
+
+  const reserved = file.ast.program.extra?.registeredExports?.get(exportName);
+  if (reserved) return { ...reserved, filename };
+
+  for (const child of file.ast.program.body) {
+    if (
+      (child.type !== "ExportNamedDeclaration" &&
+        child.type !== "ExportAllDeclaration") ||
+      !child.source ||
+      (child.exportKind || "value") !== "value"
+    ) {
+      continue;
+    }
+
+    const sourceFile = loadFileForImport(file, child.source.value);
+    if (!sourceFile) continue;
+
+    if (child.type === "ExportAllDeclaration") {
+      const resolved = resolveRegisteredExport(sourceFile, exportName, seen);
+      if (resolved) return resolved;
+      continue;
+    }
+
+    for (const specifier of child.specifiers) {
+      if (
+        specifier.type !== "ExportSpecifier" ||
+        (specifier.exportKind || "value") !== "value" ||
+        getExportedName(specifier) !== exportName
+      ) {
+        continue;
+      }
+
+      const resolved = resolveRegisteredExport(
+        sourceFile,
+        specifier.local.name,
+        seen,
+      );
+      if (resolved) return resolved;
+    }
+  }
+}
+
+function resolveSerializeReason(exprExtras: Set<t.NodeExtra>) {
+  let reason: undefined | SerializeReason;
+  for (const exprExtra of exprExtras) {
+    reason = mergeSerializeReasons(
+      reason,
+      getAllSerializeReasonsForExtra(getCanonicalExtra(exprExtra)),
+    );
+  }
+
+  return reason;
+}
+
+function registerImportedFn({ node, ...importedFn }: ImportedFn) {
+  const extra = (node.extra ??= {});
+  extra.registeredImportedFns ??= [];
+  extra.registeredImportedFns.push(importedFn);
+  getProgram().node.extra.isInteractive = true;
+}
+
+// An exported function is always module scoped, so any template that imports it
+// can register it as is; the id is reserved here so every one of them agrees.
+// A function exported under several names still gets one id, keyed by the first.
+function reserveExportRegisterId(
+  fnExtra: RegisteredFnExtra,
+  fn: t.NodePath<t.Function>,
+  markoRoot: MarkoExprRootPath,
+) {
+  if (!isStaticRoot(markoRoot)) return;
+  const exportNames = getExportNames(fn, markoRoot);
+  // The generated module imports the function by name, so the id is keyed by a
+  // name that can be spelled in an import.
+  const exportName = exportNames?.find((name) => t.isValidIdentifier(name));
+  if (!exportName) return;
+
+  const {
+    markoOpts,
+    opts: { filename },
+  } = getFile();
+  const programExtra = getProgram().node.extra;
+  const registerId = getTemplateId(
+    markoOpts,
+    filename as string,
+    `${fnExtra.section.id}/export/${exportName}`,
+  );
+
+  fnExtra.exportRegisterId = registerId;
+  programExtra.registeredExports ??= new Map();
+  for (const name of exportNames!) {
+    programExtra.registeredExports.set(name, { registerId, exportName });
+  }
+}
+
+// Only a function that _is_ an exported value can be registered by an importer,
+// whether it is exported where it is declared or by a later `export { … }`.
+function getExportNames(
+  fn: t.NodePath<t.Function>,
+  markoRoot: MarkoExprRootPath,
+) {
+  const localName = getExportableName(fn);
+  if (localName === undefined) return;
+
+  const exportNames =
+    markoRoot.isExportNamedDeclaration() && !markoRoot.node.source
+      ? [localName]
+      : [];
+
+  // A later `export { … }` reads the binding, so its specifiers are among the
+  // references babel already tracks for it.
+  const binding = fn.scope.getBinding(localName);
+  if (binding) {
+    for (const ref of binding.referencePaths) {
+      const specifier = ref.parent;
+      if (
+        specifier?.type === "ExportSpecifier" &&
+        (specifier.exportKind || "value") === "value" &&
+        !(ref.parentPath!.parent as t.ExportNamedDeclaration).source
+      ) {
+        const exportName = getExportedName(specifier);
+        // A template's default export is the template itself.
+        if (exportName !== "default") {
+          exportNames.push(exportName);
+        }
+      }
+    }
+  }
+
+  return exportNames.length ? exportNames : undefined;
+}
+
+// The name this function is declared under, when it is bound to one it cannot
+// be reassigned through — the register id is bound to the value, not the name.
+function getExportableName(fn: t.NodePath<t.Function>) {
+  const { node, parent } = fn;
+  if (node.type === "FunctionDeclaration") {
+    return node.id?.name;
+  }
+
+  if (
+    t.isVariableDeclarator(parent) &&
+    parent.init === node &&
+    t.isIdentifier(parent.id) &&
+    t.isVariableDeclaration(fn.parentPath!.parent, { kind: "const" })
+  ) {
+    return parent.id.name;
+  }
+}
+
+function getExportedName(specifier: t.ExportSpecifier) {
+  const { exported } = specifier;
+  return exported.type === "Identifier" ? exported.name : exported.value;
 }
 
 function canIgnoreRegister(
@@ -115,8 +337,6 @@ function canIgnoreRegister(
 }
 
 function getStaticDeclRefs(
-  // oxlint-disable-next-line only-used-in-recursion
-  fnExtra: RegisteredFnExtra,
   path: t.NodePath<t.Node>,
   refs = new Set<t.NodeExtra>(),
   seen = new Set<t.Node>(),
@@ -131,27 +351,36 @@ function getStaticDeclRefs(
       for (const name in ids) {
         const binding = decl.scope.getBinding(name);
         if (!binding) continue;
-        for (const ref of binding.referencePaths) {
-          if (isInvokedFunction(ref) || ref.parentPath!.type === "Program")
-            continue;
-          const exprRoot = getExprRoot(ref);
-          const markoRoot = getMarkoRoot(exprRoot);
-          if (!markoRoot || canIgnoreRegister(markoRoot, exprRoot)) continue;
-          if (isStaticRoot(markoRoot)) {
-            if (getStaticDeclRefs(fnExtra, ref, refs, seen) === true) {
-              return true;
-            }
-          } else if (shouldAlwaysRegister(markoRoot)) {
-            return true;
-          } else {
-            refs.add((exprRoot.node.extra ??= {}));
-          }
+        if (addBindingRefs(binding, refs, seen) === true) {
+          return true;
         }
       }
     }
   }
 
   return refs;
+}
+
+function addBindingRefs(
+  binding: NonNullable<ReturnType<t.Scope["getBinding"]>>,
+  refs: Set<t.NodeExtra>,
+  seen: Set<t.Node>,
+) {
+  for (const ref of binding.referencePaths) {
+    if (isInvokedFunction(ref) || ref.parentPath!.type === "Program") continue;
+    const exprRoot = getExprRoot(ref);
+    const markoRoot = getMarkoRoot(exprRoot);
+    if (!markoRoot || canIgnoreRegister(markoRoot, exprRoot)) continue;
+    if (isStaticRoot(markoRoot)) {
+      if (getStaticDeclRefs(ref, refs, seen) === true) {
+        return true;
+      }
+    } else if (shouldAlwaysRegister(markoRoot)) {
+      return true;
+    } else {
+      refs.add((exprRoot.node.extra ??= {}));
+    }
+  }
 }
 
 function shouldAlwaysRegister(markoRoot: MarkoExprRootPath) {
@@ -207,11 +436,13 @@ function registerFunction(fnExtra: RegisteredFnExtra, reason: SerializeReason) {
   program.node.extra.isInteractive = true;
   fnExtra.registerReason = reason;
   fnExtra.name = generateUid(fnExtra.name);
-  fnExtra.registerId = getTemplateId(
-    markoOpts,
-    filename as string,
-    `${fnExtra.section.id}/${fnExtra.name.slice(1)}`,
-  );
+  fnExtra.registerId =
+    fnExtra.exportRegisterId ??
+    getTemplateId(
+      markoOpts,
+      filename as string,
+      `${fnExtra.section.id}/${fnExtra.name.slice(1)}`,
+    );
 }
 
 function isMarkoAttribute(

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -15,11 +15,17 @@ import { callRuntime } from "../util/runtime";
 import { createProgramState } from "../util/state";
 import { toMemberExpression } from "../util/to-property-name";
 import type { TemplateVisitor } from "../util/visitors";
+import {
+  resolveRegisteredExport,
+  type ResolvedExport,
+  trackImportedFn,
+} from "./function";
 
 declare module "@marko/compiler/dist/types" {
   export interface NodeExtra {
     tagImport?: string;
     loadImport?: LoadImportConfig;
+    registeredImportedFns?: (ResolvedExport & { local: string })[];
   }
 }
 
@@ -53,6 +59,8 @@ export default {
       if (!tags.includes(tagImport)) {
         tags.push(tagImport);
       }
+
+      trackImportedRegisteredFns(importDecl);
     }
 
     const loadAttrPath = node.attributes?.length
@@ -222,6 +230,31 @@ function getOrCreateHtmlLoadWrapped(
     ),
   );
   return wrappedName;
+}
+
+function trackImportedRegisteredFns(
+  importDecl: t.NodePath<t.ImportDeclaration>,
+) {
+  const { node } = importDecl;
+  // Type imports are already stripped: the compiler turns `stripTypes` on for
+  // every output this translator runs for.
+  const childFile = loadFileForImport(importDecl.hub.file, node.source.value);
+  if (!childFile) return;
+
+  for (const specifier of importDecl.get("specifiers")) {
+    if (!specifier.isImportSpecifier()) continue;
+    const { imported } = specifier.node;
+    const importedName =
+      imported.type === "Identifier" ? imported.name : imported.value;
+    // A default specifier is skipped by its type; this is the same import
+    // written as a name, and a template's default export is the template.
+    if (importedName === "default") continue;
+
+    const resolved = resolveRegisteredExport(childFile, importedName);
+    if (resolved) {
+      trackImportedFn(importDecl, specifier.node.local.name, resolved);
+    }
+  }
 }
 
 function getLoadImportConfig(

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -3,6 +3,7 @@ import { importDefault } from "@marko/compiler/babel-utils";
 
 import { scopeIdentifier } from ".";
 import { isSectionRendererElided } from "../../util/binding-has-prop";
+import { writeModuleRegistrations } from "../../util/module-registrations";
 import { forEach } from "../../util/optional";
 import {
   BindingType,
@@ -213,6 +214,8 @@ export default {
       if (extraDecls) {
         program.node.body.unshift(t.variableDeclaration("const", extraDecls));
       }
+
+      writeModuleRegistrations(program);
 
       program.node.body.push(
         t.exportDefaultDeclaration(

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -8,6 +8,7 @@ import {
 import { getDeclaredBindingExpression } from "../../util/get-declared-binding-expression";
 import isStatic from "../../util/is-static";
 import { getMarkoOpts } from "../../util/marko-config";
+import { writeModuleRegistrations } from "../../util/module-registrations";
 import { forEach } from "../../util/optional";
 import {
   BindingType,
@@ -163,6 +164,8 @@ export default {
           }
         }
       }
+
+      writeModuleRegistrations(program);
 
       const contentId = usedSharedUid("content") && getTemplateContentName();
       const contentFn = t.arrowFunctionExpression(

--- a/scripts/inspect-compiled-output.mts
+++ b/scripts/inspect-compiled-output.mts
@@ -46,6 +46,16 @@ for (const entry of args.positionals) {
     optimize: !args.values.dev,
     sourceMaps: false,
     modules: "esm",
+    // Generated modules are written beside the output, with their path
+    // flattened into the name so they stay in one directory.
+    resolveVirtualDependency(filename, { virtualPath, code }) {
+      const request =
+        "./" + virtualPath.replace(/^\.\//, "").replaceAll("/", "__");
+      const virtualFileName = path.resolve(filename, "..", request);
+      fs.writeFileSync(virtualFileName, code);
+      console.log(virtualFileName);
+      return request;
+    },
     babelConfig: {
       babelrc: false,
       configFile: false,


### PR DESCRIPTION
Fixes #3687.

A template that imports a function from another `.marko` file and then serializes it had no way to register it, so the serializer hit an unregistered function and failed at render time — passing it to a tag only worked when wrapped in an inline arrow. A template that exports a function now reserves a register id for it *without* registering it, and importing templates pull in a generated module that registers it under that id — only once their own references reach something serialized, so an export nothing serializes still ships zero bytes.

That module is emitted for the dom output only, keyed by the declaring template and the export's canonical name, so every importer shares one registration no matter which path or alias it imports through; the html output registers inline, having no bundle to keep small. Reserved ids resolve on demand (`resolveRegisteredExport`), following `export … from` / `export *` hops, so re-export chains and import cycles work. Ids are allocated during the exporting template's analyze, which is cached across the html and dom compiles, so both sides agree.

Two pre-existing bugs surfaced along the way and are fixed here. An exported function that a template registered *itself* emitted no registration at all, because the dom registration codegen was only reachable from the scriptlet visitor and never visited program-level exports; that case stays inline, since importing its own registration back would cycle through the declaration being registered. And a default export in a template was accepted despite the template already compiling into the module's default export, silently producing a module with two — `<export>` now rejects any statement whose exported name is `default`.

Known gaps, all unchanged from before and still reported as a located `Unable to serialize` at render time in debug: `export let` (the id binds to a value, not a name) and namespace imports (`import * as ns`).