### PR TITLE
perf(compiler): prune unreachable babel code from the bundled compiler

### DIFF
--- a/.changeset/prune-browser-parser-plugins.md
+++ b/.changeset/prune-browser-parser-plugins.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Prune unreachable Babel code from the bundled compiler. The parser's flow, jsx, estree and v8intrinsic syntax plugins are stubbed; `helper-create-class-features-plugin` is pointed at the one module the TypeScript transform uses instead of its barrel; the runtime helper table keeps only the four helpers anything here can request; and the flow/jsx printers and node definitions, the generated `assertFoo` helpers, the uppercase builder aliases and the missing-plugin suggestion table are dropped. `dist/babel.js` goes from 2084 KB to 1626 KB and `dist/babel.web.js` from 1966 KB to 1509 KB, with compiled output unchanged.

--- a/packages/compiler/scripts/bundle.mts
+++ b/packages/compiler/scripts/bundle.mts
@@ -41,6 +41,143 @@ const presetTypeScriptVersionStub = {
   },
 };
 
+// Marko's parser options only ever enable `objectRestSpread`, `classProperties`
+// and `typescript`. The parser keeps its syntax plugins in one object literal
+// that is indexed by name, so nothing can tree-shake the rest; stubbing the
+// entries makes those mixins unreachable and DCE drops them.
+const UNUSED_PARSER_PLUGINS = [
+  "estree",
+  "jsx",
+  "flow",
+  "v8intrinsic",
+  "placeholders",
+];
+const REGISTRY =
+  "const mixinPlugins = {\n  estree,\n  jsx,\n  flow,\n  typescript,\n  v8intrinsic,\n  placeholders\n};";
+const pruneParserPlugins = {
+  name: "prune-parser-plugins",
+  transform(code: string, id: string) {
+    if (!id.includes("@babel/parser")) return null;
+    if (!code.includes(REGISTRY)) {
+      throw new Error(
+        "prune-parser-plugins: @babel/parser mixin registry not found; the pruning is stale",
+      );
+    }
+    const stubs = UNUSED_PARSER_PLUGINS.map(
+      (name) =>
+        `  ${name}: () => { throw new Error("@marko/compiler: the '${name}' parser plugin is not available in the browser build."); },`,
+    ).join("\n");
+    return code.replace(
+      REGISTRY,
+      `const mixinPlugins = {\n${stubs}\n  typescript,\n  placeholders\n};`,
+    );
+  },
+};
+
+// `plugin-transform-typescript` reaches for exactly one export here,
+// `injectInitialization`, but the package barrel eagerly requires its class
+// fields and decorators transforms, which no plugin in either bundle runs.
+// Point the specifier at the module that export actually lives in. A user's
+// own babel plugins resolve their copy of this package themselves, so they are
+// unaffected.
+const CLASS_FEATURES = "@babel/helper-create-class-features-plugin";
+const classFeaturesMiscOnly = {
+  name: "class-features-misc-only",
+  async resolveId(id: string, importer: string | undefined) {
+    if (id !== CLASS_FEATURES) return null;
+    const resolved = await this.resolve(id, importer, { skipSelf: true });
+    return resolved && resolved.id.replace(/index\.js$/, "misc.js");
+  },
+};
+
+// Babel ships 122 runtime helpers in one object literal indexed by name. The
+// only ones anything here can request are the four the bundled transforms name
+// outright, and none of those declare dependencies, so the rest is unreachable
+// weight. A helper that is dropped but somehow asked for still fails loudly:
+// babel reports it as an unknown helper.
+const USED_HELPERS = new Set([
+  "classNameTDZError",
+  "interopRequireDefault",
+  "interopRequireWildcard",
+  "newArrowCheck",
+]);
+const pruneHelpers = {
+  name: "prune-helpers",
+  transform(code: string, id: string) {
+    if (
+      !id.includes("@babel/helpers") ||
+      !id.endsWith("helpers-generated.js")
+    ) {
+      return null;
+    }
+
+    // The table is split across an object literal and an `Object.assign` that
+    // tops it up, so both get the same treatment.
+    let total = 0;
+    const out = code.replace(
+      /(\{\n  __proto__: null,|Object\.assign\(helpers, \{)([\s\S]*?)(\n\}\);|\n\};)/g,
+      (whole, head: string, body: string, tail: string) => {
+        const entry = /\n  ([A-Za-z_$][\w$]*): helper\(/g;
+        const marks: [string, number][] = [];
+        for (let m = entry.exec(body); m; m = entry.exec(body)) {
+          marks.push([m[1], m.index]);
+        }
+        if (!marks.length) return whole;
+        total += marks.length;
+        let kept = "";
+        for (let i = 0; i < marks.length; i++) {
+          const to = i + 1 < marks.length ? marks[i + 1][1] : body.length;
+          if (USED_HELPERS.has(marks[i][0]))
+            kept += body.slice(marks[i][1], to);
+        }
+        return head + kept + tail;
+      },
+    );
+
+    if (total < 100) {
+      throw new Error(
+        `prune-helpers: found ${total} helpers, expected the full table; the pruning is stale`,
+      );
+    }
+    for (const name of USED_HELPERS) {
+      if (!out.includes(`\n  ${name}: helper(`)) {
+        throw new Error(`prune-helpers: dropped ${name}, which is still used`);
+      }
+    }
+    return out;
+  },
+};
+
+// Modules nothing in the bundle can reach. The flow and jsx printers exist for
+// nodes the pruned parser can no longer produce, and the missing-plugin helper
+// is a table of suggestions naming babel plugins this compiler does not bundle.
+const EMPTY_MODULE =
+  '"use strict";Object.defineProperty(exports,"__esModule",{value:true});';
+const DEAD_MODULES: Record<string, string> = {
+  "@babel/generator/lib/generators/flow.js": EMPTY_MODULE,
+  "@babel/generator/lib/generators/jsx.js": EMPTY_MODULE,
+  // Node definitions for syntax the pruned parser cannot produce.
+  "@babel/types/lib/definitions/flow.js": EMPTY_MODULE,
+  "@babel/types/lib/definitions/jsx.js": EMPTY_MODULE,
+  // `t.assertFoo()` and the uppercase `t.Foo()` builder aliases: neither the
+  // compiler nor any bundled babel package calls one.
+  "@babel/types/lib/asserts/generated/index.js": EMPTY_MODULE,
+  "@babel/types/lib/builders/generated/uppercase.js": EMPTY_MODULE,
+  "@babel/core/lib/parser/util/missing-plugin-helper.js":
+    EMPTY_MODULE +
+    "exports.default=(name)=>`Support for the experimental syntax '${name}' is not enabled.`;",
+};
+const stubDeadModules = {
+  name: "stub-dead-modules",
+  transform(code: string, id: string) {
+    const normalized = id.replace(/\\/g, "/");
+    for (const suffix in DEAD_MODULES) {
+      if (normalized.endsWith(suffix)) return DEAD_MODULES[suffix];
+    }
+    return null;
+  },
+};
+
 await Promise.all([
   // Every published entry is built in ONE rolldown pass so shared modules land
   // in shared chunks. `taglib/config` is a mutated singleton (`configure()`,
@@ -88,7 +225,13 @@ await Promise.all([
   ...(["browser", "node"] as const).map((platform) =>
     build({
       platform,
-      plugins: [presetTypeScriptVersionStub],
+      plugins: [
+        presetTypeScriptVersionStub,
+        pruneParserPlugins,
+        classFeaturesMiscOnly,
+        pruneHelpers,
+        stubDeadModules,
+      ],
       input: "internal/babel/index.ts",
       cwd,
       external: ["browserslist", "path", "assert", "fs"],


### PR DESCRIPTION
Babel keeps its syntax plugins, runtime helpers and node builders in registries indexed by name, so nothing tree-shakes them even though the compiler reaches a small fraction of each.

| | node | browser |
|---|---|---|
| baseline | 2084 KB | 1966 KB |
| **after** | **1626 KB** | **1509 KB** |
| | **−458 KB (22%)** | **−457 KB (23%)** |

Dropped:

- **Parser syntax plugins** — only `objectRestSpread`, `classProperties` and `typescript` are ever enabled, so flow, jsx, estree and v8intrinsic are stubbed. Flow alone is 70 KB.
- **The class-features barrel** — `plugin-transform-typescript` uses one export, `injectInitialization`, while the barrel eagerly requires the class fields and decorators transforms.
- **118 of 122 runtime helpers** — the bundled transforms name four: `classNameTDZError`, `interopRequireDefault`, `interopRequireWildcard`, `newArrowCheck`. None declare dependencies.
- **Flow and jsx printers and node definitions** — they describe syntax the pruned parser can no longer produce.
- **Generated `assertFoo` helpers and uppercase builder aliases** — neither the compiler nor any bundled babel package calls one.
- **The missing-plugin suggestion table** — a list of babel plugins this compiler does not bundle.

`placeholders` stays: `@babel/template` parses with it, so the TypeScript transform needs it for parameter properties and namespaces.

Each rewrite throws at build time if its registry stops matching the expected shape, so a Babel upgrade cannot quietly turn one into a no-op. That guard already earned its keep: the helper table turned out to be split across an object literal and an `Object.assign` top-up, and the check refused to proceed when it saw only part of it.

Verified against the built artifacts rather than the source. Compiling `.marko` files covering reactive state, TypeScript with parameter properties, imports, control flow and `<await>`, in both `html` and `dom`, produces **byte-identical output** to the unpruned build. Suite is 10302 passing.

This assumes the compiler is not a general-purpose Babel that user plugins extend, which is what makes the parser pruning safe for the node build too.