### PR TITLE
perf(runtime-tags): let a conditional bound its own section

### DIFF
--- a/.changeset/olive-cats-invent.md
+++ b/.changeset/olive-cats-invent.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Let an exhaustive conditional that is a section's only content bound the section itself, so no marker or anchor nodes are created for it. A `<for>` over `<if>`/`<else>` now allocates one fewer node per item and renders no comment markers for the conditional.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26671,
-        "brotli": 9915
+        "min": 26819,
+        "brotli": 9999
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6558,
-        "brotli": 2884
+        "min": 6704,
+        "brotli": 2949
       },
       "total": {
-        "min": 7203,
-        "brotli": 3248
+        "min": 7349,
+        "brotli": 3313
       }
     },
     {

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6558 (min) 2884 (brotli)
+// size: 6704 (min) 2949 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   delegate = (type, handler) =>
@@ -345,9 +345,21 @@ function setConditionalRenderer(scope, nodeAccessor, newRenderer, createBranch) 
       ? (newBranch
           ? insertBranchBefore(newBranch, parentNode, prevBranch.S)
           : parentNode.insertBefore(referenceNode, prevBranch.S),
+        adoptRange(scope, prevBranch, newBranch || referenceNode),
         removeAndDestroyBranch(prevBranch))
       : newBranch &&
-        (insertBranchBefore(newBranch, parentNode, referenceNode), referenceNode.remove());
+        (insertBranchBefore(newBranch, parentNode, referenceNode),
+        referenceNode.remove(),
+        adoptRange(scope, referenceNode, newBranch));
+}
+function adoptRange(scope, prev, next) {
+  let prevStart = prev.S || prev,
+    prevEnd = prev.K || prev,
+    branch = scope.F;
+  for (; branch && (branch.S === prevStart || branch.K === prevEnd);)
+    (branch.S === prevStart && (branch.S = next.S || next),
+      branch.K === prevEnd && (branch.K = next.K || next),
+      (branch = branch.N));
 }
 /* @__NO_SIDE_EFFECTS__ */
 function loop(forEach) {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26671 (min) 9915 (brotli)
+// size: 26819 (min) 9999 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let empty = [],
   rest = Symbol(),
@@ -1890,9 +1890,21 @@ function setConditionalRenderer(scope, nodeAccessor, newRenderer, createBranch) 
       ? (newBranch
           ? insertBranchBefore(newBranch, parentNode, prevBranch.S)
           : parentNode.insertBefore(referenceNode, prevBranch.S),
+        adoptRange(scope, prevBranch, newBranch || referenceNode),
         removeAndDestroyBranch(prevBranch))
       : newBranch &&
-        (insertBranchBefore(newBranch, parentNode, referenceNode), referenceNode.remove());
+        (insertBranchBefore(newBranch, parentNode, referenceNode),
+        referenceNode.remove(),
+        adoptRange(scope, referenceNode, newBranch));
+}
+function adoptRange(scope, prev, next) {
+  let prevStart = prev.S || prev,
+    prevEnd = prev.K || prev,
+    branch = scope.F;
+  for (; branch && (branch.S === prevStart || branch.K === prevEnd);)
+    (branch.S === prevStart && (branch.S = next.S || next),
+      branch.K === prevEnd && (branch.K = next.K || next),
+      (branch = branch.N));
 }
 /* @__NO_SIDE_EFFECTS__ */
 function loop(forEach) {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62566,
-        "brotli": 19293
+        "min": 62714,
+        "brotli": 19360
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63809,
-        "brotli": 19881
+        "min": 63954,
+        "brotli": 19976
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63689,
-        "brotli": 19841
+        "min": 63841,
+        "brotli": 19886
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62566,
-        "brotli": 19293
+        "min": 62714,
+        "brotli": 19360
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63848,
-        "brotli": 19876
+        "min": 63996,
+        "brotli": 19985
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62464,
-        "brotli": 19322
+        "min": 62612,
+        "brotli": 19355
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62505,
-        "brotli": 19321
+        "min": 62653,
+        "brotli": 19365
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63796,
-        "brotli": 19869
+        "min": 63942,
+        "brotli": 19932
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63915,
-        "brotli": 19856
+        "min": 64061,
+        "brotli": 19970
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62617,
-        "brotli": 19387
+        "min": 62765,
+        "brotli": 19451
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64110,
-        "brotli": 20008
+        "min": 64256,
+        "brotli": 20060
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65386,
-        "brotli": 20272
+        "min": 65536,
+        "brotli": 20358
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63738,
-        "brotli": 19806
+        "min": 63890,
+        "brotli": 19861
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64022,
-        "brotli": 19939
+        "min": 64167,
+        "brotli": 19992
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63809,
-        "brotli": 19888
+        "min": 63954,
+        "brotli": 19913
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62871,
-        "brotli": 19502
+        "min": 63019,
+        "brotli": 19553
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62543,
-        "brotli": 19345
+        "min": 62691,
+        "brotli": 19361
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64247,
-        "brotli": 20047
+        "min": 64397,
+        "brotli": 20118
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63750,
-        "brotli": 19808
+        "min": 63897,
+        "brotli": 19892
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63421,
-        "brotli": 19736
+        "min": 63569,
+        "brotli": 19807
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63914,
-        "brotli": 19916
+        "min": 64065,
+        "brotli": 19957
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63525,
-        "brotli": 19719
+        "min": 63673,
+        "brotli": 19801
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62925,
-        "brotli": 19541
+        "min": 63073,
+        "brotli": 19592
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64618,
-        "brotli": 20279
+        "min": 64766,
+        "brotli": 20291
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6029,
-      "brotli": 2759
+      "min": 6176,
+      "brotli": 2821
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7523,
-      "brotli": 3299
+      "min": 7671,
+      "brotli": 3361
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6277,
-      "brotli": 2852
+      "min": 6424,
+      "brotli": 2907
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8920,
-      "brotli": 3886
+      "min": 9066,
+      "brotli": 3936
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8897,
-        "brotli": 3874
+        "min": 9044,
+        "brotli": 3933
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9959,
-        "brotli": 4343
+        "min": 10107,
+        "brotli": 4375
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10218,
-      "brotli": 4368
+      "min": 10366,
+      "brotli": 4428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6838,
-      "brotli": 3103
+      "min": 6987,
+      "brotli": 3177
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6313,
-      "brotli": 2895
+      "min": 6460,
+      "brotli": 2951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7004,
-      "brotli": 3187
+      "min": 7149,
+      "brotli": 3247
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7093,
-      "brotli": 3212
+      "min": 7238,
+      "brotli": 3269
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7138,
-      "brotli": 3220
+      "min": 7283,
+      "brotli": 3279
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7595,
-      "brotli": 3385
+      "min": 7743,
+      "brotli": 3439
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7192,
-      "brotli": 3213
+      "min": 7339,
+      "brotli": 3262
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-remove-parent/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9123,
-      "brotli": 3937
+      "min": 9269,
+      "brotli": 3997
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7142,
-      "brotli": 3170
+      "min": 7289,
+      "brotli": 3233
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7192,
-      "brotli": 3213
+      "min": 7339,
+      "brotli": 3262
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-after-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8905,
-      "brotli": 3866
+      "min": 9053,
+      "brotli": 3925
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-update-before-resume/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8907,
-      "brotli": 3866
+      "min": 9055,
+      "brotli": 3922
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6322,
-      "brotli": 2880
+      "min": 6469,
+      "brotli": 2946
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6320,
-      "brotli": 2876
+      "min": 6467,
+      "brotli": 2941
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6389,
-      "brotli": 2900
+      "min": 6536,
+      "brotli": 2966
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9475,
-        "brotli": 4108
+        "min": 9623,
+        "brotli": 4171
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6402,
-      "brotli": 2925
+      "min": 6549,
+      "brotli": 2988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6291,
-      "brotli": 2876
+      "min": 6438,
+      "brotli": 2939
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7219,
-      "brotli": 3275
+      "min": 7364,
+      "brotli": 3338
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7176,
-      "brotli": 3255
+      "min": 7321,
+      "brotli": 3315
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7176,
-      "brotli": 3255
+      "min": 7321,
+      "brotli": 3315
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7196,
-      "brotli": 3264
+      "min": 7341,
+      "brotli": 3329
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6959,
-      "brotli": 3153
+      "min": 7106,
+      "brotli": 3215
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7719,
-        "brotli": 3417
+        "min": 7868,
+        "brotli": 3487
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6305,
-      "brotli": 2870
+      "min": 6454,
+      "brotli": 2938
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6488,
-        "brotli": 2958
+        "min": 6633,
+        "brotli": 3010
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7653,
-        "brotli": 3397
+        "min": 7801,
+        "brotli": 3459
       },
       "files": {
         "tags/child.marko": 604,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6287,
-      "brotli": 2857
+      "min": 6436,
+      "brotli": 2925
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6470,
-        "brotli": 2940
+        "min": 6615,
+        "brotli": 2998
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6319,
-      "brotli": 2885
+      "min": 6466,
+      "brotli": 2942
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $for_content__content = /*@__PURE__*/ _const("content", ($scope) => {
 	$if_content__content($scope);
 });
 const $for_content__$params = ($scope, $params2) => $for_content__content($scope, ($params2?.[0]).content);
-const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<!>", "b%", 0, $for_content__$params);
 const $input_section = ($scope, input_section) => $for($scope, [input_section]);
 const $input = ($scope, input) => $input_section($scope, input.section);
 var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", $setup$1, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.js
@@ -7,7 +7,7 @@ const $for_content__content = /*@__PURE__*/ _const(3, ($scope) => {
 	$if_content__content($scope);
 });
 const $for_content__$params = ($scope, $params2) => $for_content__content($scope, ($params2?.[0]).content);
-const $for = /*@__PURE__*/ _for_of(0, "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of(0, "<!>", "b%", 0, $for_content__$params);
 const $input_section = ($scope, input_section) => $for($scope, [input_section]);
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11060,
-        "brotli": 4814
+        "min": 11202,
+        "brotli": 4847
       },
       "files": {
-        "tags/sections.marko": 734,
+        "tags/sections.marko": 728,
         "template.marko": 598
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $for_content__content = /*@__PURE__*/ _const("content", ($scope) => {
 	$if_content__content($scope);
 });
 const $for_content__$params = ($scope, $params2) => $for_content__content($scope, ($params2?.[0]).content);
-const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<!>", "b%", 0, $for_content__$params);
 const $input_section = ($scope, input_section) => $for($scope, [input_section]);
 const $input = ($scope, input) => $input_section($scope, input.section);
 var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", $setup$1, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6027,
-      "brotli": 2775
+      "min": 6174,
+      "brotli": 2825
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6368,
-        "brotli": 2761
+        "min": 6515,
+        "brotli": 2824
       },
       "files": {
         "tags/my-dialog.marko": 293,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8432,
-      "brotli": 3661
+      "min": 8580,
+      "brotli": 3723
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14308,
-      "brotli": 5583
+      "min": 14456,
+      "brotli": 5644
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13865,
-      "brotli": 5375
+      "min": 14013,
+      "brotli": 5433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13739,
-      "brotli": 5325
+      "min": 13887,
+      "brotli": 5382
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14026,
-      "brotli": 5434
+      "min": 14174,
+      "brotli": 5502
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9014,
-        "brotli": 3682
+        "min": 9161,
+        "brotli": 3740
       },
       "files": {
         "tags/my-select.marko": 297,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9029,
-        "brotli": 3909
+        "min": 9177,
+        "brotli": 3979
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9013,
-        "brotli": 3903
+        "min": 9161,
+        "brotli": 3969
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8941,
-        "brotli": 3882
+        "min": 9089,
+        "brotli": 3940
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,7 @@ const $if_content__text = /*@__PURE__*/ _closure_get("text", ($scope) => _text($
 const $Child_content__if = /*@__PURE__*/ _if("#text/0", "<span> </span>", " D ", $if_content__setup);
 const $Child_content__value = /*@__PURE__*/ _closure_get("value", ($scope) => $Child_content__if($scope, $scope._.value ? 0 : 1));
 const $Child_content__setup = $Child_content__value;
-const $Child_content = /*@__PURE__*/ _content("__tests__/template.marko_1_content", "<!><!><!>", "b%", $Child_content__setup);
+const $Child_content = /*@__PURE__*/ _content("__tests__/template.marko_1_content", "<!>", "b%", $Child_content__setup);
 const $value = /*@__PURE__*/ _const("value", ($scope) => {
 	$value_class($scope, $scope.value?.class);
 	$text($scope, $scope.value?.text);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6440,
-      "brotli": 2928
+      "min": 6587,
+      "brotli": 2992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8843,
-        "brotli": 3821
+        "min": 8990,
+        "brotli": 3888
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/dom.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-const $Foo_content__walks = "b%c", $Foo_content__template = "<!><!><!>";
+const $Foo_content__walks = "b%c", $Foo_content__template = "<!>";
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($Foo_content__template);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($Foo_content__walks);
 const $else_content__input_message = /*@__PURE__*/ _if_closure("#text/0", 1, ($scope) => _text($scope["#text/0"], JSON.stringify($scope._.input_message)));

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/dom.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-const $Foo_content__walks = "b%c", $Foo_content__template = "<!><!><!>";
+const $Foo_content__walks = "b%c", $Foo_content__template = "<!>";
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($Foo_content__template);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($Foo_content__walks);
 const $else_content__input_message = /*@__PURE__*/ _if_closure("#text/0", 1, ($scope) => _text($scope["#text/0"], JSON.stringify($scope._.input_message)));

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6706,
-      "brotli": 3059
+      "min": 6853,
+      "brotli": 3123
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6372,
-      "brotli": 2931
+      "min": 6519,
+      "brotli": 2988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6214,
-      "brotli": 2827
+      "min": 6361,
+      "brotli": 2890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $a__closure = /*@__PURE__*/ _closure($if_content__a);
 const $a = /*@__PURE__*/ _let("a/2", $a__closure);
 const $b__closure = /*@__PURE__*/ _closure($if_content__b);
 const $b = /*@__PURE__*/ _let("b/3", $b__closure);
-const $try = /*@__PURE__*/ _try("#text/1", "<!><!><!>", "b%", $try_content__setup);
+const $try = /*@__PURE__*/ _try("#text/1", "<!>", "b%", $try_content__setup);
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
 	$a($scope, $scope.a + 1);
 	$b($scope, $scope.b + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5804,
-      "brotli": 2706
+      "min": 5951,
+      "brotli": 2759
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.debug.js
@@ -32,7 +32,7 @@ const $customtag_content = /*@__PURE__*/ _content("__tests__/template.marko_1_co
 const $b = /*@__PURE__*/ _const("b");
 const $c__closure = /*@__PURE__*/ _closure($customtag_content__c, $if_content2__c);
 const $c = /*@__PURE__*/ _let("c/4", $c__closure);
-const $if = /*@__PURE__*/ _if("#div/2", "<!><!><!>", "b%", $if_content__setup);
+const $if = /*@__PURE__*/ _if("#div/2", "<!>", "b%", $if_content__setup);
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
 	$c($scope, 4);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5955,
-      "brotli": 2678
+      "min": 6102,
+      "brotli": 2746
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8786,
-      "brotli": 3809
+      "min": 8933,
+      "brotli": 3870
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8674,
-      "brotli": 3761
+      "min": 8822,
+      "brotli": 3820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9584,
-        "brotli": 4099
+        "min": 9732,
+        "brotli": 4163
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9663,
-        "brotli": 4124
+        "min": 9812,
+        "brotli": 4177
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9476,
-        "brotli": 4056
+        "min": 9624,
+        "brotli": 4123
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6433,
-        "brotli": 2925
+        "min": 6580,
+        "brotli": 2984
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9499,
-        "brotli": 4069
+        "min": 9647,
+        "brotli": 4134
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14642,
-        "brotli": 5673
+        "min": 14790,
+        "brotli": 5739
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13719,
-        "brotli": 5343
+        "min": 13867,
+        "brotli": 5405
       },
       "files": {
         "tags/my-tag.marko": 533,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8667,
-      "brotli": 3691
+      "min": 8814,
+      "brotli": 3751
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9430,
-        "brotli": 4070
+        "min": 9579,
+        "brotli": 4119
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9521,
-        "brotli": 4068
+        "min": 9669,
+        "brotli": 4132
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8640,
-      "brotli": 3740
+      "min": 8787,
+      "brotli": 3795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8904,
-        "brotli": 3842
+        "min": 9052,
+        "brotli": 3899
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6822,
-      "brotli": 3077
+      "min": 6969,
+      "brotli": 3140
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $for_content__item_id = /*@__PURE__*/ _const("item_id", ($scope) => {
 	$if_content__item_id($scope);
 	$else_content__item_id($scope);
 });
-const $for = /*@__PURE__*/ _for_of("#div/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#div/0", "<!>", "b%", 0, $for_content__$params);
 const $list_2__OR__list_0__OR__list___script = _script("__tests__/template.marko_0_list_2_list_0_list_1", ($scope) => _on($scope["#button/1"], "click", function() {
 	$list($scope, [
 		$scope.list_2,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/__snapshots__/dom.bundle.js
@@ -12,7 +12,7 @@ const $for_content__item_id = /*@__PURE__*/ _const(4, ($scope) => {
 	$if_content__item_id($scope);
 	$else_content__item_id($scope);
 });
-const $for = /*@__PURE__*/ _for_of(0, "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of(0, "<!>", "b%", 0, $for_content__$params);
 const $list_2__OR__list_0__OR__list_ = _script("a0", ($scope) => _on($scope.b, "click", function() {
 	$list($scope, [
 		$scope.d,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8000,
-      "brotli": 3633
+      "min": 8142,
+      "brotli": 3688
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8083,
-      "brotli": 3662
+      "min": 8231,
+      "brotli": 3716
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,46 @@
+// template.marko
+const $template = "<div class=list></div><button class=rotate>Rotate</button><button class=toggle>Toggle</button><button class=drop>Drop</button>";
+const $walks = " b b b b";
+const $if_content__item_id = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => _text($scope["#text/0"], $scope._.item_id));
+const $if_content__setup = $if_content__item_id;
+const $for_content__if = /*@__PURE__*/ _if("#text/0", "<p>item <!></p>", "Db%", $if_content__setup);
+const $for_content__item_show = ($scope, item_show) => $for_content__if($scope, item_show ? 0 : 1);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_show($scope, $params2[0]?.show);
+	$for_content__item_id($scope, $params2[0]?.id);
+};
+const $for_content__item_id = /*@__PURE__*/ _const("item_id", $if_content__item_id);
+const $for = /*@__PURE__*/ _for_of("#div/0", "<!>", "b%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, "id"]));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/1"], "click", function() {
+		$items($scope, [...$scope.items.slice(1), $scope.items?.[0]]);
+	});
+	_on($scope["#button/2"], "click", function() {
+		$items($scope, $scope.items.map((item) => ({
+			...item,
+			show: !item.show
+		})));
+	});
+	_on($scope["#button/3"], "click", function() {
+		$items($scope, $scope.items.slice(1));
+	});
+});
+function $setup($scope) {
+	$items($scope, [
+		{
+			id: 0,
+			show: true
+		},
+		{
+			id: 1,
+			show: false
+		},
+		{
+			id: 2,
+			show: true
+		}
+	]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/dom.bundle.js
@@ -1,0 +1,25 @@
+// template.marko
+const $if_content__item_id = /*@__PURE__*/ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.e));
+const $for_content__if = /*@__PURE__*/ _if(0, "<p>item <!></p>", "Db%", $if_content__item_id);
+const $for_content__item_show = ($scope, item_show) => $for_content__if($scope, item_show ? 0 : 1);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__item_show($scope, $params2[0]?.show);
+	$for_content__item_id($scope, $params2[0]?.id);
+};
+const $for_content__item_id = /*@__PURE__*/ _const(4, $if_content__item_id);
+const $for = /*@__PURE__*/ _for_of(0, "<!>", "b%", 0, $for_content__$params);
+const $items = /*@__PURE__*/ _let(4, ($scope) => $for($scope, [$scope.e, "id"]));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.b, "click", function() {
+		$items($scope, [...$scope.e.slice(1), $scope.e?.[0]]);
+	});
+	_on($scope.c, "click", function() {
+		$items($scope, $scope.e.map((item) => ({
+			...item,
+			show: !item.show
+		})));
+	});
+	_on($scope.d, "click", function() {
+		$items($scope, $scope.e.slice(1));
+	});
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: 0,
+			show: true
+		},
+		{
+			id: 1,
+			show: false
+		},
+		{
+			id: 2,
+			show: true
+		}
+	];
+	_html("<div class=list>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_if(() => {
+			if (item.show) {
+				const $scope2_id = _scope_id();
+				_html(`<p>item <!>${_escape(item.id)}${_el_resume($scope2_id, "#text/0")}</p>`);
+				writeScope($scope2_id, {}, "__tests__/template.marko", "5:4");
+				return 0;
+			}
+		}, $scope1_id, "#text/0", 1, 1, 1, 0, 1);
+		writeScope($scope1_id, { item_id: item?.id }, "__tests__/template.marko", "4:3", { item_id: ["item.id", "4:7"] });
+	}, "id", $scope0_id, "#div/0", 1, 1, 1, "</div>");
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "#button/1")}<button class=toggle>Toggle</button>${_el_resume($scope0_id, "#button/2")}<button class=drop>Drop</button>${_el_resume($scope0_id, "#button/3")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { items }, "__tests__/template.marko", 0, { items: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/html.bundle.js
@@ -1,0 +1,36 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = [
+		{
+			id: 0,
+			show: true
+		},
+		{
+			id: 1,
+			show: false
+		},
+		{
+			id: 2,
+			show: true
+		}
+	];
+	_html("<div class=list>");
+	_for_of(items, (item) => {
+		const $scope1_id = _scope_id();
+		_if(() => {
+			if (item.show) {
+				const $scope2_id = _scope_id();
+				_html(`<p>item <!>${_escape(item.id)}${_el_resume($scope2_id, "a")}</p>`);
+				writeScope($scope2_id, {});
+				return 0;
+			}
+		}, $scope1_id, "a", 1, 1, 1, 0, 1);
+		writeScope($scope1_id, { e: item?.id });
+	}, "id", $scope0_id, "a", 1, 1, 1, "</div>");
+	_html(`<button class=rotate>Rotate</button>${_el_resume($scope0_id, "b")}<button class=toggle>Toggle</button>${_el_resume($scope0_id, "c")}<button class=drop>Drop</button>${_el_resume($scope0_id, "d")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { e: items });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/render.debug.md
@@ -1,0 +1,216 @@
+# Render
+```html
+<div
+  class="list"
+>
+  <p>
+    item 0
+  </p>
+  <p>
+    item 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p
+REMOVE: .list > p + p
+UPDATE: .list > p::text@5 "" => "1"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 0
+  </p>
+  <p>
+    item 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p:nth-of-type(1) + p
+INSERT: .list > p:nth-of-type(1) + p
+UPDATE: .list > p:nth-of-type(1)::text@5 "" => "0"
+UPDATE: .list > p:nth-of-type(2)::text@5 "" => "2"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 2
+  </p>
+  <p>
+    item 0
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p:nth-of-type(1) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + p
+REMOVE: .list > p + p
+UPDATE: .list > p::text@5 "" => "1"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/render.md
@@ -1,0 +1,216 @@
+# Render
+```html
+<div
+  class="list"
+>
+  <p>
+    item 0
+  </p>
+  <p>
+    item 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p
+REMOVE: .list > p + p
+UPDATE: .list > p::text@5 "" => "1"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 0
+  </p>
+  <p>
+    item 2
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p:nth-of-type(1) + p
+INSERT: .list > p:nth-of-type(1) + p
+UPDATE: .list > p:nth-of-type(1)::text@5 "" => "0"
+UPDATE: .list > p:nth-of-type(2)::text@5 "" => "2"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 2
+  </p>
+  <p>
+    item 0
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p:nth-of-type(1) + p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+INSERT: .list > p
+REMOVE: .list > p + p
+REMOVE: .list > p + p
+UPDATE: .list > p::text@5 "" => "1"
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```
+```html
+<div
+  class="list"
+>
+  <p>
+    item 1
+  </p>
+</div>
+<button
+  class="rotate"
+>
+  Rotate
+</button>
+<button
+  class="toggle"
+>
+  Toggle
+</button>
+<button
+  class="drop"
+>
+  Drop
+</button>
+```
+## Change
+```
+REMOVE: .list > p
+INSERT: .list > p
+```
+
+# Update
+```js
+(document.querySelector(selector)).click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<div class=list><!--M_[-->
+  <p>item <!>0<!--M_*3 #text/0--></p>
+  <!--M_|2 #text/0 3--><!--M_[2--><!--M_|4 #text/0--><!--M_[4-->
+  <p>item <!>2<!--M_*6 #text/0--></p><!--M_|5 #text/0 6--><!--M_)1 #div/0 5-->
+</div><button class=rotate>Rotate</button><!--M_*1 #button/1--><button
+  class=toggle>Toggle</button><!--M_*1 #button/2--><button
+  class=drop>Drop</button><!--M_*1 #button/3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      items: [{
+        id: 0,
+        show: !0
+      }, {
+        id: 1,
+        show: !1
+      }, {
+        id: 2,
+        show: !0
+      }]
+    }, {
+      item_id: 0
+    }, 1, {
+      item_id: 1
+    }, {
+      item_id: 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<div class=list><!--M_[-->
+  <p>item <!>0<!--M_*3 a--></p>
+  <!--M_|2 a 3--><!--M_[2--><!--M_|4 a--><!--M_[4-->
+  <p>item <!>2<!--M_*6 a--></p><!--M_|5 a 6--><!--M_)1 a 5-->
+</div><button class=rotate>Rotate</button><!--M_*1 b--><button
+  class=toggle>Toggle</button><!--M_*1 c--><button
+  class=drop>Drop</button><!--M_*1 d-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: [{
+      id: 0,
+      show: !0
+    }, {
+      id: 1,
+      show: !1
+    }, {
+      id: 2,
+      show: !0
+    }]
+  }, {
+    e: 0
+  }, 1, {
+    e: 1
+  }, {
+    e: 2
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8119,
+      "brotli": 3671
+    }
+  },
+  "html": {
+    "min": 686,
+    "brotli": 374
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/template.marko
@@ -1,0 +1,15 @@
+<let/items=[{ id: 0, show: true }, { id: 1, show: false }, { id: 2, show: true }]/>
+
+<div.list>
+	<for|item| of=items by="id">
+		<if=item.show>
+			<p>item ${item.id}</p>
+		</if>
+	</for>
+</div>
+
+<button.rotate onClick() { items = [...items.slice(1), items[0]]; }>Rotate</button>
+<button.toggle onClick() {
+	items = items.map((item) => ({ ...item, show: !item.show }));
+}>Toggle</button>
+<button.drop onClick() { items = items.slice(1); }>Drop</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-empty-only-child-range/test.ts
@@ -1,0 +1,21 @@
+import type { TestConfig } from "../../main.test";
+
+// A `<for>` whose only child is a non-exhaustive `<if>` has no boundary markers:
+// an item's range is its branch while shown, and the bare anchor while hidden.
+// Emptying every item, refilling, and reordering across a mix of both must keep
+// the list in source order.
+const press = (selector: string) => (document: Document) => {
+  (document.querySelector(selector) as HTMLButtonElement).click();
+};
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    press("button.toggle"),
+    press("button.toggle"),
+    press("button.rotate"),
+    press("button.toggle"),
+    press("button.rotate"),
+    press("button.drop"),
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $for_content__item_id = /*@__PURE__*/ _const("item_id", ($scope) => {
 	$if_content__item_id($scope);
 	$else_content__item_id($scope);
 });
-const $for = /*@__PURE__*/ _for_of("#div/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#div/0", "<!>", "b%", 0, $for_content__$params);
 const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, "id"]));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	_on($scope["#button/1"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/__snapshots__/dom.bundle.js
@@ -12,7 +12,7 @@ const $for_content__item_id = /*@__PURE__*/ _const(4, ($scope) => {
 	$if_content__item_id($scope);
 	$else_content__item_id($scope);
 });
-const $for = /*@__PURE__*/ _for_of(0, "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of(0, "<!>", "b%", 0, $for_content__$params);
 const $items = /*@__PURE__*/ _let(4, ($scope) => $for($scope, [$scope.e, "id"]));
 const $setup__script = _script("a0", ($scope) => {
 	_on($scope.b, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8053,
-      "brotli": 3633
+      "min": 8197,
+      "brotli": 3695
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6600,
-      "brotli": 2998
+      "min": 6747,
+      "brotli": 3066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7779,
-        "brotli": 3573
+        "min": 7926,
+        "brotli": 3645
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8193,
-        "brotli": 3734
+        "min": 8340,
+        "brotli": 3824
       },
       "files": {
         "tags/child.marko": 516,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9286,
-        "brotli": 3974
+        "min": 9434,
+        "brotli": 4036
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
@@ -45,7 +45,7 @@ const $if_content2__setup = ($scope) => {
 const $if_content__if = /*@__PURE__*/ _if("#text/0", $template$2, /*@__PURE__*/ ((_w0) => `0${_w0}&`)(" b"), $if_content2__setup);
 const $if_content__input_show = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $if_content__if($scope, $scope._.input_show ? 0 : 1));
 const $if_content__setup = $if_content__input_show;
-const $if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b%", $if_content__setup);
+const $if = /*@__PURE__*/ _if("#text/0", "<!>", "b%", $if_content__setup);
 const $input_show = /*@__PURE__*/ _const("input_show", ($scope) => {
 	$if($scope, $scope.input_show ? 0 : 1);
 	$if_content__input_show($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10048,
-        "brotli": 4260
+        "min": 10196,
+        "brotli": 4315
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
@@ -39,7 +39,7 @@ const $if_content2__setup = ($scope) => $if_content2__dynamicTag($scope, 1 && ch
 const $if_content__if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b1", $if_content2__setup);
 const $if_content__input_show = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $if_content__if($scope, $scope._.input_show ? 0 : 1));
 const $if_content__setup = $if_content__input_show;
-const $if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b%", $if_content__setup);
+const $if = /*@__PURE__*/ _if("#text/0", "<!>", "b%", $if_content__setup);
 const $input_show = /*@__PURE__*/ _const("input_show", ($scope) => {
 	$if($scope, $scope.input_show ? 0 : 1);
 	$if_content__input_show($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9094,
-        "brotli": 3889
+        "min": 9242,
+        "brotli": 3958
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var/__snapshots__/dom.bundle.debug.js
@@ -20,7 +20,7 @@ const $if_content2__setup = ($scope) => {
 const $if_content__if = /*@__PURE__*/ _if("#text/0", /*@__PURE__*/ ((_w0) => `<div></div>${_w0}`)(""), /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)(""), $if_content2__setup);
 const $if_content__input_show = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $if_content__if($scope, $scope._.input_show ? 0 : 1));
 const $if_content__setup = $if_content__input_show;
-const $if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b%", $if_content__setup);
+const $if = /*@__PURE__*/ _if("#text/0", "<!>", "b%", $if_content__setup);
 const $input_show = /*@__PURE__*/ _const("input_show", ($scope) => {
 	$if($scope, $scope.input_show ? 0 : 1);
 	$if_content__input_show($scope);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6423,
-      "brotli": 2925
+      "min": 6570,
+      "brotli": 2989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6412,
-      "brotli": 2915
+      "min": 6559,
+      "brotli": 2975
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6009,
-      "brotli": 2755
+      "min": 6156,
+      "brotli": 2812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6283,
-      "brotli": 2876
+      "min": 6428,
+      "brotli": 2932
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6150,
-      "brotli": 2810
+      "min": 6297,
+      "brotli": 2881
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6528,
-        "brotli": 2971
+        "min": 6677,
+        "brotli": 3030
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6742,
-        "brotli": 3039
+        "min": 6889,
+        "brotli": 3107
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6711,
-        "brotli": 3024
+        "min": 6858,
+        "brotli": 3094
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-swap-before-await-resume/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6261,
-        "brotli": 2869
+        "min": 6408,
+        "brotli": 2922
       },
       "files": {
         "tags/cart-state.marko": 474,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9548,
-        "brotli": 4081
+        "min": 9696,
+        "brotli": 4143
       },
       "files": {
         "tags/handlers.marko": 431,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,12 @@
 // template.marko
-const $Child_content__walks = "b%c", $Child_content__template = "<!><!><!>";
+const $Child_content__walks = "b%c", $Child_content__template = "<!>";
 const $template = /*@__PURE__*/ ((_w0) => `<button> </button>${_w0}<!>`)($Child_content__template);
 const $walks = /*@__PURE__*/ ((_w0) => ` D l/${_w0}&b`)($Child_content__walks);
 const $if_content2__input_name = /*@__PURE__*/ _closure_get("input_name", ($scope) => _text($scope["#text/0"], $scope._._.input_name || "Fallback"), ($scope) => $scope._._);
 const $if_content2__setup = $if_content2__input_name;
 const $if_content__if = /*@__PURE__*/ _if("#text/0", "<div> </div>", "D ", $if_content2__setup);
 const $if_content__setup = ($scope) => $if_content__if($scope, true ? 0 : 1);
-const $Child_content__if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b%", $if_content__setup);
+const $Child_content__if = /*@__PURE__*/ _if("#text/0", "<!>", "b%", $if_content__setup);
 const $Child_content__input_count = ($scope, input_count) => $Child_content__if($scope, input_count ? 0 : 1);
 const $Child_content__tag_input_name__closure = /*@__PURE__*/ _closure($if_content2__input_name);
 const $Child_content__tag_input_name = /*@__PURE__*/ _const("input_name", $Child_content__tag_input_name__closure);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/dom.bundle.js
@@ -2,7 +2,7 @@
 const $if_content2__input_name = /*@__PURE__*/ _closure_get(5, ($scope) => _text($scope.a, $scope._._.e || "Fallback"), ($scope) => $scope._._);
 const $if_content__if = /*@__PURE__*/ _if(0, "<div> </div>", "D ", $if_content2__input_name);
 const $if_content__setup = ($scope) => $if_content__if($scope, 0);
-const $Child_content__if = /*@__PURE__*/ _if(0, "<!><!><!>", "b%", $if_content__setup);
+const $Child_content__if = /*@__PURE__*/ _if(0, "<!>", "b%", $if_content__setup);
 const $Child_content__input_count = ($scope, input_count) => $Child_content__if($scope, input_count ? 0 : 1);
 const $count = /*@__PURE__*/ _let(3, ($scope) => {
 	_text($scope.b, $scope.d);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6497,
-      "brotli": 2960
+      "min": 6638,
+      "brotli": 3021
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/test.marko
-const $Tag_content__walks = "b%c", $Tag_content__template = "<!><!><!>";
+const $Tag_content__walks = "b%c", $Tag_content__template = "<!>";
 const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($Tag_content__template);
 const $walks$1 = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($Tag_content__walks);
 const $if_content__count = /*@__PURE__*/ _closure_get("count", ($scope) => _text($scope["#text/0"], $scope._._.count), ($scope) => $scope._._);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // tags/test.marko
-const $Tag_content__walks = "b%c", $Tag_content__template = "<!><!><!>";
+const $Tag_content__walks = "b%c", $Tag_content__template = "<!>";
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($Tag_content__template);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($Tag_content__walks);
 const $Tag_content__if = /*@__PURE__*/ _if(0, "<div> </div>", "D ", /* @__PURE__ */ _closure_get(2, ($scope) => _text($scope.a, $scope._._.b), ($scope) => $scope._._));

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-closure/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6435,
-        "brotli": 2932
+        "min": 6576,
+        "brotli": 2987
       },
       "files": {
-        "tags/test.marko": 682,
+        "tags/test.marko": 676,
         "template.marko": 396
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $htmlInput = /*@__PURE__*/ _const("htmlInput", ($scope) => {
 	_attrs($scope, "#div/0", $scope.htmlInput);
 	$htmlInput__script($scope);
 });
-const $for = /*@__PURE__*/ _for_of("#div/0", "<!><!><!>", "b%", 0, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#div/0", "<!>", "b%", 0, $for_content__$params);
 const $buttons = ($scope, buttons) => $for($scope, [buttons]);
 const $input = ($scope, input) => {
 	(({ button, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7871,
-      "brotli": 3515
+      "min": 8021,
+      "brotli": 3581
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7893,
-      "brotli": 3518
+      "min": 8043,
+      "brotli": 3584
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11430,
-      "brotli": 4910
+      "min": 11578,
+      "brotli": 4970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 11311,
-      "brotli": 4849
+      "min": 11459,
+      "brotli": 4901
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 11092,
-      "brotli": 4774
+      "min": 11240,
+      "brotli": 4839
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7835,
-      "brotli": 3465
+      "min": 7985,
+      "brotli": 3531
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7835,
-      "brotli": 3465
+      "min": 7985,
+      "brotli": 3531
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/dom.bundle.debug.js
@@ -25,7 +25,7 @@ const $try_content__show = /*@__PURE__*/ _closure_get("show", ($scope) => $try_c
 const $try_content__setup = $try_content__show;
 const $show__closure = /*@__PURE__*/ _closure($try_content__show);
 const $show = /*@__PURE__*/ _let("show/2", $show__closure);
-const $try = /*@__PURE__*/ _try("#text/1", "<!><!><!>", "b%", $try_content__setup);
+const $try = /*@__PURE__*/ _try("#text/1", "<!>", "b%", $try_content__setup);
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
 	$show($scope, true);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 8178,
-      "brotli": 3606
+      "min": 8326,
+      "brotli": 3665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 6163,
-      "brotli": 2786
+      "min": 6310,
+      "brotli": 2857
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/__snapshots__/dom.bundle.debug.js
@@ -26,7 +26,7 @@ const $try_content__show = /*@__PURE__*/ _closure_get("show", ($scope) => $try_c
 const $try_content__setup = $try_content__show;
 const $show__closure = /*@__PURE__*/ _closure($try_content__show);
 const $show = /*@__PURE__*/ _let("show/2", $show__closure);
-const $try = /*@__PURE__*/ _try("#text/1", "<!><!><!>", "b%", $try_content__setup);
+const $try = /*@__PURE__*/ _try("#text/1", "<!>", "b%", $try_content__setup);
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
 	$show($scope, true);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 8189,
-      "brotli": 3607
+      "min": 8337,
+      "brotli": 3666
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 140
     },
     "shared": {
-      "min": 11150,
-      "brotli": 4826
+      "min": 11298,
+      "brotli": 4891
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder-script-runs-after-insert/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 87
     },
     "shared": {
-      "min": 6113,
-      "brotli": 2767
+      "min": 6260,
+      "brotli": 2830
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 74
     },
     "shared": {
-      "min": 7264,
-      "brotli": 3254
+      "min": 7413,
+      "brotli": 3315
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 112
     },
     "shared": {
-      "min": 6775,
-      "brotli": 3048
+      "min": 6924,
+      "brotli": 3109
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9428,
-      "brotli": 4068
+      "min": 9574,
+      "brotli": 4122
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6527,
-        "brotli": 2934
+        "min": 6674,
+        "brotli": 3001
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6756,
-      "brotli": 2987
+      "min": 6903,
+      "brotli": 3058
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9439,
-      "brotli": 4054
+      "min": 9588,
+      "brotli": 4110
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9969,
-      "brotli": 4334
+      "min": 10117,
+      "brotli": 4377
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9079,
-        "brotli": 3927
+        "min": 9227,
+        "brotli": 3993
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8096,
-      "brotli": 3665
+      "min": 8244,
+      "brotli": 3714
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-const/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $for_content__if = /*@__PURE__*/ _if("#text/0", " ", " ", $if_content__set
 const $for_content__setup = ($scope) => $for_content__if($scope, true ? 0 : 1);
 const $for_content__$params = ($scope, $params2) => $for_content__foo($scope, $params2[0]);
 const $for_content__foo = /*@__PURE__*/ _const("foo");
-const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", $for_content__setup, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<!>", "b%", $for_content__setup, $for_content__$params);
 function $setup($scope) {
 	$for($scope, [["foo"]]);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-closure-alias-let/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__if = /*@__PURE__*/ _if("#text/0", " ", " ", $if_content__set
 const $for_content__setup = ($scope) => $for_content__if($scope, true ? 0 : 1);
 const $for_content__$params = ($scope, $params2) => $for_content__foo($scope, $params2[0]);
 const $for_content__foo = /*@__PURE__*/ _const("foo");
-const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", $for_content__setup, $for_content__$params);
+const $for = /*@__PURE__*/ _for_of("#text/0", "<!>", "b%", $for_content__setup, $for_content__$params);
 function $setup($scope) {
 	$for($scope, [["foo"]]);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8041,
-      "brotli": 3660
+      "min": 8189,
+      "brotli": 3703
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8772,
-        "brotli": 3961
+        "min": 8920,
+        "brotli": 4022
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7753,
-      "brotli": 3536
+      "min": 7900,
+      "brotli": 3592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6713,
-      "brotli": 3018
+      "min": 6860,
+      "brotli": 3075
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15054,
-        "brotli": 5958
+        "min": 15202,
+        "brotli": 6044
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8984,
-        "brotli": 3882
+        "min": 9132,
+        "brotli": 3941
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6293,
-      "brotli": 2862
+      "min": 6440,
+      "brotli": 2923
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9886,
-        "brotli": 4189
+        "min": 10034,
+        "brotli": 4262
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $if_content__setup = $if_content__a;
 const $Foo_content__if = /*@__PURE__*/ _if("#text/0", " ", " ", $if_content__setup);
 const $Foo_content__v = ($scope, v) => $Foo_content__if($scope, v ? 0 : 1);
 const $Foo_content__$params = ($scope, $params3) => $Foo_content__v($scope, $params3[0]);
-const $Foo_content = _content_resume("__tests__/template.marko_1_content", "<!><!><!>", "b%", 0, $Foo_content__$params);
+const $Foo_content = _content_resume("__tests__/template.marko_1_content", "<!>", "b%", 0, $Foo_content__$params);
 const $count = /*@__PURE__*/ _let("count/2", ($scope) => $Foo_content2__input_value($scope["#childScope/1"], $scope.count));
 const $a = /*@__PURE__*/ _const("a");
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/dom.bundle.js
@@ -5,7 +5,7 @@ const $Foo_content2__input_value = /*@__PURE__*/ _const(4, $Foo_content2__input_
 const $Foo_content__if = /*@__PURE__*/ _if(0, " ", " ", /* @__PURE__ */ _closure_get(4, ($scope) => _text($scope.a, $scope._._.d), ($scope) => $scope._._));
 const $Foo_content__v = ($scope, v) => $Foo_content__if($scope, v ? 0 : 1);
 const $Foo_content__$params = ($scope, $params3) => $Foo_content__v($scope, $params3[0]);
-const $Foo_content = _content_resume("a1", "<!><!><!>", "b%", 0, $Foo_content__$params);
+const $Foo_content = _content_resume("a1", "<!>", "b%", 0, $Foo_content__$params);
 const $count = /*@__PURE__*/ _let(2, ($scope) => $Foo_content2__input_value($scope.b, $scope.c));
 const $setup__script = _script("a2", ($scope) => _on($scope.a, "click", function() {
 	$count($scope, $scope.c + 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9340,
-      "brotli": 4022
+      "min": 9482,
+      "brotli": 4083
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6209,
-        "brotli": 2829
+        "min": 6356,
+        "brotli": 2889
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6431,
-        "brotli": 2932
+        "min": 6578,
+        "brotli": 2994
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6950,
-      "brotli": 3116
+      "min": 7099,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6950,
-      "brotli": 3116
+      "min": 7099,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7533,
-      "brotli": 3324
+      "min": 7680,
+      "brotli": 3383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6685,
-        "brotli": 3037
+        "min": 6832,
+        "brotli": 3103
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9058,
-      "brotli": 3937
+      "min": 9209,
+      "brotli": 3999
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7166,
-      "brotli": 3230
+      "min": 7311,
+      "brotli": 3300
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6123,
-      "brotli": 2776
+      "min": 6268,
+      "brotli": 2831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9434,
-      "brotli": 4102
+      "min": 9584,
+      "brotli": 4154
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9104,
-      "brotli": 3942
+      "min": 9252,
+      "brotli": 4008
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/control-flow.ts
+++ b/packages/runtime-tags/src/dom/control-flow.ts
@@ -738,10 +738,39 @@ export function setConditionalRenderer<T>(
       );
     }
 
+    adoptRange(scope, prevBranch, newBranch || referenceNode);
     removeAndDestroyBranch(prevBranch);
   } else if (newBranch) {
     insertBranchBefore(newBranch, parentNode, referenceNode);
     referenceNode.remove();
+    adoptRange(scope, referenceNode, newBranch);
+  }
+}
+
+// A section whose whole content is this conditional is bounded by the branch
+// itself, so every owner still holding the replaced range follows it.
+function adoptRange(
+  scope: Scope,
+  prev: BranchScope | ChildNode,
+  next: BranchScope | ChildNode,
+) {
+  const prevStart = (prev as BranchScope)[AccessorProp.StartNode] || prev;
+  const prevEnd = (prev as BranchScope)[AccessorProp.EndNode] || prev;
+  let branch = scope[AccessorProp.ClosestBranch];
+  while (
+    branch &&
+    (branch[AccessorProp.StartNode] === prevStart ||
+      branch[AccessorProp.EndNode] === prevEnd)
+  ) {
+    if (branch[AccessorProp.StartNode] === prevStart) {
+      branch[AccessorProp.StartNode] =
+        (next as BranchScope)[AccessorProp.StartNode] || (next as ChildNode);
+    }
+    if (branch[AccessorProp.EndNode] === prevEnd) {
+      branch[AccessorProp.EndNode] =
+        (next as BranchScope)[AccessorProp.EndNode] || (next as ChildNode);
+    }
+    branch = branch[AccessorProp.ParentBranch];
   }
 }
 

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -16,6 +16,7 @@ import { isConditionTag, isCoreTagName } from "../util/is-core-tag";
 import {
   getOnlyChildParentTagName,
   getOptimizedOnlyChildNodeBinding,
+  isOnlyChildOfSection,
 } from "../util/is-only-child-in-parent";
 import { addSorted } from "../util/optional";
 import {
@@ -88,6 +89,9 @@ export const IfTag = {
         binding: nodeBinding,
         prefix: getAccessorPrefix().BranchScopes,
       };
+      ifTagSection.rangeFromChild =
+        !getOnlyChildParentTagName(ifTag, branches.length) &&
+        isOnlyChildOfSection(ifTag, branches.length);
       // TODO: remove all branches if none have body content.
 
       for (const [branchTag, branchBodySection] of branches) {

--- a/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
+++ b/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
@@ -36,6 +36,20 @@ export function getOnlyChildParentTagName(
       : false);
 }
 
+export function isOnlyChildOfSection(
+  tag: t.NodePath<t.MarkoTag>,
+  branchSize: number,
+) {
+  const parentTag = getParentTag(tag);
+  return !!(
+    parentTag &&
+    !getTagDef(parentTag)?.html &&
+    (tag.parent as t.MarkoTagBody).body.filter(
+      (node) => node.type !== "MarkoComment",
+    ).length === branchSize
+  );
+}
+
 export function getOptimizedOnlyChildNodeBinding(
   tag: t.NodePath<t.MarkoTag>,
   section: Section,

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -77,6 +77,9 @@ export interface Section {
   abortSignalExprs: number;
   readsOwner: boolean;
   isBranch: boolean;
+  /** An exhaustive conditional is the section's whole content, so its branch
+   * bounds the section and no markers or anchor are emitted for it. */
+  rangeFromChild: boolean;
   content: null | {
     startType: ContentType;
     endType: ContentType;
@@ -152,6 +155,7 @@ export function startSection(
       abortSignalExprs: 0,
       readsOwner: false,
       isBranch: false,
+      rangeFromChild: false,
     };
     sections.push(section);
   }

--- a/packages/runtime-tags/src/translator/util/writer.ts
+++ b/packages/runtime-tags/src/translator/util/writer.ts
@@ -98,9 +98,15 @@ export const [getSectionMeta] = createSectionState<SectionMeta>(
   "SectionMeta",
   (section) => {
     const writePrefix =
-      section.content?.startType === ContentType.Dynamic ? "<!>" : "";
+      section.content?.startType === ContentType.Dynamic &&
+      !section.rangeFromChild
+        ? "<!>"
+        : "";
     const writePostfix =
-      section.content?.endType === ContentType.Dynamic ? "<!>" : "";
+      section.content?.endType === ContentType.Dynamic &&
+      !section.rangeFromChild
+        ? "<!>"
+        : "";
     const writes = getWrites(section);
     const meta = {
       walks: getWalkString(section),


### PR DESCRIPTION
A section whose only content is an `<if>` chain was still emitting boundary markers and an anchor to delimit a range the conditional's own branch already bounds — three comment nodes per item for a `<for>` over a conditional. The section now emits none of them, and the rendered branch *is* the section's range; on each swap the conditional retargets any owner still holding the replaced range. When the chain renders nothing its anchor bounds the section instead, so this covers a chain with no `<else>` as well.

Worth ~12% on rebuilding a large keyed list, and removes every comment marker the conditional produced (42 to 0 in a chat-style fixture, matching a markerless framework's node count exactly). Costs +84 bytes brotli.