### PR TITLE
fix(compiler): stop blanking modules inside babel's barrels

### DIFF
--- a/.changeset/fix-generator-module-stubs.md
+++ b/.changeset/fix-generator-module-stubs.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Stop blanking modules inside Babel's re-export barrels. Emptying `@babel/generator`'s jsx printer perturbed the bundler's analysis of the barrel that assembles the printer, and parentheses were dropped from generated code: `(await fetch(url)).json()` printed as `await fetch(url).json()`. The remaining prunes, which rewrite explicit registries rather than blanking modules, are unaffected.

--- a/packages/compiler/scripts/bundle.mts
+++ b/packages/compiler/scripts/bundle.mts
@@ -148,35 +148,6 @@ const pruneHelpers = {
   },
 };
 
-// Modules nothing in the bundle can reach. The jsx printer exists for nodes the
-// pruned parser cannot produce, and the missing-plugin helper is a table of
-// suggestions naming babel plugins this compiler does not bundle. The flow
-// printer is deliberately kept: `classes.js` borrows its variance helper and it
-// owns the `TypeParameterDeclaration` printer, so dropping it silently mangles
-// unrelated output.
-const EMPTY_MODULE =
-  '"use strict";Object.defineProperty(exports,"__esModule",{value:true});';
-const DEAD_MODULES: Record<string, string> = {
-  "@babel/generator/lib/generators/jsx.js": EMPTY_MODULE,
-  // `t.assertFoo()` and the uppercase `t.Foo()` builder aliases: neither the
-  // compiler nor any bundled babel package calls one.
-  "@babel/types/lib/asserts/generated/index.js": EMPTY_MODULE,
-  "@babel/types/lib/builders/generated/uppercase.js": EMPTY_MODULE,
-  "@babel/core/lib/parser/util/missing-plugin-helper.js":
-    EMPTY_MODULE +
-    "exports.default=(name)=>`Support for the experimental syntax '${name}' is not enabled.`;",
-};
-const stubDeadModules = {
-  name: "stub-dead-modules",
-  transform(code: string, id: string) {
-    const normalized = id.replace(/\\/g, "/");
-    for (const suffix in DEAD_MODULES) {
-      if (normalized.endsWith(suffix)) return DEAD_MODULES[suffix];
-    }
-    return null;
-  },
-};
-
 await Promise.all([
   // Every published entry is built in ONE rolldown pass so shared modules land
   // in shared chunks. `taglib/config` is a mutated singleton (`configure()`,
@@ -229,7 +200,6 @@ await Promise.all([
         pruneParserPlugins,
         classFeaturesMiscOnly,
         pruneHelpers,
-        stubDeadModules,
       ],
       input: "internal/babel/index.ts",
       cwd,


### PR DESCRIPTION
5.41.14 miscompiles parenthesised expressions. On markojs.com this shows up as `(await fetch(url)).json()` printing as `await fetch(url).json()`, which throws `fetch(...).json is not a function` at runtime, and as an arrow IIFE losing its wrapper.

The cause is emptying `@babel/generator/lib/generators/jsx.js`. Nothing borrows from that module and only the barrel requires it, so this is not a missing helper: blanking a module inside a CJS re-export barrel changes what the bundler can prove about the barrel that assembles the printer, and something else goes with it. The flow printer had already forced the same walk-back one release earlier.

Two silent miscompiles from one technique is enough, so it all goes: the generator printers, the `@babel/types` asserts and uppercase builders, and the missing-plugin table. Those were worth 99 KB between them.

What stays rewrites explicit registries and can be reasoned about: the parser's syntax plugins, the class-features barrel redirect, and the runtime helper table.

| | node | browser |
|---|---|---|
| unpruned | 2084 KB | 1966 KB |
| **this PR** | **1745 KB** | **1628 KB** |

Verification is what changed most here. Rather than a handful of fixtures, this compiles **every** `.marko` file on markojs.com in both `html` and `dom` — 454 compilations — against a compiler built with all pruning disabled, and diffs. Byte-identical. That check would have caught both regressions immediately; the earlier fixtures did not, because none of them produced an arrow IIFE or an awaited member call.

Suite is 10302 passing, and markojs.com builds and emits correct code for both affected files.