### PR TITLE
docs(runtime-tags): note why resumed closure subscribers register no unsubscribe

### DIFF
--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -268,6 +268,8 @@ export function subscribeToScopeSet(
   scope: Scope,
 ) {
   const subscribers = (ownerScope[accessor] ||= new Set()) as Set<Scope>;
+  // Resume adopts the server's set already holding its subscribers, so those
+  // register no unsubscribe: bounded, and `_closure` skips destroyed scopes.
   if (!subscribers.has(scope)) {
     subscribers.add(scope);
     $signal(scope, -1).addEventListener("abort", () =>


### PR DESCRIPTION
A scope adopted from a server render is already in the owner's subscriber set, so `subscribeToScopeSet`'s guard skips it and no unsubscribe is registered — destroying it leaves it in the set until the owner goes.

That reads like a leak and isn't worth fixing: it is one scope per initial-render subscriber and does not grow (client-side subscriptions are recorded and removed), and it is behaviourally inert because `_closure` skips scopes whose `Gen` is 0. Two lines at the guard so it doesn't get re-diagnosed.