### PR TITLE
perf(runtime-tags): insert into a detached parent without a fragment

### DIFF
--- a/.changeset/olive-moons-repeat.md
+++ b/.changeset/olive-moons-repeat.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Move nodes directly into a detached parent instead of staging them in a `DocumentFragment`, speeding up building and tearing down keyed lists.

--- a/.changeset/quiet-cheetahs-sort.md
+++ b/.changeset/quiet-cheetahs-sort.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Speed up keyed lists. A section whose only content is an exhaustive conditional now builds no node of its own — the conditional's content IS the section's range — so a `<for>` over `<if>`/`<else>` allocates one fewer template clone, walk and DOM swap per item, and the rendered DOM carries no marker comments for it. A loop item whose args are unchanged skips its whole params pass, including any nested loop it would otherwise re-run per item. Also drops the per-scope `AbortController` behind closure subscriptions, holds a lone child branch directly instead of allocating a `Set`, memoizes the per-branch cloner lookup, skips the `DocumentFragment` when inserting into a detached tree, keys `_or`'s pending counter by string, and walks cloned templates without a `TreeWalker`.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26624,
-        "brotli": 9899
+        "min": 26657,
+        "brotli": 9896
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 119
       },
       "runtime": {
-        "min": 3995,
-        "brotli": 1757
+        "min": 4028,
+        "brotli": 1775
       },
       "total": {
-        "min": 4156,
-        "brotli": 1876
+        "min": 4189,
+        "brotli": 1894
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 80
       },
       "runtime": {
-        "min": 2463,
-        "brotli": 1239
+        "min": 2681,
+        "brotli": 1312
       },
       "total": {
-        "min": 2543,
-        "brotli": 1319
+        "min": 2761,
+        "brotli": 1392
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6521,
-        "brotli": 2867
+        "min": 6554,
+        "brotli": 2873
       },
       "total": {
-        "min": 7166,
-        "brotli": 3231
+        "min": 7199,
+        "brotli": 3237
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 101
       },
       "runtime": {
-        "min": 2668,
-        "brotli": 1309
+        "min": 2886,
+        "brotli": 1385
       },
       "total": {
-        "min": 2783,
-        "brotli": 1410
+        "min": 3001,
+        "brotli": 1486
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6521 (min) 2867 (brotli)
+// size: 6554 (min) 2873 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -287,17 +287,21 @@ function removeChildNodes(startNode, endNode) {
   }
 }
 function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
-  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  if (parentNode.isConnected)
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  else {
+    let stop = endNode.nextSibling;
+    for (; startNode !== stop;) {
+      let next = startNode.nextSibling;
+      (parentNode.insertBefore(startNode, referenceNode), (startNode = next));
+    }
+  }
+  return parentNode;
 }
 function toInsertNode(startNode, endNode) {
-  if (startNode === endNode) return startNode;
-  let parent = new DocumentFragment(),
-    stop = endNode.nextSibling;
-  for (; startNode !== stop;) {
-    let next = startNode.nextSibling;
-    (parent.appendChild(startNode), (startNode = next));
-  }
-  return parent;
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }
 function _if(nodeAccessor, ...branchesArgs) {
   nodeAccessor = decodeAccessor(nodeAccessor);

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2668 (min) 1309 (brotli)
+// size: 2886 (min) 1385 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -198,6 +198,23 @@ function _text(node, value) {
 }
 function normalizeAttrValue(value) {
   if (isNotVoid(value)) return value === !0 ? "" : value + "";
+}
+function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
+  if (parentNode.isConnected)
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  else {
+    let stop = endNode.nextSibling;
+    for (; startNode !== stop;) {
+      let next = startNode.nextSibling;
+      (parentNode.insertBefore(startNode, referenceNode), (startNode = next));
+    }
+  }
+  return parentNode;
+}
+function toInsertNode(startNode, endNode) {
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 3995 (min) 1757 (brotli)
+// size: 4028 (min) 1775 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -206,17 +206,21 @@ function removeChildNodes(startNode, endNode) {
   }
 }
 function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
-  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  if (parentNode.isConnected)
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  else {
+    let stop = endNode.nextSibling;
+    for (; startNode !== stop;) {
+      let next = startNode.nextSibling;
+      (parentNode.insertBefore(startNode, referenceNode), (startNode = next));
+    }
+  }
+  return parentNode;
 }
 function toInsertNode(startNode, endNode) {
-  if (startNode === endNode) return startNode;
-  let parent = new DocumentFragment(),
-    stop = endNode.nextSibling;
-  for (; startNode !== stop;) {
-    let next = startNode.nextSibling;
-    (parent.appendChild(startNode), (startNode = next));
-  }
-  return parent;
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2463 (min) 1239 (brotli)
+// size: 2681 (min) 1312 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -185,6 +185,23 @@ function _to_text(value) {
 function _text(node, value) {
   let normalizedValue = _to_text(value);
   node.data !== normalizedValue && (node.data = normalizedValue);
+}
+function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
+  if (parentNode.isConnected)
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  else {
+    let stop = endNode.nextSibling;
+    for (; startNode !== stop;) {
+      let next = startNode.nextSibling;
+      (parentNode.insertBefore(startNode, referenceNode), (startNode = next));
+    }
+  }
+  return parentNode;
+}
+function toInsertNode(startNode, endNode) {
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26624 (min) 9899 (brotli)
+// size: 26657 (min) 9896 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -1168,17 +1168,21 @@ function removeChildNodes(startNode, endNode) {
   }
 }
 function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
-  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  if (parentNode.isConnected)
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  else {
+    let stop = endNode.nextSibling;
+    for (; startNode !== stop;) {
+      let next = startNode.nextSibling;
+      (parentNode.insertBefore(startNode, referenceNode), (startNode = next));
+    }
+  }
+  return parentNode;
 }
 function toInsertNode(startNode, endNode) {
-  if (startNode === endNode) return startNode;
-  let parent = new DocumentFragment(),
-    stop = endNode.nextSibling;
-  for (; startNode !== stop;) {
-    let next = startNode.nextSibling;
-    (parent.appendChild(startNode), (startNode = next));
-  }
-  return parent;
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }
 function resolveCursorPosition(inputType, initialPosition, initialValue, updatedValue) {
   if (

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62523,
-        "brotli": 19264
+        "min": 62557,
+        "brotli": 19329
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63771,
-        "brotli": 19846
+        "min": 63805,
+        "brotli": 19884
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63654,
-        "brotli": 19824
+        "min": 63688,
+        "brotli": 19855
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62523,
-        "brotli": 19264
+        "min": 62557,
+        "brotli": 19329
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63809,
-        "brotli": 19849
+        "min": 63843,
+        "brotli": 19891
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62421,
-        "brotli": 19228
+        "min": 62455,
+        "brotli": 19261
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62462,
-        "brotli": 19233
+        "min": 62496,
+        "brotli": 19281
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63758,
-        "brotli": 19808
+        "min": 63792,
+        "brotli": 19833
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63877,
-        "brotli": 19849
+        "min": 63911,
+        "brotli": 19897
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62577,
-        "brotli": 19321
+        "min": 62611,
+        "brotli": 19314
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64067,
-        "brotli": 20002
+        "min": 64101,
+        "brotli": 19985
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65343,
-        "brotli": 20251
+        "min": 65379,
+        "brotli": 20315
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63703,
-        "brotli": 19856
+        "min": 63737,
+        "brotli": 19816
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63985,
-        "brotli": 19912
+        "min": 64019,
+        "brotli": 19946
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63771,
-        "brotli": 19846
+        "min": 63805,
+        "brotli": 19826
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62828,
-        "brotli": 19419
+        "min": 62862,
+        "brotli": 19473
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62500,
-        "brotli": 19276
+        "min": 62534,
+        "brotli": 19311
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64205,
-        "brotli": 20033
+        "min": 64239,
+        "brotli": 20037
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63714,
-        "brotli": 19810
+        "min": 63748,
+        "brotli": 19836
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63383,
-        "brotli": 19710
+        "min": 63417,
+        "brotli": 19685
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63875,
-        "brotli": 19914
+        "min": 63909,
+        "brotli": 19856
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63485,
-        "brotli": 19687
+        "min": 63519,
+        "brotli": 19738
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62885,
-        "brotli": 19473
+        "min": 62919,
+        "brotli": 19441
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64576,
-        "brotli": 20186
+        "min": 64607,
+        "brotli": 20195
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5992,
-      "brotli": 2739
+      "min": 6025,
+      "brotli": 2746
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7490,
-      "brotli": 3281
+      "min": 7523,
+      "brotli": 3299
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6240,
-      "brotli": 2825
+      "min": 6273,
+      "brotli": 2842
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8882,
-      "brotli": 3851
+      "min": 8915,
+      "brotli": 3866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8860,
-        "brotli": 3834
+        "min": 8893,
+        "brotli": 3853
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3600,
-        "brotli": 1649
+        "min": 3633,
+        "brotli": 1664
       },
       "files": {
         "tags/hello/index.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3583,
-        "brotli": 1659
+        "min": 3616,
+        "brotli": 1670
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3583,
-        "brotli": 1663
+        "min": 3616,
+        "brotli": 1669
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9921,
-        "brotli": 4292
+        "min": 9954,
+        "brotli": 4299
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7261,
-        "brotli": 3300
+        "min": 7294,
+        "brotli": 3341
       },
       "files": {
         "tags/child/index.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10182,
-      "brotli": 4337
+      "min": 10212,
+      "brotli": 4356
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6803,
-      "brotli": 3079
+      "min": 6836,
+      "brotli": 3094
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6276,
-      "brotli": 2869
+      "min": 6309,
+      "brotli": 2878
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6967,
-      "brotli": 3156
+      "min": 7000,
+      "brotli": 3167
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7056,
-      "brotli": 3179
+      "min": 7089,
+      "brotli": 3194
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7101,
-      "brotli": 3187
+      "min": 7134,
+      "brotli": 3199
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7562,
-      "brotli": 3369
+      "min": 7595,
+      "brotli": 3385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7159,
-      "brotli": 3191
+      "min": 7192,
+      "brotli": 3213
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9085,
-      "brotli": 3899
+      "min": 9118,
+      "brotli": 3920
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7109,
-      "brotli": 3154
+      "min": 7142,
+      "brotli": 3170
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7159,
-      "brotli": 3191
+      "min": 7192,
+      "brotli": 3213
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8869,
-      "brotli": 3836
+      "min": 8902,
+      "brotli": 3851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8871,
-      "brotli": 3837
+      "min": 8904,
+      "brotli": 3853
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6285,
-      "brotli": 2852
+      "min": 6318,
+      "brotli": 2870
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6283,
-      "brotli": 2852
+      "min": 6316,
+      "brotli": 2859
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6352,
-      "brotli": 2873
+      "min": 6385,
+      "brotli": 2894
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7632,
-        "brotli": 3493
+        "min": 7665,
+        "brotli": 3507
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9437,
-        "brotli": 4078
+        "min": 9469,
+        "brotli": 4096
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4576,
-      "brotli": 2118
+      "min": 4609,
+      "brotli": 2126
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6367,
-      "brotli": 2898
+      "min": 6400,
+      "brotli": 2915
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7169,
-      "brotli": 3265
+      "min": 7202,
+      "brotli": 3314
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7432,
-      "brotli": 3353
+      "min": 7465,
+      "brotli": 3379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6254,
-      "brotli": 2850
+      "min": 6287,
+      "brotli": 2863
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7180,
-      "brotli": 3240
+      "min": 7213,
+      "brotli": 3258
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7137,
-      "brotli": 3224
+      "min": 7170,
+      "brotli": 3240
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7137,
-      "brotli": 3224
+      "min": 7170,
+      "brotli": 3240
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7157,
-      "brotli": 3229
+      "min": 7190,
+      "brotli": 3249
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6922,
-      "brotli": 3119
+      "min": 6955,
+      "brotli": 3133
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7924,
-        "brotli": 3602
+        "min": 7957,
+        "brotli": 3632
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7681,
-        "brotli": 3393
+        "min": 7714,
+        "brotli": 3406
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6268,
-      "brotli": 2845
+      "min": 6301,
+      "brotli": 2865
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6451,
-        "brotli": 2922
+        "min": 6484,
+        "brotli": 2937
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8346,
-        "brotli": 3764
+        "min": 8379,
+        "brotli": 3777
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7874,
-        "brotli": 3584
+        "min": 7907,
+        "brotli": 3599
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7615,
-        "brotli": 3376
+        "min": 7648,
+        "brotli": 3383
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6250,
-      "brotli": 2832
+      "min": 6283,
+      "brotli": 2848
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6433,
-        "brotli": 2907
+        "min": 6466,
+        "brotli": 2930
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6282,
-      "brotli": 2846
+      "min": 6315,
+      "brotli": 2864
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11020,
-        "brotli": 4765
+        "min": 11054,
+        "brotli": 4796
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5990,
-      "brotli": 2744
+      "min": 6023,
+      "brotli": 2749
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8551,
-      "brotli": 3799
+      "min": 8584,
+      "brotli": 3820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6335,
-        "brotli": 2740
+        "min": 6368,
+        "brotli": 2761
       },
       "files": {
         "tags/my-dialog.marko": 293,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8394,
-      "brotli": 3628
+      "min": 8427,
+      "brotli": 3642
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14269,
-      "brotli": 5550
+      "min": 14302,
+      "brotli": 5566
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13826,
-      "brotli": 5349
+      "min": 13859,
+      "brotli": 5360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13700,
-      "brotli": 5298
+      "min": 13733,
+      "brotli": 5314
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13986,
-      "brotli": 5402
+      "min": 14020,
+      "brotli": 5421
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9153,
-      "brotli": 3957
+      "min": 9186,
+      "brotli": 3971
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9378,
-      "brotli": 4033
+      "min": 9411,
+      "brotli": 4042
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8977,
-        "brotli": 3652
+        "min": 9010,
+        "brotli": 3672
       },
       "files": {
         "tags/my-select.marko": 297,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8991,
-        "brotli": 3885
+        "min": 9024,
+        "brotli": 3900
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8976,
-        "brotli": 3868
+        "min": 9009,
+        "brotli": 3890
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8904,
-        "brotli": 3844
+        "min": 8937,
+        "brotli": 3863
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1685,
-        "brotli": 895
+        "min": 1903,
+        "brotli": 977
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6403,
-      "brotli": 2908
+      "min": 6436,
+      "brotli": 2914
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8806,
-        "brotli": 3789
+        "min": 8839,
+        "brotli": 3808
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6669,
-      "brotli": 3032
+      "min": 6702,
+      "brotli": 3044
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6335,
-      "brotli": 2899
+      "min": 6368,
+      "brotli": 2910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4665,
-        "brotli": 2146
+        "min": 4698,
+        "brotli": 2158
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7461,
-        "brotli": 3390
+        "min": 7494,
+        "brotli": 3413
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6177,
-      "brotli": 2797
+      "min": 6210,
+      "brotli": 2816
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5771,
-      "brotli": 2687
+      "min": 5804,
+      "brotli": 2706
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5918,
-      "brotli": 2645
+      "min": 5951,
+      "brotli": 2671
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8749,
-      "brotli": 3782
+      "min": 8782,
+      "brotli": 3801
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8636,
-      "brotli": 3731
+      "min": 8669,
+      "brotli": 3749
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9546,
-        "brotli": 4074
+        "min": 9579,
+        "brotli": 4094
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9625,
-        "brotli": 4086
+        "min": 9658,
+        "brotli": 4113
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9438,
-        "brotli": 4026
+        "min": 9471,
+        "brotli": 4042
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6396,
-        "brotli": 2902
+        "min": 6429,
+        "brotli": 2914
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9461,
-        "brotli": 4039
+        "min": 9494,
+        "brotli": 4061
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14603,
-        "brotli": 5639
+        "min": 14636,
+        "brotli": 5660
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13679,
-        "brotli": 5313
+        "min": 13713,
+        "brotli": 5325
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8541,
-      "brotli": 3276
+      "min": 8574,
+      "brotli": 3302
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8634,
-      "brotli": 3673
+      "min": 8667,
+      "brotli": 3691
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9392,
-        "brotli": 4037
+        "min": 9425,
+        "brotli": 4053
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9483,
-        "brotli": 4040
+        "min": 9516,
+        "brotli": 4061
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8603,
-      "brotli": 3709
+      "min": 8636,
+      "brotli": 3729
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8541,
-      "brotli": 3276
+      "min": 8574,
+      "brotli": 3302
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4042,
-        "brotli": 1879
+        "min": 4075,
+        "brotli": 1890
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8866,
-        "brotli": 3813
+        "min": 8899,
+        "brotli": 3833
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6785,
-      "brotli": 3054
+      "min": 6818,
+      "brotli": 3065
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7331,
-      "brotli": 3362
+      "min": 7364,
+      "brotli": 3358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7960,
-      "brotli": 3599
+      "min": 7993,
+      "brotli": 3611
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7427,
-      "brotli": 3367
+      "min": 7460,
+      "brotli": 3385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8045,
-      "brotli": 3628
+      "min": 8078,
+      "brotli": 3647
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7534,
-      "brotli": 3360
+      "min": 7567,
+      "brotli": 3402
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,51 @@
+// template.marko
+const $template = "<div class=list></div><button class=rotate>Rotate</button><button class=toggle>Toggle</button><button class=drop>Drop</button>";
+const $walks = " b b b b";
+const $else_content__item_id = /*@__PURE__*/ _if_closure("#text/0", 1, ($scope) => _text($scope["#text/0"], $scope._.item_id));
+const $else_content__setup = $else_content__item_id;
+const $if_content__item_id = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => _text($scope["#text/0"], $scope._.item_id));
+const $if_content__setup = $if_content__item_id;
+const $for_content__if = /*@__PURE__*/ _if("#text/0", "<pre>code <!></pre>", "Db%", $if_content__setup, "<p>text <!></p>", "Db%", $else_content__setup);
+const $for_content__item_code = ($scope, item_code) => $for_content__if($scope, item_code ? 0 : 1);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_code($scope, $params2[0]?.code);
+	$for_content__item_id($scope, $params2[0]?.id);
+};
+const $for_content__item_id = /*@__PURE__*/ _const("item_id", ($scope) => {
+	$if_content__item_id($scope);
+	$else_content__item_id($scope);
+});
+const $for = /*@__PURE__*/ _for_of("#div/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, "id"]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/1"], "click", function() {
+		$items($scope, [...$scope.items.slice(1), $scope.items?.[0]]);
+	});
+	_on($scope["#button/2"], "click", function() {
+		$items($scope, $scope.items.map((item) => ({
+			...item,
+			code: !item.code
+		})));
+	});
+	_on($scope["#button/3"], "click", function() {
+		$items($scope, $scope.items.slice(1));
+	});
+});
+function $setup($scope) {
+	$items($scope, [
+		{
+			id: 0,
+			code: false
+		},
+		{
+			id: 1,
+			code: true
+		},
+		{
+			id: 2,
+			code: false
+		}
+	]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+const $else_content__item_id = /*@__PURE__*/ _if_closure(0, 1, ($scope) => _text($scope.a, $scope._.e));
+const $else_content__setup = $else_content__item_id;
+const $if_content__item_id = /*@__PURE__*/ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.e));
+const $for_content__if = /*@__PURE__*/ _if(0, "<pre>code <!></pre>", "Db%", $if_content__item_id, "<p>text <!></p>", "Db%", $else_content__setup);
+const $for_content__item_code = ($scope, item_code) => $for_content__if($scope, item_code ? 0 : 1);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_code($scope, $params2[0]?.code);
+	$for_content__item_id($scope, $params2[0]?.id);
+};
+const $for_content__item_id = /*@__PURE__*/ _const(4, ($scope) => {
+	$if_content__item_id($scope);
+	$else_content__item_id($scope);
+});
+const $for = /*@__PURE__*/ _for_of(0, "<!><!><!>", "b%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let(4, ($scope) => $for($scope, [$scope.e, "id"]));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.b, "click", function() {
+		$items($scope, [...$scope.e.slice(1), $scope.e?.[0]]);
+	});
+	_on($scope.c, "click", function() {
+		$items($scope, $scope.e.map((item) => ({
+			...item,
+			code: !item.code
+		})));
+	});
+	_on($scope.d, "click", function() {
+		$items($scope, $scope.e.slice(1));
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: 0,
+			code: false
+		},
+		{
+			id: 1,
+			code: true
+		},
+		{
+			id: 2,
+			code: false
+		}
+	];
+	_html("<div class=list>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_if(() => {
+			if (item.code) {
+				const $scope2_id = _scope_id();
+				_html(`<pre>code <!>${_escape(item.id)}${_el_resume($scope2_id, "#text/0")}</pre>`);
+				writeScope($scope2_id, {}, "__tests__/template.marko", "5:6");
+				return 0;
+			} else {
+				const $scope3_id = _scope_id();
+				_html(`<p>text <!>${_escape(item.id)}${_el_resume($scope3_id, "#text/0")}</p>`);
+				writeScope($scope3_id, {}, "__tests__/template.marko", "8:6");
+				return 1;
+			}
+		}, $scope1_id, "#text/0", 1, 1, 1, 0, 1);
+		writeScope($scope1_id, { item_id: item?.id }, "__tests__/template.marko", "4:4", { item_id: ["item.id", "4:8"] });
+	}, "id", $scope0_id, "#div/0", 1, 1, 1, "</div>");
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "#button/1")}<button class=toggle>Toggle</button>${_el_resume($scope0_id, "#button/2")}<button class=drop>Drop</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { items }, "__tests__/template.marko", 0, { items: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/html.bundle.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: 0,
+			code: false
+		},
+		{
+			id: 1,
+			code: true
+		},
+		{
+			id: 2,
+			code: false
+		}
+	];
+	_html("<div class=list>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_if(() => {
+			if (item.code) {
+				const $scope2_id = _scope_id();
+				_html(`<pre>code <!>${_escape(item.id)}${_el_resume($scope2_id, "a")}</pre>`);
+				writeScope($scope2_id, {});
+				return 0;
+			} else {
+				const $scope3_id = _scope_id();
+				_html(`<p>text <!>${_escape(item.id)}${_el_resume($scope3_id, "a")}</p>`);
+				writeScope($scope3_id, {});
+				return 1;
+			}
+		}, $scope1_id, "a", 1, 1, 1, 0, 1);
+		writeScope($scope1_id, { e: item?.id });
+	}, "id", $scope0_id, "a", 1, 1, 1, "</div>");
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "b")}<button class=toggle>Toggle</button>${_el_resume($scope0_id, "c")}<button class=drop>Drop</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: items });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/render.debug.md
@@ -1,0 +1,235 @@
+# Render
+```html
+<div
+  class="list"
+>
+  <p>
+    text 0
+  </p>
+  <pre>
+    code 1
+  </pre>
+  <p>
+    text 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 1
+  </pre>
+  <p>
+    text 2
+  </p>
+  <p>
+    text 0
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p:nth-of-type(1) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    text 1
+  </p>
+  <pre>
+    code 2
+  </pre>
+  <pre>
+    code 0
+  </pre>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + pre
+INSERT: .list > p + pre
+REMOVE: .list > pre:nth-of-type(1) + p
+INSERT: .list > pre:nth-of-type(1) + pre
+REMOVE: .list > pre:nth-of-type(2) + p
+UPDATE: .list > p::text@5 "" => "1"
+UPDATE: .list > pre:nth-of-type(1)::text@5 "" => "2"
+UPDATE: .list > pre:nth-of-type(2)::text@5 "" => "0"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 2
+  </pre>
+  <pre>
+    code 0
+  </pre>
+  <p>
+    text 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > pre:nth-of-type(2) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 0
+  </pre>
+  <p>
+    text 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > pre
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    text 0
+  </p>
+  <pre>
+    code 1
+  </pre>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + pre
+INSERT: .list > p + pre
+REMOVE: .list > pre + p
+UPDATE: .list > p::text@5 "" => "0"
+UPDATE: .list > pre::text@5 "" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/render.md
@@ -1,0 +1,235 @@
+# Render
+```html
+<div
+  class="list"
+>
+  <p>
+    text 0
+  </p>
+  <pre>
+    code 1
+  </pre>
+  <p>
+    text 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 1
+  </pre>
+  <p>
+    text 2
+  </p>
+  <p>
+    text 0
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p:nth-of-type(1) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    text 1
+  </p>
+  <pre>
+    code 2
+  </pre>
+  <pre>
+    code 0
+  </pre>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + pre
+INSERT: .list > p + pre
+REMOVE: .list > pre:nth-of-type(1) + p
+INSERT: .list > pre:nth-of-type(1) + pre
+REMOVE: .list > pre:nth-of-type(2) + p
+UPDATE: .list > p::text@5 "" => "1"
+UPDATE: .list > pre:nth-of-type(1)::text@5 "" => "2"
+UPDATE: .list > pre:nth-of-type(2)::text@5 "" => "0"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 2
+  </pre>
+  <pre>
+    code 0
+  </pre>
+  <p>
+    text 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > pre:nth-of-type(2) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <pre>
+    code 0
+  </pre>
+  <p>
+    text 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > pre
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    text 0
+  </p>
+  <pre>
+    code 1
+  </pre>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + pre
+INSERT: .list > p + pre
+REMOVE: .list > pre + p
+UPDATE: .list > p::text@5 "" => "0"
+UPDATE: .list > pre::text@5 "" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/writes.debug.html
@@ -1,0 +1,33 @@
+<div class=list><!--M_[-->
+  <p>text <!>0<!--M_*3 #text/0--></p><!--M_|2 #text/0 3--><!--M_[2-->
+  <pre>code <!>1<!--M_*5 #text/0--></pre><!--M_|4 #text/0 5--><!--M_[4-->
+  <p>text <!>2<!--M_*7 #text/0--></p><!--M_|6 #text/0 7--><!--M_)1 #div/0 6-->
+</div><button class=rotate>Rotate</button><!--M_*1 #button/1--><button
+  class=toggle>Toggle</button><!--M_*1 #button/2--><button
+  class=drop>Drop</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      items: [{
+        id: 0,
+        code: !1
+      }, {
+        id: 1,
+        code: !0
+      }, {
+        id: 2,
+        code: !1
+      }]
+    }, {
+      "ConditionalRenderer:#text/0": 1,
+      item_id: 0
+    }, 1, {
+      item_id: 1
+    }, 1, {
+      "ConditionalRenderer:#text/0": 1,
+      item_id: 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/writes.html
@@ -1,0 +1,31 @@
+<div class=list><!--M_[-->
+  <p>text <!>0<!--M_*3 a--></p><!--M_|2 a 3--><!--M_[2-->
+  <pre>code <!>1<!--M_*5 a--></pre><!--M_|4 a 5--><!--M_[4-->
+  <p>text <!>2<!--M_*7 a--></p><!--M_|6 a 7--><!--M_)1 a 6-->
+</div><button class=rotate>Rotate</button><!--M_*1 b--><button
+  class=toggle>Toggle</button><!--M_*1 c--><button
+  class=drop>Drop</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: [{
+      id: 0,
+      code: !1
+    }, {
+      id: 1,
+      code: !0
+    }, {
+      id: 2,
+      code: !1
+    }]
+  }, {
+    Da: 1,
+    e: 0
+  }, 1, {
+    e: 1
+  }, 1, {
+    Da: 1,
+    e: 2
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8047,
+      "brotli": 3616
+    }
+  },
+  "html": {
+    "min": 733,
+    "brotli": 392
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/template.marko
@@ -1,0 +1,18 @@
+<let/items=[{ id: 0, code: false }, { id: 1, code: true }, { id: 2, code: false }]/>
+
+<div.list>
+  <for|item| of=items by="id">
+    <if=item.code>
+      <pre>code ${item.id}</pre>
+    </if>
+    <else>
+      <p>text ${item.id}</p>
+    </else>
+  </for>
+</div>
+
+<button.rotate onClick() { items = [...items.slice(1), items[0]]; }>Rotate</button>
+<button.toggle onClick() {
+  items = items.map((item) => ({ ...item, code: !item.code }));
+}>Toggle</button>
+<button.drop onClick() { items = items.slice(1); }>Drop</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/test.ts
@@ -1,0 +1,19 @@
+import type { TestConfig } from "../../main.test";
+
+// A `<for>` whose only child is an `<if>` has no boundary markers of its own:
+// each item's range IS whichever branch is rendered. Reordering, swapping the
+// branch, and removing items must all keep the list in source order.
+const press = (selector: string) => (document: Document) => {
+  (document.querySelector(selector) as HTMLButtonElement).click();
+};
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    press("button.rotate"),
+    press("button.toggle"),
+    press("button.rotate"),
+    press("button.drop"),
+    press("button.toggle"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7275,
-      "brotli": 3310
+      "min": 7308,
+      "brotli": 3353
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7077,
-      "brotli": 3262
+      "min": 7110,
+      "brotli": 3270
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7084,
-      "brotli": 3257
+      "min": 7117,
+      "brotli": 3279
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7345,
-      "brotli": 3348
+      "min": 7378,
+      "brotli": 3365
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7354,
-      "brotli": 3375
+      "min": 7387,
+      "brotli": 3366
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8382,
-      "brotli": 3739
+      "min": 8415,
+      "brotli": 3780
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6563,
-      "brotli": 2970
+      "min": 6596,
+      "brotli": 2989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8459,
-      "brotli": 3802
+      "min": 8490,
+      "brotli": 3827
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8206,
-      "brotli": 3692
+      "min": 8239,
+      "brotli": 3711
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7013,
-      "brotli": 3214
+      "min": 7046,
+      "brotli": 3234
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7742,
-        "brotli": 3568
+        "min": 7775,
+        "brotli": 3562
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8156,
-        "brotli": 3703
+        "min": 8189,
+        "brotli": 3716
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1947,
-      "brotli": 997
+      "min": 2165,
+      "brotli": 1079
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7092,
-      "brotli": 3227
+      "min": 7125,
+      "brotli": 3248
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7086,
-      "brotli": 3225
+      "min": 7119,
+      "brotli": 3245
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6870,
-      "brotli": 3171
+      "min": 6903,
+      "brotli": 3169
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7082,
-      "brotli": 3268
+      "min": 7115,
+      "brotli": 3276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,45 @@
+// template.marko
+const $template = "<ul></ul><button class=rotate>Rotate</button><button class=bump>Bump b</button><button class=resettle>Same items</button>";
+const $walks = " b b b b";
+const $for_content__index = ($scope, index) => _text($scope["#text/0"], index);
+const $for_content__item_id = ($scope, item_id) => _text($scope["#text/1"], item_id);
+const $for_content__item_n = ($scope, item_n) => _text($scope["#text/2"], item_n);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_id($scope, $params2[0]?.id);
+	$for_content__item_n($scope, $params2[0]?.n);
+	$for_content__index($scope, $params2[1]);
+};
+const $for = /*@__PURE__*/ _for_of("#ul/0", "<li><!>:<!>=<!></li>", "D%c%c%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, "id"]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/1"], "click", function() {
+		$items($scope, [...$scope.items.slice(1), $scope.items?.[0]]);
+	});
+	_on($scope["#button/2"], "click", function() {
+		$items($scope, $scope.items.map((item) => item.id === "b" ? {
+			...item,
+			n: item.n + 10
+		} : item));
+	});
+	_on($scope["#button/3"], "click", function() {
+		$items($scope, [...$scope.items]);
+	});
+});
+function $setup($scope) {
+	$items($scope, [
+		{
+			id: "a",
+			n: 1
+		},
+		{
+			id: "b",
+			n: 2
+		},
+		{
+			id: "c",
+			n: 3
+		}
+	]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/dom.bundle.js
@@ -1,0 +1,25 @@
+// template.marko
+const $for_content__index = ($scope, index) => _text($scope.a, index);
+const $for_content__item_id = ($scope, item_id) => _text($scope.b, item_id);
+const $for_content__item_n = ($scope, item_n) => _text($scope.c, item_n);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_id($scope, $params2[0]?.id);
+	$for_content__item_n($scope, $params2[0]?.n);
+	$for_content__index($scope, $params2[1]);
+};
+const $for = /*@__PURE__*/ _for_of(0, "<li><!>:<!>=<!></li>", "D%c%c%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let(4, ($scope) => $for($scope, [$scope.e, "id"]));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.b, "click", function() {
+		$items($scope, [...$scope.e.slice(1), $scope.e?.[0]]);
+	});
+	_on($scope.c, "click", function() {
+		$items($scope, $scope.e.map((item) => item.id === "b" ? {
+			...item,
+			n: item.n + 10
+		} : item));
+	});
+	_on($scope.d, "click", function() {
+		$items($scope, [...$scope.e]);
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,29 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: "a",
+			n: 1
+		},
+		{
+			id: "b",
+			n: 2
+		},
+		{
+			id: "c",
+			n: 3
+		}
+	];
+	_html("<ul>");
+	_for_of(items, (item, index) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(index)}${_el_resume($scope1_id, "#text/0")}:<!>${_escape(item.id)}${_el_resume($scope1_id, "#text/1")}=<!>${_escape(item.n)}${_el_resume($scope1_id, "#text/2")}</li>`);
+		writeScope($scope1_id, {}, "__tests__/template.marko", "4:4");
+	}, "id", $scope0_id, "#ul/0", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "#button/1")}<button class=bump>Bump b</button>${_el_resume($scope0_id, "#button/2")}<button class=resettle>Same items</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { items }, "__tests__/template.marko", 0, { items: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/html.bundle.js
@@ -1,0 +1,29 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: "a",
+			n: 1
+		},
+		{
+			id: "b",
+			n: 2
+		},
+		{
+			id: "c",
+			n: 3
+		}
+	];
+	_html("<ul>");
+	_for_of(items, (item, index) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(index)}${_el_resume($scope1_id, "a")}:<!>${_escape(item.id)}${_el_resume($scope1_id, "b")}=<!>${_escape(item.n)}${_el_resume($scope1_id, "c")}</li>`);
+		writeScope($scope1_id, {});
+	}, "id", $scope0_id, "a", 1, 1, 1, "</ul>", 1);
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "b")}<button class=bump>Bump b</button>${_el_resume($scope0_id, "c")}<button class=resettle>Same items</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: items });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/render.debug.md
@@ -1,0 +1,153 @@
+# Render
+```html
+<ul>
+  <li>
+    0:a=1
+  </li>
+  <li>
+    1:b=2
+  </li>
+  <li>
+    2:c=3
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:b=2
+  </li>
+  <li>
+    1:c=3
+  </li>
+  <li>
+    2:a=1
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@0 "1" => "0"
+UPDATE: ul > li:nth-of-type(2)::text@0 "2" => "1"
+UPDATE: ul > li:nth-of-type(3)::text@0 "0" => "2"
+REMOVE: ul > li
+INSERT: ul > li:nth-of-type(2) + li
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:b=12
+  </li>
+  <li>
+    1:c=3
+  </li>
+  <li>
+    2:a=1
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@4 "2" => "12"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:c=3
+  </li>
+  <li>
+    1:a=1
+  </li>
+  <li>
+    2:b=12
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@0 "1" => "0"
+UPDATE: ul > li:nth-of-type(2)::text@0 "2" => "1"
+UPDATE: ul > li:nth-of-type(3)::text@0 "0" => "2"
+REMOVE: ul > li
+INSERT: ul > li:nth-of-type(2) + li
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/render.md
@@ -1,0 +1,153 @@
+# Render
+```html
+<ul>
+  <li>
+    0:a=1
+  </li>
+  <li>
+    1:b=2
+  </li>
+  <li>
+    2:c=3
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:b=2
+  </li>
+  <li>
+    1:c=3
+  </li>
+  <li>
+    2:a=1
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@0 "1" => "0"
+UPDATE: ul > li:nth-of-type(2)::text@0 "2" => "1"
+UPDATE: ul > li:nth-of-type(3)::text@0 "0" => "2"
+REMOVE: ul > li
+INSERT: ul > li:nth-of-type(2) + li
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:b=12
+  </li>
+  <li>
+    1:c=3
+  </li>
+  <li>
+    2:a=1
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@4 "2" => "12"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<ul>
+  <li>
+    0:c=3
+  </li>
+  <li>
+    1:a=1
+  </li>
+  <li>
+    2:b=12
+  </li>
+</ul>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="bump"
+>
+  Bump b
+</button>
+<button
+  class="resettle"
+>
+  Same items
+</button>
+```
+## Change
+```
+UPDATE: ul > li:nth-of-type(1)::text@0 "1" => "0"
+UPDATE: ul > li:nth-of-type(2)::text@0 "2" => "1"
+UPDATE: ul > li:nth-of-type(3)::text@0 "0" => "2"
+REMOVE: ul > li
+INSERT: ul > li:nth-of-type(2) + li
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/writes.debug.html
@@ -1,0 +1,32 @@
+<ul>
+  <li>0<!--M_*2 #text/0-->:<!>a<!--M_*2 #text/1-->=<!>1<!--M_*2 #text/2--></li>
+  <li>1<!--M_*3 #text/0-->:<!>b<!--M_*3 #text/1-->=<!>2<!--M_*3 #text/2--></li>
+  <li>2<!--M_*4 #text/0-->:<!>c<!--M_*4 #text/1-->=<!>3<!--M_*4 #text/2--></li>
+  <!--M_}1 #ul/0 4 3 2-->
+</ul><button class=rotate>Rotate</button><!--M_*1 #button/1--><button
+  class=bump>Bump b</button><!--M_*1 #button/2--><button class=resettle>Same
+  items</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      items: [{
+        id: "a",
+        n: 1
+      }, {
+        id: "b",
+        n: 2
+      }, {
+        id: "c",
+        n: 3
+      }]
+    }, {
+      "#LoopKey": "a"
+    }, {
+      "#LoopKey": "b"
+    }, {
+      "#LoopKey": "c"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/__snapshots__/writes.html
@@ -1,0 +1,28 @@
+<ul>
+  <li>0<!--M_*2 a-->:<!>a<!--M_*2 b-->=<!>1<!--M_*2 c--></li>
+  <li>1<!--M_*3 a-->:<!>b<!--M_*3 b-->=<!>2<!--M_*3 c--></li>
+  <li>2<!--M_*4 a-->:<!>c<!--M_*4 b-->=<!>3<!--M_*4 c--></li><!--M_}1 a 4 3 2-->
+</ul><button class=rotate>Rotate</button><!--M_*1 b--><button class=bump>Bump
+  b</button><!--M_*1 c--><button class=resettle>Same items</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: [{
+      id: "a",
+      n: 1
+    }, {
+      id: "b",
+      n: 2
+    }, {
+      id: "c",
+      n: 3
+    }]
+  }, {
+    M: "a"
+  }, {
+    M: "b"
+  }, {
+    M: "c"
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7358,
+      "brotli": 3371
+    }
+  },
+  "html": {
+    "min": 727,
+    "brotli": 381
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/template.marko
@@ -1,0 +1,13 @@
+<let/items=[{ id: "a", n: 1 }, { id: "b", n: 2 }, { id: "c", n: 3 }]/>
+
+<ul>
+  <for|item, index| of=items by="id">
+    <li>${index}:${item.id}=${item.n}</li>
+  </for>
+</ul>
+
+<button.rotate onClick() { items = [...items.slice(1), items[0]]; }>Rotate</button>
+<button.bump onClick() {
+  items = items.map((item) => (item.id === "b" ? { ...item, n: item.n + 10 } : item));
+}>Bump b</button>
+<button.resettle onClick() { items = [...items]; }>Same items</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/test.ts
@@ -1,0 +1,19 @@
+import type { TestConfig } from "../../main.test";
+
+// A loop item whose args are unchanged skips its params pass, so the cases that
+// must NOT be skipped are the interesting ones: a reorder changes the index
+// while the item object stays identical, and replacing one item's object must
+// update only that row. Re-rendering with an equal list must change nothing.
+const press = (selector: string) => (document: Document) => {
+  (document.querySelector(selector) as HTMLButtonElement).click();
+};
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    press("button.rotate"),
+    press("button.bump"),
+    press("button.resettle"),
+    press("button.rotate"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7219,
-      "brotli": 3311
+      "min": 7252,
+      "brotli": 3326
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9248,
-        "brotli": 3939
+        "min": 9281,
+        "brotli": 3954
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10009,
-        "brotli": 4214
+        "min": 10042,
+        "brotli": 4232
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9056,
-        "brotli": 3863
+        "min": 9089,
+        "brotli": 3875
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6386,
-      "brotli": 2892
+      "min": 6419,
+      "brotli": 2905
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6375,
-      "brotli": 2884
+      "min": 6408,
+      "brotli": 2897
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5972,
-      "brotli": 2726
+      "min": 6005,
+      "brotli": 2745
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6246,
-      "brotli": 2853
+      "min": 6279,
+      "brotli": 2866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6113,
-      "brotli": 2778
+      "min": 6146,
+      "brotli": 2795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6491,
-        "brotli": 2942
+        "min": 6524,
+        "brotli": 2957
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6703,
-        "brotli": 3018
+        "min": 6736,
+        "brotli": 3029
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6672,
-        "brotli": 3005
+        "min": 6705,
+        "brotli": 3012
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6224,
-        "brotli": 2852
+        "min": 6257,
+        "brotli": 2866
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9510,
-        "brotli": 4055
+        "min": 9543,
+        "brotli": 4073
       },
       "files": {
         "tags/handlers.marko": 431,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6460,
-      "brotli": 2941
+      "min": 6493,
+      "brotli": 2944
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6398,
-        "brotli": 2895
+        "min": 6431,
+        "brotli": 2913
       },
       "files": {
         "tags/test.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7545,
-        "brotli": 3441
+        "min": 7578,
+        "brotli": 3435
       },
       "files": {
         "tags/inner/index.marko": 1000,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7835,
-      "brotli": 3484
+      "min": 7868,
+      "brotli": 3507
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7857,
-      "brotli": 3487
+      "min": 7890,
+      "brotli": 3510
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11392,
-      "brotli": 4881
+      "min": 11425,
+      "brotli": 4899
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 11267,
-      "brotli": 4809
+      "min": 11300,
+      "brotli": 4839
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11054,
-      "brotli": 4743
+      "min": 11087,
+      "brotli": 4756
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7799,
-      "brotli": 3434
+      "min": 7832,
+      "brotli": 3457
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7799,
-      "brotli": 3434
+      "min": 7832,
+      "brotli": 3457
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8140,
-      "brotli": 3574
+      "min": 8173,
+      "brotli": 3594
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 6126,
-      "brotli": 2760
+      "min": 6159,
+      "brotli": 2775
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8151,
-      "brotli": 3575
+      "min": 8184,
+      "brotli": 3595
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 140
     },
     "shared": {
-      "min": 11112,
-      "brotli": 4795
+      "min": 11145,
+      "brotli": 4808
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6078,
-      "brotli": 2731
+      "min": 6111,
+      "brotli": 2749
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 74
     },
     "shared": {
-      "min": 7229,
-      "brotli": 3219
+      "min": 7262,
+      "brotli": 3231
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 112
     },
     "shared": {
-      "min": 6740,
-      "brotli": 3019
+      "min": 6773,
+      "brotli": 3035
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9390,
-      "brotli": 4029
+      "min": 9423,
+      "brotli": 4051
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7791,
-        "brotli": 3530
+        "min": 7824,
+        "brotli": 3545
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6490,
-        "brotli": 2908
+        "min": 6523,
+        "brotli": 2923
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6717,
-      "brotli": 2960
+      "min": 6750,
+      "brotli": 2976
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9401,
-      "brotli": 4019
+      "min": 9434,
+      "brotli": 4040
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9931,
-      "brotli": 4286
+      "min": 9964,
+      "brotli": 4317
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-downstream-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1637,
-      "brotli": 874
+      "min": 1855,
+      "brotli": 959
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3514,
-        "brotli": 1627
+        "min": 3547,
+        "brotli": 1636
       },
       "files": {
         "tags/my-box.marko": 124,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3514,
-        "brotli": 1627
+        "min": 3547,
+        "brotli": 1636
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4253,
-        "brotli": 1968
+        "min": 4286,
+        "brotli": 1974
       },
       "files": {
         "tags/my-box.marko": 350,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9041,
-        "brotli": 3898
+        "min": 9074,
+        "brotli": 3919
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3581,
-      "brotli": 1644
+      "min": 3614,
+      "brotli": 1657
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8055,
-      "brotli": 3617
+      "min": 8088,
+      "brotli": 3633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reference-in-own-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1630,
-      "brotli": 868
+      "min": 1848,
+      "brotli": 954
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8004,
-      "brotli": 3603
+      "min": 8035,
+      "brotli": 3620
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8734,
-        "brotli": 3934
+        "min": 8767,
+        "brotli": 3955
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7716,
-      "brotli": 3500
+      "min": 7749,
+      "brotli": 3518
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4366,
-      "brotli": 2090
+      "min": 4399,
+      "brotli": 2102
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4362,
-      "brotli": 2087
+      "min": 4395,
+      "brotli": 2097
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4364,
-      "brotli": 2089
+      "min": 4397,
+      "brotli": 2098
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6676,
-      "brotli": 2989
+      "min": 6709,
+      "brotli": 2996
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4366,
-      "brotli": 2090
+      "min": 4399,
+      "brotli": 2102
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4559,
-      "brotli": 2165
+      "min": 4592,
+      "brotli": 2173
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4515,
-      "brotli": 2160
+      "min": 4548,
+      "brotli": 2166
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4433,
-      "brotli": 2119
+      "min": 4466,
+      "brotli": 2137
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4511,
-      "brotli": 2156
+      "min": 4544,
+      "brotli": 2164
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4381,
-      "brotli": 2099
+      "min": 4414,
+      "brotli": 2108
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4364,
-      "brotli": 2089
+      "min": 4397,
+      "brotli": 2098
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4521,
-      "brotli": 2163
+      "min": 4554,
+      "brotli": 2179
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3205,
-        "brotli": 1488
+        "min": 3238,
+        "brotli": 1501
       },
       "files": {
         "tags/child.marko": 151,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3542,
-        "brotli": 1636
+        "min": 3575,
+        "brotli": 1652
       },
       "files": {
         "tags/child.marko": 132,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3542,
-      "brotli": 1645
+      "min": 3575,
+      "brotli": 1649
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3542,
-        "brotli": 1630
+        "min": 3575,
+        "brotli": 1647
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15014,
-        "brotli": 5927
+        "min": 15048,
+        "brotli": 5986
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8946,
-        "brotli": 3858
+        "min": 8979,
+        "brotli": 3872
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6256,
-      "brotli": 2830
+      "min": 6289,
+      "brotli": 2849
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9847,
-        "brotli": 4170
+        "min": 9880,
+        "brotli": 4190
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9302,
-      "brotli": 4009
+      "min": 9335,
+      "brotli": 4010
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6172,
-        "brotli": 2796
+        "min": 6205,
+        "brotli": 2809
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6394,
-        "brotli": 2902
+        "min": 6427,
+        "brotli": 2927
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6913,
-      "brotli": 3086
+      "min": 6946,
+      "brotli": 3100
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6913,
-      "brotli": 3086
+      "min": 6946,
+      "brotli": 3100
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7496,
-      "brotli": 3300
+      "min": 7529,
+      "brotli": 3316
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6648,
-        "brotli": 3012
+        "min": 6681,
+        "brotli": 3024
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9022,
-      "brotli": 3912
+      "min": 9055,
+      "brotli": 3924
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7127,
-      "brotli": 3204
+      "min": 7160,
+      "brotli": 3217
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6086,
-      "brotli": 2753
+      "min": 6119,
+      "brotli": 2760
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9398,
-      "brotli": 4070
+      "min": 9431,
+      "brotli": 4082
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9066,
-      "brotli": 3914
+      "min": 9099,
+      "brotli": 3929
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -428,18 +428,23 @@ export function insertChildNodes(
   startNode: Node,
   endNode: Node,
 ) {
-  parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  // Branches are assembled into a detached tree, where staging the range in a
+  // DocumentFragment costs an allocation and buys no layout work.
+  if ((parentNode as Node).isConnected) {
+    parentNode.insertBefore(toInsertNode(startNode, endNode), referenceNode);
+  } else {
+    const stop = endNode.nextSibling;
+    while (startNode !== stop) {
+      const next = startNode.nextSibling;
+      parentNode.insertBefore(startNode, referenceNode);
+      startNode = next!;
+    }
+  }
+  return parentNode;
 }
 
 export function toInsertNode(startNode: Node, endNode: Node) {
-  if (startNode === endNode) return startNode;
-  const parent = new DocumentFragment();
-  const stop = endNode.nextSibling;
-  while (startNode !== stop) {
-    const next = startNode.nextSibling;
-    parent.appendChild(startNode);
-    startNode = next!;
-  }
-
-  return parent;
+  return startNode === endNode
+    ? startNode
+    : insertChildNodes(new DocumentFragment(), null, startNode, endNode);
 }


### PR DESCRIPTION
Branches are assembled into a detached tree, so staging a node range in a `DocumentFragment` before inserting it costs an allocation and buys no layout work. When the parent is not connected, move the nodes straight into it instead.

A fresh fragment is itself detached, so `toInsertNode` now builds one through the same path and its own copy of the loop goes away.

Worth ~7% on tearing down and rebuilding a large keyed list, and 49 bytes smaller minified (3 brotli).