### PR TITLE
feat(runtime-tags): keep persisted documents addressable

### DIFF
--- a/.changeset/lucky-pears-jam.md
+++ b/.changeset/lucky-pears-jam.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Under the compiler's `persisted` option, keep scopes, branch markers, node markers and placeholder separators unconditional, so the document stays addressable even where this render serializes no value.

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/html.bundle.persisted.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/html.bundle.persisted.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clickCount = 0;
+	_html(`<div><button>${_escape(clickCount)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}</div>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: clickCount });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/render.persisted.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/render.persisted.md
@@ -1,0 +1,56 @@
+# Render
+```html
+<div>
+  <button>
+    0
+  </button>
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    1
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: div > button::text "0" => "1"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    2
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: div > button::text "1" => "2"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div>
+  <button>
+    3
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: div > button::text "2" => "3"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/writes.persisted.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/__snapshots__/writes.persisted.html
@@ -1,0 +1,8 @@
+<div><button>0<!--M_*1 b--></button><!--M_*1 a--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.persisted.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.persisted.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2604,
+      "brotli": 1318
+    }
+  },
+  "html": {
+    "min": 363,
+    "brotli": 253
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/test.ts
@@ -5,5 +5,6 @@ function click(document: Document) {
 }
 
 export const config: TestConfig = {
+  persisted: true,
   steps: [{}, click, click, click],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+const $template = "<div class=wrap><h1>Hello <!></h1><!><!></div>";
+const $walks = "Eb%l%b%l";
+const $setup = () => {};
+const $for_content__item = ($scope, item) => _text($scope["#text/0"], item);
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $input_name = ($scope, input_name) => _text($scope["#text/0"], input_name);
+const $if = /*@__PURE__*/ _if("#text/1", "<p>shown</p>");
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $for = /*@__PURE__*/ _for_of("#text/2", "<li> </li>", "D ", 0, $for_content__$params);
+const $input_items = ($scope, input_items) => $for($scope, [input_items]);
+const $input = ($scope, input) => {
+	$input_name($scope, input.name);
+	$input_show($scope, input.show);
+	$input_items($scope, input.items);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 1), $sg__input_show = _serialize_guard($scope0_reason, 2), $sg__input_items = _serialize_guard($scope0_reason, 3);
+	const $scope0_id = _scope_id();
+	_html(`<div class=wrap><h1>Hello ${_sep($sg__input_name)}${_escape(input.name)}${_el_resume($scope0_id, "#text/0", $sg__input_name)}</h1>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html("<p>shown</p>");
+			_serialize_if($scope0_reason, 2) && writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
+			return 0;
+		}
+	}, $scope0_id, "#text/1", $sg__input_show, $sg__input_show, $sg__input_show, 0, 1);
+	_for_of(input.items, (item) => {
+		const $scope2_id = _scope_id();
+		_html(`<li>${_escape(item)}${_el_resume($scope2_id, "#text/0", $sg__input_items)}</li>`);
+		_serialize_if($scope0_reason, 3) && writeScope($scope2_id, {}, "__tests__/template.marko", "6:4");
+	}, 0, $scope0_id, "#text/2", $sg__input_items, $sg__input_items, $sg__input_items, 0, 1);
+	_html("</div>");
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 1), $sg__input_show = _serialize_guard($scope0_reason, 2), $sg__input_items = _serialize_guard($scope0_reason, 3);
+	const $scope0_id = _scope_id();
+	_html(`<div class=wrap><h1>Hello ${_sep($sg__input_name)}${_escape(input.name)}${_el_resume($scope0_id, "a", $sg__input_name)}</h1>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html("<p>shown</p>");
+			_serialize_if($scope0_reason, 2) && writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "b", $sg__input_show, $sg__input_show, $sg__input_show, 0, 1);
+	_for_of(input.items, (item) => {
+		const $scope2_id = _scope_id();
+		_html(`<li>${_escape(item)}${_el_resume($scope2_id, "a", $sg__input_items)}</li>`);
+		_serialize_if($scope0_reason, 3) && writeScope($scope2_id, {});
+	}, 0, $scope0_id, "c", $sg__input_items, $sg__input_items, $sg__input_items, 0, 1);
+	_html("</div>");
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.persisted.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.persisted.js
@@ -1,0 +1,21 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div class=wrap><h1>Hello <!>${_escape(input.name)}${_el_resume($scope0_id, "a")}</h1>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html("<p>shown</p>");
+			writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "b", 1, 1, _serialize_guard($scope0_reason, 1), 0, 1);
+	_for_of(input.items, (item) => {
+		const $scope2_id = _scope_id();
+		_html(`<li>${_escape(item)}${_el_resume($scope2_id, "a")}</li>`);
+		writeScope($scope2_id, {});
+	}, 0, $scope0_id, "c", 1, 1, _serialize_guard($scope0_reason, 2), 0, 1);
+	_html("</div>");
+	writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.debug.md
@@ -1,0 +1,19 @@
+# Render `{"name":"world","show":true,"items":[1,2]}`
+```html
+<div
+  class="wrap"
+>
+  <h1>
+    Hello world
+  </h1>
+  <p>
+    shown
+  </p>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.md
@@ -1,0 +1,19 @@
+# Render `{"name":"world","show":true,"items":[1,2]}`
+```html
+<div
+  class="wrap"
+>
+  <h1>
+    Hello world
+  </h1>
+  <p>
+    shown
+  </p>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.persisted.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/render.persisted.md
@@ -1,0 +1,19 @@
+# Render `{"name":"world","show":true,"items":[1,2]}`
+```html
+<div
+  class="wrap"
+>
+  <h1>
+    Hello world
+  </h1>
+  <p>
+    shown
+  </p>
+  <li>
+    1
+  </li>
+  <li>
+    2
+  </li>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.debug.html
@@ -1,0 +1,6 @@
+<div class=wrap>
+  <h1>Hello world</h1>
+  <p>shown</p>
+  <li>1</li>
+  <li>2</li>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.html
@@ -1,0 +1,6 @@
+<div class=wrap>
+  <h1>Hello world</h1>
+  <p>shown</p>
+  <li>1</li>
+  <li>2</li>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.persisted.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/writes.persisted.html
@@ -1,0 +1,9 @@
+<div class=wrap>
+  <h1>Hello <!>world<!--M_*1 a--></h1>
+  <p>shown</p><!--M_|1 b 2-->
+  <li>1<!--M_*3 a--></li>
+  <li>2<!--M_*4 a--></li><!--M_|1 c 4 3-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_")
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 74,
+    "brotli": 72
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.persisted.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.persisted.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 375,
+      "brotli": 249
+    }
+  },
+  "html": {
+    "min": 420,
+    "brotli": 297
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/template.marko
@@ -1,0 +1,9 @@
+<div class="wrap">
+  <h1>Hello ${input.name}</h1>
+  <if=input.show>
+    <p>shown</p>
+  </if>
+  <for|item| of=input.items>
+    <li>${item}</li>
+  </for>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/test.ts
@@ -1,0 +1,6 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  persisted: true,
+  steps: [{ name: "world", show: true, items: [1, 2] }],
+};

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -69,6 +69,8 @@ export type TestConfig = {
   fix_guide?: boolean;
   /** Compiles the fixture with a custom `runtimeId` compiler option. */
   runtime_id?: string;
+  /** Also compiles the fixture with the `persisted` compiler option. */
+  persisted?: boolean;
 };
 
 // `scripts/test-parallel` fans the fixtures across CPU cores by giving each
@@ -82,6 +84,19 @@ const slots = process.env.MARKO_TEST_SLOTS
   : null;
 function inShard(index: number) {
   return slots === null || slots.has(index % slotTotal);
+}
+
+type Mode = "debug" | "optimize" | "persisted";
+
+const MODE_SUFFIX: Record<Mode, string> = {
+  debug: ".debug",
+  optimize: "",
+  persisted: ".persisted",
+};
+
+function withModeSuffix(file: string, mode: Mode) {
+  const suffix = MODE_SUFFIX[mode];
+  return suffix ? file.replace(/(\.[^.]+)$/, `${suffix}$1`) : file;
 }
 
 function noop() {}
@@ -140,11 +155,16 @@ function testFixtures(interop?: true) {
         return;
       }
 
+      const domBundles: Partial<Record<Mode, string>> = {};
+
       for (const mode of config.skip_optimize
-        ? ["debug"]
-        : (["debug", "optimize"] as const)) {
+        ? (["debug"] as const)
+        : config.persisted
+          ? (["debug", "optimize", "persisted"] as const)
+          : (["debug", "optimize"] as const)) {
         describe(mode, () => {
-          const optimize = mode === "optimize";
+          const optimize = mode !== "debug";
+          const persisted = mode === "persisted";
           const equivalent = config.equivalent !== false;
           const skipSSR =
             hasCompilerError || skipDOM || skipHTML || config.skip_ssr;
@@ -189,6 +209,7 @@ function testFixtures(interop?: true) {
                 browserslistConfigFile: false,
               },
               optimize,
+              persisted,
               optimizeKnownTemplates: optimize
                 ? (
                     fs.readdirSync(fixtureDir, {
@@ -221,14 +242,9 @@ function testFixtures(interop?: true) {
             return snap(
               fn,
               fixtureDir,
-              optimize
-                ? resolvedFile
-                : resolvedFile.replace(/(\.[^.]+)$/, ".debug$1"),
+              withModeSuffix(resolvedFile, mode),
               expectErr,
-              actualFile &&
-                (optimize
-                  ? actualFile
-                  : actualFile.replace(/(\.[^.]+)$/, ".debug$1")),
+              actualFile && withModeSuffix(actualFile, mode),
             );
           };
 
@@ -262,11 +278,26 @@ function testFixtures(interop?: true) {
               return;
             }
 
+            if (output === "dom" && persisted) {
+              // No revival: a persisted build must not bundle code an ordinary
+              // build tree-shakes, so its client output cannot differ at all.
+              const { snapshot, sizes } = await (await ssrRunner()).domBundle();
+              if (sizes) stats.dom = sizes;
+              assert.strictEqual(
+                await stripFixtureDir(snapshot),
+                domBundles.optimize,
+                "persisted dom output must match the ordinary build",
+              );
+              return;
+            }
+
             await snapMode(async () => {
               const runner = await ssrRunner();
               const { snapshot, sizes } = await runner[`${output}Bundle`]();
               if (optimize && sizes) stats.dom = sizes;
-              return stripFixtureDir(snapshot);
+              const stripped = await stripFixtureDir(snapshot);
+              if (output === "dom") domBundles[mode] = stripped;
+              return stripped;
             }, `${output}.bundle.js`);
           };
 
@@ -400,7 +431,10 @@ function testFixtures(interop?: true) {
           optimize &&
             !hasCompilerError &&
             after(() => {
-              const sizesFile = path.join(fixtureDir, "sizes.json");
+              const sizesFile = path.join(
+                fixtureDir,
+                persisted ? "sizes.persisted.json" : "sizes.json",
+              );
               const actual = JSON.stringify(stats, null, 2) + "\n";
               // Assert instead of rewriting: a --grep test:update refreshes only
               // matched fixtures, so a silent rewrite would bury stale sizes.

--- a/packages/runtime-tags/src/translator/util/marko-config.ts
+++ b/packages/runtime-tags/src/translator/util/marko-config.ts
@@ -17,6 +17,10 @@ export function isOptimize() {
   return getMarkoOpts().optimize;
 }
 
+export function isPersisted() {
+  return getMarkoOpts().persisted === true;
+}
+
 export function getReadyId(file: t.BabelFile = getFile()) {
   const { markoOpts } = file;
   if (!markoOpts.linkAssets) return undefined;

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -14,7 +14,7 @@ import { getExprRoot, getFnParent, getFnRoot, getMarkoRoot } from "./get-root";
 import { isEventOrChangeHandler } from "./is-event-or-change-handler";
 import isInvokedFunction from "./is-invoked-function";
 import { finalizeKnownTags } from "./known-tag";
-import { isOptimize, isOutputDOM } from "./marko-config";
+import { isOptimize, isOutputDOM, isPersisted } from "./marko-config";
 import {
   addSorted,
   concat,
@@ -1120,9 +1120,15 @@ export function finalizeReferences() {
     ) {
       addSerializeReason(
         section,
-        !!(section.isHoistThrough || section.hoisted) ||
+        isPersisted() ||
+          !!(section.isHoistThrough || section.hoisted) ||
           getSerializeSourcesForRef(getDirectClosures(section)),
         kBranchSerializeReason,
+      );
+      addSerializeReason(
+        section.parent,
+        isPersisted(),
+        section.sectionAccessor.binding,
       );
       addSerializeExpr(
         section,
@@ -1283,8 +1289,12 @@ export function finalizeReferences() {
   }
 
   forEachSection(finalizeParamSerializeReasonGroups);
+  const persisted = isPersisted();
   forEachSectionReverse((section) => {
     finalizeKnownTags(section);
+    // Spine: a persisted document must stay addressable by a later patch, which
+    // is a separate decision from whether this render serializes any value.
+    if (persisted) addSerializeReason(section, true);
     finalizeSerializeReason(section);
     // TODO: this duplication is needed when a known tag is circular. We should find a better way.
     finalizeParamSerializeReasonGroups(section);

--- a/packages/runtime-tags/src/translator/util/writer.ts
+++ b/packages/runtime-tags/src/translator/util/writer.ts
@@ -7,7 +7,7 @@ import {
   type Section,
 } from "../util/sections";
 import { generateUidIdentifier } from "./generate-uid";
-import { isOutputHTML } from "./marko-config";
+import { isOutputHTML, isPersisted } from "./marko-config";
 import normalizeStringExpression, {
   appendLiteral,
 } from "./normalize-string-expression";
@@ -152,6 +152,9 @@ export function markNode(
   }
 
   if (isOutputHTML()) {
+    // Spine: a persisted document marks every markable node so a later patch
+    // can address it, even when this render serializes no value for it.
+    if (isPersisted()) reason = true;
     if (reason) {
       const section = getSection(path);
       // Deferred markers ride the stream trailer alongside a deferred end tag

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -6,7 +6,7 @@ import { injectTextCoercion, kRawText } from "../util/body-to-text-literal";
 import evaluate from "../util/evaluate";
 import { isCoreTagName } from "../util/is-core-tag";
 import { isNonHTMLText } from "../util/is-non-html-text";
-import { isOutputHTML } from "../util/marko-config";
+import { isOutputHTML, isPersisted } from "../util/marko-config";
 import normalizeStringExpression from "../util/normalize-string-expression";
 import {
   type Binding,
@@ -238,7 +238,7 @@ function writeSeparator(
   section: Section,
   reason: Exclude<ReturnType<typeof getSerializeReason>, undefined | false>,
 ) {
-  if (reason === true || reason.state) {
+  if (isPersisted() || reason === true || reason.state) {
     write`<!>`;
   } else {
     write`${callRuntime("_sep", getSerializeGuard(section, reason, true))}`;


### PR DESCRIPTION
Stacked on #3695.

Structure and value are two different questions. With the compiler's `persisted` option, a section's scope, its branch marker, node markers and the placeholder separator are emitted unconditionally — the document stays addressable — while what a render actually serializes is unchanged.

Client output must not move at all, so the fixture harness gains a `persisted` mode that asserts the dom bundle is byte-identical to the ordinary build and snapshots the html/SSR side separately. A fully stateful fixture (`basic-counter`) comes out identical either way; the cost lands only where server structure was previously disposable.