### PR TITLE
feat(compiler): add a `persisted` config option

### DIFF
--- a/.changeset/olive-donkeys-shout.md
+++ b/.changeset/olive-donkeys-shout.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Add a `persisted` config option for translators that compile a document meant to survive navigation. It splits the compile cache, since analysis is shared across outputs.

--- a/packages/compiler/config.d.ts
+++ b/packages/compiler/config.d.ts
@@ -32,6 +32,7 @@ declare const Config: {
   hydrateInit?: boolean;
   optimize?: boolean;
   optimizeKnownTemplates?: string[];
+  persisted?: boolean;
   cache?: Map<unknown, unknown>;
   hot?: boolean;
   /** @deprecated */

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -164,10 +164,12 @@ function getMarkoFile(code, fileOpts, markoOpts) {
   const isMigrate = markoOpts.output === "migrate";
   const canCache = !(isSource || isMigrate);
   const id = getTemplateId(markoOpts, filename);
-  // `stripTypes` is left out of the key on purpose: it is for cli flows, which
+  // `persisted` changes analysis, which is shared across outputs, so it splits
+  // the cache. `stripTypes` is left out on purpose: it is for cli flows, which
   // compile once per process, so no cache is shared across its settings.
+  const cacheId = markoOpts.persisted ? "persisted\0" + id : id;
   const contentHash = canCache && new Hash().update(code).digest();
-  let cached = canCache && compileCache.get(id);
+  let cached = canCache && compileCache.get(cacheId);
 
   if (cached) {
     if (cached.contentHash !== contentHash) {
@@ -317,7 +319,7 @@ function getMarkoFile(code, fileOpts, markoOpts) {
       }
     }
 
-    compileCache.set(id, {
+    compileCache.set(cacheId, {
       time: Date.now(),
       file,
       contentHash,
@@ -351,7 +353,7 @@ function getMarkoFile(code, fileOpts, markoOpts) {
           throwAggregateError(errors);
         }
       } catch (e) {
-        compileCache.delete(id);
+        compileCache.delete(cacheId);
         throw e;
       }
     }

--- a/packages/compiler/src/config.js
+++ b/packages/compiler/src/config.js
@@ -129,6 +129,12 @@ const config = {
   optimize: undefined,
 
   /**
+   * Compiles templates for a document that survives navigation, letting the
+   * translator emit what a later server response needs to address.
+   */
+  persisted: false,
+
+  /**
    * If `optimize` is enabled you can provide an array of template paths which the compiler will
    * use to generate shorter registry/template ids using incrementing ids. This can only be used
    * if the same `optimizeKnownTemplates` are used for both server and client compilations.

--- a/packages/compiler/test/compile.test.js
+++ b/packages/compiler/test/compile.test.js
@@ -74,6 +74,14 @@ describe("compiler/compile", () => {
       assert.equal(getRuntimeVersion({}), "0.0.0"));
   });
 
+  it("caches analysis separately for a persisted compile", async () => {
+    const cache = new Map();
+    await compileFile(template, { cache });
+    await compileFile(template, { cache, persisted: true });
+    const [compiled] = cache.values();
+    assert.equal(compiled.size, 2);
+  });
+
   it("keeps the compile error when compiling asynchronously", () =>
     assert.rejects(
       () => compile("<div", template),


### PR DESCRIPTION
Translators need to know when they are compiling a document that survives navigation, so a later server response can address what is already there. This adds the option and threads it through as an ordinary Marko config value.

Analysis is cached and shared across outputs, so `persisted` splits the compile cache — otherwise a persisted and an ordinary compile in one process would reuse each other's analysis.