### PR TITLE
fix(compiler): restore babel modules the prune wrongly removed

### DIFF
--- a/.changeset/fix-overpruned-babel.md
+++ b/.changeset/fix-overpruned-babel.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Restore three Babel modules that the last release pruned but the compiler does reach. `@babel/generator`'s flow printer is borrowed by the class printer and owns `TypeParameterDeclaration`, so dropping it mangled unrelated output: an arrow IIFE lost its wrapping parentheses and emitted `}()`. The flow and jsx node definitions are needed because `helper-create-class-features-plugin` registers a `JSXIdentifier` visitor, which `@babel/traverse` rejects when the type is missing.

--- a/packages/compiler/scripts/bundle.mts
+++ b/packages/compiler/scripts/bundle.mts
@@ -148,17 +148,16 @@ const pruneHelpers = {
   },
 };
 
-// Modules nothing in the bundle can reach. The flow and jsx printers exist for
-// nodes the pruned parser can no longer produce, and the missing-plugin helper
-// is a table of suggestions naming babel plugins this compiler does not bundle.
+// Modules nothing in the bundle can reach. The jsx printer exists for nodes the
+// pruned parser cannot produce, and the missing-plugin helper is a table of
+// suggestions naming babel plugins this compiler does not bundle. The flow
+// printer is deliberately kept: `classes.js` borrows its variance helper and it
+// owns the `TypeParameterDeclaration` printer, so dropping it silently mangles
+// unrelated output.
 const EMPTY_MODULE =
   '"use strict";Object.defineProperty(exports,"__esModule",{value:true});';
 const DEAD_MODULES: Record<string, string> = {
-  "@babel/generator/lib/generators/flow.js": EMPTY_MODULE,
   "@babel/generator/lib/generators/jsx.js": EMPTY_MODULE,
-  // Node definitions for syntax the pruned parser cannot produce.
-  "@babel/types/lib/definitions/flow.js": EMPTY_MODULE,
-  "@babel/types/lib/definitions/jsx.js": EMPTY_MODULE,
   // `t.assertFoo()` and the uppercase `t.Foo()` builder aliases: neither the
   // compiler nor any bundled babel package calls one.
   "@babel/types/lib/asserts/generated/index.js": EMPTY_MODULE,


### PR DESCRIPTION
Three of the modules stubbed in 5.41.13 are reachable after all, and building markojs.com against it fails.

**`@babel/generator`'s flow printer.** `generators/classes.js` requires it for its variance helper, and it owns the `TypeParameterDeclaration` and `TypeParameterInstantiation` printers. Stubbing it did not throw — it silently mangled unrelated output, dropping the parentheses around an arrow IIFE so `(() => { ... })()` printed as `}()`, which then fails to parse downstream.

**The flow and jsx node definitions.** `helper-create-class-features-plugin` builds `getScopeInformationVisitor` with a `JSXIdentifier` key, and `@babel/traverse` throws for a visitor on a type it does not know: `You gave us a visitor for the node type JSXIdentifier but it's not a valid type`.

The other prunes stand. Sizes land at 2084 KB → 1662 KB for node and 1966 KB → 1545 KB for the browser, against 1626/1509 in the bad release.

Verified by building markojs.com against the fixed compiler, and by diffing compiled output for templates covering reactive state, TypeScript with parameter properties, imports, control flow and `<await>` in both `html` and `dom` — byte-identical to pre-prune. Suite is 10302 passing.

The suite did not catch either fault, which is the real gap: it never exercised a `.marko` file whose compiled output contains an arrow IIFE, and the `JSXIdentifier` visitor is only constructed on the `stripTypes` path. Worth adding a fixture for both.