### PR TITLE
perf(runtime-tags): hold a lone child branch without a Set

### DIFF
--- a/.changeset/lucky-hounds-clap.md
+++ b/.changeset/lucky-hounds-clap.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Hold a branch's lone child directly instead of allocating a `Set` for it, cutting the cost of building and tearing down keyed lists.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26624,
-        "brotli": 9899
+        "min": 26706,
+        "brotli": 9933
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 119
       },
       "runtime": {
-        "min": 3995,
-        "brotli": 1757
+        "min": 4077,
+        "brotli": 1797
       },
       "total": {
-        "min": 4156,
-        "brotli": 1876
+        "min": 4238,
+        "brotli": 1916
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6521,
-        "brotli": 2867
+        "min": 6603,
+        "brotli": 2897
       },
       "total": {
-        "min": 7166,
-        "brotli": 3231
+        "min": 7248,
+        "brotli": 3261
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6521 (min) 2867 (brotli)
+// size: 6603 (min) 2897 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -6,7 +6,9 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   parsers = {},
   nextScopeId = 1e6,
   destroyNestedScopes = function destroyNestedScopes(scope) {
-    ((scope.H = 0), scope.D?.forEach(destroyNestedScopes), scope.B?.forEach(cleanupScope));
+    ((scope.H = 0),
+      scope.D && (scope.D.$ ? destroyNestedScopes(scope.D) : scope.D.forEach(destroyNestedScopes)),
+      scope.B?.forEach(cleanupScope));
   },
   isScheduled,
   channel,
@@ -107,7 +109,9 @@ function skipScope() {
   return nextScopeId++;
 }
 function destroyBranch(branch) {
-  (branch.N?.D?.delete(branch), destroyNestedScopes(branch));
+  let parent = branch.N;
+  (parent?.D && (parent.D.$ ? parent.D === branch && (parent.D = void 0) : parent.D.delete(branch)),
+    destroyNestedScopes(branch));
 }
 function cleanupScope(scope) {
   scope.Z?.forEach(unsubscribe, scope);
@@ -216,7 +220,12 @@ function createBranch($global, renderer, parentScope, parentNode) {
 }
 function setParentBranch(branch, parentBranch) {
   (parentBranch &&
-    ((branch.N = parentBranch), (parentBranch.D ||= /* @__PURE__ */ new Set()).add(branch)),
+    ((branch.N = parentBranch),
+    (parentBranch.D = parentBranch.D
+      ? parentBranch.D.$
+        ? /* @__PURE__ */ new Set([parentBranch.D, branch])
+        : parentBranch.D.add(branch)
+      : branch)),
     (branch.F = branch));
 }
 function createAndSetupBranch($global, renderer, parentScope, parentNode) {

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 3995 (min) 1757 (brotli)
+// size: 4077 (min) 1797 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -6,7 +6,9 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   parsers = {},
   nextScopeId = 1e6,
   destroyNestedScopes = function destroyNestedScopes(scope) {
-    ((scope.H = 0), scope.D?.forEach(destroyNestedScopes), scope.B?.forEach(cleanupScope));
+    ((scope.H = 0),
+      scope.D && (scope.D.$ ? destroyNestedScopes(scope.D) : scope.D.forEach(destroyNestedScopes)),
+      scope.B?.forEach(cleanupScope));
   },
   isScheduled,
   channel,
@@ -89,7 +91,9 @@ function skipScope() {
   return nextScopeId++;
 }
 function destroyBranch(branch) {
-  (branch.N?.D?.delete(branch), destroyNestedScopes(branch));
+  let parent = branch.N;
+  (parent?.D && (parent.D.$ ? parent.D === branch && (parent.D = void 0) : parent.D.delete(branch)),
+    destroyNestedScopes(branch));
 }
 function cleanupScope(scope) {
   scope.Z?.forEach(unsubscribe, scope);
@@ -151,7 +155,12 @@ function createBranch($global, renderer, parentScope, parentNode) {
 }
 function setParentBranch(branch, parentBranch) {
   (parentBranch &&
-    ((branch.N = parentBranch), (parentBranch.D ||= /* @__PURE__ */ new Set()).add(branch)),
+    ((branch.N = parentBranch),
+    (parentBranch.D = parentBranch.D
+      ? parentBranch.D.$
+        ? /* @__PURE__ */ new Set([parentBranch.D, branch])
+        : parentBranch.D.add(branch)
+      : branch)),
     (branch.F = branch));
 }
 function _content(id, template, walks, setup, params, dynamicScopesAccessor) {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26624 (min) 9899 (brotli)
+// size: 26706 (min) 9933 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -26,7 +26,9 @@ let empty = [],
   nextScopeId = 1e6,
   collectingScopes,
   destroyNestedScopes = function destroyNestedScopes(scope) {
-    ((scope.H = 0), scope.D?.forEach(destroyNestedScopes), scope.B?.forEach(cleanupScope));
+    ((scope.H = 0),
+      scope.D && (scope.D.$ ? destroyNestedScopes(scope.D) : scope.D.forEach(destroyNestedScopes)),
+      scope.B?.forEach(cleanupScope));
   },
   isScheduled,
   channel,
@@ -417,7 +419,9 @@ function findBranchWithKey(scope, key) {
   return branch;
 }
 function destroyBranch(branch) {
-  (branch.N?.D?.delete(branch), destroyNestedScopes(branch));
+  let parent = branch.N;
+  (parent?.D && (parent.D.$ ? parent.D === branch && (parent.D = void 0) : parent.D.delete(branch)),
+    destroyNestedScopes(branch));
 }
 function destroyScope(scope) {
   scope.H && (destroyNestedScopes(scope), cleanupScope(scope));
@@ -941,7 +945,12 @@ function createBranch($global, renderer, parentScope, parentNode) {
 }
 function setParentBranch(branch, parentBranch) {
   (parentBranch &&
-    ((branch.N = parentBranch), (parentBranch.D ||= /* @__PURE__ */ new Set()).add(branch)),
+    ((branch.N = parentBranch),
+    (parentBranch.D = parentBranch.D
+      ? parentBranch.D.$
+        ? /* @__PURE__ */ new Set([parentBranch.D, branch])
+        : parentBranch.D.add(branch)
+      : branch)),
     (branch.F = branch));
 }
 function createAndSetupBranch($global, renderer, parentScope, parentNode) {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62523,
-        "brotli": 19264
+        "min": 62605,
+        "brotli": 19387
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63771,
-        "brotli": 19846
+        "min": 63853,
+        "brotli": 19845
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63654,
-        "brotli": 19824
+        "min": 63736,
+        "brotli": 19856
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62523,
-        "brotli": 19264
+        "min": 62605,
+        "brotli": 19387
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63809,
-        "brotli": 19849
+        "min": 63891,
+        "brotli": 19898
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62421,
-        "brotli": 19228
+        "min": 62503,
+        "brotli": 19308
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62462,
-        "brotli": 19233
+        "min": 62544,
+        "brotli": 19279
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63758,
-        "brotli": 19808
+        "min": 63840,
+        "brotli": 19862
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63877,
-        "brotli": 19849
+        "min": 63959,
+        "brotli": 19918
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62577,
-        "brotli": 19321
+        "min": 62659,
+        "brotli": 19381
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64067,
-        "brotli": 20002
+        "min": 64149,
+        "brotli": 20056
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65343,
-        "brotli": 20251
+        "min": 65425,
+        "brotli": 20331
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63703,
-        "brotli": 19856
+        "min": 63785,
+        "brotli": 19852
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63985,
-        "brotli": 19912
+        "min": 64067,
+        "brotli": 19964
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63771,
-        "brotli": 19846
+        "min": 63853,
+        "brotli": 19887
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62828,
-        "brotli": 19419
+        "min": 62910,
+        "brotli": 19479
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62500,
-        "brotli": 19276
+        "min": 62582,
+        "brotli": 19351
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64205,
-        "brotli": 20033
+        "min": 64287,
+        "brotli": 20062
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63714,
-        "brotli": 19810
+        "min": 63796,
+        "brotli": 19855
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63383,
-        "brotli": 19710
+        "min": 63465,
+        "brotli": 19708
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63875,
-        "brotli": 19914
+        "min": 63957,
+        "brotli": 19925
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63485,
-        "brotli": 19687
+        "min": 63567,
+        "brotli": 19737
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62885,
-        "brotli": 19473
+        "min": 62967,
+        "brotli": 19556
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64576,
-        "brotli": 20186
+        "min": 64658,
+        "brotli": 20278
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5992,
-      "brotli": 2739
+      "min": 6074,
+      "brotli": 2768
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7490,
-      "brotli": 3281
+      "min": 7572,
+      "brotli": 3307
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6240,
-      "brotli": 2825
+      "min": 6322,
+      "brotli": 2852
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8882,
-      "brotli": 3851
+      "min": 8964,
+      "brotli": 3886
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8860,
-        "brotli": 3834
+        "min": 8942,
+        "brotli": 3862
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9921,
-        "brotli": 4292
+        "min": 10003,
+        "brotli": 4329
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7261,
-        "brotli": 3300
+        "min": 7343,
+        "brotli": 3359
       },
       "files": {
         "tags/child/index.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10182,
-      "brotli": 4337
+      "min": 10264,
+      "brotli": 4373
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6803,
-      "brotli": 3079
+      "min": 6885,
+      "brotli": 3117
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6276,
-      "brotli": 2869
+      "min": 6358,
+      "brotli": 2895
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6967,
-      "brotli": 3156
+      "min": 7049,
+      "brotli": 3189
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7056,
-      "brotli": 3179
+      "min": 7138,
+      "brotli": 3216
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7101,
-      "brotli": 3187
+      "min": 7183,
+      "brotli": 3222
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7562,
-      "brotli": 3369
+      "min": 7644,
+      "brotli": 3404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7159,
-      "brotli": 3191
+      "min": 7241,
+      "brotli": 3223
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9085,
-      "brotli": 3899
+      "min": 9167,
+      "brotli": 3931
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7109,
-      "brotli": 3154
+      "min": 7191,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7159,
-      "brotli": 3191
+      "min": 7241,
+      "brotli": 3223
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8869,
-      "brotli": 3836
+      "min": 8951,
+      "brotli": 3868
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8871,
-      "brotli": 3837
+      "min": 8953,
+      "brotli": 3869
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6285,
-      "brotli": 2852
+      "min": 6367,
+      "brotli": 2887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6283,
-      "brotli": 2852
+      "min": 6365,
+      "brotli": 2884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6352,
-      "brotli": 2873
+      "min": 6434,
+      "brotli": 2905
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7632,
-        "brotli": 3493
+        "min": 7714,
+        "brotli": 3520
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9437,
-        "brotli": 4078
+        "min": 9519,
+        "brotli": 4113
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6367,
-      "brotli": 2898
+      "min": 6449,
+      "brotli": 2933
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7169,
-      "brotli": 3265
+      "min": 7251,
+      "brotli": 3296
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7432,
-      "brotli": 3353
+      "min": 7514,
+      "brotli": 3402
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6254,
-      "brotli": 2850
+      "min": 6336,
+      "brotli": 2890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7180,
-      "brotli": 3240
+      "min": 7262,
+      "brotli": 3277
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7137,
-      "brotli": 3224
+      "min": 7219,
+      "brotli": 3258
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7137,
-      "brotli": 3224
+      "min": 7219,
+      "brotli": 3258
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7157,
-      "brotli": 3229
+      "min": 7239,
+      "brotli": 3269
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6922,
-      "brotli": 3119
+      "min": 7004,
+      "brotli": 3155
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7924,
-        "brotli": 3602
+        "min": 8006,
+        "brotli": 3655
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7681,
-        "brotli": 3393
+        "min": 7763,
+        "brotli": 3429
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6268,
-      "brotli": 2845
+      "min": 6350,
+      "brotli": 2882
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6451,
-        "brotli": 2922
+        "min": 6533,
+        "brotli": 2957
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8346,
-        "brotli": 3764
+        "min": 8428,
+        "brotli": 3801
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7874,
-        "brotli": 3584
+        "min": 7956,
+        "brotli": 3631
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7615,
-        "brotli": 3376
+        "min": 7697,
+        "brotli": 3413
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6250,
-      "brotli": 2832
+      "min": 6332,
+      "brotli": 2872
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6433,
-        "brotli": 2907
+        "min": 6515,
+        "brotli": 2949
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6282,
-      "brotli": 2846
+      "min": 6364,
+      "brotli": 2881
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11020,
-        "brotli": 4765
+        "min": 11102,
+        "brotli": 4803
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5990,
-      "brotli": 2744
+      "min": 6072,
+      "brotli": 2771
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8551,
-      "brotli": 3799
+      "min": 8633,
+      "brotli": 3831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6335,
-        "brotli": 2740
+        "min": 6417,
+        "brotli": 2781
       },
       "files": {
         "tags/my-dialog.marko": 293,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8394,
-      "brotli": 3628
+      "min": 8476,
+      "brotli": 3662
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14269,
-      "brotli": 5550
+      "min": 14351,
+      "brotli": 5584
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13826,
-      "brotli": 5349
+      "min": 13908,
+      "brotli": 5386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13700,
-      "brotli": 5298
+      "min": 13782,
+      "brotli": 5333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13986,
-      "brotli": 5402
+      "min": 14068,
+      "brotli": 5440
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9153,
-      "brotli": 3957
+      "min": 9235,
+      "brotli": 3986
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9378,
-      "brotli": 4033
+      "min": 9460,
+      "brotli": 4081
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8977,
-        "brotli": 3652
+        "min": 9059,
+        "brotli": 3688
       },
       "files": {
         "tags/my-select.marko": 297,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8991,
-        "brotli": 3885
+        "min": 9073,
+        "brotli": 3916
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8976,
-        "brotli": 3868
+        "min": 9058,
+        "brotli": 3909
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8904,
-        "brotli": 3844
+        "min": 8986,
+        "brotli": 3885
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6403,
-      "brotli": 2908
+      "min": 6485,
+      "brotli": 2944
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8806,
-        "brotli": 3789
+        "min": 8888,
+        "brotli": 3821
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6669,
-      "brotli": 3032
+      "min": 6751,
+      "brotli": 3070
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6335,
-      "brotli": 2899
+      "min": 6417,
+      "brotli": 2930
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7461,
-        "brotli": 3390
+        "min": 7543,
+        "brotli": 3441
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6177,
-      "brotli": 2797
+      "min": 6259,
+      "brotli": 2837
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5771,
-      "brotli": 2687
+      "min": 5853,
+      "brotli": 2721
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5918,
-      "brotli": 2645
+      "min": 6000,
+      "brotli": 2683
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8749,
-      "brotli": 3782
+      "min": 8831,
+      "brotli": 3813
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8636,
-      "brotli": 3731
+      "min": 8718,
+      "brotli": 3768
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9546,
-        "brotli": 4074
+        "min": 9628,
+        "brotli": 4106
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9625,
-        "brotli": 4086
+        "min": 9707,
+        "brotli": 4132
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9438,
-        "brotli": 4026
+        "min": 9520,
+        "brotli": 4060
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6396,
-        "brotli": 2902
+        "min": 6478,
+        "brotli": 2938
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9461,
-        "brotli": 4039
+        "min": 9543,
+        "brotli": 4073
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14603,
-        "brotli": 5639
+        "min": 14685,
+        "brotli": 5675
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13679,
-        "brotli": 5313
+        "min": 13761,
+        "brotli": 5346
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8634,
-      "brotli": 3673
+      "min": 8716,
+      "brotli": 3710
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9392,
-        "brotli": 4037
+        "min": 9474,
+        "brotli": 4073
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9483,
-        "brotli": 4040
+        "min": 9565,
+        "brotli": 4072
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8603,
-      "brotli": 3709
+      "min": 8685,
+      "brotli": 3744
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8866,
-        "brotli": 3813
+        "min": 8948,
+        "brotli": 3846
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6785,
-      "brotli": 3054
+      "min": 6867,
+      "brotli": 3097
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3372,
-      "brotli": 1652
+      "min": 3391,
+      "brotli": 1663
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2865,
-      "brotli": 1397
+      "min": 2884,
+      "brotli": 1406
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7331,
-      "brotli": 3362
+      "min": 7413,
+      "brotli": 3371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7960,
-      "brotli": 3599
+      "min": 8042,
+      "brotli": 3633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7427,
-      "brotli": 3367
+      "min": 7509,
+      "brotli": 3388
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8045,
-      "brotli": 3628
+      "min": 8127,
+      "brotli": 3662
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7534,
-      "brotli": 3360
+      "min": 7616,
+      "brotli": 3395
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7275,
-      "brotli": 3310
+      "min": 7357,
+      "brotli": 3340
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7077,
-      "brotli": 3262
+      "min": 7159,
+      "brotli": 3291
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7084,
-      "brotli": 3257
+      "min": 7166,
+      "brotli": 3287
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7345,
-      "brotli": 3348
+      "min": 7427,
+      "brotli": 3384
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7354,
-      "brotli": 3375
+      "min": 7436,
+      "brotli": 3385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8382,
-      "brotli": 3739
+      "min": 8464,
+      "brotli": 3812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6563,
-      "brotli": 2970
+      "min": 6645,
+      "brotli": 3005
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8459,
-      "brotli": 3802
+      "min": 8541,
+      "brotli": 3833
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8206,
-      "brotli": 3692
+      "min": 8288,
+      "brotli": 3719
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7013,
-      "brotli": 3214
+      "min": 7095,
+      "brotli": 3242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7742,
-        "brotli": 3568
+        "min": 7824,
+        "brotli": 3585
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8156,
-        "brotli": 3703
+        "min": 8238,
+        "brotli": 3730
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7092,
-      "brotli": 3227
+      "min": 7174,
+      "brotli": 3259
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7086,
-      "brotli": 3225
+      "min": 7168,
+      "brotli": 3255
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6870,
-      "brotli": 3171
+      "min": 6952,
+      "brotli": 3182
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7082,
-      "brotli": 3268
+      "min": 7164,
+      "brotli": 3292
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7219,
-      "brotli": 3311
+      "min": 7301,
+      "brotli": 3355
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9248,
-        "brotli": 3939
+        "min": 9330,
+        "brotli": 3971
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10009,
-        "brotli": 4214
+        "min": 10091,
+        "brotli": 4255
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9056,
-        "brotli": 3863
+        "min": 9138,
+        "brotli": 3898
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6386,
-      "brotli": 2892
+      "min": 6468,
+      "brotli": 2927
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6375,
-      "brotli": 2884
+      "min": 6457,
+      "brotli": 2919
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5972,
-      "brotli": 2726
+      "min": 6054,
+      "brotli": 2766
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6246,
-      "brotli": 2853
+      "min": 6328,
+      "brotli": 2881
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6113,
-      "brotli": 2778
+      "min": 6195,
+      "brotli": 2821
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6491,
-        "brotli": 2942
+        "min": 6573,
+        "brotli": 2972
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6703,
-        "brotli": 3018
+        "min": 6785,
+        "brotli": 3054
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6672,
-        "brotli": 3005
+        "min": 6754,
+        "brotli": 3038
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6224,
-        "brotli": 2852
+        "min": 6306,
+        "brotli": 2870
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9510,
-        "brotli": 4055
+        "min": 9592,
+        "brotli": 4087
       },
       "files": {
         "tags/handlers.marko": 431,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6460,
-      "brotli": 2941
+      "min": 6542,
+      "brotli": 2982
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6398,
-        "brotli": 2895
+        "min": 6480,
+        "brotli": 2931
       },
       "files": {
         "tags/test.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7545,
-        "brotli": 3441
+        "min": 7627,
+        "brotli": 3461
       },
       "files": {
         "tags/inner/index.marko": 1000,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7835,
-      "brotli": 3484
+      "min": 7917,
+      "brotli": 3515
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7857,
-      "brotli": 3487
+      "min": 7939,
+      "brotli": 3518
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11392,
-      "brotli": 4881
+      "min": 11474,
+      "brotli": 4918
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 11267,
-      "brotli": 4809
+      "min": 11349,
+      "brotli": 4846
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11054,
-      "brotli": 4743
+      "min": 11136,
+      "brotli": 4776
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7799,
-      "brotli": 3434
+      "min": 7881,
+      "brotli": 3465
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7799,
-      "brotli": 3434
+      "min": 7881,
+      "brotli": 3465
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8140,
-      "brotli": 3574
+      "min": 8222,
+      "brotli": 3607
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 6126,
-      "brotli": 2760
+      "min": 6208,
+      "brotli": 2794
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8151,
-      "brotli": 3575
+      "min": 8233,
+      "brotli": 3608
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 140
     },
     "shared": {
-      "min": 11112,
-      "brotli": 4795
+      "min": 11194,
+      "brotli": 4828
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6078,
-      "brotli": 2731
+      "min": 6160,
+      "brotli": 2767
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 74
     },
     "shared": {
-      "min": 7229,
-      "brotli": 3219
+      "min": 7311,
+      "brotli": 3250
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 112
     },
     "shared": {
-      "min": 6740,
-      "brotli": 3019
+      "min": 6822,
+      "brotli": 3060
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9390,
-      "brotli": 4029
+      "min": 9472,
+      "brotli": 4067
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7791,
-        "brotli": 3530
+        "min": 7873,
+        "brotli": 3561
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6490,
-        "brotli": 2908
+        "min": 6572,
+        "brotli": 2948
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6717,
-      "brotli": 2960
+      "min": 6799,
+      "brotli": 2993
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9401,
-      "brotli": 4019
+      "min": 9483,
+      "brotli": 4055
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9931,
-      "brotli": 4286
+      "min": 10013,
+      "brotli": 4323
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9041,
-        "brotli": 3898
+        "min": 9123,
+        "brotli": 3933
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8055,
-      "brotli": 3617
+      "min": 8137,
+      "brotli": 3655
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8004,
-      "brotli": 3603
+      "min": 8086,
+      "brotli": 3641
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8734,
-        "brotli": 3934
+        "min": 8816,
+        "brotli": 3970
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7716,
-      "brotli": 3500
+      "min": 7798,
+      "brotli": 3557
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4366,
-      "brotli": 2090
+      "min": 4387,
+      "brotli": 2110
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4362,
-      "brotli": 2087
+      "min": 4383,
+      "brotli": 2105
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4364,
-      "brotli": 2089
+      "min": 4385,
+      "brotli": 2109
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6676,
-      "brotli": 2989
+      "min": 6758,
+      "brotli": 3020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4366,
-      "brotli": 2090
+      "min": 4387,
+      "brotli": 2110
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4559,
-      "brotli": 2165
+      "min": 4580,
+      "brotli": 2185
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4515,
-      "brotli": 2160
+      "min": 4536,
+      "brotli": 2170
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4433,
-      "brotli": 2119
+      "min": 4454,
+      "brotli": 2138
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4511,
-      "brotli": 2156
+      "min": 4532,
+      "brotli": 2165
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4381,
-      "brotli": 2099
+      "min": 4402,
+      "brotli": 2112
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4364,
-      "brotli": 2089
+      "min": 4385,
+      "brotli": 2109
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4521,
-      "brotli": 2163
+      "min": 4542,
+      "brotli": 2182
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15014,
-        "brotli": 5927
+        "min": 15096,
+        "brotli": 5966
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8946,
-        "brotli": 3858
+        "min": 9028,
+        "brotli": 3887
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6256,
-      "brotli": 2830
+      "min": 6338,
+      "brotli": 2870
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9847,
-        "brotli": 4170
+        "min": 9929,
+        "brotli": 4207
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9302,
-      "brotli": 4009
+      "min": 9384,
+      "brotli": 4031
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6172,
-        "brotli": 2796
+        "min": 6254,
+        "brotli": 2825
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6394,
-        "brotli": 2902
+        "min": 6476,
+        "brotli": 2935
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6913,
-      "brotli": 3086
+      "min": 6995,
+      "brotli": 3121
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6913,
-      "brotli": 3086
+      "min": 6995,
+      "brotli": 3121
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7496,
-      "brotli": 3300
+      "min": 7578,
+      "brotli": 3337
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6648,
-        "brotli": 3012
+        "min": 6730,
+        "brotli": 3045
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9022,
-      "brotli": 3912
+      "min": 9104,
+      "brotli": 3944
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7127,
-      "brotli": 3204
+      "min": 7209,
+      "brotli": 3243
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6086,
-      "brotli": 2753
+      "min": 6168,
+      "brotli": 2776
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9398,
-      "brotli": 4070
+      "min": 9480,
+      "brotli": 4104
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9066,
-      "brotli": 3914
+      "min": 9148,
+      "brotli": 3951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/common/types.ts
+++ b/packages/runtime-tags/src/common/types.ts
@@ -12,7 +12,7 @@ export interface BranchScope extends Scope {
   [AccessorProp.EndNode]: ChildNode;
   [AccessorProp.ParentBranch]: BranchScope | undefined;
   [AccessorProp.AbortScopes]: Set<Scope> | undefined;
-  [AccessorProp.BranchScopes]: Set<BranchScope> | undefined;
+  [AccessorProp.BranchScopes]: Set<BranchScope> | BranchScope | undefined;
   [AccessorProp.Renderer]: ClientRenderer | string;
   [AccessorProp.AwaitCounter]: AwaitCounter | undefined;
   [AccessorProp.PendingEffects]: unknown[] | undefined;

--- a/packages/runtime-tags/src/dom/renderer.ts
+++ b/packages/runtime-tags/src/dom/renderer.ts
@@ -56,7 +56,17 @@ export function setParentBranch(
 ) {
   if (parentBranch) {
     branch[AccessorProp.ParentBranch] = parentBranch;
-    (parentBranch[AccessorProp.BranchScopes] ||= new Set()).add(branch);
+    // Most branches parent exactly one child; hold it directly and pay for a Set
+    // only on the second. A scope always carries `$global`; a Set never does.
+    parentBranch[AccessorProp.BranchScopes] = parentBranch[
+      AccessorProp.BranchScopes
+    ]
+      ? (parentBranch[AccessorProp.BranchScopes] as BranchScope)[
+          AccessorProp.Global
+        ]
+        ? new Set([parentBranch[AccessorProp.BranchScopes], branch])
+        : parentBranch[AccessorProp.BranchScopes].add(branch)
+      : branch;
   }
   branch[AccessorProp.ClosestBranch] = branch;
 }

--- a/packages/runtime-tags/src/dom/scope.ts
+++ b/packages/runtime-tags/src/dom/scope.ts
@@ -72,9 +72,16 @@ export function findBranchWithKey(
 }
 
 export function destroyBranch(branch: BranchScope) {
-  branch[AccessorProp.ParentBranch]?.[AccessorProp.BranchScopes]?.delete(
-    branch,
-  );
+  const parent = branch[AccessorProp.ParentBranch];
+  if (parent?.[AccessorProp.BranchScopes]) {
+    if (
+      (parent[AccessorProp.BranchScopes] as BranchScope)[AccessorProp.Global]
+    ) {
+      if (parent[AccessorProp.BranchScopes] === branch) {
+        parent[AccessorProp.BranchScopes] = undefined;
+      }
+    } else parent[AccessorProp.BranchScopes].delete(branch);
+  }
   destroyNestedScopes(branch);
 }
 
@@ -88,7 +95,12 @@ export function destroyScope(scope: Scope) {
 // TODO: turn into normal function declaration when resolved: https://github.com/oxc-project/oxc/issues/17364?issue=rolldown%7Crolldown%7C7666
 const destroyNestedScopes = function destroyNestedScopes(scope: Scope) {
   scope[AccessorProp.Gen] = 0;
-  scope[AccessorProp.BranchScopes]?.forEach(destroyNestedScopes);
+  if (scope[AccessorProp.BranchScopes]) {
+    // A lone child is held directly: a scope always carries `$global`, a Set never.
+    (scope[AccessorProp.BranchScopes] as BranchScope)[AccessorProp.Global]
+      ? destroyNestedScopes(scope[AccessorProp.BranchScopes])
+      : scope[AccessorProp.BranchScopes].forEach(destroyNestedScopes);
+  }
   scope[AccessorProp.AbortScopes]?.forEach(cleanupScope);
 };
 


### PR DESCRIPTION
Most branches parent exactly one child, but every one of them allocated a `Set` to hold its children. Hold a lone child directly instead and pay for the `Set` only when a second child arrives; the two shapes are told apart by `$global`, which a scope always carries and a `Set` never does.

Worth ~4.5% on tearing down and rebuilding a large keyed list.