### PR TITLE
perf(runtime-tags): walk cloned templates without a TreeWalker

### DIFF
--- a/.changeset/olive-pears-shake.md
+++ b/.changeset/olive-pears-shake.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Walk cloned templates with direct node traversal instead of a `TreeWalker`, speeding up branch creation.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26657,
-        "brotli": 9896
+        "min": 26671,
+        "brotli": 9915
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 119
       },
       "runtime": {
-        "min": 4028,
-        "brotli": 1775
+        "min": 4032,
+        "brotli": 1792
       },
       "total": {
-        "min": 4189,
-        "brotli": 1894
+        "min": 4193,
+        "brotli": 1911
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6554,
-        "brotli": 2873
+        "min": 6558,
+        "brotli": 2884
       },
       "total": {
-        "min": 7199,
-        "brotli": 3237
+        "min": 7203,
+        "brotli": 3248
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6554 (min) 2873 (brotli)
+// size: 6558 (min) 2884 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -11,7 +11,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   isScheduled,
   channel,
   _var_change = (scope, value) => scope.U?.(value),
-  walker = /* @__PURE__ */ document.createTreeWalker(document),
+  currentNode,
   walkInternal = function walkInternal(currentWalkIndex, walkCodes, scope) {
     let value,
       currentMultiplier,
@@ -23,12 +23,11 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         (currentMultiplier = storedMultiplier),
         (storedMultiplier = 0),
         value === 32)
-      ) {
-        let node = walker.currentNode;
-        scope[decodeAccessor(currentScopeIndex++)] = node;
-      } else if (value === 37 || value === 49)
-        (walker.currentNode.replaceWith(
-          (walker.currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
+      )
+        scope[decodeAccessor(currentScopeIndex++)] = currentNode;
+      else if (value === 37 || value === 49)
+        (currentNode.replaceWith(
+          (currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
         ),
           value === 49 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value === 38) return currentWalkIndex;
@@ -40,14 +39,22 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         )),
           value === 48 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value < 92)
-        for (value = 25 * currentMultiplier + value - 67; value--;) walker.nextNode();
+        for (value = 25 * currentMultiplier + value - 67; value--;) walkNextNode();
       else if (value < 107)
-        for (value = 10 * currentMultiplier + value - 97; value--;) walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 97; value--;) walkNextSibling();
       else if (value < 117) {
-        for (value = 10 * currentMultiplier + value - 107; value--;) walker.parentNode();
-        walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 107; value--;)
+          currentNode = currentNode.parentNode || currentNode;
+        walkNextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
+  walkNextNode = () => {
+    if (currentNode.firstChild) return (currentNode = currentNode.firstChild);
+    for (; !currentNode.nextSibling && currentNode.parentNode;)
+      currentNode = currentNode.parentNode;
+    walkNextSibling();
+  },
+  walkNextSibling = () => (currentNode = currentNode.nextSibling || currentNode),
   registeredValues = {},
   branchesEnabled,
   cloneCache = {},
@@ -196,8 +203,9 @@ function _script(id, fn) {
     }
   );
 }
+/** Cloned templates are small, where a TreeWalker's per-step cost dominates. */
 function walk(startNode, walkCodes, branch) {
-  ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
+  ((currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
 function enableBranches() {
   branchesEnabled || ((branchesEnabled = 1), skipDestroyedRenders());

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 4028 (min) 1775 (brotli)
+// size: 4032 (min) 1792 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -11,7 +11,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   isScheduled,
   channel,
   _var_change = (scope, value) => scope.U?.(value),
-  walker = /* @__PURE__ */ document.createTreeWalker(document),
+  currentNode,
   walkInternal = function walkInternal(currentWalkIndex, walkCodes, scope) {
     let value,
       currentMultiplier,
@@ -23,12 +23,11 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         (currentMultiplier = storedMultiplier),
         (storedMultiplier = 0),
         value === 32)
-      ) {
-        let node = walker.currentNode;
-        scope[decodeAccessor(currentScopeIndex++)] = node;
-      } else if (value === 37 || value === 49)
-        (walker.currentNode.replaceWith(
-          (walker.currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
+      )
+        scope[decodeAccessor(currentScopeIndex++)] = currentNode;
+      else if (value === 37 || value === 49)
+        (currentNode.replaceWith(
+          (currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
         ),
           value === 49 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value === 38) return currentWalkIndex;
@@ -40,14 +39,22 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
         )),
           value === 48 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value < 92)
-        for (value = 25 * currentMultiplier + value - 67; value--;) walker.nextNode();
+        for (value = 25 * currentMultiplier + value - 67; value--;) walkNextNode();
       else if (value < 107)
-        for (value = 10 * currentMultiplier + value - 97; value--;) walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 97; value--;) walkNextSibling();
       else if (value < 117) {
-        for (value = 10 * currentMultiplier + value - 107; value--;) walker.parentNode();
-        walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 107; value--;)
+          currentNode = currentNode.parentNode || currentNode;
+        walkNextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
+  walkNextNode = () => {
+    if (currentNode.firstChild) return (currentNode = currentNode.firstChild);
+    for (; !currentNode.nextSibling && currentNode.parentNode;)
+      currentNode = currentNode.parentNode;
+    walkNextSibling();
+  },
+  walkNextSibling = () => (currentNode = currentNode.nextSibling || currentNode),
   registeredValues = {},
   cloneCache = {},
   rendering,
@@ -134,8 +141,9 @@ function _script(id, fn) {
     }
   );
 }
+/** Cloned templates are small, where a TreeWalker's per-step cost dominates. */
 function walk(startNode, walkCodes, branch) {
-  ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
+  ((currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
 function _resume(id, obj) {
   return (registeredValues[id] = obj);

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26657 (min) 9896 (brotli)
+// size: 26671 (min) 9915 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -33,7 +33,7 @@ let empty = [],
   _return = (scope, value) => scope.T?.(value),
   _var_change = (scope, value) => scope.U?.(value),
   tagIdsByGlobal = /* @__PURE__ */ new WeakMap(),
-  walker = /* @__PURE__ */ document.createTreeWalker(document),
+  currentNode,
   walkInternal = function walkInternal(currentWalkIndex, walkCodes, scope) {
     let value,
       currentMultiplier,
@@ -45,12 +45,11 @@ let empty = [],
         (currentMultiplier = storedMultiplier),
         (storedMultiplier = 0),
         value === 32)
-      ) {
-        let node = walker.currentNode;
-        scope[decodeAccessor(currentScopeIndex++)] = node;
-      } else if (value === 37 || value === 49)
-        (walker.currentNode.replaceWith(
-          (walker.currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
+      )
+        scope[decodeAccessor(currentScopeIndex++)] = currentNode;
+      else if (value === 37 || value === 49)
+        (currentNode.replaceWith(
+          (currentNode = scope[decodeAccessor(currentScopeIndex++)] = new Text()),
         ),
           value === 49 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value === 38) return currentWalkIndex;
@@ -62,14 +61,22 @@ let empty = [],
         )),
           value === 48 && (scope[decodeAccessor(currentScopeIndex++)] = skipScope()));
       else if (value < 92)
-        for (value = 25 * currentMultiplier + value - 67; value--;) walker.nextNode();
+        for (value = 25 * currentMultiplier + value - 67; value--;) walkNextNode();
       else if (value < 107)
-        for (value = 10 * currentMultiplier + value - 97; value--;) walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 97; value--;) walkNextSibling();
       else if (value < 117) {
-        for (value = 10 * currentMultiplier + value - 107; value--;) walker.parentNode();
-        walker.nextSibling();
+        for (value = 10 * currentMultiplier + value - 107; value--;)
+          currentNode = currentNode.parentNode || currentNode;
+        walkNextSibling();
       } else storedMultiplier = currentMultiplier * 10 + value - 117;
   },
+  walkNextNode = () => {
+    if (currentNode.firstChild) return (currentNode = currentNode.firstChild);
+    for (; !currentNode.nextSibling && currentNode.parentNode;)
+      currentNode = currentNode.parentNode;
+    walkNextSibling();
+  },
+  walkNextSibling = () => (currentNode = currentNode.nextSibling || currentNode),
   registeredValues = {},
   curRenders,
   branchesEnabled,
@@ -663,8 +670,9 @@ function _hoist(...path) {
 function _hoist_resume(id, ...path) {
   return _resume(id, _hoist(...path));
 }
+/** Cloned templates are small, where a TreeWalker's per-step cost dominates. */
 function walk(startNode, walkCodes, branch) {
-  ((walker.currentNode = startNode), walkInternal(0, walkCodes, branch));
+  ((currentNode = startNode), walkInternal(0, walkCodes, branch));
 }
 function enableBranches() {
   branchesEnabled || ((branchesEnabled = 1), skipDestroyedRenders());

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62557,
-        "brotli": 19329
+        "min": 62566,
+        "brotli": 19293
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63805,
-        "brotli": 19884
+        "min": 63809,
+        "brotli": 19881
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63688,
-        "brotli": 19855
+        "min": 63689,
+        "brotli": 19841
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62557,
-        "brotli": 19329
+        "min": 62566,
+        "brotli": 19293
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63843,
-        "brotli": 19891
+        "min": 63848,
+        "brotli": 19876
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62455,
-        "brotli": 19261
+        "min": 62464,
+        "brotli": 19322
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62496,
-        "brotli": 19281
+        "min": 62505,
+        "brotli": 19321
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63792,
-        "brotli": 19833
+        "min": 63796,
+        "brotli": 19869
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63911,
-        "brotli": 19897
+        "min": 63915,
+        "brotli": 19856
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62611,
-        "brotli": 19314
+        "min": 62617,
+        "brotli": 19387
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64101,
-        "brotli": 19985
+        "min": 64110,
+        "brotli": 20008
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65379,
-        "brotli": 20315
+        "min": 65386,
+        "brotli": 20272
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63737,
-        "brotli": 19816
+        "min": 63738,
+        "brotli": 19806
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64019,
-        "brotli": 19946
+        "min": 64022,
+        "brotli": 19939
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63805,
-        "brotli": 19826
+        "min": 63809,
+        "brotli": 19888
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62862,
-        "brotli": 19473
+        "min": 62871,
+        "brotli": 19502
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62534,
-        "brotli": 19311
+        "min": 62543,
+        "brotli": 19345
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64239,
-        "brotli": 20037
+        "min": 64247,
+        "brotli": 20047
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63748,
-        "brotli": 19836
+        "min": 63750,
+        "brotli": 19808
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63417,
-        "brotli": 19685
+        "min": 63421,
+        "brotli": 19736
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63909,
-        "brotli": 19856
+        "min": 63914,
+        "brotli": 19916
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63519,
-        "brotli": 19738
+        "min": 63525,
+        "brotli": 19719
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62919,
-        "brotli": 19441
+        "min": 62925,
+        "brotli": 19541
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64607,
-        "brotli": 20195
+        "min": 64618,
+        "brotli": 20279
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6025,
-      "brotli": 2746
+      "min": 6029,
+      "brotli": 2759
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6273,
-      "brotli": 2842
+      "min": 6277,
+      "brotli": 2852
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8915,
-      "brotli": 3866
+      "min": 8920,
+      "brotli": 3886
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8893,
-        "brotli": 3853
+        "min": 8897,
+        "brotli": 3874
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3633,
-        "brotli": 1664
+        "brotli": 1683
       },
       "files": {
         "tags/hello/index.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3616,
-        "brotli": 1670
+        "brotli": 1684
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3616,
-        "brotli": 1669
+        "brotli": 1683
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9954,
-        "brotli": 4299
+        "min": 9959,
+        "brotli": 4343
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7294,
-        "brotli": 3341
+        "min": 7298,
+        "brotli": 3368
       },
       "files": {
         "tags/child/index.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10212,
-      "brotli": 4356
+      "min": 10218,
+      "brotli": 4368
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6836,
-      "brotli": 3094
+      "min": 6838,
+      "brotli": 3103
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6309,
-      "brotli": 2878
+      "min": 6313,
+      "brotli": 2895
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7000,
-      "brotli": 3167
+      "min": 7004,
+      "brotli": 3187
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7089,
-      "brotli": 3194
+      "min": 7093,
+      "brotli": 3212
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7134,
-      "brotli": 3199
+      "min": 7138,
+      "brotli": 3220
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9118,
-      "brotli": 3920
+      "min": 9123,
+      "brotli": 3937
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8902,
-      "brotli": 3851
+      "min": 8905,
+      "brotli": 3866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8904,
-      "brotli": 3853
+      "min": 8907,
+      "brotli": 3866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6318,
-      "brotli": 2870
+      "min": 6322,
+      "brotli": 2880
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6316,
-      "brotli": 2859
+      "min": 6320,
+      "brotli": 2876
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6385,
-      "brotli": 2894
+      "min": 6389,
+      "brotli": 2900
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7665,
-        "brotli": 3507
+        "min": 7667,
+        "brotli": 3541
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9469,
-        "brotli": 4096
+        "min": 9475,
+        "brotli": 4108
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4609,
-      "brotli": 2126
+      "brotli": 2137
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6400,
-      "brotli": 2915
+      "min": 6402,
+      "brotli": 2925
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7202,
+      "min": 7206,
       "brotli": 3314
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7465,
-      "brotli": 3379
+      "min": 7469,
+      "brotli": 3384
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6287,
-      "brotli": 2863
+      "min": 6291,
+      "brotli": 2876
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7213,
-      "brotli": 3258
+      "min": 7219,
+      "brotli": 3275
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7170,
-      "brotli": 3240
+      "min": 7176,
+      "brotli": 3255
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7170,
-      "brotli": 3240
+      "min": 7176,
+      "brotli": 3255
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7190,
-      "brotli": 3249
+      "min": 7196,
+      "brotli": 3264
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6955,
-      "brotli": 3133
+      "min": 6959,
+      "brotli": 3153
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7957,
-        "brotli": 3632
+        "min": 7963,
+        "brotli": 3630
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7714,
-        "brotli": 3406
+        "min": 7719,
+        "brotli": 3417
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6301,
-      "brotli": 2865
+      "min": 6305,
+      "brotli": 2870
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6484,
-        "brotli": 2937
+        "min": 6488,
+        "brotli": 2958
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8379,
-        "brotli": 3777
+        "min": 8384,
+        "brotli": 3782
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7907,
-        "brotli": 3599
+        "min": 7911,
+        "brotli": 3608
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7648,
-        "brotli": 3383
+        "min": 7653,
+        "brotli": 3397
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6283,
-      "brotli": 2848
+      "min": 6287,
+      "brotli": 2857
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6466,
-        "brotli": 2930
+        "min": 6470,
+        "brotli": 2940
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6315,
-      "brotli": 2864
+      "min": 6319,
+      "brotli": 2885
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11054,
-        "brotli": 4796
+        "min": 11060,
+        "brotli": 4814
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6023,
-      "brotli": 2749
+      "min": 6027,
+      "brotli": 2775
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8584,
-      "brotli": 3820
+      "min": 8592,
+      "brotli": 3819
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8427,
-      "brotli": 3642
+      "min": 8432,
+      "brotli": 3661
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14302,
-      "brotli": 5566
+      "min": 14308,
+      "brotli": 5583
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13859,
-      "brotli": 5360
+      "min": 13865,
+      "brotli": 5375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13733,
-      "brotli": 5314
+      "min": 13739,
+      "brotli": 5325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14020,
-      "brotli": 5421
+      "min": 14026,
+      "brotli": 5434
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9186,
-      "brotli": 3971
+      "min": 9192,
+      "brotli": 3984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9411,
-      "brotli": 4042
+      "min": 9417,
+      "brotli": 4080
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9010,
-        "brotli": 3672
+        "min": 9014,
+        "brotli": 3682
       },
       "files": {
         "tags/my-select.marko": 297,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9024,
-        "brotli": 3900
+        "min": 9029,
+        "brotli": 3909
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9009,
-        "brotli": 3890
+        "min": 9013,
+        "brotli": 3903
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8937,
-        "brotli": 3863
+        "min": 8941,
+        "brotli": 3882
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6436,
-      "brotli": 2914
+      "min": 6440,
+      "brotli": 2928
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8839,
-        "brotli": 3808
+        "min": 8843,
+        "brotli": 3821
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6702,
-      "brotli": 3044
+      "min": 6706,
+      "brotli": 3059
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6368,
-      "brotli": 2910
+      "min": 6372,
+      "brotli": 2931
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4698,
-        "brotli": 2158
+        "min": 4700,
+        "brotli": 2172
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7494,
-        "brotli": 3413
+        "min": 7498,
+        "brotli": 3425
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6210,
-      "brotli": 2816
+      "min": 6214,
+      "brotli": 2827
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5951,
-      "brotli": 2671
+      "min": 5955,
+      "brotli": 2678
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8782,
-      "brotli": 3801
+      "min": 8786,
+      "brotli": 3809
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8669,
-      "brotli": 3749
+      "min": 8674,
+      "brotli": 3761
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9579,
-        "brotli": 4094
+        "min": 9584,
+        "brotli": 4099
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9658,
-        "brotli": 4113
+        "min": 9663,
+        "brotli": 4124
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9471,
-        "brotli": 4042
+        "min": 9476,
+        "brotli": 4056
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6429,
-        "brotli": 2914
+        "min": 6433,
+        "brotli": 2925
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9494,
-        "brotli": 4061
+        "min": 9499,
+        "brotli": 4069
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14636,
-        "brotli": 5660
+        "min": 14642,
+        "brotli": 5673
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13713,
-        "brotli": 5325
+        "min": 13719,
+        "brotli": 5343
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8574,
-      "brotli": 3302
+      "min": 8578,
+      "brotli": 3309
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9425,
-        "brotli": 4053
+        "min": 9430,
+        "brotli": 4070
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9516,
-        "brotli": 4061
+        "min": 9521,
+        "brotli": 4068
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8636,
-      "brotli": 3729
+      "min": 8640,
+      "brotli": 3740
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8574,
-      "brotli": 3302
+      "min": 8578,
+      "brotli": 3309
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-in-body/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4075,
-        "brotli": 1890
+        "brotli": 1900
       },
       "files": {
         "tags/child.marko": 146,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8899,
-        "brotli": 3833
+        "min": 8904,
+        "brotli": 3842
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6818,
-      "brotli": 3065
+      "min": 6822,
+      "brotli": 3077
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7364,
-      "brotli": 3358
+      "min": 7368,
+      "brotli": 3377
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7993,
-      "brotli": 3611
+      "min": 8000,
+      "brotli": 3633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7460,
-      "brotli": 3385
+      "min": 7464,
+      "brotli": 3394
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8078,
-      "brotli": 3647
+      "min": 8083,
+      "brotli": 3662
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7567,
-      "brotli": 3402
+      "min": 7571,
+      "brotli": 3397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8047,
-      "brotli": 3616
+      "min": 8053,
+      "brotli": 3633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7308,
-      "brotli": 3353
+      "min": 7312,
+      "brotli": 3360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7110,
-      "brotli": 3270
+      "min": 7114,
+      "brotli": 3320
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7117,
-      "brotli": 3279
+      "min": 7121,
+      "brotli": 3287
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7378,
-      "brotli": 3365
+      "min": 7382,
+      "brotli": 3384
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7387,
-      "brotli": 3366
+      "min": 7391,
+      "brotli": 3383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8415,
-      "brotli": 3780
+      "min": 8417,
+      "brotli": 3779
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6596,
-      "brotli": 2989
+      "min": 6600,
+      "brotli": 2998
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8490,
+      "min": 8496,
       "brotli": 3827
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8239,
-      "brotli": 3711
+      "min": 8243,
+      "brotli": 3732
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7046,
-      "brotli": 3234
+      "min": 7050,
+      "brotli": 3271
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7775,
-        "brotli": 3562
+        "min": 7779,
+        "brotli": 3573
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8189,
-        "brotli": 3716
+        "min": 8193,
+        "brotli": 3734
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7125,
-      "brotli": 3248
+      "min": 7129,
+      "brotli": 3247
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7119,
-      "brotli": 3245
+      "min": 7123,
+      "brotli": 3244
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-with-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6903,
-      "brotli": 3169
+      "min": 6907,
+      "brotli": 3187
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7115,
-      "brotli": 3276
+      "min": 7119,
+      "brotli": 3298
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7358,
-      "brotli": 3371
+      "min": 7362,
+      "brotli": 3388
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7252,
-      "brotli": 3326
+      "min": 7256,
+      "brotli": 3341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9281,
-        "brotli": 3954
+        "min": 9286,
+        "brotli": 3974
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10042,
-        "brotli": 4232
+        "min": 10048,
+        "brotli": 4260
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9089,
-        "brotli": 3875
+        "min": 9094,
+        "brotli": 3889
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6419,
-      "brotli": 2905
+      "min": 6423,
+      "brotli": 2925
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6408,
-      "brotli": 2897
+      "min": 6412,
+      "brotli": 2915
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6005,
-      "brotli": 2745
+      "min": 6009,
+      "brotli": 2755
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6279,
-      "brotli": 2866
+      "min": 6283,
+      "brotli": 2876
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6146,
-      "brotli": 2795
+      "min": 6150,
+      "brotli": 2810
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6524,
-        "brotli": 2957
+        "min": 6528,
+        "brotli": 2971
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6736,
-        "brotli": 3029
+        "min": 6742,
+        "brotli": 3039
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6705,
-        "brotli": 3012
+        "min": 6711,
+        "brotli": 3024
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6257,
-        "brotli": 2866
+        "min": 6261,
+        "brotli": 2869
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9543,
-        "brotli": 4073
+        "min": 9548,
+        "brotli": 4081
       },
       "files": {
         "tags/handlers.marko": 431,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6493,
-      "brotli": 2944
+      "min": 6497,
+      "brotli": 2960
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6431,
-        "brotli": 2913
+        "min": 6435,
+        "brotli": 2932
       },
       "files": {
         "tags/test.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7578,
-        "brotli": 3435
+        "min": 7582,
+        "brotli": 3459
       },
       "files": {
         "tags/inner/index.marko": 1000,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7868,
-      "brotli": 3507
+      "min": 7871,
+      "brotli": 3515
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7890,
-      "brotli": 3510
+      "min": 7893,
+      "brotli": 3518
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11425,
-      "brotli": 4899
+      "min": 11430,
+      "brotli": 4910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 11300,
-      "brotli": 4839
+      "min": 11311,
+      "brotli": 4849
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11087,
-      "brotli": 4756
+      "min": 11092,
+      "brotli": 4774
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7832,
-      "brotli": 3457
+      "min": 7835,
+      "brotli": 3465
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7832,
-      "brotli": 3457
+      "min": 7835,
+      "brotli": 3465
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8173,
-      "brotli": 3594
+      "min": 8178,
+      "brotli": 3606
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 6159,
-      "brotli": 2775
+      "min": 6163,
+      "brotli": 2786
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8184,
-      "brotli": 3595
+      "min": 8189,
+      "brotli": 3607
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 140
     },
     "shared": {
-      "min": 11145,
-      "brotli": 4808
+      "min": 11150,
+      "brotli": 4826
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6111,
-      "brotli": 2749
+      "min": 6113,
+      "brotli": 2767
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 74
     },
     "shared": {
-      "min": 7262,
-      "brotli": 3231
+      "min": 7264,
+      "brotli": 3254
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 112
     },
     "shared": {
-      "min": 6773,
-      "brotli": 3035
+      "min": 6775,
+      "brotli": 3048
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9423,
-      "brotli": 4051
+      "min": 9428,
+      "brotli": 4068
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7824,
-        "brotli": 3545
+        "min": 7827,
+        "brotli": 3548
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6523,
-        "brotli": 2923
+        "min": 6527,
+        "brotli": 2934
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6750,
-      "brotli": 2976
+      "min": 6756,
+      "brotli": 2987
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9434,
-      "brotli": 4040
+      "min": 9439,
+      "brotli": 4054
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9964,
-      "brotli": 4317
+      "min": 9969,
+      "brotli": 4334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3547,
-        "brotli": 1636
+        "brotli": 1657
       },
       "files": {
         "tags/my-box.marko": 124,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3547,
-        "brotli": 1636
+        "brotli": 1657
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4286,
-        "brotli": 1974
+        "brotli": 1986
       },
       "files": {
         "tags/my-box.marko": 350,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9074,
-        "brotli": 3919
+        "min": 9079,
+        "brotli": 3927
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3614,
-      "brotli": 1657
+      "brotli": 1667
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8088,
-      "brotli": 3633
+      "min": 8096,
+      "brotli": 3665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8035,
-      "brotli": 3620
+      "min": 8041,
+      "brotli": 3660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8767,
-        "brotli": 3955
+        "min": 8772,
+        "brotli": 3961
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7749,
-      "brotli": 3518
+      "min": 7753,
+      "brotli": 3536
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6709,
-      "brotli": 2996
+      "min": 6713,
+      "brotli": 3018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3238,
-        "brotli": 1501
+        "brotli": 1510
       },
       "files": {
         "tags/child.marko": 151,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3575,
-        "brotli": 1652
+        "brotli": 1664
       },
       "files": {
         "tags/child.marko": 132,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3575,
-      "brotli": 1649
+      "brotli": 1665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3575,
-        "brotli": 1647
+        "brotli": 1665
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15048,
-        "brotli": 5986
+        "min": 15054,
+        "brotli": 5958
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8979,
-        "brotli": 3872
+        "min": 8984,
+        "brotli": 3882
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6289,
-      "brotli": 2849
+      "min": 6293,
+      "brotli": 2862
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9880,
-        "brotli": 4190
+        "min": 9886,
+        "brotli": 4189
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9335,
-      "brotli": 4010
+      "min": 9340,
+      "brotli": 4022
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6205,
-        "brotli": 2809
+        "min": 6209,
+        "brotli": 2829
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6427,
-        "brotli": 2927
+        "min": 6431,
+        "brotli": 2932
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6946,
-      "brotli": 3100
+      "min": 6950,
+      "brotli": 3116
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6946,
-      "brotli": 3100
+      "min": 6950,
+      "brotli": 3116
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7529,
-      "brotli": 3316
+      "min": 7533,
+      "brotli": 3324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6681,
-        "brotli": 3024
+        "min": 6685,
+        "brotli": 3037
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9055,
-      "brotli": 3924
+      "min": 9058,
+      "brotli": 3937
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7160,
-      "brotli": 3217
+      "min": 7166,
+      "brotli": 3230
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6119,
-      "brotli": 2760
+      "min": 6123,
+      "brotli": 2776
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9431,
-      "brotli": 4082
+      "min": 9434,
+      "brotli": 4102
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9099,
-      "brotli": 3929
+      "min": 9104,
+      "brotli": 3942
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/walker.ts
+++ b/packages/runtime-tags/src/dom/walker.ts
@@ -9,7 +9,8 @@ import {
 } from "../common/types";
 import { createScope, skipScope } from "./scope";
 
-export const walker = /* @__PURE__ */ document.createTreeWalker(document);
+/** Cloned templates are small, where a TreeWalker's per-step cost dominates. */
+let currentNode: Node;
 
 // Laws of the walks string:
 //  - Always prefer Get to Before to After, or Replace
@@ -25,7 +26,7 @@ export const walker = /* @__PURE__ */ document.createTreeWalker(document);
 //  - A component must assume the walker is on its first node, and include instructions for walking to its assumed nextSibling
 
 export function walk(startNode: Node, walkCodes: string, branch: BranchScope) {
-  walker.currentNode = startNode;
+  currentNode = startNode;
   walkInternal(0, walkCodes, branch);
 }
 
@@ -46,18 +47,17 @@ const walkInternal = function walkInternal(
     storedMultiplier = 0;
 
     if (value === WalkCode.Get) {
-      const node = walker.currentNode;
       scope[
         MARKO_DEBUG
-          ? getDebugKey(currentScopeIndex++, node)
+          ? getDebugKey(currentScopeIndex++, currentNode)
           : decodeAccessor(currentScopeIndex++)
-      ] = node;
+      ] = currentNode;
     } else if (
       value === WalkCode.Replace ||
       value === WalkCode.DynamicTagWithVar
     ) {
-      (walker.currentNode as ChildNode).replaceWith(
-        (walker.currentNode = scope[
+      (currentNode as ChildNode).replaceWith(
+        (currentNode = scope[
           MARKO_DEBUG
             ? getDebugKey(currentScopeIndex++, "#text")
             : decodeAccessor(currentScopeIndex++)
@@ -99,19 +99,19 @@ const walkInternal = function walkInternal(
     } else if (value < WalkCode.NextEnd + 1) {
       value = WalkRangeSize.Next * currentMultiplier + value - WalkCode.Next;
       while (value--) {
-        walker.nextNode();
+        walkNextNode();
       }
     } else if (value < WalkCode.OverEnd + 1) {
       value = WalkRangeSize.Over * currentMultiplier + value - WalkCode.Over;
       while (value--) {
-        walker.nextSibling();
+        walkNextSibling();
       }
     } else if (value < WalkCode.OutEnd + 1) {
       value = WalkRangeSize.Out * currentMultiplier + value - WalkCode.Out;
       while (value--) {
-        walker.parentNode();
+        currentNode = currentNode.parentNode || currentNode;
       }
-      walker.nextSibling();
+      walkNextSibling();
     } else {
       if (
         MARKO_DEBUG &&
@@ -140,3 +140,14 @@ export function getDebugKey(index: number, node: Node | string) {
 
   return index;
 }
+
+const walkNextNode = () => {
+  if (currentNode.firstChild) return (currentNode = currentNode.firstChild);
+  while (!currentNode.nextSibling && currentNode.parentNode) {
+    currentNode = currentNode.parentNode;
+  }
+  walkNextSibling();
+};
+
+const walkNextSibling = () =>
+  (currentNode = currentNode.nextSibling || currentNode);


### PR DESCRIPTION
Templates are cloned into small detached trees, where a `TreeWalker`'s per-step cost dominates the traversal it saves. Track the cursor in a module-local instead and step it with `firstChild`/`nextSibling`/`parentNode` directly.

Worth ~3% on building a large keyed list, for +14 bytes minified (+19 brotli).