### PR TITLE
Validate and triage the agent-feedback backlog

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,1425 +2,518 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## `Sorted.isSuperset` arithmetic is wrong but the current behavior is load-bearing
+## Fix `Sorted.isSuperset` arithmetic together with a proper-superset test in `isSupersetSources`
 
 `packages/runtime-tags/src/translator/util/optional.ts` › `Sorted.isSuperset` | 2026-07-03 | impact:med | effort:med
 
-`isSuperset` walks `subset` from the top and rejects with
-`supLen - found <= i`, which compares the remaining superset slots against `i`
-(the count of _smaller_ elements) instead of `subLen - i` (the count still to
-place). It returns `false` for many genuine superset relationships, including
-two identical sorted arrays: `isSuperset([1,2,3],[1,2,3])` is `false`. The one caller,
-`isSupersetSources` (`references.ts:2395`), gates intersection serialization at
-`references.ts:1131`/`1145`. Naively correcting the arithmetic to
-`supLen - found < subLen - i` makes `isSupersetSources` return `true` for
-equal-source bindings, so both symmetric `addSerializeReason` calls are skipped
-and neither binding in the intersection serializes — this under-serializes and
-breaks resume (the `bound-attr-shapes` fixture throws `Unable to serialize
-"ControlledHandler:#input/2"`). The current over-serializing behavior is
-therefore relied upon for correctness. A real fix needs `isSupersetSources` to
-use a strict/proper-superset test (equal sources must not prune each other)
-_and_ the corrected arithmetic, then a full snapshot audit — out of scope for a
-one-line change.
+The loop rejects with `supLen - found <= i`, comparing remaining superset slots against the count of _smaller_ elements instead of `subLen - i`, the count still to place; `isSuperset([1,2,3],[1,2,3])` is `false`. Its only caller, `isSupersetSources` in `translator/util/references.ts`, gates the symmetric `addSerializeReason` pair for intersections, so today's false negatives over-serialize — and that over-serialization is load-bearing: correcting the arithmetic alone makes equal-source bindings prune each other and the `bound-attr-shapes` fixture fails to resume with `Unable to serialize "ControlledHandler:#input/2"`. A real fix needs `isSupersetSources` to use a strict/proper-superset test _and_ the corrected comparison, followed by a snapshot audit. Re-verify: run the loop standalone under `node -e` and confirm `isSuperset([1,2,3],[1,2,3])` returns `true`.
 
-## Inline reorder runtime holds only one pending `onNextSibling` callback
-
-`packages/runtime-tags/src/html/inlined-runtimes.debug.ts` › `REORDER_RUNTIME_CODE` | 2026-07-10 | impact:low | effort:med
-
-`runtime.x` keeps a single `nextSibling`/`onNextSibling` pair. A `<t hidden>`
-swap callback pending at the element's next sibling is overwritten if, while
-walking the `<t>`'s children, a placeholder-end comment (`!id`) matches the
-"content arrived before its end marker" branch and re-assigns the pair — the
-outer swap then never fires. Tracing current server emission orders suggests
-this is unreachable today (catch/content `<t>`s and their end markers always
-stream in an order where the earlier callback fires before the overwrite),
-but it is one flush-ordering change away from a silent hydration freeze. A
-queue (or firing the pending callback before re-assigning) would make the
-inline runtime robust; weigh against inline-runtime byte cost.
-
-## Inert Class parent drops client resume for a stateful Tags-API descendant
+## Resume a stateful Tags-API descendant rendered through an inert Class-API parent
 
 `packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `translate.exit` | 2026-07-13 | impact:high | effort:high
 
-A Tags-API page that renders an inert Class-API component (no class block /
-component-browser) which itself renders a stateful Tags-API grandchild produces
-a dead (non-resuming) grandchild after SSR: clicking a `<button onClick>` in the
-grandchild does nothing, in **both** debug and optimize. In optimize the class
-boundary is additionally removed outright by the inert-child optimization here
-(`!classHydration && !tagsSerializeReason` → `tag.remove()`), because
-`getClassHydrationMode` (`packages/runtime-class/src/translator/index.js:714`)
-only detects interactivity via `meta.component` and never inspects a Tags-API
-child's `isInteractive` (which lives on `program.node.extra`, not
-`metadata.marko`). But disabling that removal does **not** fix the dead button,
-so the root cause is a deeper resume gap for stateful-tags-inside-inert-class,
-not just the optimization. Repro (CSR works, SSR-resume dead): tags page
-`// use tags` + `<class-wrapper/>`; `class-wrapper.marko` =
-`<div><tags-counter/></div>` (no class block); `tags-counter.marko` =
-`<let/n=0/><button onClick(){n++}>${n}</button>`. A fix likely needs the tags
-translator to surface interactivity on `metadata.marko`, `getClassHydrationMode`
-to return DESCENDANT for interactive tags children, and the boundary to actually
-resume.
+A Tags page rendering an inert Class component (no class block) that renders a stateful Tags grandchild leaves the grandchild dead after SSR — its `<button onClick>` does nothing, in debug and optimize. `getClassHydrationMode` (`packages/runtime-class/src/translator/index.js`) detects interactivity only via `meta.component`, never a Tags child's `isInteractive` (on `program.node.extra`, not `metadata.marko`), so `classHydration` is undefined and the optimize path here (`!classHydration && !tagsSerializeReason` → `tag.remove()`) deletes the boundary outright; disabling that removal alone does not revive the button, so the resume gap is deeper. A fix likely needs the tags translator to surface interactivity on `metadata.marko`, `getClassHydrationMode` to return DESCENDANT for it, and the boundary to actually resume. Re-verify: with `template.marko` = `// use tags` + `<class-wrapper/>`, `components/class-wrapper.marko` = `<div><tags-counter/></div>` and `tags/tags-counter.marko` = `<let/n=0/><button onClick(){n++}>${n}</button>`, run `scripts/inspect-compiled-output.mts -t class -o dom` — today it emits `$setup = () => {}`.
 
-## `_dynamic_tag` compares only the renderer id, conflating instances of the same content
+## Compare `(id, owner)` in dynamic-tag change checks, not the renderer id alone
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_dynamic_tag` | 2026-07-14 | impact:high | effort:med
 
-The dynamic-tag change checks compare `renderer?.[RendererProp.Id] || renderer` (`:535` for `_dynamic_tag`, `:647` for `_dynamic_tag_content`, plus the DOM `_attr_content`). `RendererProp.Id` is the template/section resume id, identical for every _instance_ of one content section — instances differ only by their `RendererProp.Owner` scope. So switching a dynamic tag between two instances of the same content — two `<attrs.content>` from two instances of one provider tag, or the list-detail `<${selected.content}/>` — is a silent no-op: no teardown or re-render, and closures stay subscribed to the old owner's scope. A control with two _distinct_ tag files behaves correctly, pinning the defect to the id-only comparison. Fix: compare `(id, owner)` — content renderer objects are recreated per render so identity alone over-fires, while the owner scope is stable per instance; the resume handshake must serialize a scope-registered renderer as its registered reference so the first post-resume update stays instance-aware.
+`_dynamic_tag` and `_dynamic_tag_content` gate re-render on `renderer?.[RendererProp.Id] || renderer`; `dom.ts` › `_attr_content` on `content?.[RendererProp.Id]`. `_content(id, …)` bakes one id per content section, so switching a single dynamic-tag slot between two _instances_ of that section — two `<attrs.content>` from two provider instances, or list-detail `<${selected.content}/>` — short-circuits: `setConditionalRenderer` is skipped, the branch is never torn down, and `branch[AccessorProp.Owner]` (set once in `createBranch` from `RendererProp.Owner`) plus the `_closure_get` `subscribeToScopeSet` stay pinned to the first owner, so the content keeps rendering the previous instance's state. Values arriving via `RendererProp.LocalClosureValues` do keep updating (that loop runs outside the change check), which is why some shapes look fine; the damage shows whenever the content reads its owner through `$scope[AccessorProp.Owner]`. Two distinct tag files switch correctly, isolating the defect to the id-only compare. Fix by comparing `(id, owner)` — renderer objects are recreated per render, so identity alone over-fires — and by making the resume handshake serialize a scope-registered renderer as its registered reference. Re-verify: `tags/provider.marko` = `<let/count = input.n/><button onClick() { count++ }>bump</button><define/body><div>value ${count}</div></define><return=body/>`, `template.marko` = `<provider/a n=1/><provider/b n=2/><let/sel = 0/><button onClick() { sel = 1 - sel }>toggle</button><${sel ? b : a}/>`; toggling `sel` must swap the rendered body.
 
-## Initialize tag variables for dynamic native tags
+## Initialize tag variables for dynamic tags that resolve to a native tag name
 
 `packages/runtime-tags/src/html/dynamic-tag.ts` › `_dynamic_tag` | 2026-07-15 | impact:med | effort:high
 
-The string-renderer branch of HTML `_dynamic_tag` never assigns `result` (the inline TODO calls this out), and the DOM branch creates the element but never sends its getter through the branch's `AccessorProp.TagVariable` callback (`dom/control-flow.ts:547`). Verified by adding `<${input.show && "div"}/el/><script>el().textContent = "set"</script>` to the `dynamic-tag-var` fixture: both CSR and SSR-resume left the `<div>` empty because `el` was never initialized, so its dependent effect never ran. Static native tags instead create a registered `_el(...)` getter; the dynamic-native path needs the equivalent getter tied to the created/resumed branch element in both runtimes.
+The string-renderer branch never assigns `result` (its inline TODO says so) and the DOM branch never pushes the created element through the child scope's `AccessorProp.TagVariable` callback, so `<${cond && "div"}/el/>` leaves `el` undefined in CSR and after resume. Hoisted reads make it a hard failure: debug SSR runs `_assert_hoist(el)` on `undefined` and throws `Hoisted values must be functions, received type "undefined"`, while optimize drops the assert, serializes `el: undefined`, and breaks later on the client. CSR is runtime-only (push `() => childScope[AccessorProp.StartNode]` through the callback in `dom/control-flow.ts`); resume needs the compiler, since a native branch scope serializes no state, leaving `dom/resume.ts`'s `BranchEndNativeTag` handler no `#TagVariable` to invoke. A cheap independent step is a compile-time diagnostic when a tag variable sits on a dynamic tag that can resolve to a native name. See also "Guard the tag-variable assignment in `_dynamic_tag` when the dynamic tag becomes falsy" — the unguarded write it reports is in this same block, and its option of moving that write into the `normalizedRenderer` branch would reshape the CSR fix here. Re-verify: compile `<if=input.show><${input.name || "div"}/el/></if><script>el()</script>` with `-d -o html` and see `_assert_hoist(el)` applied to an `el` the html `_dynamic_tag` never assigns.
 
-CSR is a runtime-only fix: push `() => childScope[AccessorProp.StartNode]` through the child scope's `TagVariable` callback right after the native branch is created in `dom/control-flow.ts`. SSR-resume is the hard part and needs the translator, not just the runtime. The native branch scope carries no state, so `_var`'s `writeScopePassive` `#TagVariable` slot is never serialized (the server fill contains only the parent scope); a dynamic _component_ tag var only resumes because its scope serializes anyway, carrying `{ "#TagVariable": _(1, "…/var") }`. So on resume there is no callback to invoke from the `BranchEndNativeTag` marker handler (`dom/resume.ts:232`). Runtime-only escapes don't exist: `_dynamic_tag` is never told a tag var is present (the compiler emits a separate `_var`), and forcing every tag var to serialize its scope actively regresses payload size for all of them. Delivering the getter across the dynamic boundary requires the compiler to serialize/reconstruct an element reference (a client-side `_el(id, accessor)` for the resumed branch element) — hence effort:high spanning compiler + runtime + serialization.
-
-A live `@marko/run` app shows this manifests as a HARD SSR 500 in dev, not just an empty render: reading the ref (`<${shape}/mark .../>` then `<effect>{ mark().getBBox() }` or a `<script>` reader) makes the HTML `_dynamic_tag` return `undefined` for `mark`, which the compiler guards with `_assert_hoist(mark)` — throwing MARKO_DEBUG's misleading `Hoisted values must be functions, received type "undefined"` (`packages/runtime-tags/src/common/errors.ts:109-114`), with a stack pointing at compiled runtime rather than the user's tag-variable construct. Under optimize `_assert_hoist` is compiled out, so SSR instead succeeds but serializes `mark: undefined`, and on the client `_hoist("mark")()` throws "undefined is not a function" when the effect/script runs — a silent dev-vs-prod divergence. Beyond the full high-effort compiler+serialization fix already noted, a low-effort, independently-valuable improvement is a compile-time error/warning when a tag variable is placed on a dynamic tag that can resolve to a native tag name, so users get a source-level diagnostic instead of an internal assert (dev) or broken hydration (prod).
-
-## Reject (or drop references for) duplicate `<return>` attributes — today they emit a module that references an undeclared signal
+## Reject duplicate `<return>` attributes instead of emitting an undeclared signal reference
 
 `packages/runtime-tags/src/translator/util/get-known-attr-values.ts` › `getKnownAttrValues` | 2026-07-23 | impact:med | effort:low
 
-`getKnownAttrValues` folds a tag's `MarkoAttribute`s into a `Record<string,
-t.Expression>`, so a repeated attribute silently keeps only the last value — but
-the generic reference tracker has already created a binding for the dropped
-expression. `core/return.ts` › `analyze` is the one consumer with no duplicate
-guard (`core/let.ts:48` and `core/script.ts:78` both throw "Invalid duplicate
-value attribute.", `core/await.ts` rejects extra attrs, and native tags warn +
-`dropNodes(attr.value)` in `visitors/tag/native-tag.ts` `analyze.enter`), so it
-calls `addSetupExpr(section, attrs.value)` for the surviving value only. The
-dropped binding then has a read but no signal, and the DOM output emits
-`$input($scope, input) { $input_a($scope, input.a); ... }` where `$input_a` is
-never declared — a `ReferenceError` at first render in both debug and optimize,
-with zero compile diagnostics (`meta.diagnostics` is `[]` under
-`errorRecovery`). Fix by giving `<return>` the same duplicate check as
-`<let>`/`<script>`, or by centralizing it: have `getKnownAttrValues` warn and
-`dropNodes` the shadowed value so every core-tag consumer is covered. Re-verify:
-compile `<return=input.a value=input.b/>` (or `<return value=input.a
-value=input.b/>`, or the same with duplicate `valueChange=`) with `-o dom` and
-grep the output for `$input_a` — it appears in `$input` but is never declared.
+`getKnownAttrValues` folds a tag's `MarkoAttribute`s into a record, so a repeated attribute keeps only the last value even though the reference tracker already created a binding for the dropped expression. `core/return.ts` › `analyze` is the one consumer with no duplicate guard (`core/let.ts` and `core/script.ts` throw "Invalid duplicate value attribute.", `core/await.ts` rejects extra attrs, native tags warn and `dropNodes`), so the shadowed binding keeps a read with no signal and the DOM output calls a `$input_a` it never declares — a `ReferenceError` on first render in debug and optimize, with zero compile diagnostics. Give `<return>` the same duplicate check, or centralize it by having `getKnownAttrValues` warn and `dropNodes` the shadowed value so every core-tag consumer is covered. Re-verify: compile `<return=input.a value=input.b/>` with `-o dom` and grep for `$input_a` — it is called from `$input` but never declared.
 
-## Accept 3-character `on<Uppercase>` handlers in `isEventOrChangeHandler`; `onX` is rejected while `on-x` works
+## Anchor `isEventOrChangeHandler`'s regex: it rejects `onX` and misreads `data-exChange`
 
 `packages/runtime-tags/src/translator/util/is-event-or-change-handler.ts` › `isEventOrChangeHandler` | 2026-07-23 | impact:low | effort:low
 
-The regex `/^on[-A-Z][a-zA-Z0-9_$]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$/` requires at
-least one character _after_ the `[-A-Z]`, so it rejects every 3-character
-handler name `onA`…`onZ`, while the runtime's own `isEventHandler`
-(`src/common/helpers.ts`, `/^on[A-Z-]/`) plus `getEventHandlerName`
-(`name.slice(2).toLowerCase()`) accept them and map them to a single-letter
-event. In `visitors/tag/native-tag.ts` `analyze.enter`,
-`assertNativeAttrValueType` runs before the `isEventHandler` branch and bails
-out early only for names `isEventOrChangeHandler` recognizes, so `<div onX() { …
-}>` dies with the misleading compile error "The `onX` attribute cannot be a
-function." even though the equivalent `<div on-x() { … }>` compiles to
-`_on($scope["#div/0"], "x", …)`. Dropping the trailing `[a-zA-Z0-9_$]` from the
-first alternative (and anchoring the alternation, e.g.
-`/^(?:on[-A-Z]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$)/`) realigns the translator with
-the runtime. Distinct from the existing dx.md entry about miscased event
-attributes, which is about type-check messaging for `onKeydown` vs `onKeyDown`.
-matches any attribute
-name merely _ending_ in `<word>Change`, including hyphenated HTML names that can
-never be a Marko controllable pair. In `visitors/tag/native-tag.ts`
-`analyze.enter` that makes `assertNativeHandlerAttr` fire on ordinary custom
-attributes, so `<div data-exChange="x"/>` dies with "The `data-exChange` change
-handler on a [native tag] must be a function or a falsey value" while the
-equivalent `<div data-ex-change="x"/>` compiles; it also makes
-`assertNativeAttrValueType` skip its function/object checks for such names, so
-`<div data-exChange=(() => {})/>` compiles to `_attr("data-exChange",
-_resume(() => {}, …))` — where the hyphenated spelling is correctly rejected —
-and an optimized (non-`MARKO_DEBUG`) build then stringifies the closure's source
-into the markup as ` data-exChange="(v) => { return v + 1 }"`. The unhyphenated
-`fooChange` case is deliberate, since the runtime's `assertValidAttrValue`
-(`src/common/errors.ts`) special-cases `/Change$/` to hint that a change handler
-only applies with its matching controllable attribute, so the fix is the anchored
-regex above plus limiting the native change-handler assertion to the four real
-controllables. Re-verify: `pnpm run compile -o html -d` on `<div
-data-exChange="x"/>` fails with the change-handler error and on `<div
-data-exChange=(() => {})/>` succeeds, while `<div data-ex-change="x"/>` compiles
-and `<div data-ex-change=(() => {})/>` fails with "The `data-ex-change` attribute
-cannot be a function."
+`/^on[-A-Z][a-zA-Z0-9_$]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$/` demands a character after `[-A-Z]` and leaves the second alternative unanchored, so it disagrees with the runtime's `isEventHandler` (`/^on[A-Z-]/`) at both ends. `<div onX() {}/>` fails `assertNativeAttrValueType` with "The `onX` attribute cannot be a function." though `<div on-x() {}/>` compiles. Conversely any name ending in `Change` counts as a change handler: `<div data-exChange="x"/>` errors, while `<div data-exChange=(() => {})/>` skips the function check and emits `_attr("data-exChange", _resume(() => {}, …))`, which an optimized build stringifies into the markup. Use `/^(?:on[-A-Z]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$)/` and scope `assertNativeHandlerAttr` to the real controllables. Distinct from dx.md's "Surface a near-miss suggestion (or document the casing rule) for miscased event attributes", which is about type-check messaging for `onKeydown` vs `onKeyDown`, not this regex. Re-verify: `node -r ~ts scripts/inspect-compiled-output.mts -o dom -d` on those four templates — today only the hyphenated spellings behave.
 
-## Validate (or coerce) `from`/`step` in `forTo`/`forUntil`; a string `from` silently produces concatenated indices
+## Coerce (or validate) `forTo`/`forUntil`'s `from`; a string `from` concatenates the indices
 
 `packages/runtime-tags/src/common/for.ts` › `forTo` | 2026-07-23 | impact:med | effort:low
 
-`forTo`/`forUntil` guard only the upper bound (`assertValidRangeBound("to", to)`
-/ `("until", until)`) and then compute `const start = from || 0` and `cb(start +
-i * delta)`. The `steps` division coerces a non-numeric `from`, but `start + i *
-delta` does not: a string `from` makes `+` string concatenation, so `<for|i|
-from="2" to=5>` yields the indices `"20", "21", "22", "23"` instead of `2, 3, 4,
-5` — wrong values and a wrong count, silently, in both runtimes and in
-MARKO_DEBUG. An object `from` yields zero iterations with no diagnostic. This is
-reachable from ordinary code because the translator passes the attribute
-straight through (`_for_to(5, input.start, 1, …)`,
-`packages/runtime-tags/src/translator/core/for.ts` `getForRuntimeArgs`) and the
-core-tag metadata's `from: { type: "number" }` is autocomplete/LSP data, not a
-compile-time check — so a range bound arriving as a query-string or JSON string
-is unvalidated end to end. Either extend the debug guard to the other two bounds
-(allowing nullish, since both default) or make the arithmetic coerce (`const
-start = +from || 0`, one byte) so the numeric-string case is at least right.
-Re-verify: `node -r ~ts -e 'const
-{forTo}=require("<repo>/packages/runtime-tags/src/common/for.ts"); const o=[];
-forTo(5,"2",1,v=>o.push(v)); console.log(o)'` — prints `[ '20', '21', '22', '23'
-]` today.
+Both helpers guard only the upper bound (`assertValidRangeBound`) and then compute `const start = from || 0; cb(start + i * delta)`, so a non-numeric `from` is never coerced: `forTo(5, "2", 1, cb)` yields `"20", "21", "22", "23"` instead of `2, 3, 4, 5` — wrong values and count, silently, even under MARKO_DEBUG. It is reachable from ordinary templates, since `getBaseArgsInForTag` (`translator/core/for.ts`) passes the attribute straight through and the core-tag metadata's `from: { type: "number" }` is LSP data, not a compile check. Either extend the debug guard to `from` (allowing nullish, since it defaults) or write `const start = +from || 0`. Re-verify: `node -r ~ts -e 'globalThis.MARKO_DEBUG=1;const{forTo}=require("./packages/runtime-tags/src/common/for.ts");const o=[];forTo(5,"2",1,v=>o.push(v));console.log(o)'` prints `[ '20', '21', '22', '23' ]`.
 
-## Give the HTML spread-attrs path the same MARKO_DEBUG attribute validation as the DOM path
+## Give the HTML spread-attrs path the same MARKO_DEBUG validation as the DOM path
 
 `packages/runtime-tags/src/html/attrs.ts` › `_attrs` | 2026-07-23 | impact:med | effort:low
 
-The two runtimes call the shared validators in
-`packages/runtime-tags/src/common/errors.ts` from different places, so debug SSR
-accepts spread attributes that debug CSR rejects — the error surfaces only on
-the first client update of an already-rendered page. (1) HTML `_attrs` puts
-`assertValidAttrName(name)` inside `if (name && !(isVoid(value) ||
-skip.test(name) || …))`, while DOM `attrsInternal`
-(`packages/runtime-tags/src/dom/dom.ts`) calls it for every key: `<div
-...{className: null}/>` renders cleanly on the server but throws "`className` is
-not a valid attribute, did you mean `class`?" in the browser, and the same holds
-for `htmlFor`/`v-if`/`"bad name"` whenever the current value is void. (2) HTML
-`_attrs_partial` filters `data` through `skip` before calling `_attrs`, so
-`assertExclusiveAttrs` never sees the statically-authored attributes, while DOM
-`_attrs_partial` checks `{...nextAttrs, ...skip}`: `<input checked=a
-checkedChange=fn ...{checkedValue:1}/>` produces no server error yet emits two
-conflicting controlled registrations, and the same input throws "The attributes
-checkedChange, checkedValue, and checked are mutually exclusive." on the client.
-Hoist `assertValidAttrName` above the void/skip guard in HTML `_attrs`, and call
-`assertExclusiveAttrs({...data, ...skip})` in HTML `_attrs_partial`. Re-verify:
-under `node -r ~ts`,
-`require('.../src/html/attrs.ts')._attrs({className:null},'a',0,'div')` returns
-`""` while `require('.../src/dom/dom.ts')._attrs({a: el},'a',{className:null})`
-throws.
-
-## Escape a carriage return in a `<textarea>` body so SSR and CSR agree
-
-`packages/runtime-tags/src/html/attrs.ts` › `_textarea_value` | 2026-07-27 | impact:low | effort:low
-
-`_textarea_value` writes the value as element text, and the HTML tokenizer
-normalizes every CR and CRLF in text to a single LF, so a `\r` anywhere in the
-value — not just at the start — is lost on SSR: `"a\rb"` and `"a\r\nb"` both
-parse back as `"a\nb"`. CSR keeps them, since `_attr_input_value_default`
-assigns `el.defaultValue` verbatim, so the two halves disagree and a controlled
-`<textarea>` resumes with a value the server never rendered. Writing `\r` as
-`&#13;` survives, because character references are decoded after newline
-normalization. Weigh that against the bytes it costs every textarea, since a
-lone CR in user input is rare. Re-verify: SSR-render `<textarea value=input.v/>`
-with `v = "a\rb"` and parse the output — the value is `"a\nb"`.
+Debug SSR accepts spread attributes debug CSR rejects, so the error surfaces only on the first client update of an already-rendered page. HTML `_attrs` calls `assertValidAttrName(name)` inside `if (name && !(isVoid(value) || skip.test(name) || …))` while DOM `attrsInternal` (`dom/dom.ts`) calls it for every key, so `<div ...{className: null}/>` renders clean on the server yet throws "did you mean `class`?" in the browser (same for `htmlFor`/`v-if` on a void value). HTML `_attrs_partial` filters `data` through `skip` before `_attrs`, so `assertExclusiveAttrs` never sees the static attrs, while DOM passes `{...nextAttrs, ...skip}`: `<input ...attrs checked=a checkedChange=fn/>` with `attrs = {checkedValue: 1}` is silent on the server, throws "mutually exclusive" on the client. Hoist `assertValidAttrName` above the void/skip guard and call `assertExclusiveAttrs({...data, ...skip})` in HTML `_attrs_partial`. The `<input>` ladder that `assertExclusiveAttrs` heads is separately misaligned with DOM `_controllable_input` — see "Align the spread `<input>` controllable ladders in HTML `_attrs` and DOM `_controllable_input`"; these assert moves land in the same block but do not catch that case. Re-verify under `node -r ~ts` with `MARKO_DEBUG`: html `_attrs_partial({checkedValue:1},{checked:1,checkedChange:1},"#input/0",0,"input")` returns `""` where the dom call throws.
 
 ## Don't emit the "no matching `<option>`" dev error when a controlled `<select>`'s options render asynchronously
 
 `packages/runtime-tags/src/html/attrs.ts` › `_attr_select_value` | 2026-07-23 | impact:med | effort:med
 
-The MARKO_DEBUG branch of `_attr_select_value` (attrs.ts:88-103) wraps `content`
-in `withContext(kSelectedValueMatched, matched, …)` and then inspects
-`matched.value` immediately after `content()` returns. When the select's body
-contains an `<await>` on a real promise, `content()` returns as soon as `_await`
-forks the chunk (`html/writer.ts` `_await`, async path) and the `<option>`s —
-and therefore `_attr_option_value`'s `matched.value = true` — run in a later
-chunk, so the check always sees `false` and logs `A controlled <select>'s value
-has no matching <option>: <value>` even though the emitted HTML is correct and
-does contain `<option value=b selected>`. Fetching a select's options
-asynchronously is idiomatic, so this fires a false alarm on a correct page and
-trains developers to ignore the warning (and it costs real debugging time
-chasing a nonexistent mismatch). Fix by deferring the assertion until the
-select's content has actually finished — e.g. run it from the boundary/chunk
-completion rather than synchronously, or skip it when the content forked an
-async chunk. Re-verify: server-render `<let/v="b"/><select
-value:=v><await|opts|=input.opts><for|o| of=opts><option
-value=o>${o}</option></for></await></select>` with MARKO_DEBUG and `input.opts =
-Promise.resolve(["a","b","c"])` — `console.error` fires while the HTML shows
-`<option value=b selected>`; passing the same array (or dropping the `<await>`)
-is silent.
+The MARKO_DEBUG branch wraps `content` in `withContext(kSelectedValueMatched, matched, …)` and reads `matched.value` the instant `content()` returns. When the body holds an `<await>` on a real promise, `_await` (`html/writer.ts`) forks the chunk and returns, so the `<option>`s — and `_attr_option_value`'s `matched.value = true` — run in a later chunk and the check always sees `false`. Fetching options asynchronously is idiomatic, so this fires on correct pages and trains developers to ignore the warning. Run the assertion from boundary/chunk completion instead, or skip it when the content forked an async chunk. Re-verify: SSR-render `<let/v="b"/><select value:=v><await|opts|=input.opts><for|o| of=opts><option value=o>${o}</option></for></await></select>` with `input.opts = Promise.resolve(["a","b","c"])` — `console.error` fires while the HTML shows `<option value=b selected>`; the plain array is silent.
 
 ## Reconcile `<html-comment>` escaping: SSR writes a literal `&gt;` into comment data that CSR writes raw
 
 `packages/runtime-tags/src/html/content.ts` › `_escape_comment` | 2026-07-23 | impact:med | effort:med
 
-`_escape_comment` replaces every `>` with `&gt;`, but HTML comments are not
-parsed for character references, so the server-rendered comment's data literally
-contains `&gt;` while the DOM runtime writes the raw character (`dom/dom.ts`
-`_text` assigns `node.data = _to_text(value)` with no comment escaping). For
-`<html-comment>${"-->"}</html-comment>` the resumed/SSR document has
-`comment.data === "--&gt;"` and a client-rendered document has `comment.data ===
-"-->"` — anything that reads comments (a `NodeIterator` over `SHOW_COMMENT`, a
-comment carrying JSON/config, edge-side markers) sees different content
-depending on which runtime produced the page. The escaping is also broader than
-needed: only `-->`, `--!>`, and a leading `>`/`->` can terminate a comment, so
-`>` alone never needs escaping. Pick one behavior — either escape comment data
-on the DOM side too (which also closes the client-side re-serialization hazard,
-since `comment.data = "-->"` serializes to `<!---->-->`), or narrow SSR escaping
-to the `--` sequences so both sides round-trip the author's text. Re-verify:
-parse the committed `html-comment-placeholder` snapshot `<!----&gt;-->` in jsdom
-(`data === "--&gt;"`) and compare against the fixture's own
-`dom.bundle.debug.js`, which calls `_text($scope["#comment/0"],
-`${_to_text("-->")}`)` (`data === "-->"`).
+`_escape_comment` replaces every `>` with `&gt;`, but comments are not parsed for character references, so the server-rendered comment's data literally contains `&gt;` while DOM `_text` (`dom/dom.ts`) assigns `node.data = _to_text(value)` unescaped. For `<html-comment>${"-->"}</html-comment>` an SSR/resumed document has `comment.data === "--&gt;"` and a client-rendered one `"-->"`, so anything reading comments (a `SHOW_COMMENT` `NodeIterator`, a comment carrying JSON/config, edge-side markers) sees different content per runtime. Only `-->`, `--!>`, and a leading `>`/`->` can terminate a comment, so escaping bare `>` is broader than needed. Either escape comment data on the DOM side too, or narrow SSR escaping to the `--` sequences so both sides round-trip the author's text. Re-verify: parse the committed `html-comment-placeholder` snapshot `<!----&gt;-->` in jsdom (`data === "--&gt;"`) and compare with that fixture's `dom.bundle.debug.js`.
 
-## Render a value-carrying dynamic `<select>`'s body through `_dynamic_tag` so it gets a resume branch like every other native dynamic tag
+## Render a value-carrying dynamic `<select>` through `_dynamic_tag`, and control it when it has no body
 
 `packages/runtime-tags/src/html/dynamic-tag.ts` › `_dynamic_tag` | 2026-07-23 | impact:med | effort:med
 
-In the string-renderer branch of the HTML `_dynamic_tag`, body content normally
-recurses through `_dynamic_tag(branchId, accessor, renderContent, undefined, 0,
-undefined, serializeReason)`, which emits `BranchStart`/`BranchEnd` markers and
-registers `ConditionalRenderer:#<tag>/0` on the native branch scope. The
-`renderer === "select" && ("value" in input || "valueChange" in input)` case
-instead hands `renderContent` to `_attr_select_value`, which invokes it directly
-via `withContext` — so the select's body gets no branch markers and no
-`ConditionalRenderer` entry. The DOM runtime has no such special case:
-`dom/control-flow.ts` `_dynamic_tag`'s string branch unconditionally does
-`setConditionalRenderer(scope[childScopeAccessor], "#<tag>/0", content,
-createAndSetupBranch)`, so the same template produces a different scope shape
-under CSR than under SSR-resume, and `setConditionalRenderer`'s
-`destroyBranch(prevBranch)` has no registered child branch to tear down when the
-tag switches away from `select` (the body's section scope stays in the parent's
-`ClosureScopes` set while its nodes are detached). Fix by keeping the
-`_dynamic_tag` recursion and passing it as the content callback to
-`_attr_select_value` (the `kSelectedValue` context is dynamically scoped, so it
-still reaches the options). Re-verify: server-render
-`<let/tag=input.tag/><let/n=0/><${tag} value="b"><option
-value=a>A${n}</option><option value=b>B</option></>` for `tag="div"` and
-`tag="select"` and diff the payloads.
-
-The falsy half of the same guard is a second defect, so fix both together: the `renderer === "select"` call sits inside `} else if (renderContent) {` (`html/dynamic-tag.ts:86`, the select test at `:93`), and `_attrs`' `case "select"` only widens `skip` to drop `value`/`valueChange` from the markup — so a dynamic tag resolving to `"select"` with **no body** writes neither `ControlledType`/`ControlledHandler` nor the `_dynamicTagScript` resume registration. CSR has no such guard: `dom/control-flow.ts` › `_dynamic_tag` always passes `controllableRenders[tagName]` into `_attrs`, and `dom/controllable.ts` › `_controllable_select` only tests `"value" in nextAttrs || "valueChange" in nextAttrs`, so the same template is controlled after a client mount but uncontrolled after SSR resume until the dynamic tag next re-renders. The select call is the only controllable gated on having a body — `tag="input"`/`"textarea"` register correctly because their helpers run outside the guard, and a static bodyless `<select value:=v/>` registers because the translator always hands `_attr_select_value` a body closure — so hoisting the select case out of the `renderContent` guard and passing `renderContent` (possibly undefined) as its optional `content` argument fixes this half while the recursion above fixes the other. Re-verify: compile `<let/v="a"/><${input.tag} value:=v/>` with `pnpm run compile -o html -d` and server-render it twice — the `{"tag":"input"}` payload contains `"ControlledType:#input/0":2`, `"ControlledHandler:#input/0"` and `"_dynamicTagScript 2"`, the `{"tag":"select"}` payload contains none of them.
+The `renderer === "select" && ("value" in input || "valueChange" in input)` case hands `renderContent` to `_attr_select_value` instead of recursing, so the body gets no branch markers and no `ConditionalRenderer:#select/0`; `dom/control-flow.ts` › `_dynamic_tag` always registers one, and the resumed body scope is left in the parent's `ClosureScopes` with no branch to destroy it. That case also sits inside `} else if (renderContent) {`, and `_attrs`' `case "select"` only widens `skip`, so a bodyless dynamic select writes no `ControlledType`/`ControlledHandler`. Pass the `_dynamic_tag` recursion as `_attr_select_value`'s `content` argument (`kSelectedValue` is dynamically scoped) and hoist the select case out of the guard. See also "Initialize tag variables for dynamic tags that resolve to a native tag name" — same string-renderer branch, and a restructure that always recurses may resolve both. Re-verify: SSR `<let/tag=input.tag/><let/n=0/><${tag} value="b"><option value="a">A${n}</option></>` for `"div"` vs `"select"` — only div emits `M_[` and `ConditionalRenderer:#div/0`; and `<${input.tag} value:=v/>` emits `ControlledType:#input/0` for `"input"`, nothing for `"select"`.
 
 ## Apply the `hasAttrAlias` guard in `_attrs_partial` so a `checkedValue` spread stops unchecking the box
 
 `packages/runtime-tags/src/dom/dom.ts` › `_attrs_partial` | 2026-07-23 | impact:med | effort:low
 
-`_attrs` guards its stale-attribute removal loop with `hasAttrAlias`
-(dom.ts:181, helper at :203) so an `<input>` whose next attrs carry
-`checkedValue` keeps its `checked` content attribute; `_attrs_partial`'s removal
-loop (dom.ts:224-229) tests only `!skip[name] && !(nextAttrs && name in
-nextAttrs)` and has no such guard. Because `defaultChecked` is the IDL
-reflection of that attribute, `el.removeAttribute("checked")` drops
-`defaultChecked` to `false` and (while the dirty flag is unset) `el.checked`
-with it. `_attr_input_checked_default` then reads the already-cleared
-`el.checked` as its `restoreValue` on the `scope[AccessorProp.Gen] < runId`
-branch (controllable.ts:25-32) and writes it back, so an uncontrolled
-`checkedValue` spread visibly unchecks a box whose state still selects it; the
-controlled variant keeps `checked` correct but is left with `defaultChecked ===
-false`, which corrupts `hasCheckboxChanged`/`handleFormReset`
-(controllable.ts:512-535) so a form reset reverts to unchecked and reports the
-item out of the bound list. Reachable from `<input ...attrs type="checkbox">`
-(spread before a static attr), which compiles to `_attrs_partial($scope,
-"#input/0", { checkedValue: … , value: … }, { type: 1 })`. Fix by reusing
-`hasAttrAlias` in `_attrs_partial`'s loop exactly as `_attrs` does. Re-verify:
-add a fixture like `<let/sel=["a"]/><input ...{ checkedValue: sel, value: "a" }
-type="checkbox"><button onClick(){ sel = sel.slice() }>t</button>` and click
-once — the box unchecks in `render.md` even though `sel` still contains `"a"`.
+`_attrs` guards its stale-attribute removal with `hasAttrAlias`, keeping `checked` on an `<input>` whose next attrs carry `checkedValue`; `_attrs_partial`'s loop tests only `!skip[name] && !(nextAttrs && name in nextAttrs)`, so it removes `checked`, clearing `defaultChecked` and — dirty flag unset — `el.checked`. `_attr_input_checked_default` then reads that cleared `el.checked` as `restoreValue` on the `scope[AccessorProp.Gen] < runId` branch and writes it back, unchecking a box whose bound value still selects it; the controlled variant keeps `checked` but is left `defaultChecked === false`, corrupting `hasCheckboxChanged`/`handleFormReset`. Reuse `hasAttrAlias` in `_attrs_partial`'s loop. Re-verify: `<let/sel=["a"]/><input ...{ checkedValue: sel, value: "a" } type="checkbox"><button onClick(){ sel = sel.slice() }>t</button>` compiles to `_attrs_partial(…, { type: 1 }, _controllable_input)`; one click unchecks the box.
 
-## Prefix `delegate`'s registration flag so event types named after Function properties register
+## Prefix `delegate`'s registration flag so event types named after `Function` properties register
 
 `packages/runtime-tags/src/dom/event.ts` › `delegate` | 2026-07-23 | impact:low | effort:low
 
-`delegate` memoizes its one-time `document.addEventListener` per (handler, type)
-by writing the flag onto the handler function under the raw event type:
-`(handler as any)[type] ||= (document.addEventListener(type, handler, true), 1)`
-(event.ts:28-30). Any event type that collides with an own or inherited
-`Function` property already reads truthy, so `||=` short-circuits and the
-document listener is never installed — the handler silently never fires. `name`,
-`length`, `constructor`, `toString`, `bind`, `call`, `apply`, and `prototype`
-all hit this; `caller` and `arguments` are worse, because the runtime is
-strict-mode ESM and the `Function.prototype.caller` accessor throws, so `<div
-on-caller(){}>` raises a TypeError from inside `_on`. Custom event names come
-straight from user markup (`on-<name>` on a native tag lowers to `_on(el,
-"<name>", fn)`), so this is user-reachable and fails with no diagnostic. `_on`
-already namespaces its own per-element slot as `"$" + type` (event.ts:21-25);
-using the same `"$" + type` key inside `delegate` costs a few bytes and closes
-the hole. Re-verify: `<div on-name(){ console.log("hi") }>x</div>`, then
-dispatch `new CustomEvent("name", { bubbles: true })` on the div — nothing logs
-today, and `on-click` in the same template works.
+`delegate` memoizes its one-time `document.addEventListener` as `(handler as any)[type] ||= (…, 1)`, keyed on the raw event type. Any type colliding with a `Function` property — `name`, `length`, `constructor`, `toString`, `bind`, `call`, `apply`, `prototype` — already reads truthy, so the listener is never installed and the handler silently never fires; `caller`/`arguments` instead throw a `TypeError` out of `_on`, since the runtime is strict-mode ESM. The names come from user markup: `<div on-name(){}>` compiles to `_on($scope["#div/0"], "name", fn)`. `_on` already namespaces its own slot as `"$" + type`; use that key in `delegate` too. If "Delegate events from the element's root node again; nothing inside a ShadowRoot receives events or controlled-input updates" is taken, its per-root type-keyed map deletes this keyspace outright and supersedes the `"$" + type` patch, so the two must not land separately. Re-verify: `<div on-name(){ console.log("hi") }>x</div>`, then dispatch `new CustomEvent("name", { bubbles: true })` on it — nothing logs today while `on-click` works.
 
 ## Treat a falsy-but-defined `<for by>` value as "no key" in the DOM runtime, matching SSR
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_for_of` | 2026-07-23 | impact:med | effort:low
 
-The DOM loops normalize `by` with an ES default parameter — `_for_of` uses
-`([all, by = bySecondArg], cb)` and `_for_in`/`_for_to`/`_for_until` use `by =
-byFirstArg` — which only substitutes for `undefined`. The HTML runtime instead
-uses a truthiness check (`forOfBy`/`forInBy`/`forStepBy` in `src/html/for.ts`:
-`return by ? ... : index`). So a `by` expression that evaluates to `false`,
-`null`, or `0` renders fine on the server and then throws `TypeError: by is not
-a function` on the client. This is reachable from idiomatic authoring — `by=cond
-&& "id"` or `by=input.by` — because the translator gates on the _attribute's
-presence_, not its runtime value (`if (forAttrs.by) loopArgs.push(forAttrs.by)`
-in `translator/core/for.ts`), emitting `$for($scope, [$scope.input_items,
-$scope.input_useKey && "id"])`. Fix by normalizing on truthiness in the four
-`loop` wrappers (`by ||= bySecondArg` / `byFirstArg`) so falsy means index/name
-keying exactly as SSR does; note `by=""` is a related hazard (DOM takes the
-string branch and reads `item[""]`, producing duplicate keys) that the same
-normalization fixes. Re-verify with a fixture `<for|item| of=input.items
-by=input.useKey && "id">` and steps `[{items, useKey:true}, {items,
-useKey:false}]`; today the second step throws in CSR while SSR renders both.
+`_for_of` destructures `([all, by = bySecondArg], cb)` and `_for_in`/`_for_to`/`_for_until` use `by = byFirstArg`, so the default substitutes only for `undefined`, while `html/for.ts`'s `forOfBy`/`forInBy`/`forStepBy` fall back on truthiness. A `by` evaluating to `false`, `null`, or `0` therefore renders on the server and throws `TypeError: by is not a function` on the client. The translator gates on the attribute's presence (`if (forAttrs.by) loopArgs.push(forAttrs.by)` in `translator/core/for.ts`), so `by=input.useKey && "id"` compiles to `$for($scope, [$scope.input_items, $scope.input_useKey && "id"])`. Use `by ||= bySecondArg` / `byFirstArg` in the four `loop` wrappers; that also fixes `by=""`, which today takes the string branch and reads `item[""]`. Re-verify with `<for|item| of=input.items by=input.useKey && "id">` and steps `[{useKey:true},{useKey:false}]` — the second CSR step throws while SSR renders both.
 
 ## Guard the tag-variable assignment in `_dynamic_tag` when the dynamic tag becomes falsy
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_dynamic_tag` | 2026-07-23 | impact:med | effort:low
 
-Inside `_dynamic_tag`'s change block, `setConditionalRenderer(...)` assigns
-`scope[AccessorPrefix.BranchScopes + nodeAccessor] = newRenderer &&
-createBranch(...)` — so when the new renderer is falsy the child scope becomes
-`undefined`. The very next statement (control-flow.ts:551-554) then does
-`scope[childScopeAccessor][AccessorProp.TagVariable] = (value) =>
-getTagVar()(scope, value)` with no guard, throwing `TypeError: Cannot set
-properties of undefined (setting '#TagVariable')`. This only fires when the tag
-variable exists and the value transitions from rendered to falsy (the
-initial-falsy case is skipped because the change check compares `undefined !==
-undefined`), i.e. `<${input.tag}/el/>` going `"div"` →
-`undefined`/`null`/`false`, which is the natural way to write an optional
-dynamic tag with a ref. Wrap the assignment (`if (getTagVar &&
-scope[childScopeAccessor])`) or move it inside the `normalizedRenderer` branch,
-and decide whether the tag variable should be pushed `undefined` on teardown.
-This is a different defect from the existing bugs.md entry "Initialize tag
-variables for dynamic native tags" (which is about the getter never being
-_supplied_ for a rendered native dynamic tag, at :547) — this one is a missing
-null guard on the clear transition. Re-verify with a fixture
-`<${input.tag}/el/>` plus `steps: [{tag:"div"}, {tag:undefined}]`; the second
-CSR step throws today.
+`setConditionalRenderer` assigns `scope[AccessorPrefix.BranchScopes + nodeAccessor] = newRenderer && createBranch(...)`, so a falsy renderer leaves the child scope `undefined`; the next statement writes `scope[childScopeAccessor][AccessorProp.TagVariable] = …` unguarded and throws `TypeError: Cannot set properties of undefined`. It fires only when a tag variable exists and the value goes rendered → falsy — `<${input.tag}/el/>` (compiled to `_dynamic_tag("#text/0", 0, () => $el)`) moving `"div"` → `undefined`, the natural way to write an optional dynamic tag with a ref; the initial-falsy case is skipped because the renderer check compares `undefined !== undefined`. Guard on `scope[childScopeAccessor]`, or move the write into the `normalizedRenderer` branch, and decide whether the tag variable should be pushed `undefined` on teardown. This is a different defect from the entry "Initialize tag variables for dynamic tags that resolve to a native tag name", where the callback installed here is never invoked for a rendered native tag — but the `normalizedRenderer` restructure touches that entry's CSR fix, so sequence them. Re-verify with `<${input.tag}/el/>` and `steps: [{tag:"div"}, {tag:undefined}]` — no fixture covers that transition and the second CSR step throws.
 
-## Renumber alias bindings too, or stop using `Binding.id` as the `bindingUtil` identity tiebreak
-
-`packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-23 | impact:med | effort:med
-
-`bindingUtil` (references.ts:1603) treats `a.section.id - b.section.id || a.id -
-b.id` as an identity comparison — `Sorted.add` skips an item whose compare is
-`0`, and `find`/`has`/`findIndexSorted` return the first `0` match. That
-requires `id` to be unique per section, but the final loop of
-`finalizeReferences` (references.ts:1321, `binding.id = nextId++`) only
-renumbers bindings reachable through `section.bindings`, which is populated with
-`getCanonicalBinding(binding)` (references.ts:1052). A non-canonical binding — a
-pure alias with `property === undefined` and `excludeProperties === undefined`,
-e.g. the one `<const/b=a>` creates via `trackVarReferences` — is never in that
-list, so it keeps its global creation-order id while its section-mates are
-renumbered to dense per-section ids. These aliases genuinely do reach sorted
-structures: an expression reading `b` resolves to `referencedBindings = b`, not
-`a` (compiling `<let/a=1/><const/b=a/><let/c=2/><div>${b + c}</div>` emits the
-intersection signal `$b__OR__c`). The collision then makes two distinct live
-bindings indistinguishable to every post-analysis sorted operation, most
-consequentially `dropReferencedBindings` (references.ts:1374), which runs after
-renumbering via the `getReferenceFinalizers()` loop (references.ts:1364) and
-rebuilds `expr.referencedBindings` with `bindingUtil.add` — a colliding pair
-silently collapses to one binding, dropping a real dependency. I did not find a
-fixture that currently miscompiles because of it, so this is a latent invariant
-break rather than an observed wrong output; the fix is either to renumber alias
-bindings alongside their canonical (or into a disjoint range) or to give
-`Binding` a separate monotonic identity field for the comparator and keep `id`
-purely as the accessor id. Re-verify: wrap `bindingUtil.compare` to collect
-every binding it sees, compile
-`packages/runtime-tags/src/__tests__/fixtures/param-destructure-default/template.marko`
-with the tags translator, then group the collected bindings by `(section, id,
-type===dom)` — section 1 id 6 holds both `$foo` (alias, `pruned === false`) and
-`$bar`, and `bindingUtil.compare($foo, $bar)` returns `0`.
-
-## Reset the scheduler's `isScheduled` guard without depending on `requestAnimationFrame`
+## Reset the scheduler's `isScheduled` guard off a path that always runs
 
 `packages/runtime-tags/src/dom/schedule.ts` › `schedule` | 2026-07-23 | impact:med | effort:low
 
-`schedule()` sets `isScheduled = 1` and queues `flushAndWaitFrame`, which
-registers `requestAnimationFrame(triggerMacroTask)` and flushes once;
-`isScheduled` is then cleared only inside the MessageChannel `onmessage` handler
-that `triggerMacroTask` posts — and `triggerMacroTask` is reachable only from
-that rAF callback. Browsers do not run rAF callbacks for a document that is not
-rendered (hidden/background tab, `display:none` or fully offscreen iframe), so
-after the very first microtask flush every later `schedule()` is a no-op and all
-`<let>`-driven work (`dom/signals.ts:47`) stalls in `pendingRenders` — including
-`<script>`/`<lifecycle>` effects doing non-visual work such as `document.title`
-badges, analytics beacons, or websocket/SSE-driven state. In a hidden tab this
-unblocks on refocus, but in a `display:none` iframe it never does;
-`queueAsyncRender`'s direct `queueMicrotask(run)` means only the synchronous
-state-write path is affected, which makes the failure look intermittent. Note
-this is distinct from the deliberate MessageChannel contract documented in the
-comment above `triggerMacroTask` (commit 2df3c969, "hosts lacking it must
-polyfill"): here MessageChannel exists and rAF is the link that never fires, so
-no polyfill helps. Direction: clear `isScheduled` from a path that always runs
-(post the MessageChannel message from `flushAndWaitFrame` itself, or race the
-rAF with a `setTimeout` fallback). Re-verify: stub
-`globalThis.requestAnimationFrame` to record-but-never-invoke, then
-`queueRender(scope, sig, 0, 'a'); schedule()` → flushes; a second and third
-`queueRender(...)+schedule()` never run until the recorded rAF callbacks are
-manually invoked.
+`schedule()` sets `isScheduled = 1`, and it is cleared only in the MessageChannel handler that `triggerMacroTask` posts — reachable only from the `requestAnimationFrame` callback `flushAndWaitFrame` registers. A document that is never rendered (background tab, `display:none` or offscreen iframe) never fires rAF, so after the first flush every later `schedule()` is a no-op and `<let>`-driven work stalls in `pendingRenders`, including non-visual effects like `document.title` badges or analytics beacons. `queueAsyncRender`'s own `queueMicrotask(run)` still runs, which makes the failure look intermittent. Distinct from the deliberate MessageChannel contract in the comment above `triggerMacroTask` (commit 2df3c969, "hosts lacking it must polyfill"): MessageChannel is present here and rAF is the link that never fires, so no polyfill helps. Clear the flag from a path that always runs: post the message from `flushAndWaitFrame`, or race the rAF with a `setTimeout` fallback. Re-verify: stub `requestAnimationFrame` to record-but-never-invoke — the first `queueRender(...)+schedule()` flushes, the second and third never do until a recorded callback is invoked by hand.
 
-## Default a nullish namespace in `parseHTML`: mounting into a DocumentFragment/ShadowRoot creates null-namespace elements
+## Default a nullish namespace in `parseHTML` so ShadowRoot/fragment mounts stay HTML
 
 `packages/runtime-tags/src/dom/parse-html.ts` › `parseHTML` | 2026-07-23 | impact:med | effort:low
 
-`parseHTML(html, ns)` builds its parser with `document.createElementNS(ns,
-"template")`, and `ns` is derived from `(parentNode as Element).namespaceURI` in
-`dom/renderer.ts` `createBranch`. A `DocumentFragment` or `ShadowRoot` has no
-`namespaceURI`, so `undefined` reaches `createElementNS`, which coerces to
-`null`; the parser is then a null-namespace `Element` (not an
-`HTMLTemplateElement`, hence the `|| parser` fallback) and the HTML fragment
-parser runs in foreign-content mode, creating every tag that is not on the
-parser's HTML-breakout list in the null namespace. The result is that
-`template.mount(input, shadowRoot)` and `template.mount(input,
-documentFragment)` — the natural way to use Marko 6 inside a web component —
-silently produce non-`HTMLElement`
-`<section>`/`<main>`/`<button>`/`<a>`/`<input>`/`<label>` with no UA styles, no
-form behavior and no `style`/`className`, while `<div>`/`<span>`/`<ul>` come out
-fine, making the breakage partial and baffling. `dom/scope.ts`
-`tempDetachBranch` already shims `fragment.namespaceURI` for exactly this
-invariant, so the fix is to close the remaining hole: default a nullish `ns` (in
-`parseHTML` and in `createCloneableHTML`'s `document.createElementNS(ns, "t")`)
-to the XHTML namespace, or have `mount` resolve it from the ShadowRoot host /
-`ownerDocument.documentElement`. Re-verify: install jsdom globals, then
-`_template('t','<section>x</section>','').mount({},
-document.createDocumentFragment())` — the child is `nodeName 'section'` with
-`namespaceURI === null`, versus `SECTION` in `http://www.w3.org/1999/xhtml` when
-mounted into `document.body`.
+`createBranch` passes `(parentNode as Element).namespaceURI` down to the clone, but a `DocumentFragment` or `ShadowRoot` has none, so `document.createElementNS(undefined, "template")` builds a null-namespace parser and `innerHTML` parses in foreign-content mode. Every tag off the HTML breakout list (`section`, `main`, `button`, `a`, `input`, `label`) becomes a null-namespace `Element` with no UA styles, form behavior, or `style`/`className`, while `div`/`span`/`ul` come out fine — so `template.mount(input, shadowRoot)`, the natural way to use Marko 6 in a web component, breaks in a partial, baffling way. Default a nullish `ns` to XHTML here and in `createCloneableHTML`'s `document.createElementNS(ns, "t")`, matching the `namespaceURI` shim `dom/scope.ts` › `tempDetachBranch` already relies on. This is a different defect from the entry "Thread the real insertion namespace into `compat.render` instead of `document.body`", where the namespace is present but wrong (`document.body`'s XHTML), so this default never fires on that path and does not fix clone-namespace derivation generally. Re-verify under jsdom: `_template('t','<section>x</section>','').mount({}, document.createDocumentFragment())` yields `nodeName 'section'` with `namespaceURI === null`, versus `SECTION` in XHTML when mounted into `document.body`.
 
-## Stop resolving the clone namespace from `document.body` in `compat.render`; SVG/MathML Tags content from a Class parent clones as HTML
+## Thread the real insertion namespace into `compat.render` instead of `document.body`
 
 `packages/runtime-tags/src/dom/compat.ts` › `compat.render` | 2026-07-23 | impact:med | effort:med
 
-`compat.render` creates the Tags branch with `createAndSetupBranch(out.global,
-renderer, renderer[RendererProp.Owner], document.body)`, and `createBranch`
-derives the clone namespace from that parent node's `namespaceURI` — so every
-Marko 6 template instantiated through the Marko 5 → Marko 6 client boundary is
-cloned in the XHTML namespace regardless of where it will actually land. A Tags
-template whose root is an SVG/MathML child element (`<circle>`, `<path>`, `<g>`,
-`<use>` — i.e. a partial used inside a parent `<svg>`) therefore becomes an
-`HTMLUnknownElement` and renders as nothing; the same template mounted normally
-into an `<svg>` is correct, which pins the defect to the hardcoded
-`document.body`. This only bites on the client-create path (pure CSR, or a Class
-parent re-rendering that constructs a new Tags child) — SSR resume adopts
-existing DOM and never clones. The insertion point genuinely is not known when
-the Class runtime renders into a detached vdom, so the fix needs the namespace
-threaded in from the caller (the `TagsCompat` renderer knows the morph host in
-the re-render case) or the clone deferred until `morphdom` inserts; note
-`dom/scope.ts` `tempDetachBranch` already establishes the "parent must carry a
-correct `namespaceURI`" invariant via its DocumentFragment shim. Re-verify: with
-jsdom globals installed, `compat.render({global:{runtimeId:'M',renderId:'_'}},
-{}, _template('b','<circle cx="1"/>',''), [{}])` returns a `CIRCLE` in
-`http://www.w3.org/1999/xhtml`, versus `circle` in `http://www.w3.org/2000/svg`
-when the same template is `mount`ed into a real `<svg>`.
+`compat.render` creates the Tags branch with `createAndSetupBranch(..., document.body)`, and `createBranch` takes the clone namespace from that parent's `namespaceURI`, so every Marko 6 template instantiated through the Marko 5 client boundary clones in XHTML. A Tags partial rooted at an SVG/MathML child (`<circle>`, `<path>`, `<g>`) clones as `HTMLUnknownElement` and renders nothing, though the same template `mount`ed into a real `<svg>` is correct; only client-create is hit, since SSR resume adopts existing DOM. The insertion point is genuinely unknown while the Class runtime renders into a detached vdom, so the namespace must be threaded from the caller or the clone deferred until morphdom inserts — morphdom already supplies it (`vNode.___actualize(host, parentEl.namespaceURI)` in `packages/runtime-class/src/runtime/vdom/morphdom/index.js`), but tags-compat's vnode `{___actualize: () => newNode}` returns a node cloned long before. Threading a real insertion point can hand `createBranch` a fragment with no `namespaceURI`, so the entry "Default a nullish namespace in `parseHTML` so ShadowRoot/fragment mounts stay HTML" has to land first or alongside this one. Re-verify under jsdom: `compat.render({global:{runtimeId:'M',renderId:'_'}}, {}, _template('b','<circle cx="1"/>',''), [{}])` returns a `CIRCLE` in `http://www.w3.org/1999/xhtml`.
 
-## Count the same unit on both sides of `resolveCursorPosition`'s alphanumeric scan; astral letters send the caret to the end
+## Count the same unit on both sides of `resolveCursorPosition`'s alphanumeric scan
 
 `packages/runtime-tags/src/dom/resolve-cursor-position.ts` › `resolveCursorPosition` | 2026-07-23 | impact:low | effort:low
 
-The fallback scan measures `count = before.replace(R, "").length`, i.e. the
-surviving alphanumerics in UTF-16 code units — an astral `\p{L}`/`\p{N}` code
-point survives the strip and contributes 2 — but then walks `updatedValue` one
-code unit at a time (`updatedValue[pos++].replace(R, "")`), and a lone surrogate
-is `\p{Cs}`, so it is stripped and never decrements `count`. For values
-containing astral letters or digits (CJK Ext-B such as 𠮷 U+20BB7, Adlam, Osage,
-mathematical alphanumerics) `count` can never reach 0, the loop runs off the end
-and the function returns `updatedValue.length`, so a controlled/masked `value:=`
-input yanks the caret to the end on every keystroke that rewrites the middle of
-the value. Emoji are unaffected because `\p{So}` is excluded on both sides; the
-bug is specific to astral characters that _are_ letters/digits, and the same
-mismatch can also return a position between surrogate halves. Fix by making both
-sides use one unit — e.g. `count = [...before.replace(R, "")].length` plus
-iterating `updatedValue` by code point (`for (const ch of updatedValue) { pos +=
-ch.length; ... }`). Re-verify: `resolveCursorPosition("", 5, "(𠮷𠮸𠮹) x", "(𠮷)
-𠮸𠮹y")` returns 10 (end of value) where 8 is correct, while the all-BMP
-`resolveCursorPosition("", 5, "(5405) 810-9227", "(540) 581-0922")` returns 7.
+`count = before.replace(R, "").length` counts alphanumerics in UTF-16 code units, so an astral `\p{L}`/`\p{N}` contributes 2, but the loop walks `updatedValue` one code unit at a time and each lone surrogate is `\p{Cs}`, so it is stripped and never decrements `count`. With astral letters or digits (CJK Ext-B, Adlam, Osage, math alphanumerics) `count` never reaches 0, the loop runs off the end, and `controllable.ts` › `setInputValue` yanks the caret to `updatedValue.length` on every keystroke that rewrites the middle of a controlled `value:=` input. Use one unit on both sides: `count = [...before.replace(R, "")].length` and iterate by code point. Re-verify: `resolveCursorPosition("", 5, "(𠮷𠮸𠮹) x", "(𠮷) 𠮸𠮹y")` returns 10 (end of value) where 7 is correct; the all-BMP `("", 5, "(5405) 810-9227", "(540) 581-0922")` returns 7 either way.
 
-## Give a hidden `<show>` a wrapper legal in table/select insertion contexts, instead of rejecting it
-
-`packages/runtime-tags/src/html/writer.ts` › `_show_start` | 2026-07-28 | impact:med | effort:high
-
-A `<show>` directly inside `<table>`/`<thead>`/`<tbody>`/`<tfoot>`/`<tr>`/`<colgroup>`/`<select>`/`<optgroup>` is now a compile error (`assertLegalHiddenContext` in `translator/core/show.ts`), because `_show_start` wraps non-displayed content in `<t hidden>` and those insertion modes discard the unknown element while keeping its children — so the content the author asked to hide rendered, visible and interactive, with a `<option>` even coming back `selected` and a `<col>` escaping into a second `<colgroup>`. The same hazard applies to the `<t hidden>` that `Chunk.flushScript` wraps reordered content in (`html/writer.ts`), which is the subject of its own entry; the shared predicate for these insertion modes is `translator/util/insertion-context.ts` › `discardsWrapperChildren`. That diagnostic only stops the silent mis-render; it does not make the construct work, and the docs still recommend `<show>` for bulky markup that may well be a table body. The blocker for a real fix is that no ordinary element is legal in both contexts: `<tbody>` accepts only `<tr>`, `<template>`, `<script>` and `<style>`, and `<select>` only `<option>`, `<optgroup>`, `<hr>`, `<script>` and `<template>`. `<template>` is the sole universal candidate and is semantically apt (its children park in a `DocumentFragment`, which is exactly the runtime's hidden representation), but its children are not in the normal tree — `firstChild` is null and the content sits on `.content` — so the resume walker and `_show`'s `<t>`-dissolve path both need to reach through it before it can be adopted. A narrower alternative is to set `hidden` on each top-level node of the body when the parent is one of these tags, which needs no wrapper at all but only works when those nodes are statically known elements. Re-verify by deleting the `assertLegalHiddenContext` call and running `pnpm run test:update -- --grep "runtime-tags/translator error-show-tag-in-table "`: `render.debug.md` shows the row inside the table despite `show=false`.
-
-## Wrap reordered out-of-order content in a parser-context-legal container; table rows streamed after a `@placeholder` are destroyed
+## Wrap reordered out-of-order content in a parser-context-legal container
 
 `packages/runtime-tags/src/html/writer.ts` › `Chunk.flushScript` | 2026-07-23 | impact:high | effort:high
 
-When a reorder chunk flushes, `flushScript` appends `"<t hidden " +
-state.commentPrefix + "=" + reorderId + ">" + reorderHTML + "</t>"` to the
-stream, and the inline reorder runtime later splices it in with `replace = (id,
-container) => runtime.l[id].replaceWith(...container.childNodes)`. `<t>` puts
-the parser in the "in body" insertion mode, so any reordered payload made of
-table-internal markup is discarded by the parser before the runtime ever sees
-it: `<tr>`/`<td>` start tags are ignored and only their text survives, and the
-runtime then splices bare text nodes into the `<tbody>` where the rows belonged.
-This breaks the canonical async-table pattern (`<try>` with a `@placeholder` of
-skeleton rows and an `<await>` that streams the real rows) with no error on
-either side; the same wrapper is also foster-parented out of the table whenever
-a flush boundary lands while the table element is still open. Direction: track
-the parser insertion context at the reorder site (the translator knows the
-static ancestor tag chain) and emit matching scaffolding around the payload —
-e.g. `<table hidden><tbody>…</tbody></table>` — with the runtime extracting from
-the corresponding depth, the approach React's Fizz writer uses for the same
-problem. Re-verify by adding a fixture
-`<table><tbody><tr><td>first</td></tr><try><@placeholder><tr><td>loading</td></tr></@placeholder><await=input.rows><tr><td>async
-row</td></tr></await></try></tbody></table>` and running `pnpm test -- --grep
-"runtime-tags/translator try-await-table-rows "`: `writes.html` will contain `<t
-hidden M_=b><tr><td>async row</td></tr></t>` while `render.md` shows the row
-reduced to a stray text node in the table.
+A reorder flush appends `<t hidden {commentPrefix}={reorderId}>reorderHTML</t>`, and the inline reorder runtime splices it in via `runtime.l[id].replaceWith(...container.childNodes)`. `<t>` puts the parser in "in body", so a table-internal payload is destroyed before the runtime sees it: `<tr>`/`<td>` start tags are ignored, only their text survives, and bare text nodes land in the `<tbody>`. That silently breaks the canonical async-table pattern (`<try>` with a skeleton-row `@placeholder` plus an `<await>` streaming the real rows), and the wrapper is foster-parented out whenever a flush lands while the table is still open. Track the reorder site's static ancestor chain in the translator and emit matching scaffolding (`<table hidden><tbody>…</tbody></table>`), extracting from that depth as React's Fizz writer does. "Give a hidden `<show>` a wrapper legal in table/select insertion contexts" covers this file's other `<t hidden>` emit site and proposes `<template>` instead, so pick the container once for both writers and reuse its `translator/util/insertion-context.ts` › `discardsWrapperChildren`, which already enumerates the offending insertion modes. Re-verify: add that fixture and run `pnpm test -- --grep "runtime-tags/translator try-await-table-rows "` — `render.md` shows the row reduced to a stray text node.
 
-## Track "a page already owns this $global" with a durable marker; `__flush__` is cleared at the first flush
+## Mark "a page entry already claimed this render" with a durable flag, not `$global.__flush__`
 
 `packages/runtime-tags/src/html/assets.ts` › `withPageAssets` | 2026-07-23 | impact:high | effort:med
 
-`withPageAssets` decides "am I nested inside another page render?" with `if
-(g.__flush__)` (assets.ts:95), but `Chunk.flushHTML` clears that same hook
-(`$global.__flush__ = undefined`, `html/writer.ts:1537`) the moment the outer
-page performs its first flush. Any page-entry template rendered after that point
-— i.e. anywhere inside `<await>`/`<try>`/reordered content — therefore takes the
-top-level branch instead: it re-arms `g.__flush__ = flush` and calls
-`template(input)` directly, skipping `writeWaitReady(assetId, template, input)`.
-Two consequences follow. (a) The nested page's `<link>`/`<script>` asset tags
-are no longer written at the tag position; they get prepended to the entire next
-flush's HTML, so they can land far from (and structurally invalid relative to)
-the markup they belong to. (b) The nested page's resume data goes into the eager
-`M._.r` queue rather than the ready-gated `M._.b[assetId]` bucket, so it
-executes before that page's entry module has registered its ids —
-`registeredValues[lastToken]` is `undefined` (`dom/resume.ts:316`) and
-`runEffects` then calls `undefined(scope)` (`dom/queue.ts:125-129`). No fixture
-covers this: `main.test.ts` renders exactly one page entry per fixture, so the
-`g.__flush__` branch is never exercised at all. Fix direction: set a dedicated
-symbol on `$global` in `withPageAssets` (never cleared) to mean "a page entry
-already claimed this render", and keep `__flush__` purely as the one-shot
-head/prefix injection hook; `_flush_head` (assets.ts:107) aliases the same state
-and should be reconciled with it. Re-verify: render a `withPageAssets`-wrapped
-template from inside an `_await` callback of another `withPageAssets`-wrapped
-template and inspect the streamed chunks — the inner page's resume payload is
-emitted as `M._.r=[…]` rather than `M._.b={innerAsset:[…]}`, and its asset tags
-appear at the head of the chunk rather than at the tag position.
+`withPageAssets` detects a nested page render with `if (g.__flush__)`, but `Chunk.flushHTML` (`html/writer.ts`) clears `$global.__flush__` at the outer page's first flush. A page entry rendered after that — inside `<await>`/`<try>`/reordered content — takes the top-level branch and calls `template(input)` instead of `writeWaitReady(assetId, template, input)`. Its resume data then joins the eager `M._.r` queue instead of `M._.b[assetId]`, so effects run before that page's entry module registers ids and `runEffects` invokes `undefined(scope)`, and its asset tags move to the head of the next flush. Use a never-cleared `$global` symbol for "a page entry claimed this render", keeping `__flush__` as the one-shot head hook (`_flush_head` reads the same asset state). Re-verify: render a `withPageAssets` template inside another's `_await` callback — the inner payload emits as `M._.r=[…]`, not `M._.b={innerAsset:[…]}`.
 
-## Arm SSR lazy-load triggers against the finished document, not the flushed prefix
+## Retry SSR lazy-load trigger selectors after the document parses, and warn under `MARKO_DEBUG`
 
 `packages/runtime-tags/src/html/assets.ts` › `writeTriggerScript` | 2026-07-23 | impact:med | effort:med
 
-The inline trigger script emitted for a `with { load: "visible…" | "on-…" }`
-import resolves its selector eagerly with `document.querySelector(sel) || l()` —
-and `l()` is the "load now" callback. That script is written through
-`writeScript`, so it lands at the end of the _current flush chunk_, not the end
-of the document. Any flush boundary (i.e. any `<await>`/`<try>`/lazy content)
-between the lazy tag and its selector target means the target has not streamed
-yet, `querySelector` returns null, and the module is fetched immediately — the
-trigger silently degrades to eager loading and the code-split is lost. This also
-contradicts the reference docs, which promise `"If a trigger's selector does not
-match any element on the page, the tag's JavaScript is loaded immediately (with
-a warning in development)"`: the CSR implementation does warn (`dom/load.ts` ›
-`getSelectorOrResolve`, `MARKO_DEBUG && console.warn(...)`), but the SSR string
-built here has no `MARKO_DEBUG` branch at all, so on server-rendered pages — the
-primary path, since a resumed lazy tag is driven only by this script — the
-degradation is completely silent. Direction: make the trigger script retry once
-the document is parsed (re-run `querySelector` on `DOMContentLoaded`, or observe
-until the node appears) before falling back to `l()`, and gate a `console.warn`
-on `MARKO_DEBUG` in the emitted string so dev builds surface the miss on SSR
-too. Re-verify: render a page whose lazy tag with a `visible#footer` trigger
-precedes an `<await>` whose body contains `<footer id=footer>` — the first
-flushed chunk contains `…document.querySelector("#footer")||l()… ` while
-`<footer id=footer>` only appears in the next chunk.
+The inline trigger script for `with { load: "visible…" | "on-…" }` resolves its target as `document.querySelector(sel) || l()`, and `writeScript` lands it at the end of the current flush chunk, not the document. A flush boundary (`<await>`, `<try>`, lazy content) between the tag and its target means `querySelector` returns null and `l()` fetches the module immediately — the code split degrades to eager loading. The CSR path warns on this miss (`dom/load.ts` › `getSelectorOrResolve`); the emitted SSR string has no `MARKO_DEBUG` branch, so on server-rendered pages it degrades silently. Re-check on `DOMContentLoaded` (or observe until the node appears) before falling back to `l()`, and emit a `MARKO_DEBUG`-gated warn. Re-verify: a `visible #footer` lazy tag placed before an `<await>` whose body holds `<footer id=footer>` — the first chunk already contains `document.querySelector("#footer")||l()`.
 
-## Look up `debug.vars` with the raw accessor, not the escaped object key
+## Restore the variable name and source location in `throwUnserializable`
 
 `packages/runtime-tags/src/html/serializer.ts` › `throwUnserializable` | 2026-07-23 | impact:low | effort:low
 
-`writeObjectProps` passes the _escaped_ key (`toObjectKey(key)`,
-serializer.ts:1696) as the Reference accessor, but `throwUnserializable` uses
-that accessor to index the translator-supplied debug map
-(`debug.vars?.[ref.accessor]`, serializer.ts:1792), whose keys are the _raw_
-accessors emitted by `writeHTMLResumeStatements` in
-`packages/runtime-tags/src/translator/util/signals.ts`
-(`toObjectProperty(getScopeAccessor(binding), ...)`). Any accessor that is not a
-bare identifier — e.g. `#LoopKey`, which holds the user's `<for by=...>` key
-expression and does appear in generated debug vars as `{ "#LoopKey": "2:17" }`
-in `fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.debug.js` —
-never matches, so the per-variable source location and the `["item.id", loc]`
-alias name are silently discarded, and the name is printed double-quoted because
-`JSON.stringify` is applied to the already-quoted key. Fix by carrying the raw
-key alongside the escaped one on `Reference` (or keying `debugVars` by
-`toObjectKey(...)` in the translator). Re-verify: call `setDebugInfo(scope,
-"template.marko", "3:1", { "#LoopKey": "3:11" })` and serialize `{ "#LoopKey":
-class Foo {} }` for that scope — the abort message reads `Unable to serialize
-"\"#LoopKey\"" in template.marko:3:1` instead of `... "#LoopKey" in
-template.marko:3:11`.
+Two lookups drop translator-emitted debug info. (1) `writeObjectProps` passes the escaped key (`toObjectKey(key)`) as the `Reference` accessor while `debug.vars` is keyed by the raw accessor from `writeHTMLResumeStatements` (`translator/util/signals.ts`), so `#LoopKey` never matches and prints double-quoted. (2) `while (ref?.accessor)` stops at the null-accessor `Reference` that `writeArrayArg`, `writeGenerator`, and `writeMaybeIterableProps` create for a collection's backing array, so anything inside a Map/Set/generator never reaches the scope `Reference` holding `debug`. Carry the raw key alongside the escaped one, and keep walking past null accessors. Re-verify with `node -r ~ts`: after `setDebugInfo(scope, "page.marko", "2:6", { selected: ["selected","2:6"] })`, serializing `{selected: new Set([new Thing()])}` aborts with `Unable to serialize (reading [0])` while the plain-array form reports `"selected" in page.marko:2:6`.
 
-`throwUnserializable` walks the accessor chain with `while (ref?.accessor)`, so it stops at the first `Reference` whose accessor is `null` — and `writeArrayArg` (Map/Set), `writeGenerator`, and `writeMaybeIterableProps` each create exactly that for the collection's backing array (`new Reference(ref, null, state.flush, …)`). Any unserializable value reached through a Map, Set, generator, or custom iterable therefore never reaches the scope `Reference` that carries `debug`, so a `<let/selected = new Set([new Thing()])/>` that is read from an event handler aborts the render with `Unable to serialize (reading [0])` — no variable name, no `.marko` path, no line — while the identical value in a plain array reports `Unable to serialize "selected" in template.marko:2:6 (reading [0])`. The index path that does survive is into the internal entries array, so a Map member prints `(reading [0][1])`, which names nothing in the user's source. A backing-array reference is an implementation detail rather than a real accessor, so the loop should skip null accessors and keep walking — `while (ref) { … if (ref.accessor) access = toAccess(ref.accessor) + access; ref = ref.parent; }`, consulting `debug` only when `ref.accessor` is set — which restores both the variable name and the file/line for these shapes. Re-verify from the repo root: `node -r ~ts -e 'const { Serializer, setDebugInfo } = require("./packages/runtime-tags/src/html/serializer.ts"); class Thing {} for (const [name, val] of [["array", [new Thing()]], ["Set", new Set([new Thing()])], ["Map", new Map([["k", new Thing()]])]]) { const scope = {}; setDebugInfo(scope, "page.marko", "2:6", { selected: ["selected", "2:6"] }); new Serializer().stringifyScopes([[1, scope, { selected: val }]], { signal: { aborted: false }, abort: (e) => console.log(name, "=>", e.message) }); }'` prints the full `"selected" in page.marko:2:6` message for the array and a bare `Unable to serialize (reading …)` for the Set and the Map.
-
-## Disambiguate `buildResumeRegisterKey` — `_`-joined binding names collide and silently break resume
+## Make `buildResumeRegisterKey` unambiguous — `_`-joined binding names collide and break resume
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `buildResumeRegisterKey` | 2026-07-23 | impact:med | effort:med
 
-`buildResumeRegisterKey` (signals.ts:920) builds a resume id as `${section.id}`
-plus `_${name}` per referenced binding, with no separator that binding names
-cannot contain and no namespace per registration kind, so structurally different
-registrations in one section can produce the identical key — and `getTemplateId`
-hashes the key, so equal keys give equal ids in optimize too. Two verified
-collisions: (a) an intersection `[a, b]` and a binding literally named `a_b`
-both key `${section.id}_a_b`, so `writeSignals` emits two `_script(<same id>,
-fn)` registrations and `writeHTMLResumeStatements` (signals.ts:1275) emits
-`_script($scopeId, <same id>)` twice; (b) a section's content-renderer id
-`getResumeRegisterId(section, "content")` (`visitors/program/dom.ts:112`,
-`util/translate-attrs.ts:434`) collides with the effect id of a binding
-literally named `content`, so `_content_resume` and `_script` register the same
-key. Because `_resume` is `registeredValues[id] = obj` (`dom/resume.ts:464`) and
-resume resolves effects by `registeredValues[lastToken]` (`dom/resume.ts:316`)
-before `runEffects` invokes `fn(scope)` (`dom/queue.ts:125`), the later
-registration wins: in (a) the `console.log(a, b)` effect never runs after SSR
-and `console.log(a_b)` runs twice; in (b) the `<script>` effect is replaced by
-`_content`'s `(owner) => Renderer` factory, which resume calls and discards, so
-the effect silently never runs. CSR is unaffected (distinct function
-references), so this only appears post-resume, and no fixture currently
-exercises it (a scan of every committed `__snapshots__/dom.bundle*.js` for
-repeated
-`_script`/`_content_resume`/`_var_resume`/`_hoist_resume`/`_el`/`_resume` id
-literals found zero duplicates). Fix by making the key unambiguous before
-hashing — e.g. key on the binding/intersection numeric ids rather than `name`,
-and give the string-keyed kinds (`"content"`) their own namespace segment — then
-regenerate snapshots (every resume id changes) and add fixtures for both shapes.
-Re-verify: compile `<let/a=1/><let/b=2/><let/a_b=3/><button
-onClick(){a++;b++;a_b++}>x</button><script>{console.log(a,b)}</script><script>{console.log(a_b)}</script>`
-with `npm run compile -- -o dom` and observe two `_script("<same hash>", …)`
-registrations.
-
-A third collision needs no exotic identifier at all: native element bindings are named after their tag, so two element refs on same-named tags in one section — `<div/a/><div/b/>` — both key `${section.id}_#div`. The DOM output emits `_el("…_0_#div", "#div/0")` followed by `_el("…_0_#div", "#div/1")`, and since `_resume` is `registeredValues[id] = obj` the second registration wins, while SSR serializes `<const/box = { a, b }/>` as `{box:{a:_(1,"…_0_#div"),b:_(1,"…_0_#div")}}` — so after resume `box.a` and `box.b` are the same getter and both read `b`'s element. CSR is unaffected (the two getters are distinct local consts), so this only shows up post-resume, as silently-wrong element references. That makes the defect reachable from ordinary authoring rather than from a binding literally named `a_b`, and reinforces keying on binding/intersection ids — which are already distinct for these two `#div` bindings — instead of `name`. Re-verify: `printf '<div/a/>\n<div/b/>\n<const/box = { a, b }/>\n<button onClick() { console.log(box.a(), box.b()); }>go</button>\n' > /tmp/refs.marko && pnpm run compile -o dom -d /tmp/refs.marko && grep -n '_el(' /tmp/refs.marko.js` prints two `_el(...)` calls whose first argument is the identical string.
+The key is `${section.id}` plus `_${name}` per referenced binding — no separator a name cannot contain, no namespace per registration kind — so different registrations in one section hash to the same `getResumeRegisterId`. Three collisions compile today: `<div/a/><div/b/>` yields two `_el("…_0_#div", …)`; an intersection `[a, b]` and a binding named `a_b` both yield `…_0_a_b`; and `getResumeRegisterId(section, "content")` collides with the effect id of a binding named `content` (`_script("…_1_content")` beside `_content_resume("…_1_content")`). Since `_resume` is `registeredValues[id] = obj` the later registration wins, so post-resume an effect silently never runs or two element refs resolve to the same node; CSR is unaffected. Key on binding/intersection numeric ids and namespace the string kinds, then regenerate snapshots. Re-verify: compile `<div/a/><div/b/><const/box={a,b}/>` with `-o dom` — two `_el(` calls share one id.
 
 ## Apply `ToNumeric` when lowering `++`/`--` on a tag variable
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-27 | impact:med | effort:med
 
-The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix
-subtracting 1 from the result), which is `x = x + 1` rather than JS's
-`x = ToNumeric(x) + 1`. For `<let/x="5"/>` an `x++` therefore sets `x` to `"51"`
-and yields `50`, instead of setting `6` and yielding `5`. A `<let>` holding a
-bigint is worse: `1n + 1` throws `Cannot mix BigInt and other types`. Writing
-the read as `+scope.x` fixes the string case but breaks bigint, since unary plus
-throws on one, so the lowering needs a form that coerces the way `ToNumeric`
-does — or the operators need rejecting on a tag variable whose type is not
-known numeric. Re-verify: compile `<let/x="5"/><button onClick(){ x++ }>${x}</button>`
-with `-o dom`; the handler emits `$x($scope, $scope.x + 1)`.
+The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix subtracting 1 from the result), i.e. `x = x + 1` rather than JS's `x = ToNumeric(x) + 1`. With `<let/x="5"/>`, `x++` sets `x` to `"51"` and yields `50` instead of `6` and `5`; a `<let>` holding a bigint throws `Cannot mix BigInt and other types`. Wrapping the read in unary `+` fixes the string case but breaks bigint, so the lowering needs a real `ToNumeric` coercion — or `++`/`--` must be rejected on a tag variable whose type is not known numeric. Re-verify: compile `<let/x="5"/><button onClick(){ const v = x++ }>${x}</button>` with `-o dom`; the handler emits `const v = $x($scope, $scope.x + 1) - 1`.
 
-## Lower (or reject) `for (x of …)` / `for (x in …)` writes to a tag variable — they bypass the signal
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-23 | impact:low | effort:med
-
-`replaceAssignedNode` only rewrites `AssignmentExpression` and
-`UpdateExpression`, so a `ForOfStatement`/`ForInStatement` whose `left` is a
-bare tag variable falls through to `replaceBindingReadNode` →
-`getReadReplacement`, which (because analysis never set `extra.assignment` for
-that position — `getReadReplacement` returns early on `extra.assignment`,
-references.ts ~:1962) rewrites it as a plain scope read. `<let/x="a"/>` with
-`<button onClick(){ for (x of ["b","c"]) {} }>` compiles to `for ($scope.x of
-["b", "c"]) {}`, which mutates the scope slot in place without calling the
-`_let` signal, so `schedule()`/`queueRender` never fire (dom/signals.ts:43-49)
-and the `_text` bound to `${x}` keeps showing the stale value while the scope
-holds the new one — silent, with no compile diagnostic in either output mode
-(`for (x in …)` behaves identically). The fix is either to mark for-of/for-in
-loop targets as assignments during reference analysis and lower them through the
-binding's assignment builder (bind a temp and call `$x(scope, tmp)` at the top
-of the loop body), or to raise a compile error naming the unsupported construct.
-Re-verify: `npm run compile -- -o dom -d f.marko` on `<let/x="a"/><button
-onClick(){ for (x of ["b","c"]) {} }>s</button>${x}` emits `for ($scope.x of
-["b", "c"]) {}` with no `$x(` call in the handler.
-
-## Clear the tag-variable change handler when `<return valueChange>` evaluates falsy
+## Clear the tag-variable change handler when `<return valueChange>` goes falsy
 
 `packages/runtime-tags/src/dom/signals.ts` › `_return_change` | 2026-07-23 | impact:med | effort:low
 
-`_return_change(scope, changeHandler)` (signals.ts:360-367) only writes
-`scope[AccessorProp.TagVariableChange]` when `changeHandler` is truthy, so a
-handler can be installed but never revoked. The translator emits it as a
-re-runnable render statement (`src/translator/core/return.ts` ›
-`translate.dom.exit`, scheduled on
-`attrs.valueChange.extra.referencedBindings`), so `<return=x
-valueChange=input.canEdit && ((v)=>{x=v})/>` compiles to
-`_const("input_canEdit", $scope => _return_change($scope, $scope.input_canEdit
-&& $valueChange($scope)))` — when `canEdit` flips false the call re-runs with
-`false` and the previous closure stays installed. The parent's `v = 42` then
-silently mutates through the stale handler instead of raising the documented
-readonly error, and the handler is a closure from an earlier render. This also
-diverges from SSR, which serializes `valueChange || void 0` (`core/return.ts` ›
-`translate.html.exit`), so a server render with the same falsy condition resumes
-readonly. The sibling helper `_let_change` in the same file already assigns
-unconditionally (`scope[valueChangeAccessor] = valueChange`); `_return_change`
-should do the same. Re-verify: with `tags/child.marko` =
-`<let/x=input.value/><return=x valueChange=input.canEdit && ((v)=>{x=v})/>` and
-a parent `<let/canEdit=true/><child/v value=1 canEdit=canEdit/>` plus buttons
-that toggle `canEdit` and assign `v = 42`, assigning after the toggle updates
-the value instead of throwing `v is a readonly tag variable.`
+`_return_change` writes `scope[AccessorProp.TagVariableChange]` only when the handler is truthy, but `core/return.ts` › `translate.dom.exit` emits it as a render statement keyed on `valueChange.extra.referencedBindings`. `<return=x valueChange=input.canEdit && ((v)=>{x=v})/>` compiles to `_const("input_canEdit", $scope => _return_change($scope, $scope.input_canEdit && $valueChange($scope)))`, so once `canEdit` flips false the stale closure stays installed and the parent's `v = 42` silently mutates instead of throwing `v is a readonly tag variable.` SSR disagrees — `translate.html.exit` serializes `valueChange || void 0`, so a resumed render is readonly. Assign unconditionally like `_let_change`, normalizing falsy to `undefined` so the production `scope[...]?.(value)` read stays a no-op. Re-verify: toggle `canEdit` false, then assign the tag variable from the parent; it must throw the readonly error.
 
-## Key the renderer clone cache with a null-prototype map so `Object.prototype` member names cannot be templates
+## Key the renderer clone cache with a null-prototype map
 
-`packages/runtime-tags/src/dom/renderer.ts` › `_content (cloneCache)` | 2026-07-23 | impact:low | effort:low
+`packages/runtime-tags/src/dom/renderer.ts` › `_content` | 2026-07-23 | impact:low | effort:low
 
-`_content`'s clone closure memoizes parsed template HTML with `((cloneCache[ns]
-||= {})[template] ||= createCloneableHTML(template, ns))(branch, walks)`
-(renderer.ts:96-101, cache declared at :154). Because the inner cache is a plain
-object literal and `template` is the section's raw static HTML, a section whose
-entire static markup equals an `Object.prototype` member name resolves the
-inherited property instead of a cache miss: `__proto__` yields
-`Object.prototype` and throws `TypeError: cloneCache[ns][template] is not a
-function`, while `constructor`/`toString` yield a callable that silently does
-nothing, leaving `branch[AccessorProp.StartNode]`/`[EndNode]` undefined so the
-later `insertChildNodes` throws `Failed to execute 'insertBefore' on 'Node':
-parameter 1 is not of type 'Node'`. The trigger is exotic but reachable from
-ordinary source: `<for|w| of=input.words>constructor</for>` compiles to
-`_for_of(..., "constructor", "b")` -> `_content("", "constructor", ...)`. The
-fix is one line — `Object.create(null)` (or a `Map`) for the per-namespace
-cache; `parseHTML`'s `parsers` object in `src/dom/parse-html.ts` has the same
-shape but is keyed by namespace URI, so it is safe today and worth a comment
-rather than a change. Re-verify: compile `<div><for|w|
-of=input.words>constructor</for></div>` for dom and mount it with `{ words:
-["a"] }` — it throws before rendering, while the same template with body text
-`x` renders fine.
+`_content`'s clone closure memoizes parsed markup with `((cloneCache[ns] ||= {})[template] ||= createCloneableHTML(template, ns))(branch, walks)`. The inner cache is a plain object literal keyed by the section's raw static HTML, so a section whose entire markup is an `Object.prototype` member name resolves the inherited property instead of missing: `constructor`/`toString` return a callable that does nothing, leaving `branch[AccessorProp.StartNode]`/`[EndNode]` unset until `insertChildNodes` throws, and `__proto__` throws `is not a function` immediately. It is reachable from ordinary source — `<div><for|w| of=input.words>constructor</for></div>` compiles to `_for_of(0, "constructor")` -> `_content("", "constructor", ...)`. Fix: `Object.create(null)` or a `Map` for the per-namespace cache. Re-verify: mount that template with `{ words: ["a"] }` — it throws, while body text `x` renders fine.
 
 ## Key the bound-attribute change-handler cache by refining function, not just the binding
 
 `packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandler` | 2026-07-23 | impact:med | effort:low
 
-`getChangeHandler` memoizes one change-handler node per binding in the
-module-level `BINDING_CHANGE_HANDLER` WeakMap, keyed only on
-`binding.identifier` (set at :243 / :273, read at :208), but the
-refining-function shorthand (`value:parseFloat:=x`, i.e. `attr.modifier`) is
-read per attribute at the top of the same function. So for an identifier-valued
-`:=`, the FIRST usage's refining function is baked into a shared handler and
-every later `:=` on that same identifier reuses it verbatim — its own modifier
-is computed, validated, then silently discarded. `<let/value=0><input
-value:parseInt:=value><input value:=value>` compiles both inputs to the same
-`$scope.$valueChange` = `_new_value => $value($scope, parseInt(_new_value))`, so
-the plain input wrongly parses; reversing the order drops `parseInt` entirely;
-`value:parseInt:=` followed by `value:parseFloat:=` applies `parseInt` to both.
-The documented desugaring (website `docs/reference/language.md`, "Refining
-function") is per-usage, and the member-expression branch of the same function
-correctly re-derives per attribute (no cache), so only the identifier branch is
-affected. Fix direction: make the cache key `(binding.identifier,
-modifier-name-or-none)` — e.g. a nested Map — so only genuinely identical
-handlers dedupe, keeping the existing `bound-attr-repeated-let` dedupe intact.
-Re-verify: compile `<let/value=0/><input type="number"
-value:parseInt:=value/><input type="text" value:=value/>` with `pnpm run compile
--o dom -d <file>.marko` and confirm the second `_attr_input_value` no longer
-receives a `parseInt`-wrapped handler.
+`getChangeHandler` memoizes one change-handler node per binding in `BINDING_CHANGE_HANDLER`, keyed only on `binding.identifier`, while the refining-function shorthand (`value:parseInt:=value`) is read per attribute. For an identifier-valued `:=`, the first usage's refining function is baked into the shared handler and every later `:=` on that identifier reuses it verbatim, silently discarding its own modifier. `<let/value=0/><input value:parseInt:=value/><input value:=value/>` compiles both inputs to the same `$scope.$valueChange` = `_new_value => $value($scope, parseInt(_new_value))`; reversing the order drops `parseInt` entirely, and `parseInt` followed by `parseFloat` applies `parseInt` to both. Only the identifier branch is affected — the member-expression branch re-derives per attribute — so make the key `(binding.identifier, modifier-name-or-none)`. Re-verify: compile that pair with `-o dom -d` and confirm the second input's handler is unwrapped.
 
 ## Preserve `computed`/`static` when lowering registered object and class methods in DOM output
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `replaceRegisteredFunctionNode` | 2026-07-23 | impact:med | effort:low
 
-`util/signals.ts`'s `replaceRegisteredFunctionNode` (:1673, used for DOM output
-via `replaceRenderNode` at :1466) rewrites a registered
-`ObjectMethod`/`ClassMethod`/`ClassPrivateMethod` into a property with
-`t.objectProperty(node.key, replacement)` / `t.classProperty(node.key,
-replacement)` / `t.classPrivateProperty(node.key, replacement)`, dropping the
-node's `computed` and `static` flags. Its twin in `visitors/program/html.ts`
-(`replaceRegisteredFunctionNode`, :244) — the HTML-output copy of the same
-switch — already forwards `node.computed` and `node.static`, so the two outputs
-disagree. Two consequences, both reproduced: a computed key whose expression is
-reactive lowers to a scope read and then fails Babel validation with a raw
-internal `TypeError: Property key of ObjectProperty expected node to be of a
-type [...] but instead got "MemberExpression"` (no Marko code frame); a computed
-key that stays a valid key node miscompiles silently — `<const/handlers={
-[key]() { n++ } }/>` emits `{ key: $handlers($scope) }` in DOM while HTML emits
-`{ [key]: _resume(...) }`, so on the client `handlers[key]` is `undefined` and
-`_on(el, "click", undefined)` wires nothing. Fix: forward the flags exactly as
-the html.ts copy does (and consider collapsing the two near-duplicate
-`replaceRegisteredFunctionNode`/`getRegisteredFnExpression` pairs onto one
-shared node-shape helper so they cannot drift again). Re-verify: compile `static
-const key = "bump";` + `<let/n=0/><const/handlers = { [key]() { n++ } }/><button
-onClick=handlers[key]>${n}</button>` with `-o dom -d` and `-o html -d`; today
-DOM prints `{ key: ... }` and HTML prints `{ [key]: ... }`.
-
-## Two-way binding a computed-key destructured param emits a pattern property the analyzer always rejects
-
-`packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandlerFromObjectPattern` | 2026-07-23 | impact:low | effort:low
-
-When a `:=` target resolves to an object-pattern property with `computed ===
-true`, `getChangeHandlerFromObjectPattern` (:373-386) appends a synthetic
-property whose key is `t.binaryExpression("+", parent.get("key").node,
-t.stringLiteral("Change"))`. Analyze then runs
-`createBindingsAndTrackReferences`
-(`packages/runtime-tags/src/translator/util/references.ts`, ObjectPattern case)
-which accepts only a non-computed `Identifier` key or a `StringLiteral` key and
-otherwise throws "Only identifier and string literal keys are supported when
-destructuring." — so this branch can never produce a compilable template. It is
-reachable exactly for a computed _string-literal_ key (all other computed keys
-are already rejected with or without the binding), and there the compile error
-is attributed to the synthetic node, which has no `loc`, so the caret lands on
-the `<define>` tag start and never mentions two-way binding: `<define/Wrap|{
-["a"]: val }|><input value:=val/></define>` fails, while the identical
-`<define>` without the bound attribute compiles fine. The same branch also
-reuses `parent.get("key").node` without `t.cloneNode` (every other synthesized
-expression in this file clones), putting one node in two AST positions. Fix
-direction: either normalize a computed string-literal key to a plain key before
-synthesizing the `…Change` property (and clone the key node), or throw an
-explicit diagnostic in the style of the sibling array-pattern message ("Cannot
-two-way bind to `a` because it comes from array destructuring…", :226).
-Re-verify: compile `<let/n="x"/><define/Wrap|{ ["a"]: val }|><input
-value:=val/></define><Wrap a=n aChange(v){ n = v }/>` and observe the
-destructuring-key error pointing at the `<define>` tag; deleting `value:=val`
-makes it compile.
+The DOM copy rewrites a registered `ObjectMethod`/`ClassMethod`/`ClassPrivateMethod` with `t.objectProperty(node.key, replacement)` / `t.classProperty(...)` / `t.classPrivateProperty(...)`, dropping the node's `computed` and `static` flags; its twin in `visitors/program/html.ts` forwards both. A reactive computed key then crashes the compiler with a raw `TypeError: Property key of ObjectProperty expected node to be of a type [...] but instead got "MemberExpression"` and no Marko code frame; a static computed key miscompiles silently — `<const/handlers={ [key]() { n++ } }/>` emits `{ key: $handlers($scope) }` in DOM versus `{ [key]: _resume(...) }` in HTML, so `handlers[key]` is `undefined` on the client and `_on(el, "click", undefined)` wires nothing. Forward the flags exactly as html.ts does. Re-verify: compile `static const key = "bump";` plus that `<const>` and `<button onClick=handlers[key]>` with `-o dom -d` and `-o html -d`, then compare the object keys.
 
 ## Flush pending HTML before the `<debug>`/`<log>` statement so SSR keeps the tag's source position
 
 `packages/runtime-tags/src/translator/core/debug.ts` › `translate.exit` | 2026-07-23 | impact:low | effort:low
 
-In `html` output `<debug>` inserts its `debugger;` with
-`tag.insertBefore(statement)` (debug.ts:48-49) without first calling
-`writer.flushBefore(tag)`, so the writer's buffered markup is emitted _after_
-the statement and the debugger fires before any preceding content of the
-template has been written or evaluated; `core/log.ts`'s `console.log` does the
-identical thing. Every other statement-emitting core tag (`core/if.ts:122`,
-`core/for.ts:210`, `core/await.ts:138`, `core/try.ts:102`, `core/return.ts:89`,
-`core/define.ts:115`) calls `writer.flushBefore` first, and the `dom` output
-keeps source order, so SSR and CSR disagree: for `<div>${bump()}</div>` /
-`<log=n/>` / `<div>${bump()}</div>` the DOM `$setup` emits `_text(...bump());
-console.log(n); _text(...bump())` while the HTML render emits `console.log(n);
-_html(\`<div>${_escape(bump())}</div><div>${_escape(bump())}</div>\`)`. That
-contradicts the reference docs, which say `<debug>`"will be executed once the
-tag renders" and`<log>`"logs … on both server and client" (website`docs/reference/core-tag.md`, `<log>`/`<debug>`headings). Add`writer.flushBefore(tag)`in the`isOutputHTML()`branch of both tags before`insertBefore`; the existing `debug-tag`fixture never surfaces this because it
-contains no markup between the`<debug>`tags, so a fixture with a`<log>`/`<debug>`between two elements should be added. Re-verify:`pnpm run
-compile -- -o html -d`on`<div>a</div>`/`<log="x"/>`/`<div>b</div>`currently yields`console.log("x"); _html("<div>a</div><div>b</div>");`, versus
-`-o dom` which keeps the call between the two text writes.
+The `isOutputHTML()` branch calls `tag.insertBefore(statement)` without first calling `writer.flushBefore(tag)`, and `core/log.ts` does the identical thing, so the writer's buffered markup is emitted after the statement. Every other statement-emitting core tag (`if`, `for`, `await`, `try`, `return`, `define`, `show`) flushes first, and DOM output keeps source order, so the two diverge: for `<div>${bump()}</div>` / `<log=bump()/>` / `<div>${bump()}</div>`, HTML emits `console.log(bump()); _html(...)` while DOM's `$setup` emits `_text(...bump()); console.log(bump()); _text(...bump())` — the server logs before preceding content is even evaluated. Add `writer.flushBefore(tag)` in the `isOutputHTML()` branch of both tags. The `debug-tag` and `log-tag` fixtures have no markup between the tags, so add one that does. Re-verify: `pnpm run compile -o html -d` on that template should emit the first `_html(...)` before `console.log`.
 
-## Drop escaped placeholders that confidently render an empty string, so the DOM walk does not gain a step for a node that is never written
+## Drop escaped placeholders that render an empty string so they stop claiming a walk step
 
 `packages/runtime-tags/src/translator/util/static-text.ts` › `isStaticText` | 2026-07-23 | impact:med | effort:low
 
-`isStaticText` classifies an escaped `MarkoPlaceholder` as a static text node
-with `confident && isNotVoid(computed)` — the _attribute_ void rule (`value !=
-null && value !== false`, `common/helpers.ts`) — but the text actually emitted
-is `_escape(computed)` (`html/content.ts` › `_escape`: `val ? escapeXMLStr(val +
-"") : val === 0 ? "0" : ""`), which yields `""` for `""`, `NaN` and `0n`.
-`visitors/placeholder.ts` uses the same mismatched rule to decide removal
-(`analyze`/`translate.exit`: `if (confident && isVoid(computed))
-return/remove`), so such a placeholder survives, writes nothing, and still calls
-`walks.enterShallow(placeholder)` — emitting an `over` step for a DOM node that
-does not exist. Every later walk step in that section is then off by one:
-`<div>${""}${input.x}<b/><i/></div>` compiles to `$template =
-"<div><!><b></b><i></i></div>"` with `$walks = /* next(1), over(1), replace,
-out(1) */`, and the `replace` lands on `<b>` and destroys it — CSR mount renders
-`<div><!---->HELLO<i></i></div>` instead of `<div>HELLO<b></b><i></i></div>`,
-identically in debug and optimize; the variant
-`<div>${""}<b/><i>${input.x}</i><u/></div>` instead throws `TypeError: Cannot
-read properties of undefined (reading 'data')` from `_text` (`dom/dom.ts`) under
-MARKO_DEBUG and silently renders nothing under optimize. `${0/0}` (NaN) and
-`${0n}` reproduce it too; SSR is unaffected because resume is marker-driven
-(`_el_resume`), so this only bites client render and branch re-creation. Fix:
-replace the `isVoid`/`isNotVoid` tests in `isStaticText`, `isEmptyPlaceholder`
-and the two `placeholder.ts` drop checks with the text-coercion emptiness rule
-(`computed || computed === 0`) so these placeholders are removed outright —
-output-identical, since they already emit the empty string. Re-verify: `pnpm run
-compile -o dom -d x.marko` on `<div>${""}${input.x}<b/><i/></div>` and on the
-same template
-without `${""}`; the walk comments differ (`next(1), over(1), replace, out(1)`
-vs `next(1), get, out(1)`) even though the DOM the two describe is the same
-shape.
+`isStaticText` accepts a confident escaped placeholder when `isNotVoid(computed)` — the attribute void rule — but the emitted text is `_escape(computed)`, which is `""` for `""`, `NaN` and `0n`; `placeholder.ts` (`analyze`, `translate.exit`) drops on the matching `isVoid`. Such a placeholder writes nothing yet still calls `walks.enterShallow`, so every later walk step in the section is off by one: `<div>${""}${input.x}<b/><i/></div>` compiles to `next(1), over(1), replace, out(1)` and the `replace` destroys `<b>`, while `<div>${""}<b/><i>${input.x}</i><u/></div>` walks off the end and throws `reading 'data'` from `_text`. SSR is marker-driven and unaffected. Switch `isStaticText`, `isEmptyPlaceholder` and both `placeholder.ts` checks to the text rule `computed || computed === 0`. Re-verify: `pnpm run compile -o dom -d` that template with and without the `${""}`; the walk comments differ for the same DOM shape.
 
 ## Strip the `load` import attribute from HTML output — it is emitted verbatim and Node rejects it
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low
 
-In the `tagImport && loadImport` branch of `translate.exit`, the HTML path
-rewrites `node.source.value = tagImport` and returns without removing the `load`
-import attribute, so the server module keeps `import Child from "./child.marko"
-with { load: "visible.hero" };`. `load` is not a host-recognized import
-attribute: evaluating such a module in Node throws `TypeError
-[ERR_IMPORT_ATTRIBUTE_UNSUPPORTED]: Import attribute "load" with value "render"
-is not supported`. The DOM path never leaks it (it either `importDecl.remove()`s
-or replaces the declaration with a `_load_template` const), so this is a
-one-sided oversight, and it is masked today only because every supported server
-pipeline bundles the `.marko` import away before Node sees it — an externalized
-or unbundled server module fails at import time with an error that names nothing
-Marko-related. Fix: clear `node.attributes` (or remove the `load` attribute
-path) in the HTML branch, mirroring what the `!getMarkoOpts().linkAssets` path
-in `analyze` already does with `loadAttrPath.remove()`. Re-verify: compile a
-template containing `import Child from "./child.marko" with { load:
-"visible.hero" }` with `linkAssets` configured and `output: "html"` and grep the
-emitted code for `with {`; then run `node` on a module containing `import d from
-"./dep.mjs" with { load: "render" };`.
+In the `tagImport && loadImport` branch, the HTML path rewrites `node.source.value = tagImport` and returns without clearing `node.attributes`, so the server module keeps `import Child from "./child.marko" with { load: "render" };`. Node rejects that at import time with `TypeError [ERR_IMPORT_ATTRIBUTE_UNSUPPORTED]: Import attribute "load" ... is not supported`, an error naming nothing Marko-related. The DOM path never leaks it, and bundled server pipelines strip the `.marko` import first, so only externalized or unbundled output fails. Fix: clear the attributes in the HTML branch, mirroring the `loadAttrPath.remove()` that `analyze` already does when `linkAssets` is unset. Re-verify: compile `__tests__/fixtures/lazy-tag/template.marko` with `linkAssets` configured and `output: "html"`, then grep the emitted code for `with {`.
 
-## Diagnose (or honor) two lazy imports of the same template with different `load` triggers in one program
+## Error when one program lazily imports the same template with two different `load` triggers
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `getOrCreateHtmlLoadWrapped` | 2026-07-23 | impact:low | effort:low
 
-`getOrCreateHtmlLoadWrapped` caches its generated wrapper in a per-program map
-keyed only by `readyId`, so when one template lazily imports the same `.marko`
-file twice with different triggers, the second import silently reuses the first
-wrapper — including the first import's trigger list — and all of its references
-are rewritten to the first wrapper's name. The DOM half does not dedupe (each
-import gets its own `_load_setup` with its own trigger), so server and client
-disagree about when that asset should load. The runtime already treats this as
-an invariant and warns about it (`html/assets.ts` › `addAsset` logs `The lazy
-asset "…" is imported with different \`load\` triggers`under MARKO_DEBUG), but
-the compile-time dedupe means the second trigger set never reaches`addAsset`,
-so the warning cannot fire for a same-program conflict and the mis-compile is
-completely silent. Fix direction: raise a `buildCodeFrameError`on the second
-import when its`LoadImportConfig`differs from the cached one (the runtime
-comment says an asset can only stream one trigger script, so erroring is the
-honest behavior). Re-verify: compile a template with`import A from
-"./child.marko" with { load: "render" }`and`import B from "./child.marko" with
-{ load: "idle" }`, both used, with `output: "html"`— only`$A_withLoadAssets`
-is generated and `<B/>` compiles to `$A_withLoadAssets({})`; the same file with
-`output: "dom"`emits a separate`_load_idle_trigger()` for B.
+`getOrCreateHtmlLoadWrapped` caches its wrapper in a per-program map keyed only by `readyId`, so a second lazy import of the same `.marko` silently reuses the first wrapper — including the first import's trigger list — for all its references. The DOM half does not dedupe, so server and client disagree about when the asset loads. `html/assets.ts` › `addAsset` warns about mismatched triggers under MARKO_DEBUG, but the dedupe means the second trigger set never reaches it, so a same-program conflict is silent. Raise a `buildCodeFrameError` when the second import's `LoadImportConfig` differs from the cached one. Re-verify: compile a template importing `./child.marko` with `load: "render"` and with `load: "idle"` — `output: "html"` emits only `$A_withLoadAssets` with no triggers, while `output: "dom"` emits a separate `_load_idle_trigger()`.
 
 ## Declare the element-getter `return=` in the `html-comment` / `html-script` / `html-style` type stubs
 
 `packages/runtime-tags/tags/html-comment.d.marko` › `Input` | 2026-07-23 | impact:med | effort:low
 
-`<html-comment/commentNode/>` exposes a getter for the Comment node —
-`website/docs/reference/core-tag.md` › `## <html-comment>` documents it with a
-worked example (`commentNode().parentNode.getBoundingClientRect()`) — and
-`src/translator/core/html-comment.ts` › `analyze` implements it via
-`trackDomVarReferences(tag, nodeBinding)`. But `tags/html-comment.d.marko` is
-only `export interface Input {}` with no `return=` clause, so the stub
-template's Return type is `void` (`@marko/language-tools` emits `return
-Marko._.voidReturn` for a template with no `<return>` tag). Because the tag def
-sets `types`, the language-tools script extractor routes it through the template
-path and types the tag variable as `Marko._.returned(() => rendered)`, whose
-signature is `<T>(rendered: () => T): T extends { return: { value: infer
-Returned } } ? Returned : never` — with Return `void` that resolves to `never`,
-so `commentNode()` fails type-check with TS2349 "This expression is not
-callable. Type 'never' has no call signatures." `tags/html-script.d.marko` and
-`tags/html-style.d.marko` have the identical gap (both compile to native
-`<script>`/`<style>` through `getCanonicalTagName` in
-`src/translator/visitors/tag/native-tag.ts` and accept a tag variable). Add a
-`return=` to each stub the way `tags/id.d.marko` does with `return="" as string`
-— e.g. `return=(null! as () => Comment)`, `() => HTMLScriptElement`, `() =>
-HTMLStyleElement`. Re-verify: type-check `<html-comment/c>hi</html-comment>`
-followed by `<const/x=c()/>`; with the stub unchanged the call is TS2349.
+All three tags accept a tag variable that resolves to the DOM node — `<html-comment/c><html-script/s><html-style/y>` compiles to `_el_read($scope["#comment/0"])`, `_el_read($scope["#script/1"])`, `_el_read($scope["#style/2"])`, and `core/html-comment.ts` › `analyze` wires it through `trackDomVarReferences`. But `tags/html-comment.d.marko` is only `export interface Input {}` and the script/style stubs only extend `Marko.HTML.*`; none declares a `return=`. Because each tag def sets `types`, language-tools types the tag variable from the stub's Return — which is void — so the variable resolves to `never` and calling it fails with TS2349; add a `return=` to each the way `tags/id.d.marko` does, e.g. `return=(null! as () => Comment)`, `() => HTMLScriptElement`, `() => HTMLStyleElement`. See also "Make `<let>`'s `value` optional in `tags/let.d.marko`; the valueless `<let/x/>` compiles but fails type-check" — the other broken stub in `tags/`, and its `return=(input.value as T)` is the cast pattern these clauses should follow. Re-verify: type-check `<html-comment/c>hi</html-comment>` followed by `<const/x=c()/>`.
 
-## Carry the Class-API compat boundary mode per call site instead of downgrading the whole program
-
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `pushCompatRegistration` | 2026-07-27 | impact:low | effort:med
-
-`preserveBoundary` is a per-call-site decision (`!tagsSerializeReason && …`)
-but `s(id, renderer, mode)` is emitted once per renderer, and
-`boundaryModeByRenderer` in
-`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` is
-keyed by renderer as well. The order-dependence this caused is fixed — a call
-site that cannot preserve now drops the mode for the whole program, and
-`register` keeps a plain `true` sticky across modules — but the fix is a
-downgrade, so one updating call site costs every inert call site of that class
-its split-component optimization. Carrying the mode on the per-call-site
-`_dynamic_tag` invocation instead would keep both, at the cost of a parameter on
-a helper every dynamic tag pays for; measure before taking it. Re-verify: the
-`interop-mixed-boundary-split-tags-to-class` fixture emits `s(…, renderer)`
-with no `"preserve"`, while `interop-self-interactive-split-tags-to-class`,
-whose only call site is inert, still emits it.
-
-## Enable branch machinery for spread `content=` branches; `_attr_content` creates branches without it
-
-`packages/runtime-tags/src/dom/dom.ts` › `_attr_content` | 2026-07-23 | impact:low | effort:med
-
-`_attr_content` (dom.ts:366, reached both from
-`_attrs_content`/`_attrs_partial_content` — a native tag spread carrying
-`content` — and directly for a plain static `content=` on a native tag
-(native-tag.ts:963 render statement, `:568` for HTML)) creates a live branch via
-`setConditionalRenderer(scope,
-nodeAccessor, content, createAndSetupBranch)`, but it is the only client branch
-creator that never reaches `enableBranches()`; `_if` (control-flow.ts:438),
-`_show` (:470), `_dynamic_tag` (:534), `_dynamic_tag_content` (:647) and `loop`
-(:788) all call it in their factory, and `<try>`/`<await>` get it through
-`_enable_catch` (queue.ts:193). `enableBranches()` (resume.ts:67) does two
-load-bearing things: it installs `skipDestroyedRenders()` (queue.ts:177), the
-only guard that stops a queued render from running on a scope inside a destroyed
-branch, and it sets `branchesEnabled`, which `initScope` (resume.ts:137) uses to
-link a resumed scope's serialized `#ClosestBranchId` to its branch and which
-gates branch-visit processing (resume.ts:401). A template whose only branch
-construct is a spread `content=` therefore runs with all of that off. Because
-the enable must happen at module eval (before resume processes visits), the fix
-is a translator-emitted enable at every site that emits `_attr_content` — both
-the `_attrs_content`/`_attrs_partial_content` spread sites and the plain
-`content=` site — the same shape as the existing top-level
-`_enable_catch()`/`_resume_dynamic_tag()` statements, not a call inside the
-per-render helper; while there, note `_attr_content` is a near-verbatim
-duplicate of `_dynamic_tag_content` (control-flow.ts:641: same renderer-id
-compare, same `setConditionalRenderer`, same `subscribeToScopeSet`, same
-`LocalClosures` loop), so routing one through the other fixes the gap and drops
-one of two ~243/~279-minified-byte copies of the same algorithm. `compat.render`
-(dom/compat.ts:133) calls `createAndSetupBranch` with the same omission.
-Re-verify: compile `<define/Wrap|input|><div ...input/></define>` plus `<Wrap
-class="x"><b>x</b></Wrap>` with `pnpm run compile -o dom -d <file>` — the import
-list is `_attrs_content, _attrs_script, _text, _on, _script, _const,
-_closure_get, _content, _closure, _let, _template`, containing no helper that
-enables branches, yet `_attr_content` creates a `BranchScope` at mount.
-
-## Align the spread `<input>` controllable ladders in HTML `_attrs` and DOM `attrsInternal`
+## Align the spread `<input>` controllable ladders in HTML `_attrs` and DOM `_controllable_input`
 
 `packages/runtime-tags/src/html/attrs.ts` › `_attrs` | 2026-07-23 | impact:med | effort:med
 
-The two runtimes pick a spread `<input>`'s controllable with different
-conditions: HTML `_attrs` (`html/attrs.ts:276-306`) branches on the _change
-handler_ (`data.checkedChange` → `"checkedValue" in data ||
-data.checkedValueChange` → `data.valueChange`), while DOM `attrsInternal`
-(`dom/dom.ts:269-299`) branches on _key presence_ (`"checked" in nextAttrs ||
-"checkedChange" in nextAttrs` → `"checkedValue" in … || "checkedValueChange" in
-…` → `"value" in … || "valueChange" in …`). A spread carrying a bare `checked`
-alongside a `value`/`valueChange` pair therefore takes different branches: SSR
-falls to the value branch, writes ` value=x`, and serializes
-`ControlledType.InputValue` plus the handler, while CSR takes the checked branch
-whose `skip` is only `/^checked(?:Value)?(?:Change)?$/`, so `valueChange` falls
-through to `_attr(el, "valueChange", fn)` — which throws "The `valueChange`
-attribute cannot be a function…" under MARKO_DEBUG (`common/errors.ts:18-25`)
-and, with MARKO_DEBUG stripped, stringifies the function into a
-`valueChange="function …"` attribute while the two-way binding is silently lost.
-`assertExclusiveAttrs` does not catch it (`{checked, value, valueChange}` yields
-a single exclusive attr, so length is 1) and the translator's compile-time
-`assertExclusiveAttrs(seen, …)` at `visitors/tag/native-tag.ts:197` only sees
-static attributes, so nothing rejects the combination earlier. Pick one
-canonical condition (or extract a single shared tag-name→controllable predicate
-used by both runtimes) and add a spread fixture for the combination. Re-verify:
-render `<input ...input.attrs>` with `input.attrs = { checked: false, value:
-"x", valueChange(v) {} }` — SSR emits `<input value=x>` with a controlled scope,
-while the same template mounted in CSR throws the change-handler error in debug
-(and writes a `valueChange` attribute in optimize).
+HTML `_attrs` picks an `<input>`'s controllable from the change handler (`data.checkedChange` → `"checkedValue" in data` → `data.valueChange`); DOM `_controllable_input` (`dom/controllable.ts`) picks it from key presence (`"checked" in nextAttrs || "checkedChange" in nextAttrs` first). A spread of `{ checked: false, value: "x", valueChange(v) {} }` therefore takes the value branch on the server (`value=x` plus a serialized `ControlledType.InputValue`) and the checked branch on the client, whose skip `/^checked(?:Value)?(?:Change)?$/` lets `valueChange` reach `_attr(el, "valueChange", fn)` — a debug throw, and in optimize a stringified attribute with the binding lost. Nothing rejects it earlier: `assertExclusiveAttrs` counts one exclusive attr, and the translator's copy sees only static attributes. Share one predicate between the runtimes and add a spread fixture. The debug-validation half of this same block is tracked in "Give the HTML spread-attrs path the same MARKO_DEBUG validation as the DOM path", whose `assertExclusiveAttrs` move sits at the head of this ladder, so land the predicate extraction with it in mind. Re-verify: render `<input ...attrs>` with those attrs — SSR emits `<input value=x>`, CSR throws inside `_attr`.
 
 ## Lowercase the dynamic native tag debug accessor so SSR resume matches `getDebugKey`
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_dynamic_tag` | 2026-07-23 | impact:med | effort:low
 
-Under `MARKO_DEBUG`, a dynamic native tag's element accessor is built from the
-raw renderer string at four sites — `html/dynamic-tag.ts` › `_dynamic_tag` (`` `#${renderer}/0` ``, used for `_attrs`, the
-`EventAttributes`/`ControlledHandler` lookups and the `BranchEndNativeTag`
-marker), `dom/control-flow.ts` › `_dynamic_tag` (`` `#${normalizedRenderer}/0` ``), `createBranchWithTagNameOrRenderer`, and `dynamicTagScript` — but the
-resume path stores the element under `getDebugKey(0, startVisit)`
-(`dom/resume.ts` › `init`, inside `createVisitBranches`, ~l.228), and
-`getDebugKey` (`dom/walker.ts`) lowercases via `` `#${(node as
-Element).tagName.toLowerCase()}/${index}` ``. For any tag name that is not
-already lowercase — notably SVG camelCase elements, whose `tagName` preserves
-case (`linearGradient`, `clipPath`, `foreignObject`) — the two disagree: resume
-writes `#lineargradient/0` while the client signal reads `#linearGradient/0`, so
-`scope[accessor]` is `undefined` and `_attrs`/`_attrs_script` (`dom/dom.ts`)
-dereference it (`el.attributes`, `_on(el, …)`) and throw on the first resumed
-interaction or update. Production is unaffected (both sides use the constant
-`"a"`), so this is a debug-only hard failure on an SSR-resumed `<svg><${tagName}
-onClick(){}>`; the static-tag path already gets this right by lowercasing in the
-translator (`translator/visitors/tag/native-tag.ts` `"#" +
-tagName.toLowerCase()`, covered by the `svg-camelcase-accessors` fixture, whose
-DOM bundle emits `$scope["#lineargradient/0"]`). Fix by applying
-`.toLowerCase()` to the renderer string at all four `#${…}/0` construction sites
-so they agree with `getDebugKey` and the translator convention. Re-verify: add a
-fixture `<svg><${"linearGradient"} onClick(){ … }><stop offset="0%"/></></svg>`
-with a click step and run it in debug SSR-resume mode — it throws inside
-`_attrs_script` because `scope["#linearGradient/0"]` is undefined, while the
-same template renders fine in CSR-only mode.
+Under `MARKO_DEBUG` a dynamic native tag's element accessor is built from the raw renderer string at four sites — `html/dynamic-tag.ts` › `_dynamic_tag`, `dom/control-flow.ts` › `_dynamic_tag`, `createBranchWithTagNameOrRenderer` and `dynamicTagScript` — but resume stores the element under `getDebugKey(0, startVisit)` (`dom/resume.ts`), and `getDebugKey` lowercases `tagName`. For a camelCase SVG tag the two disagree (`#lineargradient/0` written, `#linearGradient/0` read), so `scope[accessor]` is undefined and `_attrs_script` reaches `_on(undefined, …)` and throws on the first resumed interaction; production is unaffected since both sides use `"a"`. The static path already lowercases in the translator (`visitors/tag/native-tag.ts`), so apply `.toLowerCase()` at all four sites. Re-verify: SSR-resume `<svg><${"linearGradient"} onClick(){ … }><stop offset="0%"/></></svg>` in debug and click — it throws because `scope["#linearGradient/0"]` is undefined, while CSR-only renders fine.
 
-## Stop double-escaping character references in a static `<textarea>` body
+## Decode character references in a static `<textarea>` body
 
 `packages/runtime-tags/src/translator/core/textarea.ts` › `preAnalyze` | 2026-07-23 | impact:med | effort:med
 
-`preAnalyze` folds a `<textarea>` body into a synthetic `value` attribute by
-pushing each `MarkoText` child's raw source `child.value` into
-`normalizeStringExpression`, so authored markup text becomes a JS string literal
-that `_textarea_value` (`packages/runtime-tags/src/html/attrs.ts:133`,
-`_escape(normalizeStrAttrValue(value))`) then escapes again. Character
-references therefore double-escape: `<textarea>&lt;p&gt;hi&lt;/p&gt;</textarea>`
-emits `&amp;lt;p&amp;gt;hi&amp;lt;/p&amp;gt;` and the user sees the literal text
-`&lt;p&gt;hi&lt;/p&gt;`, while the identical body in `<title>` or `<div>` is
-written through verbatim and renders `<p>hi</p>`. Because `<textarea>` is parsed
-as a text-only tag, entities are the only way to author literal markup inside
-it, so this makes the common "seed an editor with escaped HTML" case
-unrepresentable, and it contradicts native-tag.md's "In HTML, `<textarea>` holds
-its value inside its body". Both SSR and CSR agree with each other (the DOM path
-passes the same literal to `_attr_textarea_value_default`), so only the
-body-vs-attribute semantics are wrong; the fix is to decode character references
-in `MarkoText` children before pushing them into `parts` — `he`'s `decode` is
-already a `@marko/compiler` dependency and is used for exactly this by the Marko
-5 translator (`packages/runtime-class/src/translator/text/index[vdom].js`).
-Re-verify: compile `<textarea>a &amp; b</textarea>` with `-o html` and check the
-emitted `_textarea_value("a &amp; b")`; at runtime it returns `"a &amp;amp; b"`,
-where the correct output is `"a &amp; b"` (matching `<title>a &amp; b</title>`,
-which compiles to raw static text).
+`preAnalyze` folds a `<textarea>` body into a synthetic `value` attribute by pushing each `MarkoText` child's raw source into `normalizeStringExpression`, and `_textarea_value` (`html/attrs.ts`) escapes it again: `<textarea>&lt;p&gt;hi</textarea>` compiles to `_textarea_value("&lt;p&gt;hi")` and shows the literal `&lt;p&gt;hi`, while the same body in `<title>`/`<div>` passes through, as it does in Marko 5. Entities are the only way to author literal markup in a text-only tag, so that case is unrepresentable. CSR matches SSR, so the fix is decoding `MarkoText` children at compile time — but `MarkoText.value` is raw source and the only decoder in the tree is `he` under `packages/compiler/node_modules` (~100KB, tree-shaken out today), so it needs a new `babel-utils` export; weigh that cost. Re-verify: compile `<textarea>&lt;p&gt;hi</textarea>` with `-o html` and check the emitted `_textarea_value` literal.
 
-Confirmed, and the effort is not low: the fix needs the static text decoded at
-compile time (CSR needs it too, since `_attr_textarea_value_default` assigns the
-literal to `el.defaultValue`), but `MarkoText.value` is raw source with no
-decoded form, `htmljs-parser` exposes no decoder, and the only one in the tree is
-`he` under `packages/compiler/node_modules` — unreachable from the translator and
-100KB, currently tree-shaken out of the compiler bundle. Using it means a new
-`babel-utils` export and that 100KB in the build-time bundle; weigh that against
-how rare authoring entities in a `<textarea>` is. Re-verify: compile
-`<textarea>&lt;p&gt;hi</textarea>` with `-o html`; the emitted literal is
-`_textarea_value("&lt;p&gt;hi")`, which escapes to `&amp;lt;p&amp;gt;hi`.
-
-## Custom tag with a tag variable evaluates its child render before attribute tag statements (TDZ crash)
+## Emit a custom tag's HTML render call after its attribute tag statements
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateHTML` | 2026-07-24 | impact:med | effort:med
 
-For a custom tag with both a tag variable and attribute tags under control flow
-(eg `<my-menu/menuEl><for|x| of=list><@item label=x/></for></my-menu>`), the
-HTML output emits `let menuEl = _myMenu({ item: $item })` via `translateVar`'s
-`tag.insertBefore` _before_ the `let $item; forOf(...)` statements produced by
-`translateAttrs`, so the render call reads `$item` in its temporal dead zone
-and SSR throws a ReferenceError. The DOM output has the same ordering problem.
-The call needs to be sequenced after the attr-tag statements (as the
-non-tag-variable path does by pushing the call onto `statements`).
-Re-verify: compile the template above with `pnpm run compile -o html -d` and
-observe the call precedes the `$item` declaration.
+For a custom tag with both a tag variable and attribute tags under control flow, `translateVar`'s `tag.insertBefore` puts `let menuEl = _myMenu({ item: $item })` ahead of the `let $item; _forOf(…)` statements that `translateAttrs` built and `tag.replaceWithMultiple(statements)` emits, so the render call reads `$item` in its temporal dead zone and SSR throws a ReferenceError. Sequence the call after the attr-tag statements, as the non-tag-variable path already does by pushing it onto `statements`. Only the HTML output is affected — the DOM output calls `_myMenu_input_item` after the loop. Re-verify: compile `<my-menu/menuEl><for|x| of=list><@item label=x/></for></my-menu>` with `pnpm run compile -o html -d`; the `let menuEl = _myMenu(…)` precedes `let $item`.
 
-## Reject (or support) assignments to attribute tag `<for>` params inside event handlers
+## Reject assignments to an attribute tag `<for>` param inside an event handler
 
 `packages/runtime-tags/src/translator/util/references.ts` › `trackAssignment` | 2026-07-24 | impact:low | effort:low
 
-An assignment like `<@item onClick() { foo = "x" }>` where `foo` is an
-attribute-tag `<for>` param (BindingType.local) is routed through the
-change-handler assignment path, generating code that calls a nonexistent
-change handler and throws at click time. Reads of such params in handlers now
-work (see `referencedLocalBindingsInFunction`), which makes the silent write
-failure more confusing by contrast. Since these loops re-run wholesale on
-input change, assignment has no meaningful reactive semantics; a compile
-error in `trackAssignment` when `binding.type === BindingType.local` would
-be cheap and clear. Re-verify: compile the template above with
-`pnpm run compile -o dom -d` and inspect the emitted assignment.
+`<@item onClick() { x = "y" }>` where `x` is an attribute-tag `<for>` param (`BindingType.local`, from `core/for.ts`) reaches the change-handler branch of `trackAssignment` and compiles to `$scope.$Change("y")`, which nothing ever assigns, so the click throws a TypeError and nothing warns at compile time. Reads of such params work now (`referencedLocalBindingsInFunction`), which makes the silent write failure more confusing. These loops re-run wholesale on input change, so assignment has no reactive meaning; a compile error when `binding.type === BindingType.local` would be cheap and clear. Re-verify: compile that template with `pnpm run compile -o dom -d` and look for `$scope.$Change` in the handler.
 
-## Declare `pipe`, `catch` and `finally` on `RenderedTemplate`
+## Match the internal `RenderedTemplate` to the published `Marko.RenderedTemplate`
 
-`packages/runtime-tags/src/common/types.ts` › `RenderedTemplate` | 2026-07-27 | impact:med | effort:low
+`packages/runtime-tags/src/common/types.ts` › `RenderedTemplate` | 2026-07-27 | impact:low | effort:low
 
-`RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> & { toReadable() }`, but `ServerRendered` in `html/template.ts` also implements `pipe`, `catch`, `finally` and a synchronous `toString`. `PromiseLike` supplies only `then`, so TypeScript rejects `result.catch(...)` and `result.finally(...)`, and `pipe` — the Node streaming entry point — is not on the type at all: `template.render(input).pipe(res)` fails to compile with TS2339 and callers have to cast. `__tests__/render-result.test.ts` carries a local `ServerResult` intersection for exactly this reason, and it should be deleted once the public type is widened. Widening is safe: the DOM build's `render` only throws (`dom/template.ts` line 35), so `RenderedTemplate` is only ever produced by the HTML build. Re-verify: `const r = template.render({}); r.pipe(process.stdout);` in a `.ts` file, then `pnpm run build:types`.
+The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> & { toReadable() }`, but `ServerRendered` (`html/template.ts`) also implements `pipe`, `catch`, `finally` and a synchronous `toString`, and the published `Marko.RenderedTemplate` in `packages/runtime-tags/index.d.ts` already declares `Promise<string>` plus `pipe` and `toString`. The two have drifted, so anything typed off `common/types` loses `.pipe`/`.catch`/`.finally`; `__tests__/render-result.test.ts` carries a local `ServerResult` intersection for exactly this and should drop it once the internal type matches. Widening is safe: the DOM build's `render` only throws, so only the HTML build ever produces one. Re-verify: in a `.ts` file, type a value as `RenderedTemplate` from `@marko/runtime-tags/common/types` and call `.pipe(process.stdout)` — TS2339.
 
-## A backslash-escaped quote in a `<style>` body swallows the rest of the file
-
-`packages/runtime-tags/src/translator/core/style.ts` › `style` | 2026-07-27 | impact:low | effort:med
-
-`<style>\n  .a\" { color: red }\n</style>` fails to compile with `EOF reached while parsing string expression`, and the caret points at the _next_ line's `<div class="a">` rather than the escape. The `"` is read as opening a string expression even though a backslash precedes it, so everything after it is consumed; `\'` inside a CSS string (`content: 'it\'s'`) fails the same way. Escaped quotes in selectors are legal CSS and are what utility frameworks emit for class names containing quotes, so this is a real if narrow miscompile, made worse by a diagnostic that names an unrelated line. A CSS unicode escape is unaffected (`content: "an \2014 escape"` compiles), which points at the quote-handling specifically rather than backslashes generally. Like the unenclosed-`>` entry above, the token rule lives in the external `htmljs-parser`, so the fix is likely honouring the backslash there or marking the `<style>` body as raw text. Re-verify: `pnpm run compile -o html -d <file>` on the snippet above.
-
-## Catch effect errors in `runEffects` — a throwing `<script>` escapes `<try>`'s `@catch` and kills every effect queued behind it
+## Catch effect errors in `runEffects`; a throwing `<script>` escapes `<try>`'s `@catch` and kills every queued effect
 
 `packages/runtime-tags/src/dom/queue.ts` › `runEffects` | 2026-07-27 | impact:med | effort:med
 
-`_enable_catch` wraps `runRender` in a `try`/`catch` that routes errors to `renderCatch`, but the `runEffects` it installs alongside only filters destroyed/pending scopes and never catches, the base `runEffects` is a bare `for` loop, and `run()` calls it outside its own `try`/`finally`. An error thrown from a `<script>`/`<lifecycle>` effect inside a `<try>` therefore never reaches `@catch` — it escapes `mount()`, or surfaces as an uncaught error out of the scheduler microtask on an update — and it aborts the rest of the flush, so unrelated components whose effects were queued behind it silently never wire up (and the same truncation repeats every flush). That contradicts the `<try>` docs ("When a runtime error occurs in the content of the `<try>` … the content is replaced with the content of the `@catch`"), and nothing covers it: `try-effects-catch`, `try-effects-catch-state` and `try-effects-async` all throw from render expressions, never from an effect body. Direction: give the `_enable_catch` `runEffects` wrapper the same per-item `try { fn(scope) } catch (e) { renderCatch(scope, e) }` treatment `runRender` gets so one bad effect is contained to its own boundary; a fix must also settle sequencing, since `renderCatch`'s `caughtError.add(pendingEffects)` and the catch branch's own queued effects land in the fresh array `run()` already swapped in, which nothing flushes. Re-verify: compile `<try><for|item| of=["a","b","c"]><div id=item>${item}</div><script>{ globalThis.order.push(item); if (item === "a") throw new Error("boom") }</script></for><@catch|err|><div id="err">caught ${err.message}</div></@catch></try>` with `pnpm run compile -o dom -d t.marko` and `mount({}, document.body)` it in jsdom with `globalThis.order = []` — `mount()` itself throws `boom`, `order` is `["a"]` (the `b`/`c` effects never run), and no `#err` element is ever rendered.
+`_enable_catch`'s `runEffects` wrapper only filters destroyed/pending scopes — it never catches — and `run()` calls it outside its own `try`/`finally`, so an error thrown from a `<script>`/`<lifecycle>` body inside `<try>` escapes `mount()` instead of reaching `@catch`, and aborts the flush so every effect queued behind it never wires up. Give the wrapper the per-item `try { fn(scope) } catch (e) { renderCatch(scope, e) }` treatment `runRender` gets; the fix must also flush the catch branch's own effects, which land in the fresh array `run()` already swapped in. Nothing covers this: `try-effects-catch`, `try-effects-catch-state` and `try-effects-async` all throw from render expressions. Re-verify: mount `<try><for|item| of=["a","b","c"]><script>{ order.push(item); if (item === "a") throw new Error("boom") }</script></for><@catch|err|>caught</@catch></try>` in jsdom — `mount()` throws `boom`, `order` is `["a"]`, and no `@catch` content renders.
 
 ## Delegate events from the element's root node again; nothing inside a ShadowRoot receives events or controlled-input updates
 
 `packages/runtime-tags/src/dom/event.ts` › `delegate` | 2026-07-27 | impact:med | effort:low
 
-`delegate` installs exactly one capture listener on `document` (`(handler as any)[type] ||= (document.addEventListener(type, handler, true), 1)`), replacing an earlier `createDelegator()` that registered per `node.getRootNode()` via a `Symbol`-keyed map on that root; the change was made for bundle size and never accounted for shadow trees. At the document level an event originating inside a shadow tree is retargeted to the host, so `handleDelegated`'s `ev.target` `parentNode` walk and `controllable.ts` `handleChange`'s `(ev.target as any)._` both see the host rather than the real element — every `on*` handler and every two-way-bound `<input>` inside a `ShadowRoot` is silently dead while the identical template in the light DOM works, and no `getRootNode()` call remains anywhere in the runtime (`syncControllableFormInput` now calls `delegate("input", …)`/`delegate("reset", …)` unnamed, and `setInputValue` reads `document.activeElement`). This is a different defect from `Default a nullish namespace in parseHTML: mounting into a DocumentFragment/ShadowRoot creates null-namespace elements`, which is about `createElementNS`, and from `Prefix delegate's registration flag so event types named after Function properties register`, which is about the memo key — this one is about _where_ the listener is installed. The two are coupled: moving the per-type flag into a map on the root removes the `(handler as any)[type]` keyspace entirely, so the per-root fix closes the `Function.prototype` collision as a side effect and the two should be fixed together rather than separately. Direction: restore the per-root delegator — `_on` already has the element and `syncControllableFormInput` has `el`, so both can pass a node, register on `node.getRootNode()`, and track the per-type flag in a map on the root instead of on the shared handler function. Re-verify: compile `<let/count=0/><button onClick(){ count++ }>count: ${count}</button>` for `dom`, mount it into a plain `<div>` appended to `host.attachShadow({ mode: "open" })` and into a light-DOM `<div>` (a plain wrapper `<div>` keeps the `parseHTML` namespace issue out of the picture), then dispatch `new MouseEvent("click", { bubbles: true, composed: true })` on each button — the light copy reads `count: 1` and the shadow copy stays `count: 0`.
+`delegate` installs one capture listener on `document`, replacing the per-`getRootNode()` `createDelegator` dropped for bundle size in 7458238e1a (#3295). At `document` an event from a shadow tree is retargeted to the host, so `handleDelegated`'s `ev.target` parent walk and `controllable.ts` › `handleChange`'s `(ev.target as any)._` both see the host, so every `on*` handler and two-way-bound input inside a `ShadowRoot` is silently dead — a regression of #2352 ("Fix issue with controllable elements inside a shadowroot"). Pass the node from `_on` and `syncControllableFormInput`, register on `node.getRootNode()`, and keep the per-type flag in a map on that root, which also deletes the handler-keyed memo behind "Prefix `delegate`'s registration flag so event types named after `Function` properties register" — that entry's `"$" + type` patch must not land separately if this one is taken. Re-verify: mount a `<let/count=0/>` counter button into a `<div>` inside `host.attachShadow({ mode: "open" })` and into a light-DOM `<div>`, then dispatch a `composed` bubbling `click` on each — light reads `count: 1`, shadow stays `count: 0`.
 
 ## Write the dynamic `<style>` marker class with `setAttribute`; a `<style>` inside `<svg>` throws on client render
 
 `packages/runtime-tags/src/dom/dom.ts` › `_style_shell` | 2026-07-27 | impact:med | effort:low
 
-`_style_shell` tags the generated stylesheet with `element.className = id`, but `SVGElement.className` is a readonly `SVGAnimatedString`, so in the runtime's strict-mode ESM that assignment throws `TypeError: Cannot set property className of #<SVGElement> which has only a getter`. A `<style>` with any `${…}` value nested inside `<svg>` is legal Marko — `<let/c="red"/><svg><style>circle { fill: ${c}; }</style><circle cx=5 cy=5 r=4/></svg>` compiles to `_style_shell($scope, "#style/0")` in `$setup` — so every client-created render of such a template (a `mount`, or a branch an `<if>`/`<for>` creates on the client) dies before anything is inserted, while SSR and resume are fine because `html/attrs.ts` › `_style_html` emits the marker as markup (`<style class=ID>`) and `_style_rule_item` only ever rewrites `textContent`. The same construct outside an `<svg>` mounts cleanly, so the failure looks like "SVG breaks dynamic styles" rather than a property-vs-attribute mismatch, and no fixture covers it. Direction: write the marker with `element.setAttribute("class", id)` in `_style_shell` so both outputs set the same attribute regardless of namespace. Re-verify: with jsdom globals installed, parse `<svg><style></style></svg><style></style>` and call `_style_shell({ s: el, $global: { runtimeId: "M", renderId: "_" } }, "s")` for each `<style>` — the `http://www.w3.org/2000/svg` one throws the TypeError above while the XHTML one becomes `<style class="cM_0">.cM_0~*{}</style>`.
+`_style_shell` tags the generated stylesheet with `element.className = id`, but `SVGElement.className` is a readonly `SVGAnimatedString`, so in the runtime's strict-mode ESM that assignment throws `TypeError: Cannot set property className of #<SVGElement> which has only a getter`. `<let/c="red"/><svg><style>circle { fill: ${c}; }</style><circle cx=5 cy=5 r=4/></svg>` compiles to `_style_shell($scope, "#style/0")`, so every client-created render of such a template (a `mount`, or an `<if>`/`<for>` branch) dies before anything is inserted; SSR and resume survive because `html/attrs.ts` › `_style_html` emits `<style class=ID>` as markup and `_style_rule_item` only rewrites `textContent`. Write the marker with `element.setAttribute("class", id)` so both outputs set the same attribute regardless of namespace. Re-verify: mount that template in jsdom — it throws, while the identical `<style>` outside `<svg>` mounts as `<style class="cM_0">`.
 
 ## Guard the empty class-object key: `class={ "": v }` renders nothing on the server and throws on the client
 
 `packages/runtime-tags/src/dom/dom.ts` › `_attr_class_item` | 2026-07-27 | impact:low | effort:low
 
-`_attr_class_item` lowers a class-object entry to `element.classList.toggle(name, !!value)`, which throws `SyntaxError: The token provided must not be empty` for an empty token. The translator only diverts _whitespace-bearing_ object keys away from the per-item helper — `trackDelimitedAttrObjectProperties` in `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` tests `!/\s/.test(keyEval.computed)` — and `""` passes that test, so `<div class={ "": count % 2 }>` compiles with `-o dom` to `_attr_class_item($scope["#div/0"], "", …)` and the first CSR render throws, taking the whole mount down (a scoped fixture run of that template fails its `csr` step with exactly that `SyntaxError`). SSR meanwhile emits `_attr_class({ "": count % 2 })`, which drops the key and renders cleanly, so the page only dies on hydrate or on the first update — a hard crash where either a compile error or a no-op belongs. Widening the guard to `!/^$|\s/.test(...)` routes the empty key into the whole-object `_attr_class` path, which already ignores it (`_attr_class({ "": true, foo: true })` yields `" class=foo"` on both runtimes); the style side needs no change, since `style.setProperty("", v)` is a silent no-op. Re-verify from the repo root: `node -r ~ts -e 'const {JSDOM}=require("jsdom"); global.document=new JSDOM("<div></div>").window.document; console.log(JSON.stringify(require("./packages/runtime-tags/src/html/attrs.ts")._attr_class({"":true}))); require("./packages/runtime-tags/src/dom/dom.ts")._attr_class_item(document.querySelector("div"), "", true)'` prints `""` for the SSR path and then throws on the DOM path.
+`_attr_class_item` lowers a class-object entry to `element.classList.toggle(name, !!value)`, which throws `SyntaxError: The token provided must not be empty` for an empty token. `trackDelimitedAttrObjectProperties` in `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` only diverts whitespace-bearing keys (`!/\s/.test(keyEval.computed)`), so `<div class={ "": count % 2 }>` still lowers to `_attr_class_item($scope["#div/0"], "", …)` and the first CSR render takes the whole mount down, while SSR's `_attr_class` drops the key and renders cleanly. Widen the guard to `!/^$|\s/.test(...)` so the empty key falls to the whole-object `_attr_class`, which already ignores it (`_attr_class({ "": true, foo: true })` → `" class=foo"`); the style side needs nothing, since `style.setProperty("", v)` is a no-op. Re-verify: compile that template with `-o dom` and mount it in jsdom — it throws before any DOM is inserted.
 
 ## Re-check serialized `$global` values after the first flush; `flushSerializer` latches `hasGlobals` even when it emitted nothing
 
 `packages/runtime-tags/src/html/writer.ts` › `flushSerializer` | 2026-07-27 | impact:med | effort:low
 
-`flushSerializer` sets `state.hasGlobals = true` before it knows whether any global was actually emitted, so a render whose allow-listed `$global` keys are all still `undefined` at the first serializer flush permanently latches "globals already sent" and never re-checks. A value assigned to `$global` later in the render — e.g. from a `<const>` inside `<await>`/`<try>` content, the same shape the `basic-flush-here` fixture uses for `$global.__flush__` — is then dropped from the resume payload, so the client reads `undefined` where the server had a value. The divergence is streaming-only and silent: the same template awaited as a promise flushes once at the end and serializes the value correctly, so `pipe()` and `await` disagree on identical input. The sibling `flushSerializerGlobals` gets this right (`if (globals) { state.hasGlobals = true; … }`), and moving the assignment inside the `if (globals)` guard in `flushSerializer` fixes every case where a later flush still has scopes to write. It does not cover a global that first becomes defined after the last scope-carrying flush, because `flushSerializer` returns early when both `serializeState.flushScopes` and `serializer.pending()` are false — that case needs an explicit globals re-check on the final flush. Re-verify: SSR-render `<let/n=0/><button onClick(){n++}>${n}</button><await|v|=input.p><const/_=($global.late="LATE")/><let/m=v/><button onClick(){m++}>${m}</button></await>` with `$global.serializedGlobals=["late"]` and an `input.p` that resolves on a later tick; the concatenated `pipe()` chunks contain no `[0,{late:…}` entry, while `await`ing the same render emits `_=>[0,{late:"LATE"},{n:0},{m:5}]`.
+`flushSerializer` sets `state.hasGlobals = true` before calling `getFilteredGlobals`, so a render whose allow-listed `$global` keys are all still `undefined` at the first serializer flush permanently latches "globals already sent" and never re-checks. A value assigned later — e.g. `<const/_=($global.late="LATE")/>` inside `<await>` content — is then dropped from the resume payload, so streaming and non-streaming disagree on identical input. Move the assignment inside an `if (globals)` guard, as the sibling `flushSerializerGlobals` already does; that covers every case where a later flush still has scopes, but a global first defined after the last scope-carrying flush needs an explicit final-flush re-check, since `flushSerializer` returns early when neither `flushScopes` nor `serializer.pending()` holds. Re-verify: render that template with `$global.serializedGlobals=["late"]` and a promise resolving on a later tick — the streamed chunks contain no `[0,{late:…}` entry, while awaiting the same render emits `_=>[0,{late:"LATE"},{n:0},{m:5}]`.
 
-## Isolate `flushTickQueue` callbacks; one render whose sink throws silently disables progressive streaming for every other concurrent render
+## Isolate `flushTickQueue` callbacks; one render whose sink throws stops progressive streaming for every other concurrent render
 
 `packages/runtime-tags/src/html/writer.ts` › `flushTickQueue` | 2026-07-27 | impact:med | effort:low
 
-`queueTick`/`flushTickQueue` share one module-level `tickQueue` `Set` across every in-flight render in the process, and `flushTickQueue` runs `cb(true)` in a bare `for…of` with no error isolation. Those callbacks are `ServerRendered.#read`'s `onNext` (`html/template.ts`), which drives the consumer's sink — `stream.write`/`stream.flush?.()` in `pipe`, `stream.end()` on close — so one sink that throws aborts the loop and drops every remaining render's callback; because each victim already set its own `tick = false` before queueing and `#read` only re-arms under `else if (tick)` (and `offTick` is a no-op once `flushTickQueue` has cleared `tickQueue`), those renders never queue again and lose _all_ subsequent progressive flushes, emitting one combined chunk at completion. Concurrent renders are the normal case on a server, so a single misbehaving `pipe` target silently degrades streaming for unrelated pages with no error surfacing on the victims. Direction: wrap `cb(true)` in try/catch and rethrow asynchronously so a broken sink cannot take the shared queue down, and/or re-arm `tick` from a `finally` in `#read`. Re-verify: compile two SSR templates with `pnpm run compile -o html -d` — A = `<div>A-head</div>` plus one `<await>`, B = `<div>B-head</div>` plus three staggered `<await>`s — and `pipe` B to a logging sink; B alone writes four chunks (head, then one per await), but with A concurrently piped to `{ write() { throw new Error("boom"); }, end() {} }` B writes nothing until it completes and then emits a single combined chunk.
+One module-level `tickQueue` holds every in-flight render's `onNext`, and `flushTickQueue` runs `cb(true)` in a bare `for…of`, so one sink that throws (`stream.write` in `pipe`, `ctrl.enqueue` in `toReadable`) aborts the loop. The skipped victims stay parked — each set `tick = false` before queueing, `#read` (`html/template.ts`) re-arms only under `else if (tick)`, and `offTick` is a no-op once the queue is cleared — so they lose every later progressive flush and emit one combined chunk at completion, while the error escapes as an uncaught exception. Wrap `cb(true)` in try/catch and rethrow asynchronously, and/or re-arm `tick` from a `finally` in `#read`. Re-verify: `queueTick(() => { throw new Error("boom") })` then `queueTick(() => (ran = true))` leaves `ran` false.
 
-## Splice page assets after the doctype; a page entry with no literal `<head>` writes `<link>`/`<script>` ahead of `<!doctype html>` and the document parses in quirks mode
+## Splice page assets after the doctype; a page entry with no literal `<head>` writes assets ahead of `<!doctype html>` and the document parses in quirks mode
 
 `packages/runtime-tags/src/html/assets.ts` › `flush` | 2026-07-27 | impact:med | effort:low
 
-`flush` ends with `return result + html`, so when it runs as the `$global.__flush__` prefix hook installed by `withPageAssets` it blindly prepends the page's asset markup to whatever `Chunk.flushHTML` produced (`html/writer.ts` › `Chunk.flushHTML`). That fallback — documented as "at the end of `<head>` when rendered, otherwise before the first flush" — is only avoided when `_flush_head()` has already drained the queue, and the translator emits `_flush_head()` solely at the close of a _literal_ native `<head>` (`translator/visitors/tag/native-tag.ts` › the `tagName === "head" && getMarkoOpts().linkAssets` branch of `translate.html.exit`). A page entry that legally omits `<head>` (`<!doctype html><html><body>…`) compiles with no diagnostic and renders `<link …><script …><!doctype html>…`; an HTML parser ignores a DOCTYPE that follows content, so the doctype is dropped and the entire document silently renders in quirks mode. The fix can stay in the runtime: skip a leading `<!doctype …>` in `html` before splicing `result` in — assets placed after the doctype but before `<html>` are hoisted into the implicit `<head>` and the document stays no-quirks. This is a different defect from the entry "Track 'a page already owns this $global' with a durable marker; `__flush__` is cleared at the first flush", which is about *nested* page renders taking the wrong `withPageAssets` branch; here the top-level page entry takes the correct branch and the prepend itself is the bug. Re-verify: compile `<!doctype html><html><body><h1>hi</h1></body></html>` with `output: "html"` plus `linkAssets: { runtime, onAsset() {} }`, wrap the default export in ``withPageAssets(tmpl, (g, type, id) => type === "block" ? `<link href="/${id}.css" rel=stylesheet>`:`<script src="/${id}.js"></script>`, "entry")`` and render it — the string begins `<link href="/entry.css" rel=stylesheet><script src="/entry.js"></script><!doctype html>…`, and adding a `<head>` to the template moves both tags inside it.
+`flush` ends with `return result + html`, so as the `$global.__flush__` hook it prepends the page's asset markup to the first chunk; the translator emits `_flush_head()` only at the close of a literal native `<head>` (`translator/visitors/tag/native-tag.ts`), so an entry like `<!doctype html><html><body>…` renders `<link …><script …><!doctype html>…`. A parser ignores a DOCTYPE that follows content, so the document silently falls into quirks mode. Fix in the runtime: skip a leading `<!doctype …>` in `html` before splicing `result` in — assets between the doctype and `<html>` land in the implicit head. Re-verify: render that template compiled with `linkAssets` and wrapped in `withPageAssets(tmpl, runtime, "entry")`, then parse the output with jsdom — `document.compatMode` is `BackCompat` and `document.doctype` is null.
 
-## Give deferred Map/Set insert arguments an eager binding — reusing one in a later flush crashes `assignId` on a null parent
+## Give deferred Map/Set call arguments an eager binding — reusing one in a later flush crashes `assignId` on a null parent
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeCallArg` | 2026-07-27 | impact:med | effort:low
 
-When a `Map`/`Set` member references an ancestor, `deferCall` moves the remaining entries out of the constructor into post-construction `.set(...)`/`.add(...)` calls, and `writeAssigned` writes each argument through `writeCallArg` as `writeProp(state, val, null, "")` — no parent, no accessor. The `Reference` left in `state.refs` (or `state.strs`, for a >12-char string) therefore has neither an id nor an accessor path, so when that value is serialized again in a later flush `assignId` skips its `pos` fast path (`ref.flush !== state.flush`) and walks `const parent = cur.parent!`, which is `null`, throwing `TypeError: Cannot read properties of null (reading 'id')` (serializer.ts:2205) out of `stringifyScopes`; since `Boundary.flush` calls `stringifyScopes` unguarded, the stream dies on an internal stack trace rather than emitting a reference. Both sibling paths already get this right — `writeArrayArg` binds the backing array (`new Set(_.a=[…])`) precisely so constructor-path members stay reusable, and the channel-mutation branch of `writeAssigned` does `valueRef.id = mutation.valueId || nextRefAccess(state)` under the comment "Reused mutation values require eager bindings because they lack an accessor path" — so `writeCallArg` should claim the same eager id for any argument that lands in `state.refs`/`state.strs`. Re-verify: with `const root = {}, inner = new Set(); root.k0 = new Set([40, root, inner]);` and a single `Serializer`, `ser.stringifyScopes([[1, {}, { value: root }]], boundary)` emits `_=>(_([1,{value:_.b={k0:_.a=new Set([40])}}]),_.a.add(_.b),_.a.add(new Set),0)` and the follow-up `ser.stringifyScopes([[2, {}, { value: inner }]], boundary)` throws in `assignId`; the same holds for a Map key or value, for a long-string argument, and for any value nested inside a deferred argument (`root.s = new Set([root, { wrap: deep }])`, then flush `deep`). Reusing the value within the same flush is fine, so only cross-flush streaming is affected, and `src/__tests__/serializer.test.ts` covers each ingredient separately (`describe("collection members referencing an ancestor")`, `it("dedupe values across flushes")`) but never together.
+`deferCall` moves the remaining Map/Set members into post-construction `.set(...)`/`.add(...)` calls, and `writeCallArg` writes each argument as `writeProp(state, val, null, "")`, so the `Reference` left in `state.refs`/`state.strs` has neither an id nor an accessor path. Serializing that value again in a later flush skips the `pos` fast path and walks `cur.parent!`, which is null, throwing `TypeError: Cannot read properties of null (reading 'id')` out of `stringifyScopes`, which `Boundary.flush` calls unguarded, so the stream dies. `writeArrayArg` and the channel-mutation branch of `writeAssigned` already claim eager ids for this reason; do the same here. Re-verify: with `root.k0 = new Set([40, root, inner])`, `stringifyScopes([[1,{},{value:root}]])` then `stringifyScopes([[2,{},{value:inner}]])` throws; a Map key/value, a long string, or a nested value behave the same.
 
 ## Preserve an Error's own enumerable properties through resume — only `message` and `cause` survive
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeError` | 2026-07-27 | impact:med | effort:med
 
-`writeError` emits exactly `new <Ctor>(message[, {cause}])`, so every own enumerable property an application hung on an error — the `status`/`code`/`details` fields HTTP and Node errors carry, and an assigned `name` — is silently dropped on resume; `writeAggregateError` has the same gap. This is reachable from idiomatic source: `<try><@catch|err|><button onClick() { report(err) }>` compiles to `_scope($scope2_id, { err })` (the whole error, not a narrowed member read like `err.status`, which the translator does serialize correctly as its own slot), so the server renders `err.status === 404` while the resumed client handler reads `undefined`, with no diagnostic. Plain objects round-trip all own enumerable props and the serializer already works to preserve `cause` and relink `AggregateError.errors`, so error payloads are clearly meant to survive — extend both writers to append the remaining own enumerable props, reusing the existing deferred-assignment path (`addAssignment`) for circular ones and emitting nothing extra when there are none so an ordinary error costs no bytes. Worth deciding at the same time: an error subclass (`class HttpError extends Error {}`) misses the constructor dispatch entirely and is dropped from the payload rather than losing only its extras. Re-verify from the repo root: `node -r ~ts -e 'const {Serializer}=require("./packages/runtime-tags/src/html/serializer.ts");console.log(new Serializer().stringifyScopes([[1,{},{value:Object.assign(new Error("boom"),{status:404,name:"HttpError"})}]],{signal:{aborted:!1}}))'` prints `_=>[1,{value:new Error("boom")}]`.
-
-## Preserve object key order when a circular property is deferred
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeObjectProps` | 2026-07-27 | impact:low | effort:med
-
-When a property's value is circular, `writeReferenceOr` queues a deferred assignment and returns `false`, so `writeObjectProps` pops the already-pushed `key:` chunk and `writeAssigned` re-creates the property at the end of the payload — moving it to the end of the object's key order. Plain objects are the only container that does this: `writeArray` keeps the slot (the `,` separator is already emitted, so the hole survives and the assignment fills it in place), and `writeMap`/`writeSet` deliberately defer every later entry once one defers, with the comment "Once an entry must defer, every later entry defers too so insertion order is preserved" and matching tests in `__tests__/serializer.test.ts` ("preserves Map key order around a deferred entry", "preserves Set insertion order around a deferred member"). Key order is observable — `common/for.ts` › `forIn` is `for (const key in obj)`, so `<for|k,v| in=obj>` renders one order on the server and another after resume, and `Object.keys`/`JSON.stringify` diverge too: a fixture with `<let/graph=makeGraph()>` where `makeGraph` returns `{ title: "t", self: null, count: 3 }` with `root.self = root`, plus `<const/keys=n + ":" + Object.keys(graph).join(",")>` and a button doing `n++`, renders `0:title,self,count` and updates to `1:title,count,self` on resume while pure CSR keeps `title,self,count`, so its `render.debug.md` snapshots disagree between the ssr and csr runs. The cheap fix matching the array behavior is to leave an `undefined` placeholder (`key:$`, setting `state.wroteUndefined`) instead of popping the chunk when the failed write queued an assignment, so the later `_.a.self=_.a` overwrites in place; that needs `writeProp`'s boolean return to distinguish "deferred" from "elided" (an `undefined` or unserializable value must still be popped). Re-verify from the repo root: `node -r ~ts -e 'const {Serializer}=require("./packages/runtime-tags/src/html/serializer.ts");const o={title:"t",self:null,count:3};o.self=o;console.log(new Serializer().stringifyScopes([[1,{},{graph:o}]],{signal:{aborted:false}}))'` prints `_=>(_([1,{graph:_.a={title:"t",count:3}}]),_.a.self=_.a,0)` — `self` last instead of second.
+`writeError` emits exactly `new <Ctor>(message[, {cause}])`, so every own enumerable property an application hung on an error — `status`/`code`/`details`, an assigned `name` — is dropped on resume; `writeAggregateError` has the same gap. This is reachable from idiomatic source: `<try><@catch|err|><button onClick() { report(err) }>` compiles to `_scope($scope2_id, { err })`, so the server renders with `err.status === 404` while the resumed handler reads `undefined`, with no diagnostic. Plain objects round-trip all own props and the serializer already preserves `cause` and relinks `AggregateError.errors`, so extend both writers to append the remaining own props, deferring circular ones through `addAssignment` and emitting nothing extra when there are none. Re-verify: `stringifyScopes([[1,{},{value:Object.assign(new Error("boom"),{status:404})}]])` prints `_=>[1,{value:new Error("boom")}]`.
 
 ## Escape a carriage return in an attribute value so SSR and CSR agree
 
 `packages/runtime-tags/src/html/attrs.ts` › `attrAssignment` | 2026-07-27 | impact:low | effort:low
 
-`attrAssignment` picks the quoting and escapes only `"`/`'`/`&`, but the HTML input-stream preprocessor normalizes every CR and CRLF inside an attribute value to a single LF, so a `\r` never survives SSR: `_attr("data-x", "a\rb")` and `"a\r\nb"` both parse back as `"a\nb"`, while CSR (`dom/dom.ts` › `_attr` → `setAttribute`) writes the `\r` verbatim. The two halves therefore disagree on every attribute — `_attr`, `_attrs`, `_attr_class`, and `_attr_style` all funnel through this escaper — and a controlled `<input value=…>` resumes with a `defaultValue` the server never rendered. Writing `\r` as `&#13;` survives, because character references are decoded after newline normalization; weigh that against the bytes it costs every attribute, since a lone CR in attribute data is rare. A U+0000 in the value is separately replaced with U+FFFD and is _not_ fixable by escaping (`&#0;` also decodes to U+FFFD), so the only option there is a MARKO_DEBUG warning. This is a different defect from the entry "Escape a carriage return in a `<textarea>` body so SSR and CSR agree", which concerns textarea _text_ content and the `_escape` path rather than the attribute-value escaper. Re-verify: under `node -r ~ts`, build `"<div" + _attr("data-x", "a\rb") + "></div>"` from `src/html/attrs.ts` and parse it with jsdom — `getAttribute("data-x")` is `"a\nb"`, while `el.setAttribute("data-x", "a\rb")` on a plain `<div>` keeps `"a\rb"`.
+`attrAssignment` escapes only `"`, `'` and `&`, but the HTML input-stream preprocessor normalizes every CR and CRLF in an attribute value to a single LF, so `_attr("data-x", "a\rb")` parses back as `"a\nb"` while CSR (`dom/dom.ts` › `_attr` → `setAttribute`) writes the CR verbatim. `_attr`, `_attrs`, `_attr_class` and `_attr_style` all funnel through this escaper, so a controlled `<input value=…>` resumes with a `defaultValue` the server never rendered. Writing `\r` as `&#13;` survives, because character references are decoded after newline normalization. A U+0000 is separately replaced with U+FFFD and cannot be escaped away, leaving only a MARKO_DEBUG warning. This is a different defect from the entry "Escape a carriage return in a `<textarea>` body so SSR and CSR agree", which concerns textarea _text_ content and the `_escape` path rather than this attribute-value escaper — but a complete "CR survives SSR" story needs both landed. Re-verify: parse `"<div" + _attr("data-x", "a\rb") + "></div>"` with jsdom — `getAttribute("data-x")` is `"a\nb"`, while `el.setAttribute("data-x", "a\rb")` keeps `"a\rb"`.
 
 ## Escape debug scope accessors that collide with `AccessorProp` — a binding named `_` overwrites the scope's owner pointer
 
 `packages/runtime-tags/src/common/constants/accessor-prop.debug.ts` › `Owner` | 2026-07-27 | impact:med | effort:low
 
-Every debug `AccessorProp` value is `#`-prefixed and therefore unreachable as a user identifier except `Owner`, which is `"_"` (a node one-liner over `accessor-prop.debug.ts` shows `Owner: "_"` and `Global: "$global"` are the only values that are valid identifiers), while `getScopeAccessor`/`getScopeAccessorLiteral` (`translator/util/references.ts`) use the raw binding name as the scope accessor whenever `optimize` is off — and `_let` strips its `/id` suffix back to that bare name. So the ignore-this-param idiom `<for|_, i| of=list>` — already used by the `for-serialize-key` and `lazy-tag-dynamic-unmount-before-load` fixtures — writes the loop item into `scope[AccessorProp.Owner]` and destroys the branch's owner pointer as soon as `_` is referenced from client code: `-o dom -d` emits `_const("_", $scope => _text($scope["#text/1"], $scope._))` beside `_for_closure("#text/0", $scope => _text($scope["#text/2"], $scope._.n))`, and `-o html -d` emits a literal duplicate object key, `_scope($scope1_id, { _, _: _scope_with_id($scope0_id) })`, so the item is silently dropped from the resume payload. Production output is unaffected because `decodeAccessor` only ever yields `[a-z][0-9a-z]*`, making this a dev-only failure with no compile-time diagnostic; the same hole exists for a binding named `$global`, which compiles to `_const("$global")` over `scope[AccessorProp.Global]`. Fix by `#`-prefixing the debug `Owner`/`Global` values (`getScopeExpression` in `translator/util/scope-read.ts` then needs a computed member instead of `t.identifier`), or by having `getScopeAccessor`/`getScopeAccessorLiteral` escape any binding whose debug accessor equals an `AccessorProp` value. Re-verify: compile `<let/n = 0/><for|_, i| of=["a", "b"]><div onClick() { n = n + 1; console.log(_) }>${_}:${n}</div></for>` with `pnpm run compile -o dom -d` and mount it with jsdom globals — it renders `<div>a:</div><div>b:</div>` instead of `a:0`/`b:0`, and a click throws `TypeError: Cannot create property 'n' on string 'a'`.
+`Owner: "_"` and `Global: "$global"` are the only debug `AccessorProp` values that are legal JS identifiers, and `getScopeAccessor`/`getScopeAccessorLiteral` (`translator/util/references.ts`) use the bare binding name as the accessor when `optimize` is off, so a binding spelled `_` or `$global` clobbers the scope's owner/global pointer. The ignore-this-param idiom `<for|_, i| of=list>` hits it with no diagnostic; production is safe because `decodeAccessor` only emits `[a-z][0-9a-z]*`. Fix by `#`-prefixing the debug `Owner`/`Global` values (`getScopeExpression` in `translator/util/scope-read.ts` then needs a computed member), or by escaping any binding whose debug accessor equals an `AccessorProp` value. Re-verify: `pnpm run compile -o dom -d` on `<let/n=0/><for|_, i| of=["a","b"]><div onClick(){ n = n + 1 }>${_}:${n}</div></for>` emits `_const("_", …)` writing `$scope._` beside reads of `$scope._.n`, and `-o html -d` emits the duplicate key `_scope($scope1_id, { _, _: _scope_with_id($scope0_id) })`.
 
 ## Accept the written-out `value=` attribute on `<if>`/`<else-if>`/`<show>` — only the `=` shorthand compiles
 
 `packages/runtime-tags/src/translator/core/if.ts` › `assertHasValueAttribute` | 2026-07-27 | impact:low | effort:low
 
-`assertHasValueAttribute` (if.ts:551) and its twin in `core/show.ts` (reached from `assertValidShow`) require `t.isMarkoAttribute(valueAttr) && valueAttr.default`, so `<if value=cond>`, `<else-if value=cond>` and `<show value=cond>` are rejected even though the language reference defines `<my-tag=1/>` as sugar for `<my-tag value=1/>` and the parser emits the identical attribute (`name: "value"`), differing only in the `default` flag (`packages/compiler/src/babel-plugin/parser.js` › `onAttrName`). Every other core tag accepts both spellings — `core/let.ts`, `core/const.ts`, `core/log.ts`, `core/debug.ts` and `core/id.ts` test `attr.default || attr.name === "value"`, `core/await.ts` and `core/return.ts` test the name — and the resulting diagnostic is self-contradictory, saying the tag "requires a `value=` attribute" while the caret sits on source that has one. Relax both asserts to `attr.name === "value"` the way `<await>` does; note that `flattenTextOnlyConditional` in the same file makes the same `.default` test, so it needs the same treatment or the text-only chain optimization silently stops applying to the written-out form (with the shorthand, `<div><if=input.x>a</if><else>b</else></div>` compiles to `$template = "<div> </div>"` with no `_if` call). The `error-if-no-default-value`/`error-elseif-no-default-value` fixtures only cover a _missing_ value (`<if>Hello World</if>`), so nothing pins the current rejection. Re-verify: `pnpm run compile -o html -d` on a file containing `<div><if value=input.x>a</if></div>` fails with "requires a [`value=` attribute]" (likewise `<else-if value=…>` and `<show value=…>`), while `<div><if=input.x>a</if></div><const/y value=input.a/><await|v| value=input.p>${v}</await>` compiles.
+`assertHasValueAttribute` and its twin in `core/show.ts` (reached from `assertValidShow`) require `t.isMarkoAttribute(valueAttr) && valueAttr.default`, so `<if value=cond>`, `<else-if value=cond>` and `<show value=cond>` are rejected with "requires a `value=` attribute" while the caret sits on source that has one. The parser emits the identical `name: "value"` attribute for both spellings (`packages/compiler/src/babel-plugin/parser.js` › `onAttrName` sets `default: !name`), and `core/let.ts`, `core/const.ts`, `core/log.ts`, `core/debug.ts`, `core/id.ts` and `core/await.ts` all accept both. Relax both asserts to also allow `attr.name === "value"`, and give `flattenTextOnlyConditional` in the same file the same treatment or the text-only chain optimization silently stops applying to the written-out form. Re-verify: `pnpm run compile -o html -d` on `<div><if value=input.x>a</if></div>` fails today, while the shorthand plus `<const/y value=input.a/>` and `<await|v| value=input.p>${v}</await>` compile.
 
 ## Make `<let>`'s `value` optional in `tags/let.d.marko`; the valueless `<let/x/>` compiles but fails type-check
 
 `packages/runtime-tags/tags/let.d.marko` › `Input` | 2026-07-27 | impact:med | effort:low
 
-`tags/let.d.marko` › `Input` declares `value: T` as required, but `src/translator/core/let.ts` › `analyze` only ever requires the tag variable and `translate.exit` falls back to `t.markoAttribute("value", t.identifier("undefined"))`, so `<let/x/>` compiles fine and emits `let x = undefined;` — unlike `<const>`, whose `analyze` really does throw "requires a `value=` attribute", which is why `tags/const.d.marko` correctly keeps `value` required. The valueless form is a first-class idiom used by eight in-repo fixtures (`let-undefined-until-dom`, `assign-to-owner-closure`, `assignment-before-tag-var`, `embed-control-flow-boundary`, `expression-statement-tag-var-assignment`, `for-by-use-index`, `known-define-tag-empty-section-closure`, `html-comment-var/tags/parent-el.marko`), yet every editor and `mtc` check of it hard-fails with TS2345 "Argument of type '{}' is not assignable to parameter of type 'Directives & Input<unknown, unknown>'. Property 'value' is missing…", which reads as if the tag were misused rather than as a stub gap. Mark it `value?: T`, but pair that with `return=(input.value as T)`: adding only the `?` widens `return=input.value` to `T | undefined` and regresses every valued `<let>` (`<let/n=0/>` followed by `${n.toFixed(2)}` then reports TS18048 "'n' is possibly 'undefined'"), while the cast keeps inference intact (`<let/n=0/>` + `n.toUpperCase()` still errors TS2339). This is a different defect from the entry "Declare the element-getter `return=` in the `html-comment` / `html-script` / `html-style` type stubs", which is about a missing `return=` collapsing the tag variable's type to `never`, not about an attribute wrongly marked required. Re-verify: point a Marko 6 project's `node_modules/@marko/runtime-tags` at this package and run `mtc` on `<let/x/>` + `<div>${x}</div>` — TS2345 at the `<let>` today, clean with `value?: T` plus `return=(input.value as T)` — while `pnpm run compile -o html -d tmp.marko` on the same source succeeds either way.
+`Input` declares `value: T` as required, but `src/translator/core/let.ts` › `analyze` only requires the tag variable and `translate.exit` falls back to `t.markoAttribute("value", t.identifier("undefined"))`, so `<let/x/>` compiles to `let x = undefined;`. The valueless form is a first-class idiom — eight in-repo fixtures use it, starting with `let-undefined-until-dom` — yet every editor and `mtc` check hard-fails with TS2345 "Property 'value' is missing…", which reads as tag misuse rather than a stub gap; `<const>`'s `analyze` really does throw on a missing value, so `tags/const.d.marko` is correct as-is. Mark it `value?: T` **and** change the return to `return=(input.value as T)`: adding only the `?` widens the return to `T | undefined` and regresses every valued `<let>` (`<let/n=0/>` then `n.toFixed(2)` reports TS18048), while the cast keeps inference intact. The same idiom sits one line over in `valueChange=(input.valueChange as (newValue: K) => void)`, and is the pattern for "Declare the element-getter `return=` in the `html-comment` / `html-script` / `html-style` type stubs" — the other broken `tags/` stub, worth fixing in the same pass. Re-verify with `node_modules/.bin/tsc --noEmit --strict` against a model of the stub: `declare function f<T, K = T>(input: Directives & Input<T, K>): T`.
 
 ## Create a native-tag binding when `content=` evaluates confidently; today `<div content=undefined/>` aborts the DOM compile with an internal error
 
 `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `analyze.enter` | 2026-07-27 | impact:med | effort:low
 
-`analyze.enter` creates the `kNativeTagBinding` only when `node.var || hasDynamicAttributes || hasEventHandlers || textPlaceholders || injectNonce || isDynamicControllable(...)` (:225-232), and a `content=` value that Babel evaluates confidently trips none of them — `content` is not an event handler, so it reaches the `!evaluate(attr.value).confident` test (:182) which leaves `hasDynamicAttributes` false. `getUsedAttrs` still records any non-`meta` `content` as `staticContentAttr` (:1203) and `translate.dom.enter` unconditionally emits `_attr_content(scope, visitAccessor, value)` for it, so with no referenced bindings that statement lands in `$setup` and contradicts the `setupEmpty` proof set at `visitors/program/index.ts:111`: a file containing only `<div content=undefined/>` aborts the dom compile in both debug and optimize with `Marko internal error: analysis marked this template's setup export as empty but translation produced statements for it. Please open an issue with a reproduction.` (thrown at `visitors/program/dom.ts:176`), while `-o html` compiles fine — so SSR-only checks pass and only the client build breaks. `content=undefined` is the documented way to clear content and is used by the repo's own fixtures (`fixtures/native-tag-spread-content/tags/my-div.marko`, `fixtures/spread-to-known-content/template.marko`), but always alongside a spread, which is why no test covers the plain form; when the template happens to have other setup work the compile succeeds instead and emits `_attr_content($scope, void 0, undefined)`, whose `undefined` node accessor reads and writes stray `"…undefined"` scope keys rather than the tag's. Fix by adding a non-`meta` `content` attribute to the binding gate so `visitAccessor` exists, or by dropping a confidently void `content` value in `analyze.enter` the way the body-wins case already calls `dropNodes(attr.value)` (:140-147) and rejecting a confidently non-renderer one with a real diagnostic. This reaches the same error string as the unreferenced-`<define>` defect fixed in `5e7e830aa1`, but through a different root cause — that one was `core/define.ts` translating a tag the analysis had already dropped, this one is the native-tag binding gate — and it is distinct from `SSR silently drops content= on void and text-only native tags…` (`translate.html.enter`, whose repro uses only dynamic values, which bind fine). Re-verify: `pnpm run compile -o dom -d` on a file containing exactly `<div content=undefined/>` throws the internal error while `-o html -d` on the same file emits `_attr_content(void 0, $scope0_id, undefined, 0)`; prefixing that file with `<let/n=0/><button onClick(){ n++ }>go</button>` makes the dom compile succeed and emit `_attr_content($scope, void 0, undefined);` in `$setup`.
+`analyze.enter` only creates `kNativeTagBinding` when `node.var || hasDynamicAttributes || hasEventHandlers || textPlaceholders || injectNonce || isDynamicControllable(...)`, and a `content=` value Babel evaluates confidently trips none of them — yet `getUsedAttrs` records it as `staticContentAttr` and `translate.dom.enter` still emits `_attr_content(scope, visitAccessor, value)`. A file containing only `<div content=undefined/>` therefore aborts `-o dom` in debug and optimize with "Marko internal error: analysis marked this template's setup export as empty but translation produced statements for it", while `-o html` compiles — SSR-only checks pass and only the client build breaks. With other setup work present it compiles instead and emits `_attr_content($scope, void 0, undefined)`, whose `undefined` accessor touches stray `"…undefined"` scope keys rather than the tag's. Fix by adding a non-`meta` `content` attribute to the binding gate, or by dropping a confidently void `content` in `analyze.enter` the way the body-wins case already calls `dropNodes(attr.value)`. See also "Enable branch machinery at every `_attr_content` site…" — it is this same static-`content=` emission its translator latch must cover, so the drop-the-void-`content` fix here changes its scope. Re-verify: `pnpm run compile -o dom -d` on exactly `<div content=undefined/>` throws, and prefixing it with `<let/n=0/><button onClick(){ n++ }>go</button>` makes it succeed.
 
-## Reject a `<style>` interpolation inside an unquoted `url()` — the emitted `url(var(--…))` silently invalidates the whole declaration
+## Reject a `<style>` interpolation inside an unquoted `url()` — the emitted `url(var(--…))` silently invalidates the declaration
 
 `packages/runtime-tags/src/translator/util/style-interpolation.ts` › `checkStyleInterpolations` | 2026-07-27 | impact:med | effort:low
 
-`checkStyleInterpolations` rejects a `${...}` in a selector, an at-rule prelude, a property name, a quoted string, and glued to a unit, but not inside an unquoted `url(...)`, which fails just as hard: `url(` followed by a non-quote is tokenized as a raw `<url-token>` that ends at the first `)`, so the substituted `var(--…)` is never resolved and the leftover `)` makes the declaration invalid. `<style>\n.a { background: url(${x}); }\n</style>` compiles with no diagnostic and extracts `.a { background: url(var(--M_…)); }`, for which Chromium computes `background-image: none` — the rule is dropped with no compile-time or runtime signal, and `url(a.png?v=${x})` behaves the same. The docs at <https://markojs.com/docs/reference/core-tag#style> list only selectors, at-rule preludes, property names and quoted strings as illegal positions, so an author has no way to discover this; note `@import url(${x})` happens to be caught as a prelude, but a declaration-level `url(${x})` and a nested `image-set(url(${x}) 1x)` are not. The function already tracks `groupDepth` for `(`/`[`, so the fix is to record whether a group was opened by a `url` ident and throw a message in the `styleStringMsg` family, pointing at moving the whole `url(...)` into the interpolated value (`background: ${x}` with `x = "url(a.png)"` resolves correctly) or at `html-style`. Re-verify: `pnpm run compile -o html -d` on `<let/x="a.png"/>` plus `<style>\n.a { background: url(${x}); }\n</style>` succeeds, while the same file with `.a::after { content: "${x}"; }` fails with the "is not substituted inside a quoted CSS string" error.
-
-## Ignore `MarkoComment` children in `assertNoBodyContent` — a comment-only `<attrs>`/`<effect>` body is a hard compile error
-
-`packages/runtime-tags/src/translator/util/assert.ts` › `assertNoBodyContent` | 2026-07-27 | impact:low | effort:low
-
-`assertNoBodyContent` tests `tag.node.body.body.length` raw, but Marko comments survive in `body.body` until `visitors/comment.ts` › `translate.exit` calls `comment.remove()`, so a body holding nothing but a comment is a hard compile error: `<attrs/{ a }><!-- todo --></attrs>` and `<effect() { … }><!-- todo --></effect>` both fail with "The `<attrs>` tag does not support body content." even though the tag renders nothing and the same tag with an empty or whitespace-only body compiles. Those two are the only reachable callers — the other seven (`const`, `let`, `id`, `return`, `log`, `debug`, `lifecycle`) set `parseOptions.openTagOnly` so the parser rejects the close tag first with `The closing "let" tag was not expected`, `<script>` sets `parseOptions.text` so its body is parsed as JS, and concise-mode `//` / `/* */` comments are dropped by the parser — so only HTML-style comments on these two (deprecated, migrate-phase) tags trip it. `translator/util/is-only-child-in-parent.ts` › `getOnlyChildParentTagName` already filters `node.type !== "MarkoComment"` for exactly this kind of body-length test; `tag.node.body.body.some((child) => child.type !== "MarkoComment")` here matches it. This is a different defect from the entry "SSR silently drops `content=` on void and text-only native tags, and on any tag whose body is only Marko comments", which is about `visitors/tag/native-tag.ts` silently discarding a `content=` attribute; this one is the shared assert helper raising a wrong error that stops the build outright. Re-verify: `pnpm run compile -o html -d` on a file containing `<effect() { console.log(1) }>`, then an indented `<!-- todo -->`, then `</effect>` prints "does not support body content", while deleting only the comment line compiles and writes the `.marko.js`.
+`checkStyleInterpolations` rejects a `${...}` in a selector, at-rule prelude, property name, quoted string and glued to a unit, but not inside an unquoted `url(...)`, where `url(` followed by a non-quote tokenizes as a raw url-token ending at the first `)`, so the substituted `var(--…)` never resolves and the declaration is dropped. `<style>.a { background: url(${x}); }</style>` compiles with no diagnostic and extracts `.a { background: url(var(--M_…)); }`; `image-set(url(${x}) 1x)` behaves the same, and the core-tag docs list only the other illegal positions, so an author cannot discover it. The function already tracks `groupDepth`, so record whether a group was opened by a `url` ident and throw a `styleStringMsg`-family error pointing at moving the whole `url(...)` into the interpolated value or at `html-style`. Re-verify: `pnpm run compile -o html -d` on `<let/x="a.png"/>` plus `<style>.a { background: url(${x}); }</style>` succeeds today, while the same file with `.a::after { content: "${x}"; }` fails with the "is not substituted inside a quoted CSS string" error.
 
 ## Use the cooked value, not `raw`, for a single-quasi template-literal tag name
 
 `packages/runtime-tags/src/translator/util/get-tag-name.ts` › `getTagName` | 2026-07-27 | impact:low | effort:low
 
-`analyzeTagNameType` classifies a single-quasi `TemplateLiteral` tag name as `TagNameType.NativeTag` — a supported form, covered by the `native-tag-name` fixture — but `getTagName` returns `quasis[0].value.raw`, so escape sequences in the name are never decoded and reach the emitted markup verbatim. A file whose only line is ``<${`h\x31`}>hi</>`` compiles to `$template = "<!><h\\x31>hi</h\\x31><!>"` in DOM output and `_html("<h\\x31>hi</h\\x31>")` in HTML output — an element name containing a literal backslash, with no diagnostic — and the same happens for the escapes a template literal _requires_, so a backtick escaped as ``\` `` inside the name is emitted as a backslash-backtick pair rather than a backtick. Reading `quasis[0].value.cooked` is the whole fix: `cooked` is always populated on this path because an invalid escape in an untagged template literal is already a hard compile error ("Invalid escape sequence in template."), so no `?? raw` fallback is needed. The trigger is exotic — escapes in tag names are rare — but it is a silent miscompile of otherwise-supported syntax, and the only consumer that reads the value as markup is the native-tag emitter (`visitors/tag/native-tag.ts`), since `isCoreTag` needs a resolvable `getTagDef` and the attribute-tag lookups key on `@`-prefixed string names. Re-verify: write ``<${`h\x31`}>hi</>`` as the only line of a `.marko` file, run `pnpm run compile -o dom -d` on it, and read the `$template` constant — it says `<h\x31>` where it should say `<h1>`.
+`analyzeTagNameType` classifies a single-quasi `TemplateLiteral` tag name as `TagNameType.NativeTag` (a supported form, covered by the `native-tag-name` fixture), but `getTagName` returns `quasis[0].value.raw`, so escape sequences in the name are never decoded and reach the emitted markup verbatim with no diagnostic. Reading `quasis[0].value.cooked` is the whole fix: `cooked` is always populated here because an invalid escape in an untagged template literal is already a hard parse error, and the only consumer that emits the value as markup is `visitors/tag/native-tag.ts`. Re-verify: compile a file whose only line is ``<${`h\x31`}>hi</>`` with `-o dom -d` and read `$template` — it says `<h\x31>` where it should say `<h1>`.
 
-## Emit real load machinery (or a compile error) when a Tags-API parent lazily imports a Class-API child — the DOM output references an undeclared identifier
+## Route `tagNameLoad` through the compat dynamic-tag path when a Tags-API parent lazily imports a Class-API child
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `translate.exit` | 2026-07-27 | impact:med | effort:med
 
-`analyzeTagName` (`translator/util/tag-name-type.ts`) downgrades a custom tag whose child template is Class API to `TagNameType.DynamicTag`, but leaves the `extra.tagNameLoad` that `analyzeExpressionTagName` already attached, so `translate.exit`'s DOM branch still sees `allKnownTagReferences` and deletes the whole `import Child from "./child.marko" with { load: … }` declaration — while the compat dynamic-tag path that actually translates the tag never reads `tagNameLoad` and emits a plain `_dynamic_tag($scope, Child, …)`. The emitted module is left with `Child` as a free identifier, so `$setup` throws `ReferenceError: Child is not defined` at first render (or the bundler fails to resolve it) with zero compile diagnostics. Declaring the import by hand would not help either: compiling that Class child with `entry: "load"` routes through the Marko 5 program visitor and emits `import "./child.marko"; init();` instead of the `ready(<readyId>)` call the lazy runtime waits on, and every `fixtures-interop/lazy-class-child*` fixture uses a Class parent, so the Tags→Class lazy boundary has no coverage at all. Either route `tagNameLoad` through the compat dynamic-tag path (Marko 5's own `loadTag` helper already backs the Class-parent direction) or raise a `buildCodeFrameError` in `analyze` when a `load` import resolves to a Class-API template. This is a different defect from the entry `Strip the `load` import attribute from HTML output — it is emitted verbatim and Node rejects it`, which is the HTML branch of the same function leaking `with { load: … }` into the server module rather than the DOM branch dropping the declaration outright. Re-verify: compile `parent.marko` = `import Child from "./child.marko" with { load: "render" }` + `<Child value=1/>` against `child.marko` = `class { onMount() {} }` + `<div>${input.value}</div>` with `{ output: "dom", linkAssets: { runtime: "asset-runtime", onAsset() {} }, translator: "marko/translator" }` — the only `Child` in the emitted module is the bare argument to `$dynamicTag`, and parsing the output with Babel puts `Child` in the Program scope's `globals`; swapping in a Tags-API child leaves `globals` empty.
+`analyzeTagNameType` downgrades a custom tag whose child template is Class API to `TagNameType.DynamicTag` but leaves `extra.tagNameLoad` attached, so `translate.exit`'s DOM branch still sees `allKnownTagReferences` and deletes the whole `import Child … with { load: … }`, while the compat dynamic-tag path never reads `tagNameLoad` and emits a bare `$dynamicTag($scope, Child, …)`. `Child` is left undeclared, so `$setup` throws `ReferenceError` at first render with zero diagnostics, and every `fixtures-interop/lazy-class-child*` fixture uses a Class parent, so this direction is uncovered. Either wire `tagNameLoad` into the compat path or `buildCodeFrameError` in `analyze` when a `load` import resolves to a Class-API template. Re-verify: compile a `<!-- use tags -->` parent holding that import plus `<Child value=1/>` against a `class {}` child with `{ output: "dom", linkAssets, translator: "marko/translator" }`; Babel puts `Child` in the Program scope's `globals`, empty with a Tags-API child.
 
-## Bound `getTagsDir` at the package root — an ancestor directory named `tags` makes every Class API template in the project fail to compile
+## Bound `getTagsDir` at the package root — an ancestor directory named `tags` breaks every Class API template under it
 
 `packages/runtime-tags/src/translator/interop/feature-detection.ts` › `getTagsDir` | 2026-07-27 | impact:med | effort:low
 
-`getTagsDir` scans the whole absolute filename right-to-left for a path segment named `tags` (stopping only at a nearer `components`) with no upper bound, so it matches directories the taglib finder never registered: `packages/compiler/src/taglib/finder/index.js` › `find` deliberately stops its own upward walk at the nearest package root (`rootPkg.__dirname`, else `markoModules.cwd`). When the two disagree, `isTagsAPI` records the synthetic `Template file within a tags directory` feature and any Class API construct in the file then throws `Cannot mix Tags API and Class API features in the same file`, so a monorepo package named `tags` — or a checkout that merely lives under a `tags/` folder — cannot compile a single Marko 5 template, with no workaround but renaming the directory. That the directory is not a real tag directory is easy to show in the same tree: a `<hello/>` referencing `<root>/tags/hello.marko` from `<root>/tags/app/src/` fails with `Unable to find entry point for custom tag`, yet `<root>/tags/app/src/page.marko` is still reported as being "within a tags directory". Bound the scan at the same package-root boundary `find` uses, or better, have the lookup expose the tag-discovery dirs it actually registered so detection stops string-matching absolute paths; while there, give the synthetic feature a real location, since the aggregate error currently prints an empty code frame for it (visible in `fixtures-interop/error-class-tags-dir/__snapshots__/error-compile-html.txt`). Re-verify: `mkdir -p /tmp/t/packages/tags/src`, write `{"name":"a","version":"1.0.0"}` to `/tmp/t/packages/tags/package.json` and `class {}` + `<h1>hi</h1>` to `/tmp/t/packages/tags/src/page.marko`, then `pnpm run compile -t class -o html -d /tmp/t/packages/tags/src/page.marko` fails with the mixing error, while renaming `packages/tags` to `packages/tag` compiles the identical file.
+`getTagsDir` scans the whole absolute filename right-to-left for a `tags` segment with no upper bound, while `packages/compiler/src/taglib/finder/index.js` › `find` stops its own walk at the nearest package root (`rootPkg.__dirname`, else `markoModules.cwd`). When they disagree, `isTagsAPI` records the synthetic `Template file within a tags directory` feature and any Class API construct then throws `Cannot mix Tags API and Class API features in the same file`, so a package named `tags` cannot compile one Marko 5 template and the only workaround is renaming the directory. Bound the scan at the same package-root boundary, and give the synthetic feature a real location — today it prints an empty code frame (`fixtures-interop/error-class-tags-dir/__snapshots__/error-compile-html.txt`). Re-verify: `class {}` + `<h1>hi</h1>` at `<tmp>/packages/tags/src/page.marko` beside a `package.json` fails `-t class -o html -d` with the mixing error, while renaming `tags` to `tag` compiles the identical file.
 
-## Restore the enclosing whitespace-preservation state when a preserve-whitespace tag closes — a `<textarea>` inside `<pre>` collapses the rest of the `<pre>`
+## Restore the enclosing whitespace-preservation state when a preserve-whitespace tag closes
 
-`packages/compiler/src/babel-plugin/parser.js` › `parseMarko (the `preservingWhitespaceUntil` slot)` | 2026-07-27 | impact:low | effort:low
+`packages/compiler/src/babel-plugin/parser.js` › `parseMarko` (the `preservingWhitespaceUntil` slot) | 2026-07-27 | impact:low | effort:low
 
-`preservingWhitespaceUntil` is a single slot: `onOpenTagName` overwrites it with the current tag node whenever that tag's `parseOptions.preserveWhitespace` is set (`:341`), and `onCloseTagEnd` clears it to `undefined` when the node closes (`:585`) instead of restoring whatever it held before. `<pre>`, `<textarea>`, `<script>` and `<style>` are exactly the four tags carrying `preserveWhitespace` in `src/taglib/marko-html.json`, and the last three nest legally inside `<pre>`, so `<pre>A   B` / an indented `<textarea>t</textarea>` / `C   D` / `</pre>` emits the text before the nested tag verbatim but collapses everything after it to ` C D` — silent whitespace corruption inside a `white-space: pre` element with no diagnostic, on the Marko 5 (`-t class`) translator as well since the damage happens in the shared parser. The same slot is seeded with the file-wide `htmlParseOptions.preserveWhitespace` flag (`:54-55`), so under that option the first `<pre>`/`<script>`/`<style>`/`<textarea>` in a file turns preservation off for everything that follows. Fix by saving the previous value — on the tag node, or in a small stack — in `onOpenTagName` and restoring it in `onCloseTagEnd` rather than assigning `undefined`. Re-verify: `pnpm run compile -o html -d` on a file containing `<pre>A   B`, an indented `<textarea>t</textarea>`, `C   D`, `</pre>` emits ``_html(`<pre>A   B\n  <textarea>${_textarea_value("t")}</textarea> C D</pre>`)``, while replacing only the `<textarea>` with a `<span>` emits `_html("<pre>A   B\n  <span>t</span>\nC   D\n</pre>")`.
+`preservingWhitespaceUntil` is a single slot: `onOpenTagName` overwrites it with the current tag node whenever `parseOptions.preserveWhitespace` is set, and `onCloseTagEnd` clears it to `undefined` instead of restoring what it held before. `<textarea>`, `<script>` and `<style>` all nest legally inside `<pre>`, so `<pre>A   B` / an indented `<textarea>t</textarea>` / `C   D` / `</pre>` collapses everything after the nested tag down to a single space plus `C D` — silent corruption inside a `white-space: pre` element, on `-t class` too since the parser is shared. The slot is also seeded from the file-wide `htmlParseOptions.preserveWhitespace`, so under that option the first such tag disables preservation for the rest of the file. Save the previous value in `onOpenTagName` and restore it in `onCloseTagEnd`. Re-verify: `-o html -d` on that file emits `<textarea>…</textarea> C D</pre>`, while swapping the `<textarea>` for a `<span>` keeps `C   D` intact.
 
 ## Pass the attribute value's end offset when parsing it — a bad attribute value swallows the rest of the file
 
 `packages/compiler/src/babel-plugin/parser.js` › `onAttrValue` | 2026-07-27 | impact:med | effort:low
 
-`onAttrValue` and `onAttrSpread` call `parseExpression(file, raw, part.value.start)` without the `sourceEnd` argument that every other handler in the same adapter passes (`onPlaceholder`, `onScriptlet`, `onTagVar`, `onTagParams`, `onTagArgs`, `onAttrMethod` all pass `value.start, value.end`). When that parse fails, `createParseError` in `packages/compiler/src/babel-utils/parse.js` computes `source: file.code.slice(start, undefined)` — the whole remainder of the file — and `getLocRange`'s `findLoc(lineIndexes, line, undefined)` returns an end position whose `column` is missing on line 1 and `NaN` on any later line, leaving `node.end` undefined. Two consequences follow: `output:"source"` and `output:"migrate"` print `MarkoParseError` as `this.token(node.source)` via the generator patch, so everything after the bad attribute is emitted twice (a formatter or codemod writing its output back doubles the file — and `output:"source"` returns before the parse-error check in `babel-plugin/index.js`, so this happens without `errorRecovery` too); and `getBoundedRange` discards Babel's real error location whenever it lands past the bogus end line, so a multi-line attribute value reports "Unexpected token" at the value's opening paren instead of the offending token, while the identical mistake inside `${…}` (which does pass `value.end`) reports exactly. Fix: pass `part.value.end` at both call sites, and in `withWrappedAttrValueHint`'s probe. Re-verify from the repo root: `node -r ~ts -e 'const {compileSync}=require("./packages/compiler/src/index.js");const t={translate:{},taglibs:[],tagDiscoveryDirs:[]};const o={output:"source",errorRecovery:true,translator:t};console.log(compileSync("<div foo=(1+)>hi</div>\n<span>tail</span>","x.marko",o).code);console.log("--- control ---");console.log(compileSync("<div>${1+}</div>\n<span>tail</span>","x.marko",o).code)'` prints the whole template twice, while the `${1+}` control round-trips once.
+`onAttrValue` and `onAttrSpread` call `parseExpression(file, raw, part.value.start)` without the `sourceEnd` every sibling handler passes, so on failure `createParseError` (`babel-utils/parse.js`) sets `source` to the whole remainder of the file and leaves `node.end` undefined. `output:"source"`/`"migrate"` then print `MarkoParseError` as `this.token(node.source)`, re-emitting everything after the bad attribute twice — and `isSource` returns before the parse-error check in `babel-plugin/index.js`, so a formatter or codemod doubles the file even without `errorRecovery`. `getBoundedRange` also drops Babel's real location, so a multi-line attribute value reports "Unexpected token" at its opening paren while the same mistake inside `${…}` points at the offending token. Pass `part.value.end` at both call sites and in `withWrappedAttrValueHint`'s probe. Re-verify: `compileSync("<div foo=(1+)>hi</div>\n<span>tail</span>", "x.marko", { output: "source", translator: … })` prints the template twice; the `${1+}` control round-trips once.
 
 ## Use the trimmed length, not `rawValue.length`, for a text node's end offset in `onText`
 
 `packages/compiler/src/babel-plugin/parser.js` › `onText` | 2026-07-27 | impact:med | effort:low
 
-The deferred `onNext` closure inside `onText` re-locates a trimmed text node with `withLoc(node, { start: trimmedStart, end: trimmedStart + rawValue.length })` where `trimmedStart = part.start + rawValue.indexOf(value)` — the start is advanced past the removed leading whitespace but the length is still the untrimmed `rawValue.length`, so the end overshoots by exactly the number of leading characters trimmed. Every text node preceded by a newline plus indentation (i.e. normal formatting) is affected: `<div>\n    hello\n</div>` produces a `MarkoText` whose `value` is `"hello"` but whose `loc` spans `"hello\n</div"`, and across `packages/runtime-tags/src/__tests__/fixtures` 147 of 1171 `MarkoText` nodes carry a `loc` whose source extent does not correspond to their value (102 templates). That corrupts every consumer of text-node ranges — editor tooling, codemods, and the source maps emitted for `output: "source"` / `"migrate"`, where a deeply indented trailing text node pushes the end past EOF: `<div>\n` + 20 spaces + `hello</div>\n` compiled with `output: "source", sourceMaps: true` decodes to an original position of line 3 column 14 on a zero-length line 3, which disappears when the indentation is removed. The fix is `end: trimmedStart + value.length`, symmetric with the start. Re-verify from the repo root: `node -r ~ts -e 'const {compileSync}=require("./packages/compiler/src/index.js");const src="<div>\n    hello\n</div>";const {ast}=compileSync(src,process.cwd()+"/x.marko",{output:"source",ast:true,translator:{translate:{},taglibs:[],tagDiscoveryDirs:[]}});const n=ast.program.body[0].body.body[0];const L=src.split("\n"),off=p=>L.slice(0,p.line-1).reduce((a,l)=>a+l.length+1,0)+p.column;console.log(JSON.stringify(n.value),JSON.stringify(n.loc),JSON.stringify(src.slice(off(n.loc.start),off(n.loc.end))));'` prints `"hello" {"start":{"line":2,"column":4},"end":{"line":3,"column":5}} "hello\n</div"` instead of an end at line 2 column 9 covering `"hello"`.
+The deferred `onNext` closure re-locates a trimmed text node with `end: trimmedStart + rawValue.length`, but `trimmedStart = part.start + rawValue.indexOf(value)` already skipped the removed leading whitespace, so the end overshoots by exactly the number of trimmed leading characters. Every text node preceded by a newline plus indentation — normal formatting — is affected, corrupting consumers of text-node ranges: editor tooling, codemods, and the source maps emitted for `output: "source"`/`"migrate"`, where a deeply indented trailing text node pushes the end past EOF. The fix is `end: trimmedStart + value.length`, symmetric with the start. Re-verify: compile `"<div>\n    hello\n</div>"` with `{ output: "source", ast: true }`; the `MarkoText` value is `"hello"` but its `loc` (2:4 → 3:5) spans `"hello\n</div"`.
 
-## Stop reindenting `<pre>`/`<textarea>`/`<style>` bodies when re-printing `.marko` source
+## Skip the source printer's reindent for whitespace-preserving tags
 
 `patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med
 
-The `.marko` source printer used by `output: "source"`/`"migrate"` pretty-prints every non-void tag body with `this.newline(1); this.indent(); this.print(node); this.dedent();` plus a trailing `newline(1)`, guarded only by `voidElements`, `svgElements`, the concise `style { … }` `rawValue` form and the `script value=() => {}` body override — nothing consults the whitespace-preserving tags that `packages/compiler/src/taglib/marko-html.json` declares via `parse-options.preserveWhitespace` (`pre`, `script`, `style`, `textarea`). Since those bodies render verbatim, re-printing silently changes what users see and is not a fixed point: `<pre>\nHello\n  World\n</pre>` becomes `<pre>\n  \nHello\n  World\n\n</pre>` after one pass and gains another indented blank line and another trailing newline on every subsequent pass, and `<textarea>abc</textarea>` compiles from `_textarea_value("abc")` to `_textarea_value("  abc\n")` after a round trip. This matters because `packages/runtime-class/bin/markoc.js` `--migrate` rewrites each `.marko` in place (`var outPath = args.migrate ? path : path + ".js"`), so a single codemod run corrupts rendered content — the shipped fixtures `packages/runtime-class/test/render/fixtures/{whitespace-pre,whitespace-textarea}/template.marko` both break on pass one, and the committed migrate snapshots under `packages/runtime-class/test/translator/fixtures/{textarea-tag,white-space-test}/snapshots/generated-expected.marko` already bake the injected whitespace in. Fix by adding a `preserveWhitespaceElements` set next to the existing `voidElements`/`svgElements` sets in the patched generator and, for those tags, emitting the body between the tags with no `newline`/`indent`/`dedent` (the concise `style { … }` branch is the shape to copy); regenerating the patch also requires refreshing those two snapshots. Re-verify from the repo root: `node -r ~ts -e 'const {compileSync}=require("./packages/compiler/src/index.js");const f=process.cwd()+"/packages/runtime-tags/src/probe.marko";const T="./packages/runtime-tags/src/translator/index.ts";let s="<pre>\nHello\n  World\n</pre>\n";console.log(JSON.stringify(s));for(let i=0;i<2;i++)console.log(JSON.stringify(s=compileSync(s,f,{output:"source",translator:T}).code));'` prints `"<pre>\n  \nHello\n  World\n\n</pre>"` then `"<pre>\n  \n  \nHello\n  World\n\n\n</pre>"`, and recompiling each with `output: "html"` emits a correspondingly different `<pre>…</pre>` literal.
+The patched `MarkoTag` printer wraps every non-void body in `newline(1)`/`indent()`/`dedent()` plus a trailing `newline(1)`, guarded only by `voidElements`, `svgElements` and the concise `style`/`script` forms — never by the `parse-options.preserveWhitespace` tags (`pre`, `script`, `style`, `textarea`) declared in `packages/compiler/src/taglib/marko-html.json`. Those bodies render verbatim, so `output:"source"`/`"migrate"` silently rewrites user content and never reaches a fixed point, and `packages/runtime-class/bin/markoc.js --migrate` rewrites each file in place. Add a `preserveWhitespaceElements` set beside `voidElements` and print those bodies with no newline/indent (the concise `style { … }` branch is the shape to copy); the committed `packages/runtime-class/test/translator/fixtures/{textarea-tag,white-space-test}/snapshots/generated-expected.marko` already bake the extra whitespace and need refreshing. Re-verify: round-tripping `<textarea>abc</textarea>` through `output:"source"` turns the `output:"html"` result's `_textarea_value("abc")` into `_textarea_value("  abc\n")`.
 
-## Merge instead of replace the attribute a `"@x <x>"` shorthand already declared — `required`, `default-value` and `autocomplete` are silently discarded
+## Merge instead of replace the attribute a `"@x <x>"` shorthand already declared
 
 `packages/compiler/src/taglib/loader/loadTagFromProps.js` › `TagLoader["*"]` | 2026-07-27 | impact:med | effort:low
 
-The `<`-branch of the shorthand handler unconditionally runs `tag.addAttribute(loadAttributeFromProps(nestedTag.targetProperty, { type: "object" }, …))` for every non-repeated nested tag, and `Tag.addAttribute` assigns straight into `this.attributes[attr.name]`, so on a combined key like `"@label <label>"` the bare `{type:"object"}` overwrites the attribute the `@`-half just built from the author's own props — `type`, `description`, `required`, `default-value`, `deprecated`, `preserve-name` and `autocomplete` are all thrown away, as is the `attrProps.type = "expression"` default the handler sets a few lines earlier (which therefore only survives for `[]`-repeated nested tags). This is not just editor metadata: `required` and `default-value` are compile-time behavior in `packages/runtime-class/src/translator/tag/util.js`, so a tag declaring `"@label <label>": {"type":"string","default-value":"L","required":true}` emits no `label` property and raises no "attribute is required" error, while the identical declaration written as plain `"@label"` does both — and Marko's own core taglib hits this, with `<await>`'s `"@then <then>"`/`"@catch <catch>"`/`"@placeholder <placeholder>"` (`packages/runtime-class/src/translator/taglib/core/index.js`) reduced to `{type:"object"}` with their `autocomplete` entries gone. Four lines up, `nestedTag.targetProperty = attrProps.targetProperty || nestedTagTargetProperty` reads only the camelCase key and overwrites whatever `loadTagFromProps` already resolved, so the dashed `"target-property"` spelling that the longhand `nested-tags` form accepts (pinned by `packages/runtime-class/test/taglib-loader/fixtures/repeated-nested-tag`) is silently dropped in shorthand and the target property falls back to the nested tag name. Direction: only synthesize the `{type:"object"}` attribute when the `@`-half did not already declare one (or merge just the type into the existing attribute), and take the target property from the already-loaded `nestedTag` rather than the raw `attrProps` key; note that `fixtures/shorthand-attrs-and-tags` passes today only because its declaration is `"@label <label>": "object"`, so the clobber is invisible there. Re-verify: `node -r ~ts -e 'const t=require("@marko/compiler").taglib.buildLookup("packages/runtime-class/test","marko/translator").getTag("await");console.log(JSON.stringify(t.attributes.then),!!t.attributes.name.autocomplete)'` prints a `then` attribute of type `object` with no `autocomplete` followed by `true` for the sibling `@name`.
+For each non-repeated nested tag the `<`-branch unconditionally adds `loadAttributeFromProps(nestedTag.targetProperty, {type:"object"})`, and `Tag.addAttribute` assigns straight into `this.attributes[attr.name]`, so `"@label <label>"` clobbers the attribute the `@`-half just built, discarding `type`, `required`, `default-value`, `description` and `autocomplete`. That is compile-time behavior — `packages/runtime-class/src/translator/tag/util.js` reads `defaultValue`/`required` — so `"@label <label>": {"type":"string","default-value":"L","required":true}` emits no default and no "attribute is required" error where plain `"@label"` does both, and core `<await>`'s `"@then <then>"` loses its autocomplete. Nearby, `nestedTag.targetProperty = attrProps.targetProperty || nestedTagTargetProperty` reads only the camelCase key, dropping the dashed `"target-property"` spelling the longhand `nested-tags` form accepts. Synthesize `{type:"object"}` only when the `@`-half declared none, and take the target property from the already-loaded `nestedTag`. Re-verify: `buildLookup("packages/runtime-class/test","marko/translator").getTag("await").attributes.then` is type `object` with no `autocomplete`, while sibling `name` keeps its own.
 
-The same handler corrupts its own input, which is a second way the shorthand loses attributes. It partitions a key's definition into `attrProps`/`tagProps` by `delete value[k]`-ing every recognized property out of the object it was handed, using "whatever is left" as the unsupported-property check (`isObjectEmpty(value)`). When one key declares more than one nested tag — `"@panels <panel> <pane>"` — the parts loop calls `loadTagFromProps(nestedTag, tagProps, …)` once per `<…>` part with the _same_ `tagProps`, so the first recursion strips the shared `@attr`/`<tag>` sub-objects and every nested tag after the first gets bare definitions with no `type`, `description`, `enum`, `required` or `default-value`. With `"@label": {"type":"string","default-value":"DEF"}` the Marko 5 translator emits `_marko_repeatable_attr_tag("panels", { "label": "DEF" })` for `<@panel/>` but `_marko_repeatable_attr_tag("panels", {})` for `<@pane/>`. The mutation also corrupts any props object loaded twice, which `taglib.register(id, props)` and the translator contract's `taglibs: [[id, props]]` both make possible since module-level JSON imports are require-cached — masked today only by the `loadedTranslatorsTaglibs` memo that `clearCaches()` never resets. Partition out of a shallow copy of `value`, or record consumed keys in a `Set` and derive the leftover list from that. Re-verify: `node -r ~ts -e 'const {taglib}=require("@marko/compiler");const l=taglib._loader;const t=l.loadTaglibFromProps(l.createTaglib("/x/marko.json"),{"<t>":{"@a <p> <q>":{"@label":{type:"string",description:"d"}}}});for(const n in t.tags.t.nestedTags)console.log(n,JSON.stringify(t.tags.t.nestedTags[n].attributes.label.type));'` prints `p "string"` then `q null`.
-
-## Key the taglib finder cache on the tag-discovery dirs — the first translator to compile a directory silently picks the runtime for every later one
+## Key the taglib finder cache on the tag-discovery dirs
 
 `packages/compiler/src/taglib/finder/index.js` › `find` | 2026-07-27 | impact:med | effort:low
 
-`find(dirname, registeredTaglibs, tagDiscoveryDirs)` stores its result as `findCache[dirname]` and returns it verbatim on every later call, but both the walk it performs and the metadata it caches depend on the two arguments the key ignores: `tagDiscoveryDirs` is `["tags"]` for `@marko/runtime-tags/translator` and `["tags", "components"]` for the interop `marko/translator` (`packages/runtime-tags/src/translator/interop/index.ts`), and `registeredTaglibs` carries the calling translator's own core taglibs. In any process that compiles with both translators — the language server over a mixed Marko 5/6 workspace, a codemod or test harness — whichever one reaches a directory first freezes that directory's taglibs and its `exclusiveTagDiscoveryDirs` for the other. The damage is silent rather than an error: `exclusiveTagDiscoveryDirs` feeds `isTagsAPI` (`packages/runtime-tags/src/translator/interop/feature-detection.ts`), so a Class API template compiled through `marko/translator` after any Marko 6 compile in the same tree emits Marko 6 codegen against `@marko/runtime-tags/debug/html` instead of `marko/src/runtime/html/index.js`, with no diagnostic; in the same setup a `components/`-only tag also stops resolving, with `Unable to find entry point for custom tag`, and in the opposite order a Marko 6 template silently gains `components/` tags its `["tags"]` discovery should never see. Fold `tagDiscoveryDirs` and the registered-taglib set identity into the cache key (this is independent of the `getTagsDir` boundary entry, which is a filename string scan in feature-detection.ts and reproduces under a single translator). Re-verify from the repo root: create `/tmp/mfx` with `package.json` `{"name":"x","version":"1.0.0"}`, `tags/my-tag.marko` and `components/my-comp.marko`, then in two fresh processes compile `<div/>` at `/tmp/mfx/b.marko` with `translator:"marko/translator"` — alone the output requires `marko/src/runtime/html/index.js`, but preceded by a `compileSync("<my-tag/>", "/tmp/mfx/a.marko", {translator:"@marko/runtime-tags/translator"})` it requires `@marko/runtime-tags`; inserting only `require("@marko/compiler").taglib._finder.clearCache()` between the two compiles restores the Marko 5 output byte for byte.
+`find(dirname, registeredTaglibs, tagDiscoveryDirs)` caches as `findCache[dirname]`, but both the walk and the cached `exclusiveTagDiscoveryDirs` depend on the ignored arguments — `tagDiscoveryDirs` is `["tags"]` for `@marko/runtime-tags/translator` and `["tags","components"]` for the interop `marko/translator`. In any process compiling with both (language server over a mixed Marko 5/6 workspace, codemod, test harness) whichever translator reaches a directory first freezes it for the other, silently: `exclusiveTagDiscoveryDirs` feeds `isTagsAPI` (`packages/runtime-tags/src/translator/interop/feature-detection.ts`), so a Class API template compiled after any Marko 6 compile emits Marko 6 codegen against `@marko/runtime-tags/debug/html`, and a `components/`-only tag stops resolving. Fold `tagDiscoveryDirs` and the registered-taglib set identity into the cache key. Re-verify: in a dir holding `package.json`, `tags/` and `components/`, compiling `<div/>` with `marko/translator` requires `marko/src/runtime/html/index.js` alone but `@marko/runtime-tags/debug/html` when preceded by a `@marko/runtime-tags/translator` compile; `taglib._finder.clearCache()` between them restores it.
 
-## Clear the memoized per-translator taglib list in `taglib.clearCaches()` — a taglib added by `register()` after the first `buildLookup` is invisible forever
+## Clear the memoized per-translator taglib list in `taglib.clearCaches()`
 
 `packages/compiler/src/taglib/index.js` › `clearCaches` | 2026-07-27 | impact:med | effort:low
 
-`buildLookup` memoizes the whole `registeredTaglibs.concat(translator taglibs)` array per translator object in the module-level `loadedTranslatorsTaglibs` Map, but `clearCaches()` resets only `loader`, `finder` and `lookupCache` — nothing reaches that Map. A taglib installed through the public `taglib.register(id, props)` (declared in `packages/compiler/index.d.ts` alongside `clearCaches`) is therefore dropped for every translator that has already been used, permanently, so the behavior is order-dependent: register before the first compile and the tag resolves, register after it and every later compile fails with `Unable to find entry point for custom tag` even though `register()` returned successfully and the documented cache clear was called. This is a regression rather than intent — `9dc4d07d1b` ("fix: support manually registered taglibs") deliberately kept `registeredTaglibs.concat(...)` outside the memo, and `4fc38e8001` moved it inside while adding the `onError` hook. Clear `loadedTranslatorsTaglibs` in `clearCaches` and invalidate it from `register`, or move the `registeredTaglibs` half back out of the memo so only the translator's own loaded taglibs are cached. Re-verify from the repo root: `d=$(mktemp -d); printf '{"name":"x"}' > "$d/package.json"; printf '<b>late</b>' > "$d/late.marko"; D="$d" node -r ~ts -e 'const{taglib}=require("@marko/compiler"),T="@marko/runtime-tags/translator",D=process.env.D;const has=t=>!!taglib.buildLookup(D,t).getTag("late-tag");console.log("before:",has(T));taglib.register("late",{"<late-tag>":{template:D+"/late.marko"}});taglib.clearCaches();console.log("after register+clearCaches:",has(T));taglib.clearCaches();console.log("memo bypassed:",has({...require(T)}));'; rm -rf "$d"` prints `false / false / true` — the third line uses a content-identical but distinct translator object, whose absence from the Map is the only reason the same registration becomes visible.
+`buildLookup` memoizes the whole `registeredTaglibs.concat(translator taglibs)` array per translator object in the module-level `loadedTranslatorsTaglibs` Map, but `clearCaches()` resets only `loader`, `finder` and `lookupCache`. A taglib installed through the public `taglib.register(id, props)` is therefore dropped forever for any translator already used: register before the first compile and the tag resolves, register after and every later compile fails with `Unable to find entry point for custom tag` even though `register()` succeeded and the documented cache clear ran. `9dc4d07d1b` deliberately kept that concat outside the memo; `4fc38e8001` moved it in. Clear `loadedTranslatorsTaglibs` in `clearCaches` and invalidate it from `register`, or move the `registeredTaglibs` half back out. Re-verify: after one `buildLookup(d, "@marko/runtime-tags/translator")`, then `register` plus `clearCaches`, `getTag("late-tag")` is still undefined, while the same lookup against a spread copy of the translator module resolves it.
 
-## Restore the dead `.js` preference in the tag-directory file scan — a sibling `index.css` is picked as the renderer
+## Restore the dead `.js` preference in the tag-directory file scan
 
 `packages/compiler/src/taglib/loader/scanTagsDir.js` › `getPath` | 2026-07-27 | impact:med | effort:low
 
-`getFileMap` keys each basename by extension _including the leading dot_ (`fileMap["index"][".js"]`), but `getPath`'s preference guard reads `if (file.js) return file[".js"]` — `file.js` is never assigned, so that branch is unreachable and resolution falls through to `for (let key in file) return file[key]`, returning whichever extension `readdirSync` happened to list first. This governs every extensionless entry in `searchFiles` (`renderer`, `index`, `migrate`, `transform`, `translate`, `parse`, `node-factory`, `code-generator`), so a Marko 5 tag directory holding `index.js` or `renderer.js` beside a same-basename sibling picks its renderer by filesystem order, and where entries come back sorted `.css` sorts before `.js` and the stylesheet wins: `<foo/>` against `components/foo/{index.js,index.css}` compiles silently to `require("./components/foo/index.css")` as the component renderer, which only fails much later at bundle or render time. Templates are unaffected because `searchFiles`' `.marko`/`.html` names are matched by full filename through `fileMap[name].__path`, so this is confined to JS-renderer tag dirs. Fix by reading `file[".js"]`, and replace the `for...in` fall-through with an explicit extension-preference list so resolution stops depending on `readdirSync` order at all. Re-verify from the repo root: create a temp dir with `package.json`, `components/foo/index.js` (a `module.exports = { renderer(){} }`), `components/foo/index.css` and `page.marko` containing `<foo/>`, then `compileSync(src, "<d>/page.marko", { output: "html", translator: "marko/translator", modules: "cjs" })` emits `require("./components/foo/index.css")`; deleting `index.css` makes the same compile emit `require("./components/foo/index.js")`.
+`getFileMap` keys each basename by extension including the leading dot (`fileMap["index"][".js"]`), but `getPath` guards with `if (file.js) return file[".js"]` — `file.js` is never assigned, so that branch is unreachable and resolution falls through to `for (let key in file) return file[key]`, returning whichever extension `readdirSync` listed first. This governs every extensionless `searchFiles` entry (`renderer`, `index`, `migrate`, `transform`, `translate`, `parse`, `node-factory`, `code-generator`), so `components/foo/{index.js,index.css}` silently compiles to `require("./components/foo/index.css")` as the renderer and only fails at bundle or render time; templates are unaffected because `.marko`/`.html` names match by full filename through `__path`. Read `file[".js"]` and replace the `for...in` fall-through with an explicit extension-preference list. Re-verify: with `components/my-widget/{index.js,index.css}` and `<my-widget/>` in `page.marko`, `pnpm run compile -t class -o html -d page.marko` names `my-widget/index.css`; deleting the CSS makes the identical source name `index.js`.
 
-The layout that hits it ships in this repo: `packages/runtime-class/test/render/fixtures/include-component/components/my-component/index.js` is exactly the `index.js`-renderer shape, so adding a sibling `index.css` to such a directory is enough. A shorter repro than the `compileSync` one above: `mkdir -p /tmp/tl/components/my-widget`, write a `module.exports = { renderer(input, out) { out.write("<b>hi</b>"); } }` to `index.js` and any CSS to `index.css`, put `<my-widget/>` in `/tmp/tl/page.marko`, then `pnpm run compile -t class -o html -d /tmp/tl/page.marko` and grep the output for `my-widget/index` — it names the `.css`, and removing the `.css` makes the identical source name the `.js`.
-
-## Reject arguments-plus-body on custom tags — `assertAttributesOrArgs` tests `node.body.length` on a `MarkoTagBody`, so `<my-tag(x)>body</my-tag>` silently drops the body
+## Reject arguments-plus-body on custom tags — the `node.body.length` check is dead
 
 `packages/compiler/src/babel-utils/assert.js` › `assertAttributesOrArgs` | 2026-07-27 | impact:med | effort:low
 
-`assertAttributesOrArgs` guards with `args.length && (node.attributes.length > 0 || node.body.length)`, but `MarkoTag.body` is a `MarkoTagBody` node whose children live in `.body.body` — `.body.length` is always `undefined`, so the "or body present" half of the condition is permanently dead and only the attributes half ever fires (`assertNoParams` two functions up already reads `path.node.body.params`, confirming the node shape). On the custom-tag path this is silent content loss: `runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `analyze.enter` calls `assertAttributesOrSingleArg`, and a single argument replaces the whole input object so `input.content` can never be delivered, yet `<my-tag("a")>hi</my-tag>` compiles to `_myTag("a");` with the body discarded and no diagnostic, while the same tag written `<my-tag("a") class="b">hi</my-tag>` correctly fails with "Tag does not support arguments when attributes or body present."; the `<define>`/tag-var form behaves the same, emitting `MyTag.content(1)` for `<MyTag(1)>hi</MyTag>`. The obvious one-word repair to `node.body.body.length` is wrong — `assertAttributesOrArgs` is also the dynamic-tag guard (`visitors/tag/dynamic-tag.ts` › `analyze.enter`), and `runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/template.marko` (`<${x}(1, 2)>Fallback Body</>`) deliberately pairs arguments with a body as the null fallback, with `__snapshots__/render.md` rendering `Fallback Body`. Since `assertAttributesOrSingleArg` has exactly one caller (`custom-tag.ts`) and `assertAttributesOrArgs` exactly one (`dynamic-tag.ts`), move the body check into `assertAttributesOrSingleArg` — rejecting `node.body.body.some((child) => child.type !== "MarkoComment")`, matching `translator/util/is-only-child-in-parent.ts` › `getOnlyChildParentTagName` — and leave the shared helper attribute-only, then add the missing error fixture beside `fixtures/custom-tag-args-and-attributes-error`. Re-verify from the repo root: `d=$(mktemp -d); printf '{"<my-tag>":{"template":"./my-tag.marko"}}' > "$d/marko.json"; printf '<div>child: <${input.content}/></div>\n' > "$d/my-tag.marko"; printf '<my-tag("a")>hi</my-tag>\n' > "$d/t.marko"; pnpm run compile -o html -d "$d/t.marko"` writes a file whose only tag call is `_myTag("a");` with `hi` nowhere in it, while adding ` class="b"` to that tag makes the same command fail with the arguments-when-attributes-or-body error.
+The guard is `args.length && (node.attributes.length > 0 || node.body.length)`, but `MarkoTag.body` is a `MarkoTagBody` whose children live in `.body.body`, so `.body.length` is always `undefined` and only the attributes half fires. On the custom-tag path (`runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `analyze.enter` → `assertAttributesOrSingleArg`) a single argument replaces the whole input object, so `<my-tag("a")>hi</my-tag>` compiles to `_myTag("a");` with the body silently dropped, while `<my-tag("a") class="b">hi</my-tag>` correctly errors and `<MyTag(1)>hi</MyTag>` emits `MyTag.content(1)`. Do not simply switch to `node.body.body.length` — `assertAttributesOrArgs` is also the dynamic-tag guard, and `fixtures/dynamic-tag-args-null-fallback` (`<${x}(1, 2)>Fallback Body</>`) deliberately pairs arguments with a body. Move the body check into `assertAttributesOrSingleArg` (sole caller `custom-tag.ts`), rejecting `node.body.body.some((child) => child.type !== "MarkoComment")`, and add an error fixture beside `fixtures/custom-tag-args-and-attributes-error`. Re-verify: compiling `<my-tag("a")>hi</my-tag>` writes a file whose only tag call is `_myTag("a");` with `hi` nowhere in it.
 
-## Fold analyzed child templates into the compile cache's own invalidation
-
-`packages/compiler/src/babel-plugin/index.js` › `getMarkoFile` | 2026-07-27 | impact:low | effort:med
-
-`getMarkoFile` invalidates a cached file on its own content hash or a newer
-mtime among `metadata.marko.watchFiles`, which holds only taglib `marko.json`
-and plugin paths — never the child `.marko` templates analysis read. Those are
-recorded apart, in `metadata.marko.analyzedTags`, which the loop ignores, so a
-shared cache serves a stale parent after a child is edited: compiling
-`parent.marko` (consuming a child tag variable), rewriting `child.marko` from
-`<return=1/>` to a stateful `<return=x/>`, then recompiling the same parent
-source with the same cache returns byte-identical output with no `_el_resume`,
-while a fresh `new Map()` emits it.
-
-The reach is narrow, though, because `analyzedTags` is a consumer contract
-rather than an oversight. `@marko/vite` reads it into `transformAnalyzedTags`
-and walks it in `hotUpdate` to invalidate parent modules — commented "when a
-child tag template changes, parent templates that analyzed it may need
-recompilation" — and clears `baseConfig.cache` outright on every hot update, so
-no stale compiler entry survives a vite edit. What is left is
-`@marko/compiler/register`, which passes no `cache` and so uses the
-process-lifetime default, plus direct `compile[Sync]` reuse.
-
-Folding `analyzedTags` into the mtime loop fixes it, but has to be transitive —
-a parent's set lists only its direct children, so a grandchild edit otherwise
-still serves a stale parent — and a transitive set means every cache hit stats
-every template in the subtree. Weigh that against a defect the main integration
-already handles. The `stripTypes` half of this entry is not a defect: that option
-is for cli flows, which compile once per process, so no cache is ever shared
-across its settings — `getMarkoFile` now says so inline.
-
-## Forward `restOffset` wherever an array rest's binding is re-created — nested and aliased array rests compile to wrong DOM reads
+## Forward `restOffset` wherever an array rest's binding is re-created
 
 `packages/runtime-tags/src/translator/util/references.ts` › `createBindingsAndTrackReferences` | 2026-07-27 | impact:med | effort:med
 
-`restOffset` — the index shift that makes an array rest read `source[i + offset]` — is assigned only in the `Identifier` case of `createBindingsAndTrackReferences`, so every path that re-creates a rest's binding silently loses it: the `ObjectPattern`/`ArrayPattern` cases reuse `upstreamAlias` verbatim when `property === undefined` (discarding the caller's `excludeProperties` too), and `trackVarReferences` forwards `excludeProperties` but not `restOffset`. A nested array rest over `[1,2,3]` — `<const/[first, ...[second, third]] = arr/>` — compiles in DOM to `$second($scope, $scope.first)` and `$third($scope, $scope.arr[1])`, rendering `1|1|2`, while `-o html` emits the source pattern unchanged and renders `1|2|3`; the same shape in tag params, `<for|a, ...[b, c]| of=list>`, maps `b` to `$params[0]` and `c` to `$scope["#LoopKey"]`. Aliasing a rest through a tag variable — `<const/[a, ...rest] = arr/>` then `<const/copy = rest/>` — makes `getSignalFn` (`translator/util/signals.ts`) take its object-rest branch and materialize `copy` as `(({0: $temp, ...copy}) => …)($scope.arr)`, i.e. the plain object `{1:2,2:3}`, so `copy[0]` is `undefined` and `copy.length` compiles to `$scope.arr.length`; both cases are SSR/CSR divergence with no compile diagnostic, even though the docs advertise full JS destructuring for tag variables and params. Direct use of a rest (`<for|x| of=rest>`, `rest.join()`) and object rests are unaffected, which localizes the defect to `restOffset` propagation. Direction: give `Binding.restOffset` the same forwarding treatment `excludeProperties` already gets — set it in the `ObjectPattern`/`ArrayPattern` cases, stop reusing `upstreamAlias` as the pattern binding when the caller supplied `excludeProperties`/`restOffset`, and thread it through `trackVarReferences` — so `trackReference`'s shift branch and `getSignalFn`'s array-vs-object rest choice both key off a correct value. Re-verify: compile `<let/arr = [1, 2, 3]/>` + `<const/[first, ...[second, third]] = arr/>` + `<div>${first}|${second}|${third}</div>` with `npm run compile -- -o dom -d file.marko` — the emitted `$second` signal body is `_text($scope["#text/1"], $scope.first)` — while `-o html` emits `const [first, ...[second, third]] = arr;`.
+`restOffset` is assigned only in the `Identifier` case, so every path that re-creates a rest's binding drops it — the `ObjectPattern`/`ArrayPattern` cases reuse `upstreamAlias` verbatim when `property === undefined`, and `trackVarReferences` forwards `excludeProperties` but not `restOffset`. `<const/[first, ...[second, third]] = arr/>` then compiles in DOM to `$second` reading `$scope.first` and `$third` reading `$scope.arr[1]` (`1|1|2` vs HTML's `1|2|3`); `<for|a, ...[b, c]|>` maps `c` to `#LoopKey`; `<const/copy = rest/>` takes `getSignalFn`'s object-rest branch, so `copy.length` reads `$scope.arr.length`. All are silent SSR/CSR divergence with no diagnostic. Set `restOffset` in the pattern cases and thread it through `trackVarReferences`. Re-verify: `pnpm run compile -o dom -d` on the nested-rest template emits `_text($scope["#text/1"], $scope.first)` for `$second`.
 
-## Hand the raw `value` to `_attr_input_value`'s default helper; a void value writes `value=""` where SSR writes no attribute
+## Hand the raw `value` to `_attr_input_value`'s default helper
 
 `packages/runtime-tags/src/dom/controllable.ts` › `_attr_input_value` | 2026-07-27 | impact:med | effort:low
 
-`_attr_input_value` computes `normalizedValue = normalizeAttrValue(value) || ""` and hands that string to `setDefault`, but the attribute-backed defaults it dispatches to — `_attr_input_value_attribute_default`, and the attribute arm of `_attr_input_value_dynamic_default` — write it through `_attr(el, "value", …)`, which only removes the attribute for `undefined`. So an `undefined`/`null`/`false` `value` renders `value=""` on the client while `html/attrs.ts` › `_attr_input_value` returns `""` and emits no attribute at all; on a checkbox or radio that leaves `el.value` as `""` in CSR and the spec default `"on"` in SSR, so the form submits a different value depending on which half rendered it. It is reached by the idiomatic two-way shorthand — `<input type="hidden" value:=v/>` and `<input type="checkbox" value:=v/>` compile to `_attr_input_value(…, _attr_input_value_attribute_default)` via `getDOMControllableDefaultHelper` in `translator/visitors/tag/native-tag.ts` — and by an uncontrolled spread whose value later goes void (`<input ...{type:"checkbox", value:v}/>` updated from `"x"` to `undefined` leaves `value=""` instead of removing it; the spread's first render escapes only because `_attrs` claims the controllable before `type` is applied, so the dynamic default still sees `type === "text"`). The sibling `_attr_input_checkedValue_default` already passes the raw `value` to `_attr`, and `_attr_input_value_default` re-normalizes with its own `|| ""`, so passing `value` rather than `normalizedValue` to `setDefault` fixes every arm with no other change; nothing covers this today — `grep -rl _attr_input_value_attribute_default packages/runtime-tags/src/__tests__` returns no files. Re-verify from the repo root: `node -r ~ts -e 'const {JSDOM}=require("jsdom");const w=new JSDOM("<input type=checkbox>").window;globalThis.document=w.document;const c=require("./packages/runtime-tags/src/dom/controllable.ts");const h=require("./packages/runtime-tags/src/html/attrs.ts");const el=w.document.querySelector("input");c._attr_input_value({"#i":el},"#i",undefined,()=>{},c._attr_input_value_attribute_default);console.log("CSR",el.outerHTML,JSON.stringify(el.value));console.log("SSR",JSON.stringify(h._attr("value",undefined)))'` prints `CSR <input type="checkbox" value=""> ""` against an empty SSR string.
+`_attr_input_value` passes `normalizeAttrValue(value) || ""` to `setDefault`, but the attribute-backed defaults (`_attr_input_value_attribute_default`, and the attribute arm of `_attr_input_value_dynamic_default`) write it through `_attr`, which removes the attribute only for `undefined`. A void `value` therefore renders `value=""` in CSR while `html/attrs.ts` emits no attribute, so a checkbox or radio submits `""` client-side and the spec default `"on"` server-side. The idiomatic `<input type="checkbox" value:=v/>` compiles straight to `_attr_input_value(…, _attr_input_value_attribute_default)`, and no test covers it. Pass `value` rather than `normalizedValue` to `setDefault`; `_attr_input_value_default` re-normalizes anyway. Re-verify: under jsdom call `_attr_input_value({"#i":el},"#i",undefined,()=>{},_attr_input_value_attribute_default)` — the element becomes `<input type="checkbox" value="">` against an empty SSR string.
 
-## Re-apply a controlled `<select>`'s value when its options arrive, instead of adopting the browser's fallback selection and overwriting app state
+## Re-apply a controlled `<select>`'s value when its options arrive
 
 `packages/runtime-tags/src/dom/controllable.ts` › `_attr_select_value_script` | 2026-07-27 | impact:high | effort:low
 
-The `observeOnce({ childList: true, subtree: true })` callback treats any divergence between the live select and the controlled value as a user change and calls `onChange`, which reports `getSelectValue(el)` back through `valueChange`. When a controlled `<select>`'s options arrive after the initial render — fetched options, a lazily loaded chunk, a `<for>` over data that resolves later — the browser's "ask for a reset" auto-selects the first option the instant they are inserted, so the observer hands the app that first option and silently replaces the value it asked for; the element is left showing the wrong option too, since `setSelectValue(el, oldValue)` inside `onChange` runs against the stale controlled value and then the re-render follows the overwritten state. Preselecting a saved value over asynchronously loaded options is idiomatic, so this loses state on a page that is otherwise correct, with no error after mount. Fix inside the callback: capture the browser's fallback via `getSelectValue(el)` first, then re-apply the controlled value with `setSelectValue`, and fall through to `onChange` (reporting the captured fallback) only when the value still did not take — `el.selectedIndex < 0` for a single select, `el.selectedOptions.length !== value.length` for `multiple`. Both the ordering and the `selectedIndex` test are load-bearing: re-applying before capturing, or re-comparing `el.value` afterwards, changes what fixture `src/__tests__/fixtures/controllable-select-mutated-option` reports when its last option is removed and re-added (controlled value `""`, `el.value` `""`, but `selectedIndex === -1`), which must still report the re-added option. Re-verify: compile `<let/value="b"/><let/opts=[]/><select value:=value><for|o| of=opts><option value=o>${o}</option></for></select><div id="result">${value}</div><button id="go" onClick(){ opts = ["a","b","c"] }>go</button>` with `pnpm run compile -o dom -d`, mount it under jsdom globals, click `#go` and read after a macrotask — `#result` and `select.value` are both `"a"` instead of `"b"`, while disconnecting the scope's `MutationObserver` right after `mount` leaves `#result` at `"b"`.
+The `observeOnce({ childList: true, subtree: true })` callback treats any divergence between the live select and the controlled value as a user change and reports `getSelectValue(el)` through `valueChange`. When a controlled select's options arrive after mount — fetched data, a `<for>` that resolves later — the browser auto-selects the first option, so the observer silently replaces the value the app asked for, with no error. Inside the callback, capture the fallback first, re-apply the controlled value with `setSelectValue`, and fall through to `onChange` only when it still did not take (`el.selectedIndex < 0`; `el.selectedOptions.length !== value.length` for `multiple`) so fixture `controllable-select-mutated-option` still reports a re-added option. Re-verify under jsdom: `_attr_select_value(scope,"#s","b",fn)` + `_attr_select_value_script(scope,"#s")` on an empty `<select>`, then append options a/b/c — `fn` fires with `"a"`.
 
-## Mint `<id>`'s fallback once per scope — a nullish `value=` re-generates the id on every DOM update
+## Mint `<id>`'s fallback once per scope
 
 `packages/runtime-tags/src/translator/core/id.ts` › `translate.exit` | 2026-07-27 | impact:med | effort:med
 
-`<id/x=value>` folds the fallback into the derived signal itself — `translate.exit` emits `value || _id($scope)` for DOM — and `_id` (`packages/runtime-tags/src/dom/signals.ts`) just bumps a per-`$global` counter, so a nullish `value` mints a brand-new id every time that signal recomputes, while the valueless `<id/x/>` calls `_id($scope)` once from `$setup` and HTML output evaluates `input.id || _id()` once per render. This is the pattern `cheatsheet.md` recommends for reusable tags (`<id/x=input.id>` "reuses a caller's"), so any such tag whose caller omits the id gets an identifier that silently changes on every update, never matches the server-rendered one after resume, and grows the counter without bound; references to that id from outside the same signal (CSS `#id`, `aria-*` set elsewhere, focus/anchor targets, third-party widgets) go stale even though the in-template `for=`/`id=` pair re-renders together. Fix by minting the fallback once per scope the way the no-value path already does — store it at setup and have the derived signal read that slot — leaving the HTML branch of `translate.exit` alone; keep `||` rather than `??`, since `packages/runtime-tags/tags/id.d.marko` types `value` as `string | null | false` and the `false` case is meant to fall through. No fixture covers the `value=` form (`src/__tests__/fixtures/id-tag` uses only `<id/x/>`), so a fixture with an input step would pin this. Re-verify: compile `<id/x=input.id>` + `<div id=x>${input.n}</div>` with `pnpm run compile -o dom -d` — it emits `export const $input_id = ($scope, input_id) => $x($scope, input_id || _id($scope))` — then mount it with jsdom globals and call `update({ id: undefined, n })` twice: the div renders `id="cM_0"`, then `id="cM_1"`, then `id="cM_2"`, whereas the same template written `<id/x/>` stays `cM_0`.
+For DOM, `translate.exit` folds the fallback into the derived signal itself (`value || _id($scope)`) and `_id` bumps a per-`$global` counter, so a nullish `value` mints a new id every time that signal recomputes — unlike valueless `<id/x/>`, which calls `_id` once from `$setup`. `<id/x=input.id>` is what `cheatsheet.md` recommends for reusable tags, so a caller omitting the id gets an identifier that changes on every update, never matches the resumed server id, and leaves outside references (CSS, `aria-*`, focus targets) stale. Mint it at setup and have the signal read that slot, leaving the HTML branch alone; keep `||`, since `tags/id.d.marko` types `value` as `string | null | false`. Fixture `id-tag` covers only the valueless form. Re-verify: mount compiled `<id/x=input.id>` + `<div id=x>` under jsdom and `update({ id: undefined, n })` twice — `id` goes `cM_0`, `cM_1`, `cM_2`.
 
-## Extend `<for>`'s `by=` loop-param check past bare identifiers — `by=item.id` compiles to a render-time ReferenceError
+## Extend `<for>`'s `by=` loop-param check past bare identifiers
 
 `packages/runtime-tags/src/translator/core/for.ts` › `analyze` | 2026-07-27 | impact:med | effort:low
 
-`analyze` rejects a `by=` value that keys off a loop parameter, but the guard is `byAttr?.type === "Identifier" && !tag.scope.getBinding(...)`, so it only fires for a bare `by=item` (the case locked by fixture `src/__tests__/fixtures/error-for-by-param` and by the "`by=item` using the loop variable" row in `cheatsheet.md`). The far more likely React/Vue spelling `by=item.id` is a MemberExpression and slips through, as does `by=`k${item.id}``, and since `by=` is emitted as an argument *outside* the iteration callback the output references an undeclared binding in both targets — HTML emits `_for_of(input.items, item => {…}, item.id, …)` and DOM emits `export const $input_items = ($scope, input_items) => $for($scope, [input_items, item.id])`. Both compile clean and then throw at first render, so the mistake surfaces as a 500 or a broken client bundle instead of the code frame the translator already knows how to produce. Widen the guard to walk the whole `by=` expression for any identifier that resolves only to `tag.node.body.params` (never `tag.scope`, so a module-scope `item` keeps working) and reuse the existing message; extend `error-for-by-param` with the member-expression form. Re-verify from the repo root: `D=$(mktemp -d ./tmp-forby-XXXXXX); printf '<for|item| of=input.items by=item.id>\n <div>${item.name}</div>\n</for>\n' > "$D/t.marko"; pnpm run compile -o html -d "$D/t.marko"; node -r ~ts --input-type=module -e "const m = await import('./$D/t.marko.js'); try { await m.default.render({items:[{id:1,name:'a'}]}).toString(); } catch (e) { console.log(e.name + ': ' + e.message); }"; rm -rf "$D"`compiles without error and prints`ReferenceError: item is not defined`, while the same template with `by=item` fails the compile.
+The guard is `byAttr?.type === "Identifier" && !tag.scope.getBinding(...)`, so it fires only for a bare `by=item` (fixture `error-for-by-param`). The commoner React/Vue spelling `by=item.id` is a MemberExpression and slips through, as does a template literal, and since `by=` is emitted outside the iteration callback both targets reference an undeclared binding — HTML emits `_for_of(input.items, item => {…}, item.id, …)`, DOM emits `$for($scope, [input_items, item.id])`. Both compile clean and throw at first render, so the mistake surfaces as a 500 or a broken bundle instead of a code frame. Walk the whole `by=` expression for identifiers resolving only to `tag.node.body.params` (never `tag.scope`), reuse the existing message, and extend `error-for-by-param`. Re-verify: compile `<for|item| of=input.items by=item.id>` with `-o html` (succeeds) and render it — `ReferenceError: item is not defined`.
 
-## Match `undefined` in `shallowClone`'s constructor switch — the `case null:` arm is dead and a null-prototype metadata value aborts the compile
+## Match `undefined`, not `null`, in `shallowClone`'s constructor switch
 
 `packages/compiler/src/babel-plugin/index.js` › `shallowClone` | 2026-07-27 | impact:low | effort:low
 
-`shallowClone` is the only channel carrying `metadata.marko` from the cached analyze file into each output's translate metadata, and it dispatches on `v.constructor`; the `case null:` arm sitting beside `case Object:` is dead, because a prototype-less object has `constructor === undefined`, not `null`. So an `Object.create(null)` value — the idiomatic prototype-less lookup map, used freely elsewhere in the tree (`runtime-tags/src/translator/util/binding-prop-tree.ts`, `visitors/tag/native-tag.ts`) — falls through to `default` and aborts the compile with `TypeError: Cannot read properties of undefined (reading 'name')` thrown out of `Ctor.name`, instead of being spread-cloned as the arm plainly intends; the arm has been there since the switch was written, so the intent is not in question, and the `default` case cannot even name the type it rejected. Fix is two tokens plus a guard: `case undefined:` in place of `case null:`, and `Ctor?.name ?? "null prototype object"` in the `default` message so the fallback still reports something useful. Do **not** widen the surrounding `for (const key in data)` loop to `Reflect.ownKeys` while here: skipping symbol keys is load-bearing, since the compiler uses symbol-keyed metadata for per-source scratch that must not cross the analyze→translate boundary (`babel-utils/imports.js` `IMPORTS_KEY` holds NodePaths into the analyze file's AST, which `parserOverride` clones per output; also `taglib.js` `SEEN_TAGS_KEY` and `loc.js` line indexes), and `babel-utils/tags.js` states the rule inline — `const MACRO_NAMES_KEY = "__marko_macro_names__"; // must be a string literal since it is used across compiler stages.` Re-verify from the repo root: `node -r ~ts -e 'const c=require("./packages/compiler/src/index.js");const mk=v=>({taglibs:[],tagDiscoveryDirs:[],analyze:{Program:{enter(p){p.hub.file.metadata.marko.custom=v()}}},translate:{Program:{exit(p){console.log("cloned:",p.hub.file.metadata.marko.custom);p.node.body.length=0}}}});for(const[l,v]of[["Object.create(null)",()=>Object.create(null)],["{}",()=>({})]]){try{c.compileSync("<div/>","/tmp/x.marko",{output:"html",translator:mk(v),cache:new Map(),optimize:false})}catch(e){console.log(l,"->",e.message.split("\n")[0])}}'` prints `Object.create(null) -> /tmp/x.marko: Cannot read properties of undefined (reading 'name')` for the first value and `cloned: {}` for the second.
+`shallowClone` copies `metadata.marko` from the cached analyze file into each output's translate metadata by dispatching on `v.constructor`, but the `case null:` arm beside `case Object:` is dead — a prototype-less object has `constructor === undefined`. An `Object.create(null)` metadata value therefore hits `default` and aborts the compile with `TypeError: Cannot read properties of undefined (reading 'name')` out of `Ctor.name` instead of being spread-cloned. Fix: `case undefined:` plus `Ctor?.name ?? "null prototype object"` in the default message, and keep the `for (const key in data)` loop string-keyed — symbol metadata such as `IMPORTS_KEY` must not cross analyze→translate. Re-verify: `compileSync` any template with a translator whose analyze visitor sets `file.metadata.marko.custom = Object.create(null)`; it throws today, while `{}` clones fine.
 
-## Report a `pipe()` target's abort without relying on `emit("error")` returning false, and close the target
+## Report a `pipe()` abort without relying on `emit("error")` returning false, and close the target
 
 `packages/runtime-tags/src/html/template.ts` › `pipe` | 2026-07-29 | impact:high | effort:low
 
-`pipe`'s abort callback ends with `if (!stream.emit?.("error", err)) throw err;`, which assumes `emit` reports "nothing handled this" by returning false. For an `EventEmitter` that is wrong: `emit("error", …)` with no `error` listener throws, and because the callback runs asynchronously from `#read`, the throw escapes as an uncaught exception rather than the intended rethrow, so the documented `Template.render({}).pipe(res)` terminates the process under Node's default handling whenever a render aborts. A client hanging up mid-stream and an aborted `$global.signal` both reach this path, which makes an ordinary disconnect fatal to a server, and the `throw err` line is effectively dead for any EventEmitter target. Separately, `end()` is only called from the completion callback, so an aborted render never closes the target: when the target is a transform feeding the response (the `zlib.createGzip()` shape in `docs/explanation/streaming.md`) the response is left open. Direction: test for a handler explicitly (`stream.listenerCount?.("error")`) before emitting, keep the synchronous `throw` only for plain non-emitter sinks, and close the target after reporting (`stream.destroy?.(err) ?? stream.end()`) so a compression stream cannot strand the request. Re-verify: compile `<div>start</div><await|v|=input.slow><p>${v}</p></await>` with `-o html`, then `Template.render({ slow: new Promise(() => {}), $global: { signal: ctrl.signal } }).pipe(sink)` against an `EventEmitter` sink recording `write`/`end` and abort `ctrl` on a later tick; with an `error` listener the sink reports the reason and `end()` is never called, and with no listener the process dies with an uncaught `client went away`.
+`pipe`'s abort callback ends with `if (!stream.emit?.("error", err)) throw err;`, but `EventEmitter#emit("error")` throws when no `error` listener exists, and `#read` runs that callback from a tick — the throw escapes as an uncaught exception, so `render().pipe(res)` kills the process on any mid-stream abort (client hangup, aborted `$global.signal`). `end()` is only called from the completion callback, so an aborted render never closes the target and a transform sink (gzip) strands the response. Direction: check `stream.listenerCount?.("error")` before emitting, keep the synchronous `throw` for plain non-emitter sinks, and close after reporting (`stream.destroy?.(err) ?? stream.end()`); `__tests__/render-result.test.ts` asserts `ended === false` after abort, so that expectation moves with the fix. Re-verify: pipe an aborted async render into an `EventEmitter` sink — with an `error` listener `end()` never fires, without one the process dies with an uncaught error from `pipe`.
 
-## Rewrite the `<tag-name>` import shorthand in `export ... from` position, or reject it
+## Rewrite the `<tag-name>` shorthand in `export ... from` position, or reject it
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `default` | 2026-07-30 | impact:med | effort:low
 
-The `<tag-name>` shorthand is resolved by the `ImportDeclaration` visitor, which calls `resolveTagImport` and assigns the result back with `node.source.value = tagImport`. Nothing does the same for `ExportNamedDeclaration` or `ExportAllDeclaration`, and the translator has no export-declaration visitor at all, so `export { byDueDate } from "<table-sorts>"` is emitted into the module verbatim with its angle brackets intact. No bundler or runtime can resolve that specifier, and the compile produces no diagnostic, so the failure surfaces as a module-resolution error in a later build step pointing at generated code rather than at the line the author wrote. Re-exporting is otherwise supported through a relative path (`export { byDueDate } from "./table-sorts.marko"` works and `resolveRegisteredExport` in `visitors/function.ts` deliberately follows `ExportNamedDeclaration`/`ExportAllDeclaration` with a `source` to reach the owning registration), so the shorthand failing only in export position is an inconsistency rather than an unsupported feature. Direction: run the same `resolveTagImport` rewrite over an export declaration's `source`, which is the narrow fix; if re-export by shorthand is not intended to be supported, raise a `buildCodeFrameError` naming the relative form instead, since a silent verbatim emit is the worst of the three outcomes. Re-verify from the repo root: write `export { byDueDate } from "<table-sorts>"` as the only line of `tags/sort-barrel.marko` beside a `tags/table-sorts.marko` exporting `byDueDate`, run `pnpm run compile -o html -d tags/sort-barrel.marko`, and read the first line of the emitted module — it is `export { byDueDate } from "<table-sorts>";`, while the same specifier written as `import { byDueDate } from "<table-sorts>"` emits `import { byDueDate } from "./table-sorts.marko";`.
+The `<tag-name>` shorthand is rewritten only by the `ImportDeclaration` visitor (`resolveTagImport`, then `node.source.value = tagImport`); the translator has no export-declaration visitor, so `export { byDueDate } from "<table-sorts>"` is emitted verbatim with its angle brackets in both `-o html` and `-o dom` and with no diagnostic, surfacing later as a module-resolution error against generated code. Analysis already follows the shorthand here: `resolveRegisteredExport` in `visitors/function.ts` walks `ExportNamedDeclaration`/`ExportAllDeclaration` sources via `loadFileForImport`, which resolves `<tag>`. Direction: run `resolveTagImport` over an export declaration's `source` too, or raise a `buildCodeFrameError` naming the relative form if shorthand re-export is not meant to be supported. Re-verify: `pnpm run compile -o html -d tags/sort-barrel.marko` whose only line is `export { byDueDate } from "<table-sorts>"` still emits that specifier unchanged, while the `import` form emits `./table-sorts.marko`.
+
+## Queue pending `onNextSibling` callbacks in the inline reorder runtime
+
+`packages/runtime-tags/src/html/inlined-runtimes.debug.ts` › `REORDER_RUNTIME_CODE` | 2026-07-10 | impact:low | effort:med
+
+`runtime.x` keeps a single `nextSibling`/`onNextSibling` pair. A `<t hidden>` swap callback pending on that element's next sibling is silently dropped if, while walking the `<t>`'s children, a placeholder-end comment (`!id`) hits the `runtime.l[id] && placeholders[id]` branch and reassigns the pair — the outer swap then never fires and hydration freezes. Current server flush ordering appears to keep this unreachable, so this is robustness, not a live bug: fire the pending callback before reassigning (or queue), weighed against inline-runtime bytes. Re-verify: read `REORDER_RUNTIME_CODE` and confirm both the `op == "!"` and `<t>` branches assign `nextSibling`/`onNextSibling` without first draining a pending one.
+
+## Escape a carriage return in a `<textarea>` body so SSR and CSR agree
+
+`packages/runtime-tags/src/html/attrs.ts` › `_textarea_value` | 2026-07-27 | impact:low | effort:low
+
+`_textarea_value` writes the value as element text and the HTML tokenizer normalizes every CR and CRLF in text to a single LF, so a `\r` anywhere — not just at the start, which commit a6acdde917 already handles — is lost: `"a\rb"` and `"a\r\nb"` both parse back to `defaultValue === "a\nb"`. CSR keeps the CR, since `_attr_input_value_default` (`dom/controllable.ts`) assigns `el.defaultValue` verbatim and `_attr_input_value_script` seeds the resumed `ControlledValue` from `el.defaultValue`, so a resumed controlled `<textarea>` holds a different string than a client-rendered one. Writing `\r` as `&#13;` survives, because character references are decoded after newline normalization; weigh that against the bytes it costs every textarea. The attribute-value escaper has the identical gap in the entry "Escape a carriage return in an attribute value so SSR and CSR agree" — a separate fix in `attrAssignment` rather than this `_escape`-based path, but landing only one still leaves a resumed controlled `<input value=…>` diverging from its client-rendered twin. Re-verify in jsdom: `<textarea>a\rb</textarea>` reports `defaultValue === "a\nb"`, `<textarea>a&#13;b</textarea>` reports `"a\rb"`.
+
+## Renumber alias bindings too, or stop using `Binding.id` as the `bindingUtil` identity tiebreak
+
+`packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-23 | impact:med | effort:med
+
+`bindingUtil.compare` returns `0` for two distinct bindings sharing `section.id` and `id` (its `type` tiebreak applies only to a dom/non-dom pair), and `Sorted.add`/`find`/`has` treat `0` as identity. But `binding.id = nextId++` renumbers only bindings in `section.bindings`, which is filled with `getCanonicalBinding(binding)`, so a pure alias (`property` and `excludeProperties` both `undefined`) keeps its creation-order id and can collide with a renumbered section-mate. `dropReferencedBindings`, run afterwards by `getReferenceFinalizers()` and rebuilding `referencedBindings` with `bindingUtil.add`, then collapses the pair and drops a real dependency — latent today, since no fixture miscompiles. Renumber aliases alongside their canonical (or into a disjoint range), or give `Binding` a separate identity field. Re-verify: wrap `bindingUtil.compare`, compile `__tests__/fixtures/param-destructure-default/template.marko`, group by `(section.id, id, type === dom)` — section 1 id 6 holds `$foo` (param alias) and `$bar` (derived), and `compare` returns `0`.
+
+## Give a hidden `<show>` a wrapper legal in table/select insertion contexts
+
+`packages/runtime-tags/src/html/writer.ts` › `_show_start` | 2026-07-28 | impact:med | effort:high
+
+`_show_start` wraps non-displayed content in `<t hidden>`, which table/select insertion modes discard while keeping its children, so `translator/core/show.ts` › `assertLegalHiddenContext` now rejects `<show>` directly inside `<table>`/`<tbody>`/`<tr>`/`<colgroup>`/`<select>`/`<optgroup>` (predicate: `translator/util/insertion-context.ts` › `discardsWrapperChildren`). That diagnostic only stops the silent mis-render; the docs still recommend `<show>` for bulky markup, which is often a table body. No ordinary element is legal in both contexts — `<template>` is the sole candidate, but its children sit on `.content`, so the resume walker and `_show`'s `<t>`-dissolve path must reach through it first; a narrower option sets `hidden` on each statically known top-level body node. The same `<t hidden>` hazard applies to the reorder wrapper `Chunk.flushScript` writes — see "Wrap reordered out-of-order content in a parser-context-legal container" — so whichever lands first sets the container precedent for both emit sites. Re-verify: delete the `assertLegalHiddenContext` call and run `pnpm run test:update -- --grep "runtime-tags/translator error-show-tag-in-table "` — `render.debug.md` shows the row inside the table despite `show=false`.
+
+## Lower (or reject) `for (x of …)` / `for (x in …)` writes to a tag variable — they bypass the signal
+
+`packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-23 | impact:low | effort:med
+
+`replaceAssignedNode` rewrites only `AssignmentExpression` and `UpdateExpression`, so a `ForOfStatement`/`ForInStatement` whose `left` is a bare tag variable falls through to `getReadReplacement` (`util/references.ts`) and compiles to a plain scope read. `<let/x="a"/>` with `<button onClick(){ for (x of ["b","c"]) {} }>` emits `for ($scope.x of ["b", "c"]) {}`, mutating the scope slot without calling the `_let` signal, so nothing schedules a render and `${x}` keeps the stale value — no diagnostic in either output mode (`for (x in …)` is identical). Either mark for-of/for-in targets as assignments during reference analysis and route them through the binding's assignment builder, or raise a compile error naming the unsupported construct. Re-verify: `pnpm run compile -o dom -d f.marko` on that template emits `for ($scope.x of …)` with no `$x(` call in the handler.
+
+## Give a real diagnostic for two-way binding a computed-key destructured param
+
+`packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandlerFromObjectPattern` | 2026-07-23 | impact:low | effort:low
+
+For a `computed === true` object-pattern property this appends a synthetic property keyed `t.binaryExpression("+", parent.get("key").node, t.stringLiteral("Change"))`, which `createBindingsAndTrackReferences` (`translator/util/references.ts`, ObjectPattern case) always rejects with "Only identifier and string literal keys are supported when destructuring." — so the branch can never produce a compilable template. It is reachable only for a computed string-literal key, and the error attaches to the loc-less synthetic node, so the caret covers the whole `<define>` tag and never mentions two-way binding; the key node is also reused without `t.cloneNode`. Fix: normalize a computed string-literal key to a plain key before synthesizing (and clone it), or throw a targeted diagnostic like the sibling array-pattern message. Re-verify: `<define/Wrap|{ ["a"]: val }|><input value:=val/></define>` fails today; deleting `value:=val` compiles.
+
+## Carry the Class-API compat boundary mode per call site instead of downgrading the whole program
+
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `pushCompatRegistration` | 2026-07-27 | impact:low | effort:med
+
+`preserveBoundary` is a per-call-site decision (`!tagsSerializeReason && …`), but `s(id, renderer, mode)` is emitted once per renderer and `boundaryModeByRenderer` in `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` is keyed by renderer too. The order-dependence is fixed (commit fe76065063): any call site that cannot preserve truncates the emitted call to two arguments for the whole program, and `register` keeps a plain `true` sticky across modules. That fix is a downgrade, so one updating call site costs every inert call site of that class its split-component optimization. Carrying the mode on the per-call-site `_dynamic_tag` invocation would keep both, at the cost of a parameter every dynamic tag pays for — measure before taking it. Re-verify: `interop-mixed-boundary-split-tags-to-class` emits `s(…, renderer)` with no `"preserve"`, while `interop-self-interactive-split-tags-to-class` still emits it.
+
+## Enable branch machinery at every `_attr_content` site; it creates branches without it
+
+`packages/runtime-tags/src/dom/dom.ts` › `_attr_content` | 2026-07-23 | impact:low | effort:med
+
+`_attr_content` — reached from `_attrs_content`/`_attrs_partial_content` (a native-tag spread carrying `content`) and from a plain static `content=` on a native tag — creates a live branch via `setConditionalRenderer(…, createAndSetupBranch)`, yet it is the only client branch creator that never reaches `enableBranches()`; `_if`, `_show`, `_dynamic_tag`, `_dynamic_tag_content`, `loop` all call it in their factory and `<try>`/`<await>` get it through `_enable_catch`. Without it `skipDestroyedRenders()` (queue.ts) is never installed — the only guard stopping a queued render from running on a scope inside a destroyed branch, and `setConditionalRenderer` does `destroyBranch` the previous content branch — and `branchesEnabled` stays unset, so `initScope` never links a resumed scope's serialized `#ClosestBranchId` and branch-visit processing is skipped. The enable must run at module eval (before resume processes visits), so emit it from the translator, in the shape of the existing top-level `_enable_catch()`, at all three DOM-output sites in `visitors/tag/native-tag.ts`: the `_attrs_content`, `_attrs_partial_content` and `_attr_content` render statements (the HTML-output emissions in the same file need nothing). While there, `_attr_content` duplicates `_dynamic_tag_content` almost verbatim (same renderer-id compare, `setConditionalRenderer`, `subscribeToScopeSet`, `LocalClosures` loop); they differ only in shape — `_dynamic_tag_content` is a signal factory that decodes the accessor once, `_attr_content` is an inline per-render call — so routing one through the other closes the gap and drops a copy. `dom/compat.ts` › `render` has the same omission; and the plain `content=` site cannot be verified until "Create a native-tag binding when `content=` evaluates confidently…" lands, since a static-`content=` fixture aborts the DOM compile today. Re-verify: `node -r ~ts scripts/inspect-compiled-output.mts -o dom -d` on `<define/Wrap|input|><div ...input/></define>` plus `<Wrap class="x"><b>x</b></Wrap>` — the imports are exactly `_attrs_content, _attrs_script, _content, _script, _const, _template`, none of which enables branches, yet a `BranchScope` is created at mount.
+
+## Preserve object key order when a circular property is deferred
+
+`packages/runtime-tags/src/html/serializer.ts` › `writeObjectProps` | 2026-07-27 | impact:low | effort:med
+
+When a property's value is circular, `writeProp` returns false, `writeObjectProps` pops the already-pushed `key:` chunk, and `writeAssigned` re-creates it at the end of the payload, moving it last in key order. Plain objects are the only container that reorders: `writeArray` keeps the slot so the assignment fills the hole in place, and `writeMap`/`writeSet` defer every later entry once one defers. Order is observable through `common/for.ts` › `forIn` (a `for…in`), so `<for|k,v| in=obj>` renders one order on the server and another after resume. Match the array behavior by leaving an `undefined` placeholder (`key:$`, setting `state.wroteUndefined`) when the failed write queued an assignment, which needs `writeProp`'s return to separate "deferred" from "elided". Re-verify: `const o={title:"t",self:null,count:3}; o.self=o;` stringifies to `_=>(_([1,{graph:_.a={title:"t",count:3}}]),_.a.self=_.a,0)`.
+
+## Ignore `MarkoComment` children in `assertNoBodyContent` — a comment-only `<attrs>`/`<effect>` body is a hard compile error
+
+`packages/runtime-tags/src/translator/util/assert.ts` › `assertNoBodyContent` | 2026-07-27 | impact:low | effort:low
+
+`assertNoBodyContent` tests `tag.node.body.body.length` raw, but Marko comments survive in `body.body` until `visitors/comment.ts` › `translate.exit` calls `comment.remove()`, so `<attrs/{ a }><!-- todo --></attrs>` and `<effect() { … }><!-- todo --></effect>` both fail with "does not support body content" even though an empty or whitespace-only body compiles. Those two are the only reachable callers: the other seven (`const`, `let`, `id`, `return`, `log`, `debug`, `lifecycle`) set `parseOptions.openTagOnly` so the parser rejects the close tag first, and `<script>` sets `parseOptions.text`. `translator/util/is-only-child-in-parent.ts` › `getOnlyChildParentTagName` already filters `node.type !== "MarkoComment"` for exactly this kind of body-length test; `tag.node.body.body.some((child) => child.type !== "MarkoComment")` here matches it. Re-verify: `pnpm run compile -o html -d` on `<effect() { console.log(1) }>`, an indented `<!-- todo -->`, then `</effect>` prints "does not support body content", while deleting only the comment line compiles.
+
+## Fold `analyzedTags` into the compile cache's mtime invalidation
+
+`packages/compiler/src/babel-plugin/index.js` › `getMarkoFile` | 2026-07-27 | impact:low | effort:med
+
+`getMarkoFile` invalidates a cache entry on its content hash or a newer mtime among `metadata.marko.watchFiles`, which holds only taglib JSON and plugin paths; the child `.marko` templates analysis read go to `metadata.marko.analyzedTags`, which the loop ignores, so a shared cache serves a stale parent after a child edit. Reach is narrow — `@marko/vite` clears `baseConfig.cache` on every hot update — leaving `@marko/compiler/register` and direct `compile[Sync]` reuse. Any fix has to be transitive, so every cache hit would stat the whole subtree. Re-verify: `compileSync` one parent twice through a single `new Map()` cache, rewriting its child from `<return=1/>` to a stateful `<let/x=1/><button onClick(){x++}/><return=x/>` in between — output stays byte-identical with no `_el_resume`, while a fresh cache emits it.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,289 +2,98 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
-## Compat re-render writes scope nodes onto a DOM node instead of the branch scope
+## Pass the branch scope, not the fragment marker, to `setScopeNodes`
 
 `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js` › `renderAndMorph` | 2026-07-13 | impact:low | effort:low
 
-In `renderAndMorph`, after `host = rootNode.startNode`, the call
-`domCompat.setScopeNodes(host, rootNode.startNode, rootNode.endNode)` writes
-`#StartNode`/`#EndNode` onto the fragment's DOM marker node (a self-assign plus
-an unused end ref) rather than onto the tags branch **scope** — the argument was
-almost certainly meant to be `scope`. Consequence: the `host.fragment` fast-path
-at line 158 can never fire for a resumed child, so every re-render falls through
-to the `___componentLookup` / `___marko5Component.___rootNode` lookup. Correctness
-is unaffected (later renders reuse `___marko5Component.___rootNode`), so this is a
-dead optimization + a confusing stale-node invariant; verify destroy/move
-semantics before changing to `scope`.
-
----
-
-## Delete or restore the commented-out serializer test cases
-
-`packages/runtime-tags/src/__tests__/serializer.test.ts` | 2026-07-18 | impact:low | effort:low
-
-The two-line comment rule sweep that once found roughly ninety over-length
-blocks across `runtime-tags/src` was largely carried out by `9fc549115b`
-("condense over-length comments across src"): `dom/resume.ts` now has none,
-`translator/util/references.ts` one, and the remaining runtime blocks are the
-irreplaceable specs that commit deliberately preserved (the walks-string laws in
-`dom/walker.ts`, the serialize wire protocol, the abort-id invariant). What is
-left is not really a comment-length problem: `serializer.test.ts` carries 11
-multi-line `//` runs that are commented-out test cases, i.e. dead code to either
-restore or delete (the `_attrs` event-handler pair has its own entry below), and
-`packages/compiler/src/config.js` has 7 JSDoc blocks over two body lines, which
-are per-option API docs and arguably exempt. Verify: `awk` for runs of three or
-more consecutive `//` lines under `packages/runtime-tags/src` reports 36 blocks
-total, 11 of them in `serializer.test.ts`.
-
-## Normalize inconsistent local naming flagged by a terminology audit
-
-`packages/runtime-tags/src/html/serializer.ts` › `State` | 2026-07-20 | impact:low | effort:low
-
-A file-by-file terminology audit flagged several local naming inconsistencies that are too narrow for CONTEXT.md but worth normalizing when touching these files: `html/serializer.ts` uses `assigns`/`assigned`/`addAssignment` for one mechanism and names its generation counter `flush` (reads as an output flush; it is compared, not flushed — see `parent.flush === state.flush`); `translator/core/if.ts` destructures the same branches array as `branchBodySection` in one place and `branchBody` in another; `dom/controllable.ts` mixes `Controllable` (file, `syncControllableFormInput`) with `Controlled*` accessor/type prefixes for the same concept — CONTEXT.md now canonicalizes "controllable"; `translator/core/await.ts` pairs the near-homophones `startBinding` (a Binding) and `startMark` (a serialize-guard expression). Each is a rename-in-place with no behavior change; snapshots regenerate where identifiers leak into debug output. Re-verify by grepping the cited symbols.
-
-The three-line comment above `observeOnce` opens with an abandoned draft of its own next sentence: line 544 reads `// A spread re-render re-runs the setup script against the same element, so` and stops mid-clause, then lines 545-546 restate the same point in full (`… re-observing with the scope's observer updates that registration instead of adding one.`). Both lines were added together by `e91e6a1d0a` ("keep one MutationObserver per controllable element"), so the dangling line is an editing leftover rather than a second thought, but a reader still has to decide whether the clause dropped after `so` carried a constraint the surviving sentence omits. The complete sentence is accurate on its own — `observe()` on the same node replaces that node's registration, and the `||=` reuses the observer stored at `AccessorPrefix.ControlledObserver + nodeAccessor` — and the extra line also pushes the block past the two-line cap AGENTS.md sets for comments. Delete line 544. Re-verify: `grep -n -B3 "^function observeOnce" packages/runtime-tags/src/dom/controllable.ts` prints both sentences above the declaration.
-
-## Normalize the params-binding `BindingType` so a param is identifiable by type
-
-`packages/runtime-tags/src/translator/util/references.ts` › `trackParamsReferences` | 2026-07-22 | impact:med | effort:high
-
-Every section's "params binding" is created by `trackParamsReferences`, but each caller passes a different `BindingType`: `<for>`/`<await>` use `derived` (`core/for.ts`, `core/await.ts`), `<define>`/attribute-tags/dynamic-tag/known-tag use `param`, program input uses `input`, and an attribute-tag `<for>` uses `local`. So "is this a param?" cannot be answered from `binding.type` and the codebase instead keys off identity — `root === root.section.params` (see `isParamBinding`, `getDebugName`, and the assignment guard `binding.upstreamAlias === binding.section.params`). The heterogeneity is currently load-bearing, not accidental: `BindingType` selects the `resolveBindingSources` path, and `<for>`/`<await>` deliberately use `derived` so `resolveDerivedSources` makes the item param's `Sources` transparently reflect its loop/await source (`<for of=stateVal>` → `state` source; `<for of=input.list>` → `param` source), which drives serialize-reason scheduling (`isStateSerializeReason` vs `isReasonDynamic` in `serialize-reasons.ts`) and `scopeOffset` propagation (`getMaxOwnSourceOffset`). A naive `derived→param` flip severs the `setBindingDownstream` link (it goes dead before `resolveDerivedSources` runs), mis-scheduling serialization and losing scope offsets. The cleanup: give params a correct, uniform type (or a dedicated param marker on the binding) so `isParamBinding` reduces to a `binding.type` check, while moving the source-transparency of `<for>`/`<await>` params off the overloaded `derived` type onto an explicit source-resolution input. Verify current state: `rg -n "trackParamsReferences\(" packages/runtime-tags/src/translator` shows the four distinct `BindingType` args; `isParamBinding` in `references.ts` still uses the identity walk because no type distinguishes them.
-
-## Factor the duplicated await-counter construction shared by `_await_promise` and `addAwaitCounter`
-
-`packages/runtime-tags/src/dom/control-flow.ts` › `addAwaitCounter` | 2026-07-23 | impact:low | effort:med
-
-`addAwaitCounter` (control-flow.ts:283-329) and the `else` arm of
-`_await_promise`'s signal (:102-159) are the same ~25-line skeleton written
-twice: the `if (!awaitCounter?.i)` guard, the
-`tryBranch[AccessorProp.AwaitCounter] = { i: 0, c() { if (--awaitCounter.i)
-return 1; …; queueEffect(tryBranch, runPendingEffects); } }` literal, and the
-`if (!awaitCounter.i++) requestAnimationFrame(() => awaitCounter.i &&
-runEffects(prepareEffects(() => queueRender(<scope>, () => { …;
-tempDetachBranch(tryBranch); }, -1))))` frame scheduler. Only three things
-differ: the body of `c()` (anchor swap vs. `dismissPlaceholder(tryBranch)`), the
-body of the queued frame render (re-insert the await anchor vs. create and
-insert the placeholder branch), and the scope passed to `queueRender` (`scope`
-vs. `tryBranch`). Extracting a shared factory that takes `(tryBranch, onZero,
-frameScope, onFrame)` would collapse both call sites, and since bundle size is a
-tracked feature here the duplicated
-`requestAnimationFrame`/`prepareEffects`/`queueRender` chains are shipped twice
-in every app that uses `<await>`. Re-verify by diffing the two blocks side by
-side and then checking the `await-*`/`try-*` fixture `sizes.json` and the root
-`.sizes.json` after the extraction.
+After `host = rootNode.startNode`, `renderAndMorph` calls `domCompat.setScopeNodes(host, rootNode.startNode, rootNode.endNode)`, writing `#StartNode`/`#EndNode` onto the fragment's DOM marker (a self-assign plus an unused end ref) instead of onto the tags branch `scope`. Since `scope[#StartNode]` never becomes the fragment marker, the `rootNode = host.fragment` fast path can never fire for a resumed child and every re-render falls back to the `___componentLookup` / `___marko5Component.___rootNode` lookup. Correctness is unaffected, so this is a dead optimization plus a misleading invariant; passing `scope` restores it, but check destroy/move first, since the fragment markers sit inside the scope's original start/end range. Re-verify: on a second re-render of a server-rendered class child, `domCompat.getStartNode(scope).fragment` should be set.
 
 ## Delete the unreachable non-identifier tag-var guard in `trackDomVarReferences`
 
 `packages/runtime-tags/src/translator/util/references.ts` › `trackDomVarReferences` | 2026-07-23 | impact:low | effort:low
 
-`trackDomVarReferences` opens with a `!t.isIdentifier(tagVar)` check that throws
-`Tag variables on native elements cannot be destructured.`
-(references.ts:287-293), but both call sites already reject a destructured tag
-var earlier with a better, docs-linked message:
-`visitors/tag/native-tag.ts:98-104` throws "Tag variables on [native
-tags](https://markojs.com/docs/reference/native-tag) cannot be destructured." at
-the top of the same `analyze.enter` that later calls `trackDomVarReferences`
-(line 354), and `core/html-comment.ts:51-57` throws its own
-`<html-comment>`-specific version before calling it at line 86. So the guard is
-dead, and it is also the only place in the package that says "native elements"
-instead of CONTEXT.md's "native tag". Drop the branch (keeping the non-null
-cast) so the one live message is the linked one. Re-verify: compile `<div/{a}/>`
-and observe the code frame quotes the native-tag.ts wording with the docs link,
-never the references.ts wording; `grep -rn "cannot be destructured"
-packages/runtime-tags/src` shows the four distinct messages and their owners.
+`trackDomVarReferences` opens by throwing "Tag variables on native elements cannot be destructured." for a non-identifier `tag.node.var`, but both call sites already reject one with a better, docs-linked message: `visitors/tag/native-tag.ts` throws at the top of the same `analyze.enter` that later calls it, and `core/html-comment.ts` throws its `<html-comment>` variant before its call. The branch is dead, and it is the only place in the package that says "native elements" instead of CONTEXT.md's "native tag". Drop it, keeping the non-null cast, so the one live message is the linked one. Re-verify: compiling `<div/{a}/>` reports the native-tag.ts wording with the docs link, and `rg -n "cannot be destructured" packages/runtime-tags/src --glob '!**/__snapshots__/**'` shows one message per owner.
 
 ## Drop the write-only `renderReferencedBindings`/`effectReferencedBindings` signal fields
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `addRenderReferences` | 2026-07-23 | impact:low | effort:low
 
-`Signal.renderReferencedBindings` and `Signal.effectReferencedBindings`
-(signals.ts:83, 85) are initialized in `getSignal` (signals.ts:264, 266) and
-updated by `addRenderReferences`/`addEffectReferences` (signals.ts:890-898,
-880-888) but never read anywhere in the repo. Every `addStatement` and
-`addValue` therefore pays a `bindingUtil.union` — a sorted merge that allocates
-a fresh array per call (`util/optional.ts` `unionSortedRepeatable`/`addSorted`)
-— to build state that is discarded. Removing the two fields and their two
-helpers deletes two of the five post-`finalizeReferences` `bindingUtil` call
-sites, which also shrinks the surface of the binding-id renumbering hazard filed
-separately. Re-verify: `grep -rn
-"renderReferencedBindings\|effectReferencedBindings" packages/` returns only the
-eight lines in `signals.ts` listed above (declaration, initialization, and the
-two assignment helpers) and no reader.
+`Signal.renderReferencedBindings` and `Signal.effectReferencedBindings` are declared, initialized in `getSignal`, and written by `addRenderReferences`/`addEffectReferences`, but nothing in the workspace reads them. Every `addStatement` and `addValue` therefore pays a `bindingUtil.union` — `unionSortedRepeatable` in `util/optional.ts`, which allocates a fresh array per call — to build state that is discarded. Deleting the two fields also makes `addStatement`'s `usedReferences` parameter dead, so its call sites can drop it. Re-verify: `rg -n "renderReferencedBindings|effectReferencedBindings" packages/` returns only the declaration, the two `getSignal` initializers, and the two assignment helpers in `signals.ts`, with no reader.
 
 ## Stop re-exporting `forOfBy`/`forInBy`/`forStepBy` from the html runtime entry
 
-`packages/runtime-tags/src/html.ts` › `forOfBy (export block from "./html/for")` | 2026-07-23 | impact:low | effort:low
+`packages/runtime-tags/src/html.ts` › `export { … } from "./html/for"` | 2026-07-23 | impact:low | effort:low
 
-`src/html.ts` re-exports seven names from `./html/for`, but only four of them
-(`forIn`, `forOf`, `forTo`, `forUntil`) are ever emitted by codegen —
-`translator/core/for.ts` › `forTypeToRuntime` maps the four `<for>` kinds to
-exactly those. `forInBy`, `forOfBy` and `forStepBy` are private helpers of
-`html/writer.ts`, which imports them directly from `./for` and uses them inside
-`_for_of`/`_for_in`/`_for_to`/`_for_until`; no `callRuntime`/`importRuntime`
-call site names them, and `dom.ts` correspondingly exports only the four base
-helpers from `./common/for`. Keeping them on the entry has two costs: because
-`HTMLRuntimeHelpers = keyof typeof import("../../html")`
-(`translator/util/runtime.ts`), `callRuntime("forOfBy", …)` type-checks even
-though it would emit a call to a non-codegen helper; and as entry exports they
-must survive as top-level named bindings in `dist/html.mjs`, so the minifier
-cannot inline or rename them into their single use sites (SSR size is tracked in
-`.sizes/counter.ssr` et al.). Drop the three names from the `export { … } from
-"./html/for"` block. Re-verify: `rg -n "forOfBy|forInBy|forStepBy" packages/`
-returns hits only in `src/html.ts`, `src/html/for.ts` and `src/html/writer.ts`,
-and the test suite still passes for a `<for by=…>` fixture.
+`src/html.ts` re-exports seven names from `./html/for`, but codegen emits only four — `translator/core/for.ts` › `forTypeToRuntime` maps the `<for>` kinds to `forOf`/`forIn`/`forTo`/`forUntil`, which is also all `dom.ts` re-exports from `./common/for`. `forOfBy`, `forInBy` and `forStepBy` are internal helpers that `html/writer.ts` imports straight from `./for`; no `callRuntime`/`importRuntime` call site names them. Since `HTMLRuntimeHelpers = keyof typeof import("../../html")` (`translator/util/runtime.ts`), exporting them makes `callRuntime("forOfBy", …)` type-check even though codegen never emits it. Drop the three names from the export block. Re-verify: `rg -n "forOfBy|forInBy|forStepBy" packages/` hits only `src/html/for.ts` and `src/html/writer.ts`, and a `<for by=…>` fixture still renders.
 
-## Remove the dead `_attrs` event-handler assertions in html-attrs.test.ts or give the routing real coverage
+## Retitle the `_attrs` test or give its event-handler routing real coverage
 
-`packages/runtime-tags/src/__tests__/html-attrs.test.ts` › `describe("attrs") › it("should strip event handlers, invalid attribute names and content")` | 2026-07-23 | impact:low | effort:low
+`packages/runtime-tags/src/__tests__/html-attrs.test.ts` › `it("should strip event handlers, invalid attribute names and content")` | 2026-07-23 | impact:low | effort:low
 
-The test is titled "should strip event handlers, ..." but its only two
-event-handler assertions are commented out, so nothing in the file exercises
-that behavior — and the title is also wrong about what happens: `_attrs`
-(`src/html/attrs.ts`) does not strip `on*` attributes, it collects them into an
-`events` object and registers it via `_scope(scopeId, {
-[AccessorPrefix.EventAttributes + nodeAccessor]: events })`. That is why the
-commented lines cannot simply be uncommented: called outside a render they throw
-`TypeError: Cannot read properties of undefined (reading 'boundary')` from
-`_scope`. Either delete the two dead comments and retitle the test to what it
-verifies (invalid attribute names and the non-`<meta>` `content` attribute), or
-add a case that drives `_attrs` inside an active writer boundary and asserts the
-event lands on the scope under `AccessorPrefix.EventAttributes`. Re-verify:
-`node -r ~ts -e
-'require("./packages/runtime-tags/src/html/attrs.ts")._attrs({onClick(){}}, "a",
-0, "")'` throws the `boundary` TypeError, confirming the commented assertions
-can never pass as written.
+The test's only two event-handler assertions are commented out (and call a long-gone `helpers.attrs`), and the title is wrong: `_attrs` (`src/html/attrs.ts`) does not strip `on*` names, it collects them into `events` and registers them via `_scope(scopeId, { [AccessorPrefix.EventAttributes + nodeAccessor]: events })`. They cannot simply be uncommented — outside a render `_scope` reads `$chunk.boundary` and throws. Either delete the dead comments and retitle to what the test actually checks (invalid attribute names, and `content` on a non-`<meta>` tag), or drive `_attrs` inside an active writer boundary and assert the handler lands on the scope. Re-verify: `node -r ~ts -e 'require("./packages/runtime-tags/src/html/attrs.ts")._attrs({onClick(){}},"a",0,"")'` throws `TypeError: Cannot read properties of undefined (reading 'boundary')`.
 
-## Drop the ignored `state` argument from `compat.toJSON` and its two runtime-class call sites
+## Drop the ignored `state` argument from the two `htmlCompat.toJSON` call sites
 
 `packages/runtime-tags/src/html/compat.ts` › `compat.toJSON` | 2026-07-23 | impact:low | effort:low
 
-`compat.toJSON()` declares an empty parameter list, yet both call sites in
-`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` still
-pass a `State`: `renderBody.toJSON =
-htmlCompat.toJSON(htmlCompat.ensureState(out.global))` and `value.toJSON =
-htmlCompat.toJSON(state)`. The parameter was real until commit 9e043c0724
-("refactor: unify scope serialization and concurrent resume"), which replaced
-the body's `writeScopeToState(state, scopeId, {})` with `_script(scopeId,
-SET_SCOPE_REGISTER_ID)` and removed `state` from the TypeScript signature; the
-untyped JS call sites were never updated, so the code still reads as though the
-returned `toJSON` were bound to one render's `State` when it is not. The
-`ensureState` calls are still load-bearing (they seed
-`$global.runtimeId`/`renderId` and memoise the `State` that `flushScripts` later
-mutates via `walkOnNextFlush`), so the cleanup is to keep them as standalone
-statements and call `htmlCompat.toJSON()` with no argument, dropping the
-now-unused `const state` local. Re-verify: `compat.toJSON` in
-`packages/runtime-tags/src/html/compat.ts` is declared `toJSON()`, while `rg -n
-"htmlCompat\\.toJSON\\(" packages/runtime-class` returns two call sites that
-each pass an argument.
+`compat.toJSON()` takes no parameters, yet both call sites in `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` still pass a `State`: `htmlCompat.toJSON(htmlCompat.ensureState(out.global))` and `htmlCompat.toJSON(state)`. The parameter disappeared in 9e043c0724 ("refactor: unify scope serialization and concurrent resume") but the untyped JS callers were never updated, so the code reads as though the returned `toJSON` were bound to one render's `State` when it is not. Keep the `ensureState` calls — they seed `$global.runtimeId`/`renderId` and memoise the `State` — as standalone statements, call `toJSON()` with no argument, and drop the then-unused `const state` local. Re-verify: `rg -n "htmlCompat\.toJSON\(" packages/runtime-class` shows two callers passing an argument while `compat.toJSON` is declared `toJSON()`.
 
-## Extract one helper for merging repeated attribute tags into `attrTag`/`attrTags`, now duplicated four times
+## Extract one helper for the `attrTag`/`attrTags` merge duplicated in `known-tag.ts`
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `translateAttrTag` | 2026-07-23 | impact:low | effort:low
 
-The rule "a repeated attribute tag folds into `attrTags(prev, next)`, a
-non-repeated one becomes `attrTag(props)`" is implemented four separate times.
-Two of them are near-verbatim copies of the same ~35-line block, including the
-non-obvious trick of wrapping the first call in `t.parenthesizedExpression` so a
-later sibling can mutate `.expression` in place: `known-tag.ts` ›
-`translateAttrTag` (:977-1007) and the `isAttributeTag(tag)` branch of
-`known-tag.ts` › `applyAttrObject` (:913-949), which differ only in whether
-`repeated` comes from a passed `AttrTagMeta` or a fresh
-`analyzeAttributeTags(parentTag)?.[name]` lookup, and in returning the
-expression versus assigning a local. The other two express the same rule in
-different shapes: `translate-attrs.ts` › `translateAttrs` (:98-117, merging via
-`findObjectProperty` over the accumulated `contentProperties`) and
-`translate-attrs.ts` › `addDynamicAttrTagStatements` (:199-226, merging via an
-`attrTags(id, props)` assignment to the attr-tag identifier). A single helper
-taking `(attrTagMeta, translatedProps, mergeTarget)` would collapse the two
-known-tag copies outright and let the other two share the `repeated ? attrTags :
-attrTag` decision, so a future change to attr-tag merging cannot be applied to
-three of four sites. Re-verify: `rg -n 'callRuntime\("attrTags"'
-packages/runtime-tags/src/translator` lists the four call sites, and
-`translateAttrTag`/`applyAttrObject` diff to only the `repeated` lookup and the
-return style.
+The rule "a repeated attribute tag folds into `attrTags(prev, next)`, a non-repeated one becomes `attrTag(props)`" is implemented four times. `translateAttrTag` and the `isAttributeTag(tag)` branch of `applyAttrObject` are near-verbatim ~35-line copies, including the `t.parenthesizedExpression` mutation trick, differing only in where `repeated` comes from and whether the result is returned or handed to `addStatement`. `translate-attrs.ts` › `translateAttrs` and `addDynamicAttrTagStatements` encode the same rule over `contentProperties` and over an attr-tag identifier assignment. One helper would collapse the two `known-tag.ts` copies and let the other two share the `repeated ? attrTags : attrTag` decision, so a future change cannot land on three of four sites. Re-verify: `rg -n '"attrTags"' packages/runtime-tags/src/translator` lists exactly those four sites.
 
-## Drop the write-only `tagNameNullable` tag extra and the nullability bookkeeping that computes it
+## Drop the write-only `tagNameNullable` tag extra and its nullability tracking
 
 `packages/runtime-tags/src/translator/util/tag-name-type.ts` › `analyzeExpressionTagName` | 2026-07-23 | impact:low | effort:low
 
-`MarkoTagExtra.tagNameNullable` is declared (tag-name-type.ts:18, the module
-augmentation) and assigned in three places — `:50`/`:53` in `analyzeTagNameType`
-and `:208` in `analyzeExpressionTagName` — but never read anywhere in the
-workspace. It is also not computed correctly: the `while ((path = pending.pop())
-&& type !== TagNameType.DynamicTag)` loop aborts as soon as the type resolves to
-`DynamicTag`, so pending nullable operands are never visited. Delete the field
-and the `nullable` tracking, or, if it is meant to feed a future "dynamic tag
-can be null" specialization, wire it up and fix the early-exit before relying on
-it. Note the traversal's `&&`, `NullLiteral`, and `undefined`-identifier cases
-are **not** removable along with it — they exist to classify the tag name, so
-the `&&` branch must still avoid pushing `left` and the null/`undefined`
-branches must stay no-op `continue`s; collapsing them into the final `else`
-forces `TagNameType.DynamicTag` and would flip e.g. `<${cond ? null : "div"}/>`
-from NativeTag to DynamicTag.
-Re-verify: `rg -n "tagNameNullable" .` returns only the declaration and the
-three assignments in
-`packages/runtime-tags/src/translator/util/tag-name-type.ts`.
+`MarkoTagExtra.tagNameNullable` is declared in the module augmentation and assigned three times — twice in `analyzeTagNameType`, once in `analyzeExpressionTagName` — but never read, and it is wrong anyway: the `while ((path = pending.pop()) && type !== TagNameType.DynamicTag)` loop stops as soon as the type resolves, leaving pending nullable operands unvisited. Delete the field and the `nullable` local, but keep the traversal's `&&`, `NullLiteral` and `undefined`-identifier branches: they classify the tag name, so `&&` must still skip pushing `left` and the null/`undefined` cases must stay no-op `continue`s. Folding them into the final `else` forces `TagNameType.DynamicTag` and flips `<${cond ? null : "div"}/>` from NativeTag to DynamicTag. Re-verify: `rg -n "tagNameNullable" .` returns only the declaration and the three assignments in `tag-name-type.ts`.
 
 ## Delete translator/runtime residue left behind by completed refactors
 
 `packages/runtime-tags/src/translator/visitors/program/index.ts` › `isScopeIdentifier` | 2026-07-23 | impact:low | effort:low
 
-Three leftovers, each a pure delete/rename with no behavior change. (1)
-`translator/visitors/program/index.ts` still exports `isScopeIdentifier`; its
-only consumer was removed in commit `0a654cda92` ("drop the always-false
-referencesScope in the `<script>` translator", 2026-07-21), so a repo-wide `rg
--n "isScopeIdentifier"` now matches nothing but the definition — it is dead in
-the translator, where dead exports are unreachable by codegen string references
-and can simply go. (2) `html/dynamic-tag.ts:33` still carries `// TODO: refactor
-dynamicTagInput and dynamicTagArgs to be the same impl with a flag for input vs
-args.`, but neither symbol has existed since `ff59411349` (2025-03-28) and the
-refactor it asks for already shipped — `_dynamic_tag` takes a single
-`inputOrArgs` parameter plus the `inputIsArgs` flag; the comment also violates
-the AGENTS.md rule that comments capture intent and never describe removed code.
-(3) `translator/util/get-accessor-char.ts` exports only
-`getAccessorPrefix`/`getAccessorProp`; `getAccessorChar` was removed by #2577
-(`33c3979dcb`), so the filename no longer matches the module (e.g.
-`get-accessor-enums.ts`). Re-verify: `rg -n
-"isScopeIdentifier|dynamicTagInput|dynamicTagArgs|getAccessorChar"
-packages/runtime-tags` returns only the dead export declaration and the stale
-TODO line.
+Three pure deletes with no behavior change. `isScopeIdentifier` has no callers left after `0a654cda92`, though the `scopeIdentifier` it wraps is used throughout the visitors. `html/dynamic-tag.ts` still carries `// TODO: refactor dynamicTagInput and dynamicTagArgs …`, but neither symbol exists and `_dynamic_tag` already takes one `inputOrArgs` plus an `inputIsArgs` flag, so the comment describes removed code (AGENTS.md forbids that). `translator/util/get-accessor-char.ts` now exports only `getAccessorPrefix`/`getAccessorProp`, so rename it (e.g. `get-accessor-enums.ts`) and update the import specifiers. Re-verify: `rg -n "isScopeIdentifier|dynamicTagInput|dynamicTagArgs" packages/runtime-tags` matches only the dead export and the stale TODO, and `rg -n "get-accessor-char" packages/runtime-tags` lists the 11 import specifiers the rename has to follow.
 
 ## Collapse copy-pasted sibling implementations in the `<for>` and scriptlet core tags
 
 `packages/runtime-tags/src/translator/core/for.ts` › `forTypeToDOMRuntime` | 2026-07-23 | impact:low | effort:low
 
-Two copy-paste sets in the translator differ by a single token.
-`translator/core/for.ts` defines `forTypeToHTMLResumeRuntime` (`:571`) and
-`forTypeToDOMRuntime` (`:584`) as byte-identical `ForType` switches, both
-mapping `of|in|to|until` to `_for_of|_for_in|_for_to|_for_until`; they are
-called from `:261` and `:367`, so one can simply be deleted and both call sites
-pointed at the survivor, leaving `forTypeToRuntime` (`:558`, the non-underscored
-`forOf`/`forIn`/`forTo`/`forUntil` names) as the only genuinely different
-mapping. Separately, `translator/core/{client,server,static}.ts` are three
-31-line files whose only differences are the keyword stripped by
-`rawValue.replace(/^X\s*/, "")`, the third argument to `t.markoScriptlet(body,
-true, …)` (`"client"` / `"server"` / omitted), and their autocomplete strings —
-a single `createScriptletTag(keyword, target?)` factory would cut roughly 60
-lines while leaving the three `core/index.ts` registrations untouched. Both
-changes are mechanical and produce byte-identical generated output, so no
-snapshot or `sizes.json` churn. Re-verify: `diff <(sed -n '571,583p'
-packages/runtime-tags/src/translator/core/for.ts | sed
-'s/forTypeToHTMLResumeRuntime/F/') <(sed -n '584,596p'
-packages/runtime-tags/src/translator/core/for.ts | sed
-'s/forTypeToDOMRuntime/F/')` is empty, and `diff
-packages/runtime-tags/src/translator/core/client.ts
-packages/runtime-tags/src/translator/core/server.ts` reports only the four
-keyword/description lines.
+`forTypeToHTMLResumeRuntime` and `forTypeToDOMRuntime` are byte-identical `ForType` switches returning `_for_of|_for_in|_for_to|_for_until`, and both `dom` and `html` export those names, so delete one and point both call sites at the survivor; `forTypeToRuntime` stays as the only distinct mapping. Separately, `translator/core/{client,server,static}.ts` are three 31-line files differing only in the stripped keyword, the third `t.markoScriptlet(body, true, …)` argument, and their autocomplete text — a `createScriptletTag(keyword, target?)` factory would cut ~60 lines and leave the `core/index.ts` registrations untouched. Both edits are output-identical, so no snapshot or `sizes.json` churn. Re-verify: normalize the two function names and `diff` their bodies; `diff core/client.ts core/server.ts` shows only keyword/description lines.
 
 ## Stray debug `console.error` in the mocha patch
 
 `patches/mocha@11.7.6.patch` › `requireModule` | 2026-07-23 | impact:low | effort:low
 
-The repo's only mocha patch adds a bare `console.error(requireErr)` in `lib/nodejs/esm-utils.js`'s `requireModule` catch block, printing the full require error every time a spec file fails plain `require()` before mocha's `import()` fallback succeeds. With `.mocharc` `"no-warnings"` runs this is silent today only because spec requires no longer throw, but any environment where the require path fails first (e.g. an older Node loading `.ts` specs) spews stack traces for tests that then load fine. Looks like leftover debugging, not intentional patching. Fix: regenerate the patch without the `console.error` line (`pnpm patch mocha@11.7.6`), or delete the patch if that line was its only content — inspect with `cat patches/mocha@11.7.6.patch` (it is currently a single-hunk, one-line addition).
+The patch's only change adds `console.error(requireErr)` to `lib/nodejs/esm-utils.js`'s `requireModule` catch block, so any spec that fails plain `require()` and then loads fine via mocha's `import()` fallback prints a full stack trace for a passing file. Upstream already rethrows `requireErr` for the cases where it is the informative error, so the line adds nothing but noise, and it arrived with the npm→pnpm conversion (`0187289c71`) rather than as intentional patching. Fix: delete the patch file and its `pnpm-workspace.yaml` `patchedDependencies` entry, then `pnpm install`. Re-verify: `cat patches/mocha@11.7.6.patch` — the one-line hunk is the entire patch.
 
-## Delete or resurrect the dead `test/markoc` suite — mocha loads it every run for zero tests
+## Delete or resurrect the dead `test/markoc` suite
 
 `packages/runtime-class/test/markoc/index.test.js` | 2026-07-24 | impact:low | effort:low
 
-The mocha spec glob (`packages/*/@(src|test)/**/*.test.@(js|ts)`) matches this file, so every suite run loads it — and it defines no tests at all. Its entire `autotest` body has been commented out for years; the eight live lines only `require` `../__util__/test-init`, `chai`, and `../../compiler`, so the run pays that load cost for nothing. The commented body also now references `./babel-register`, which was deleted with the native-type-stripping migration, so it cannot be uncommented as written, and seven unused fixture directories remain under `fixtures/`. Either delete `test/markoc/` outright or resurrect the test by spawning `bin/markoc` with `-r ~ts` instead of a babel hook. Verify: `grep -vn "^\s*//" packages/runtime-class/test/markoc/index.test.js` lists eight non-comment lines and no `describe`/`it`.
+The mocha spec glob (`packages/*/@(src|test)/**/*.test.@(js|ts)`) matches this file, yet it declares no `describe`/`it`: the whole `mocha-autotest` body has been commented out for years, leaving five live lines that only `require` `../__util__/test-init`, `chai`, and `../../compiler`. The commented body resolves `./babel-register`, deleted in `3867db2ca8` (native type stripping), so it cannot be uncommented as written, seven `fixtures/` directories are unused, and `markoc` is still a published bin with no coverage. Delete `test/markoc/`, or resurrect it by spawning `bin/markoc` with `-r ~ts` instead of the babel hook. Re-verify: `rg -n "describe\(|it\(" packages/runtime-class/test/markoc/index.test.js` matches nothing outside comments.
+
+## Delete or restore the commented-out `Symbol.iterator` serializer test
+
+`packages/runtime-tags/src/__tests__/serializer.test.ts` | 2026-07-18 | impact:low | effort:low
+
+One commented-out test survives at `serializer.test.ts:733-751`: an `it.skip("Symbol.iterator registered", …)` case whose inner note reads "Unsupported for now since we share the reference for iterators on attribute tags." Either restore it as a live `it.skip` so the runner reports it, or delete it — commented-out code hides whether the limitation still holds. Decide it alongside "Remove the dead `_attrs` event-handler assertions in html-attrs.test.ts or give the routing real coverage", the other commented-out-assertion site in the same test suite. Re-verify: `rg -n "^\s*// *it\.skip" packages/runtime-tags/src/__tests__/serializer.test.ts` prints exactly that one block, and no other commented-out `it`/`describe` remains in the file.
+
+## Normalize the local naming flagged by the terminology audit
+
+`packages/runtime-tags/src/html/serializer.ts` › `State` | 2026-07-20 | impact:low | effort:low
+
+Three rename-in-place inconsistencies remain. `html/serializer.ts` spreads one mechanism over `assigns`/`assigned`/`addAssignment` and calls its generation counter `flush` though it is only compared (`parent.flush === state.flush`); `translator/core/if.ts` destructures the same branches entry as `branchBodySection` and as `branchBody`; `dom/controllable.ts` mixes `syncControllableFormInput` with `Controlled*` accessor/type prefixes while CONTEXT.md canonicalizes "controllable". The `startBinding`/`startMark` near-homophones live in `translator/core/show.ts`, not `core/await.ts`. While in `dom/controllable.ts`, drop the truncated first line of the three-line comment above `observeOnce` — an editing leftover that half-restates the next sentence and pushes the block past the two-line cap. Re-verify by grepping those symbols and `grep -n -B3 "^function observeOnce" packages/runtime-tags/src/dom/controllable.ts`.
+
+## Make a params binding identifiable from `binding.type`
+
+`packages/runtime-tags/src/translator/util/references.ts` › `trackParamsReferences` | 2026-07-22 | impact:med | effort:high
+
+Every section's params binding comes from `trackParamsReferences`, but callers pass four different `BindingType`s: `param` (`define`, attribute-tag, dynamic-tag, `known-tag`), `input` (program), `derived` (`core/for.ts`, `core/await.ts`) and `local` (attribute-tag `<for>`). So "is this a param?" is answered by an identity walk — `isParamBinding`, `getDebugName`, and the assignment guard `binding.upstreamAlias === binding.section.params` — instead of a type check. The heterogeneity is load-bearing: `BindingType` selects the `resolveBindingSources` branch, and `derived` routes `<for>`/`<await>` params through `resolveDerivedSources` so the item param's `Sources` reflect its loop/await source, driving serialize-reason scheduling and `scopeOffset`. Give params a uniform type or a dedicated marker and move that source transparency onto an explicit source-resolution input rather than the overloaded `derived`. Re-verify: `rg -n "trackParamsReferences\(" packages/runtime-tags/src/translator` still shows four distinct type args.
+
+## Share the await frame scheduler between `addAwaitCounter` and `_await_promise`
+
+`packages/runtime-tags/src/dom/control-flow.ts` › `addAwaitCounter` | 2026-07-23 | impact:low | effort:med
+
+`da6433e520` already factored the counter literal into `createAwaitCounter`, but the frame scheduler is still written twice: `if (!counter.i++) requestAnimationFrame(() => counter.i && runEffects(prepareEffects(() => queueRender(<scope>, …, -1))))` appears in `addAwaitCounter` (~~:280-307) and in the `else` arm of `_await_promise` (~~:139-165). Only the queued body (create and insert the placeholder branch vs. re-insert the await anchor, then `tempDetachBranch`) and the `queueRender` scope (`tryBranch` vs. `scope`) differ, so the `requestAnimationFrame`/`prepareEffects`/`queueRender` chain ships twice in every app using `<await>`. Extract a `scheduleFrame(counter, scope, onFrame)` helper alongside `createAwaitCounter`. Re-verify with the root `.sizes.json` and the `await-*`/`try-*` fixture `sizes.json` after the change.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -2,595 +2,266 @@
 
 Friction in builds, tests, tooling, or repo workflows. Format and rules: [README.md](README.md).
 
-## Migrate to Babel 8 and chai 6 as dedicated efforts (deferred from the deps upgrade)
+## Migrate to Babel 8 and chai 6 as dedicated efforts
 
 `patches/@babel__types@7.29.7.patch` | 2026-07-07 | impact:med | effort:high
 
-The dependency upgrade took everything to latest except two majors that are true migrations, not refreshes. **Babel 8** (`@babel/*` held at 7.29.7): the compiler ships four hand-authored patches against Babel 7's compiled `lib/` (`patches/@babel__{types,traverse,generator,helper-compilation-targets}@7.29.7.patch`, the types one 79 KB, injecting Marko AST node types) plus `packages/compiler` code that reaches Babel-7 internals via `@marko/compiler/internal/babel`; Babel 8 restructures those modules so the patches won't apply and the codegen needs porting. **chai 6** (held at 4.5.0): chai 5+ is ESM-only (`"type":"module"`), but there are 379 CommonJS `require("chai")` call sites (all under `packages/runtime-class/test/**` and `packages/runtime-tags/src/__tests__`), so adopting it means converting every test fixture to ESM or dynamic import. Each should be its own PR with focused testing.
+Two majors stay pinned because they are migrations, not refreshes. Babel is held at 7.29.7 behind four hand-authored patches against Babel 7's compiled `lib/` (`patches/@babel__{types,traverse,generator,helper-compilation-targets}@7.29.7.patch`; the types one is 78 KB of injected Marko AST node types) plus `packages/compiler` reaching Babel-7 internals through the `@marko/compiler/internal/babel` export — Babel 8 restructures those modules, so the patches stop applying and the codegen needs porting. chai is held at 4.5.0 because chai 5+ is ESM-only and 379 CommonJS `require("chai")` call sites remain, all under `packages/runtime-class/test/**`. Give each its own PR. Re-check with `ls patches` and `rg -c 'require\("chai"\)' packages`.
 
-## Further `test:parallel` speedups need CPU cuts, not scheduling
-
-`scripts/test-parallel.js` | 2026-07-11 | impact:med | effort:high
-
-With suite slicing in place the run is CPU-bound: ~285s of user time across
-workers (~80s wall on 4 cores, workers finish within ~2s of each other), so
-better packing or more workers no longer helps (6 workers on 4 cores measured
-neutral). A `--cpu-prof` of a fixture worker shows the spend is flat — ~17%
-node core (ESM import of per-fixture bundles, fs), ~13% `@babel/register` TS
-transform, ~13% jsdom+parse5, ~6% GC, rest compiler/translator/rolldown glue —
-and ~21% idle (JS thread waiting on rolldown's native threads). Reclaiming
-that idle by prefetching the next fixture's `createServerRunner()` build was
-considered and rejected: a concurrent build can emit console output inside
-another test's `captureConsole` window (`utils/capture-console.ts` patches the
-global console), corrupting `writes.html`/log snapshots. If someone wants the
-~10-20% win, scope the console capture (or buffer build diagnostics) first,
-then pipeline builds one fixture ahead gated on `MARKO_TEST_SLOTS`.
-
-**The profile above predates the drop of `@babel/register` and must be
-re-measured before anyone acts on it.** Node now strips types natively, so the
-~13% `@babel/register` TS transform and the cold-cache penalty on fresh CI
-checkouts no longer describe anything that exists. Coverage is no longer a
-factor either: the report is a native `zcov` pass of a few seconds rather than
-the ~65s single-threaded `c8 report` this entry was originally written against.
-Whether the run is still CPU-bound — the entry's actual conclusion — is
-untested against the current tooling.
-
-## Emit a compile-time diagnostic when an unenclosed `>`/`>=` truncates an attribute-value expression
+## Emit a compile-time diagnostic when a space-separated `>` truncates an attribute-value expression
 
 `packages/compiler/src/babel-plugin/parser.js` › `onText` | 2026-07-18 | impact:med | effort:med
 
-The htmljs-parser tokenizer treats the first unenclosed `>` in a tag/attribute-value expression as the tag close, so `<if=input.n > 0>yes</if>` compiles to `if (input.n) { _html(" 0>yes"); }` — the condition silently degrades to a truthiness check on `input.n` and ` 0>` leaks into the output as literal text. `<const/positive=input.delta >= 0>` likewise compiles to `const positive = input.delta;` plus a leaked `= 0>` text node (in a live dashboard every stat card showed the positive marker, including a `-2.3%` delta, with literal `= 0>` printed before each card). No error is raised in any mode: the parser adapter only rethrows tokenizer `onError` reports (`parser.js:141`) and faithfully emits the post-`>` remainder via `onText` (`parser.js:170`), and the truncation itself raises no `onError`. `x > y` / `x >= y` comparisons are among the most common expressions authors write in `<if>`/`<const>`/`<let>`/attribute values, so a silent wrong-logic-plus-leaked-text miscompile is a severe footgun. The ambiguity is intentional and documented (a CAUTION at website `docs/reference/language.md:212` says values cannot contain an unenclosed `>` and must be parenthesized), and the underlying token rule lives in the external `htmljs-parser` dependency (^5.12) — so rather than a grammar change, the pragmatic fix is a compiler/lint diagnostic for the tell-tale `<syntactically-complete-left-operand>` immediately followed by text beginning like a truncated operator (` 0>`, `= 0>`), which is exactly the `x > y` / `x >= y` shape.
+htmljs-parser treats the first unenclosed `>` as the tag close, so `<if=input.n > 0>yes</if>` compiles to `if (input.n) { _html(" 0>yes"); }` — wrong logic plus literal garbage in the output, with no error in any mode. The tokenizer cannot decide this form for us: `>` is indistinguishable from a legitimate tag close followed by text, so the heuristic has to live here — in `onText`, flag a text node that begins like a truncated operator (`" 0>"`) immediately after an open tag whose attribute value parsed as a syntactically complete left operand, and word the `packages/runtime-tags/cheatsheet.md` entry for it. That heuristic is necessarily lossy: `<div class=x > 0>yes</div>` is valid markup that compiles to `<div${_attr_class(x)}> 0>yes</div>` yet matches the same shape, and restricting it to "expression attributes" excludes nothing because every Marko attribute value is a JS expression (`<div class=input.n > 0 ? "a" : "b">t</div>` truncates identically), so ship it as a recoverable warning with a documented escape hatch (`&gt;` or `${input.n > 0}`) rather than a hard error. The tighter `>=` form (`<const/positive=input.delta >= 0/>`) is being fixed upstream in htmljs-parser (`src/states/ATTRIBUTE.ts` › `shouldTerminateHtmlAttrValue`), and `parser.js` › `onError` already turns any tokenizer error into a code-frame error, so that half needs nothing here beyond the version bump. `x > y` in `<if>`/`<const>`/`<let>`/attribute values is common enough to make this a severe silent miscompile. Re-verify by compiling `<if=input.n > 0>yes</if>` with `scripts/inspect-compiled-output.mts -o html -d`.
 
-## Surface a near-miss suggestion (or document the casing rule) for miscased event attributes
-
-`packages/runtime-tags/src/common/helpers.ts` › `getEventHandlerName` | 2026-07-18 | impact:low | effort:low
-
-`<input onKeydown(e) {}>` fails @marko/type-check with TS2353 "Object literal may only specify known properties, and '\"onKeydown\"' does not exist in type 'Directives & Input'" — no "did you mean onKeyDown?" — while the runtime happily binds it: `isEventHandler` matches `/^on[A-Z-]/` and `getEventHandlerName` lowercases everything after "on" (`name.slice(2).toLowerCase()`), so both casings mean `keydown` at runtime. Canonicalizing the types to exact camelCase (`onKeyDown` at `packages/runtime-tags/tags-html.d.ts:5085`, plus the `on-keydown` alias) is a reasonable choice, but the bare excess-property error on a near-miss casing makes it look like event handlers are unsupported on that element rather than misspelled. Emitting a spelling suggestion for case-only near-misses in the type-check diagnostics, or documenting the exact-camelCase rule in `cheatsheet.md`, would fix the confusion cheaply.
-
-## Give a structural error for a stray close tag / unwrapped text on a concise line instead of relaying htmljs-parser's "Unterminated regular expression."
-
-`packages/compiler/src/babel-plugin/parser.js` › `onError` | 2026-07-19 | impact:low | effort:med
-
-A concise-mode line that is bare text followed by a stray `</tag>` (or a `/`) is reported with a low-level JS-tokenizer message that names regex/type-parameter/attribute-name internals with the caret mid-identifier, never mentioning tags or text: `hello</div>` → `Unterminated regular expression.` at column 8; `Read more or/and less` → `Invalid attribute name.`; `Click here</a> to continue` → `Attribute cannot contain type parameters unless it is a shorthand method`. The exact same stray close in HTML mode or at line start is diagnosed correctly (`<div>hi</span>` → "The closing 'span' tag does not match the corresponding opening 'div' tag"; `</div>` → "The closing 'div' tag was not expected"). `parser.js:141` `onError` relays htmljs-parser's raw `part.message` verbatim (`buildCodeFrameError(…, part.message)`); in concise mode the first token is scanned as a tag name and the `/` in `</div>` starts a regex literal, so htmljs-parser (^5.12) raises an unterminated-regex tokenizer error that Marko passes through unchanged, with no post-classification that recognizes the `<word></…>`/trailing-`/` shape as a mis-structured tag or unwrapped text. Trigger is narrow (pasting an HTML fragment into a concise section, or unwrapped prose containing a slash/stray close) but opaque when hit. Detect the concise `<identifier>`-scanned-as-tag with a following `/`-started expression / stray close and remap to a tag/text structural diagnostic before rethrowing at `parser.js:141`. Distinct from the existing dx entry about an unenclosed `>`/`>=` truncating an attribute-value expression (`parser.js:170`), which is about `>` silently truncating; this is about the parser SURFACING a misleading low-level message for a tag-structure mistake.
-
-## Emit a dev-mode diagnostic when a self-referential effect re-renders past a threshold
-
-`packages/runtime-tags/src/dom/signals.ts` › `_let` | 2026-07-19 | impact:low | effort:med
-
-A `<script>` (effect) that writes a `<let>` it transitively reads re-renders once per animation frame forever with no cycle/max-depth diagnostic. `<let/n=0>` + `<script>{ if (n < 2000) n = n + 1 }>` climbs `n` toward 2000 one pass per frame; an unconditional `n = n + 1` never terminates (a terminating variant `if (n<3) …` settles at `n=3` after 4 passes, proving each self-write is a full new render+effect pass, not coalesced). The page stays responsive (rAF-paced) but pegs a core and grows state unbounded, with no console warning or error. In `_let`'s non-rendering branch (`dom/signals.ts:43-49`) any value change unconditionally calls `schedule()` + `queueRender` with no per-scope/per-run update counter; `run()` (`dom/queue.ts:83-95`) drains renders then effects and resets state with no depth tracking; `schedule()` reschedules through `queueMicrotask`→`requestAnimationFrame`→`MessageChannel` (`dom/schedule.ts`), pacing successive self-write passes one-per-frame rather than a synchronous freeze. Writing state in an effect is a documented anti-pattern (use `<const>` for derivation), so this is user error — the finding is the MISSING diagnostic, which peers provide (React "Maximum update depth exceeded"; Solid/Svelte cyclic-update detection). A `MARKO_DEBUG` update-depth guard in `run()`/`queueRender` (throw after N self-perpetuating passes on the same scope+signal) would surface the mistake with a stack instead of a mysteriously spinning page. No existing entry mentions cycles / max-update-depth / infinite loops.
-
-## Server-mode `render` can only observe the fully-resolved `<await>`/`<try>` state; a pending promise hangs the test
-
-`packages/runtime-tags/src/html/template.ts` › `ServerRendered.#promise` | 2026-07-19 | impact:med | effort:med
-
-The placeholder/loading and streaming states of Marko's own async primitive cannot be tested in a server-project (`*.server.test.ts`) render at all. `<try><await|u|=input.load()>…<@placeholder>Loading…</@placeholder><@catch|e|>…</@catch></try>`: after `String(await template.render(input))`, `@placeholder` is never observable (`queryByText("Loading…")` is null, only the resolved content is present), and a never-resolving `load()` makes the test time out because `render` awaits the whole stream to completion. `@marko/testing-library`'s server render is `String(await template.render(input))`, and Marko's `template.render` returns a `ServerRendered` thenable whose `#promise` resolves only once the boundary reaches `FlushStatus.complete` (`html/template.ts:268-293`, resolve at :287), while its synchronous `toString()` throws "Cannot consume asynchronous render with 'toString'" on any pending boundary (`:337-349`, :346). So awaiting the result necessarily drains all async content and there is no intermediate/initial-flush accessor for the helper to use — the `@await` placeholder and `@catch` paths are reachable only in the browser project (via `mount`, which paints the placeholder synchronously). Expose the first synchronous chunk from testing-library, or offer a sync/initial-flush render accessor on the `ServerRendered` result that the helper can call, so streaming states are testable without a browser. The file that awaits the full stream is `@marko/testing-library` (marko-js org, off-disk); the resolution semantics that force it are the marko html runtime cited here.
-
-## Route the agent fix-guide to the specific error instead of appending one generic whole-cheatsheet pointer
+## Key the agent fix-guide to the specific error instead of one generic cheatsheet pointer
 
 `packages/compiler/src/util/agent-fix-guide.js` › `fixGuide` | 2026-07-19 | impact:high | effort:med
 
-Every thrown compile error gets the identical appended line `\n\nFix guide: READ ${cheatsheet} before writing a fix.` (`agent-fix-guide.js:44-45`), because `fixGuide(translator)` interpolates only the resolved cheatsheet path and never consults the error's `label` or code — the same pointer is emitted for a malformed attribute, a bare-text-at-root case, an unclosed tag, or a serialization failure. The target `packages/runtime-tags/cheatsheet.md` is 174 lines (24 golden rules plus a ~24-row DON'T table), and one label routinely spans several unrelated causes (the existing dx entry at `parser.js:141` documents `Invalid attribute name.` covering both a real bad attribute and unwrapped concise text), so a whole-file pointer cannot disambiguate. This matters for agentic workflows because agents triage and fix from the error string alone: a generic "go read all 174 lines" pointer forces the agent to re-read and self-map the entire reference on every error (and mis-map, since one label spans several root causes), whereas an anchored hint lets it jump to the exact rule. Key the appended hint to the diagnostic — an anchor into the exact cheatsheet section, or a one-line cause-specific hint the emitter attaches from its AST context (e.g. `Fix guide: bare text at template root — see 'Golden rules' #1 in <path>`).
+`fixGuide(translator)` interpolates only the resolved cheatsheet path, so every thrown compile error gets the identical `Fix guide: READ <path> before writing a fix.` — verified: `<div` (EOF in open tag) and bare text at root produce byte-identical hints. `packages/runtime-tags/cheatsheet.md` is ~200 lines over 11 sections, and one label spans several causes (`Invalid attribute name.` covers both a bad attribute and unwrapped concise text), so a whole-file pointer cannot disambiguate. Pass the diagnostic (label/loc, or a hint the emitter attaches from its AST context) into `appendAgentFixGuide` and append a section anchor, e.g. `see 'Golden rules' #1 in <path>`. See also "Attach the agent fix-guide to `errorRecovery` diagnostics, not just thrown errors" — a separate coverage defect that wants the same diagnostic-keyed guide helper, so build it once. Re-verify: compile two differently-broken templates with `CLAUDECODE=1` and confirm the appended lines differ.
 
-## Thread the agent fix-guide onto `meta.diagnostics` so editor/LSP and dev-overlay consumers surface it, not just hard throws
-
-`packages/compiler/src/index.js` › `compile` | 2026-07-19 | impact:high | effort:med
-
-`appendAgentFixGuide` runs only inside the `compile`/`compileSync` catch blocks (`index.js:41` and `:52`), which are reached only when `buildResult` throws. Under `errorRecovery: true` — the mode built for tooling, where "any recoverable errors will be returned in the `meta.diagnostics` property" (`config.js:172-175`) — `buildResult` collects diagnostics and returns a successful result without throwing (`index.js:165-175`), so the catch never fires and every recovery-mode consumer gets the raw `diag.label` with no fix-guide. The compiler's own comments confirm this is exactly the editor path: analyze/parse failures are "kept as recoverable diagnostics" for "editors compiling with `errorRecovery`" (`translator/util/analyze-errors.ts:6-11`, `babel-plugin/index.js:327-331`). This is the crux for agentic workflows: agents increasingly triage from LSP diagnostics, `mtc` type-check output, and dev-server overlays rather than a raw Node stack trace — all of which run in error-recovery mode — so the one place Marko emits agent guidance is invisible exactly where agents actually read errors during dev. Thread the (ideally error-specific) guide onto the diagnostic `label`/meta in `buildResult` so recovery-mode consumers surface it, instead of restricting it to the throw boundary.
-
-## Honor an explicit `MARKO_AGENT_FIX_GUIDE` override and document the agent fix-guide so any harness can enable/suppress it deterministically
+## Honor a documented `MARKO_AGENT_FIX_GUIDE` override for the agent fix-guide
 
 `packages/compiler/src/util/agent-fix-guide.js` › `isCodingAgent` | 2026-07-19 | impact:med | effort:low
 
-`isCodingAgent()` (`agent-fix-guide.js:24-35`) enables the guide only on a fixed env allowlist — `CLAUDECODE`, `CLAUDE_CODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `CODEX_SANDBOX`, `CODEX_THREAD_ID`, `AI_AGENT`. `AI_AGENT` is a generic catch-all opt-in, but the whole feature and its markers are documented nowhere user-facing (grep of `website/` docs and package READMEs both return nothing; only `packages/compiler/AGENTS.md:16,23` mentions it internally), and there is no explicit Marko override checked before the marker sniff to force the guide on (for a harness not on the list, or one that compiles in a child process that drops the inherited marker) or off. For agentic workflows this makes the guidance nondeterministic across harnesses: an agent whose runner isn't on the allowlist, or that spawns compilation in a subprocess without the marker, silently never sees the guide and has no documented way to discover or force it. Check a documented `MARKO_AGENT_FIX_GUIDE=1/0` env override first, before the marker sniff, and document the feature plus the `AI_AGENT` opt-in so any agent framework can deterministically enable or suppress it.
+`isCodingAgent()` gates the guide on a fixed env allowlist (`CLAUDECODE`, `CLAUDE_CODE`, `CURSOR_AGENT`, `GEMINI_CLI`, `CODEX_SANDBOX`, `CODEX_THREAD_ID`, `AI_AGENT`) with no explicit override, and the feature is documented only in `packages/compiler/AGENTS.md` and a one-line changelog — nothing user-facing. A harness not on the list, or one that compiles in a subprocess that drops the inherited marker, silently never sees the guide and has no documented way to force it on or off. Check `process.env.MARKO_AGENT_FIX_GUIDE` (`1`/`0`) before the marker sniff, and document it plus the `AI_AGENT` opt-in. Re-verify: with no agent markers set, `MARKO_AGENT_FIX_GUIDE=1` appends the pointer and `=0` suppresses it.
 
-## Steer authors to the typed second-arg element; `event.currentTarget`/`target` fail mtc and are unsupported at runtime
+## Make `event.currentTarget` a type-level error that names the handler's second parameter
 
 `packages/runtime-tags/tags-html.d.ts` › `AttrEventHandler` | 2026-07-19 | impact:med | effort:low
 
-The universal DOM/JSX idiom `event.currentTarget.value` (and `event.target.value`) both fails type-check and breaks at runtime in Marko, and almost nothing steers authors to the working form. `AttrEventHandler<Event, Target> = AttrMissing | ((event: Event, target: Target) => unknown)` (`tags-html.d.ts:5873`) puts the typed element in the handler's SECOND parameter; the first stays the raw DOM event whose `currentTarget: EventTarget | null` and `target: EventTarget` are unnarrowed. `mtc` on `<input onInput(event){ event.currentTarget.value }>` errors TS18047 ("possibly null") + TS2339 ("Property 'value' does not exist on type 'EventTarget'"), while `<input onInput(event, target){ target.value }>` type-checks clean (both verified, `target` inferred as `HTMLInputElement`). At runtime Marko's delegated events make `currentTarget` worse: reading it logs a `console.error` and returns null, then deletes the property (`packages/runtime-tags/src/dom/event.ts:34-53`), and handlers are invoked as `(ev, target)` (`event.ts:47`). Yet the reference example `<button onClick(e){ console.log(e.target) }>` (`docs/reference/language.md:274`) and the tutorial's `onInput(e){ degF = +e.target.value }` (`docs/tutorial/components-and-reactivity.md:36`) both model the type-failing idiom, and the two-arg element appears only once, unexplained, as `onClick(e, el)` (`docs/explanation/class-vs-tags-api.md:59`). Every form/input handler an agent writes reaches for `event.currentTarget.value` carried over from React/DOM; it fails `mtc`, and casting past it crashes in dev, with no docs or type message naming the second arg. Direction: narrow the event's `currentTarget`/`target` to the `Target` element type (or fail with a message that names the second parameter), and update the reference/tutorial examples to `onInput(event, target)`. Distinct from the existing dx.md miscased-event-attribute entry (`common/helpers.ts:133`), which concerns attribute-name casing, not the handler's element access.
+`AttrEventHandler<Event, Target>` (`tags-html.d.ts:5937`) puts the typed element in the handler's SECOND parameter and leaves the first as the raw DOM event; no `.d.ts` in the repo mentions `currentTarget`. So the React/DOM reflex `<input onInput(event){ event.currentTarget.value }>` fails type-check with TS18047 + TS2339 ("Property 'value' does not exist on type 'EventTarget'"), `event.target.value` fails identically, and only `(event, target) => target.value` type-checks clean (`target` inferred `HTMLInputElement`) - with nothing in-repo pointing at that form: `packages/runtime-tags/cheatsheet.md:189` lists `onInput(e) { q = e.target.value }` only as a DON'T whose DO is `value:=q`, and no skill or doc mentions the second parameter. At runtime delegation makes `currentTarget` unusable: under `MARKO_DEBUG` `handleDelegated` (`src/dom/event.ts`) installs a getter that `console.error`s and returns null, so casting past the type error crashes; in a production build the property is untouched and reads as `document` (the delegated capture listener), i.e. silently wrong. Do NOT narrow `currentTarget`/`target` to `Target` - under delegation `ev.target` is the deepest dispatched element, not the handler's element. Instead type the event parameter's `currentTarget` as a string literal carrying the guidance rather than `never` - `event.currentTarget.value` then errors TS2551 with the literal quoted verbatim in the message, so the diagnostic itself names the handler's second parameter, whereas `never` yields only a bare TS2339 - reusing `handleDelegated`'s debug wording, and add the two-arg form to `cheatsheet.md`; distinct from "Surface a near-miss suggestion (or document the casing rule) for miscased event attributes", which fixes attribute-name casing, not the handler's element access. Re-verify without `mtc` (not installed in this repo): `tsc` a file containing `/// <reference path="packages/runtime-tags/tags-html.d.ts" />`, `type H = Extract<Marko.HTML.Input["onInput"], (...a: any) => any>`, and the three handler bodies.
 
-## Make ad-hoc headless verification reliable: lazy-init the DOM walker, and stop the compiler silently disabling module resolution when a `document` global exists
-
-`packages/runtime-tags/src/dom/walker.ts` › `walker` | 2026-07-19 | impact:low | effort:low
-
-A throwaway node script — the fastest way an agent confirms a compiled component actually works before writing a full test setup — is mined with two import-order traps whose error strings point nowhere near the cause. (1) The DOM runtime evaluates `document.createTreeWalker(document)` at module top level (`dom/walker.ts:12`), so requiring the compiled `dom` output before a DOM global is installed throws `ReferenceError: document is not defined` at a `marko/dist` line. (2) `@marko/compiler`'s `modules.js` decides at first-require whether it is running in a browser via `typeof document === "object"` (`packages/compiler/modules.js:3`); installing jsdom globals (which define `global.document`) BEFORE requiring `@marko/compiler` takes that branch and sets `exports.resolve`/`tryResolve` to `null` (`:8-9`), so the first attempt to load a translator throws `TypeError: _modules.default.resolve is not a function` with no hint that a DOM global caused it (the branch is evaluated once and cached for the module lifetime). The only working order — compile with no DOM globals, THEN install jsdom, THEN require the runtime — is undocumented and easy to get backwards. `@marko/vite` and `@marko/testing-library` sequence this correctly, but an agent hand-rolling a verification script gets no guidance and burns turns guessing against two opaque messages. Lazy-init the walker on first `walk()` (drop the top-level `document` read), and either make the compiler's browser sniff robust to a node process that merely has jsdom installed or throw an error naming the cause; at minimum document a compile-then-shim-then-import recipe so headless self-checks are reliable.
-
-## Mutation-tracker jsdom workaround silently hides real text updates in snapshots
+## Stop the jsdom characterData workaround from hiding real text appends
 
 `packages/runtime-tags/src/__tests__/utils/track-mutations.ts` › `formatMutationRecord` | 2026-07-14 | impact:low | effort:low
 
-The characterData filter drops records where the new value starts with the
-old value and the boundary is whitespace, to hide jsdom's duplicate records
-(jsdom#3261) — but it also matches real updates of that shape: a step
-changing text "draft" to "draft edited" produces no `## Change` entry and no
-html block, so the step looks like a no-op in the render snapshot while the
-DOM did update, which costs real debugging time on new fixtures. Fix
-direction: re-check the jsdom issue, or drop a record only when an adjacent
-record re-reports the same target, or always emit the html block even when
-every record was filtered. Verify: a fixture step appending to an existing
-text node currently yields an empty snapshot entry.
+The characterData branch drops any record whose new value starts with the old value at a whitespace boundary (the jsdom#3261 workaround), which also matches real updates: "draft" → "draft edited" passes `newValue.indexOf(oldValue) === 0` and the `/\s$/` test on `newValue[oldValue.length]`. `getStatusString` then finds no mutations, suppresses the html block for rendered steps, and returns null without an update payload, so the step vanishes from the snapshot even though the DOM changed. Drop a record only when an adjacent record re-reports the same target, or always emit the html block when every record was filtered. Re-verify: a fixture step appending " edited" to an existing text node yields no snapshot entry.
 
-## `npm test <file>` appends to the default spec glob instead of scoping to the file
+## Document (or script) how to scope `npm test` to a single file
 
-`.mocharc.json` | 2026-07-15 | impact:low | effort:low
+`.mocharc.json` › `spec` | 2026-07-15 | impact:low | effort:low
 
-Passing an explicit test file (`npm test -- <path>.test.ts`) does not scope
-the run: mocha adds positional file args to the configured spec glob, so the
-whole suite runs anyway — silently, since the named file is also included.
-Scoping to one file requires bypassing the config
-(`npx mocha --no-config --no-package --timeout 10000 --require ~ts <file>`),
-which is undocumented and easy to get wrong. Either document that
-incantation in CLAUDE.md next to the `--grep` guidance, or add a `test:file`
-script that forwards to mocha without the default spec. Verify:
-`npm test -- packages/runtime-tags/src/__tests__/serializer.test.ts` runs
-every spec file.
+Positional file args are unioned with the configured `spec` glob rather than replacing it: with mocha 11.7.6, `mocha packages/runtime-tags/src/__tests__/serializer.test.ts` resolves `argv.spec` to `["…/serializer.test.ts", "packages/*/@(src|test)/**/*.test.@(js|ts)"]`, so the whole suite runs — silently, since the named file is included. `--spec <file>` merges the same way; only `--grep` or bypassing the config (`npx mocha --no-config --no-package --timeout 10000 --require ~ts <file>`) actually scopes a run. Add a `test:file` script that forwards to mocha without the default spec, or document the incantation in CLAUDE.md beside the existing `--grep` line. Re-verify by printing the resolved `argv.spec` from mocha's run-command handler.
 
-## Error-compile fixtures never refresh or clean `sizes.json`
-
-`packages/runtime-tags/src/__tests__/main.test.ts` › `hasCompilerError` sizes gate | 2026-07-20 | impact:low | effort:low
-
-The optimize `after()` sizes assertion is gated on `!hasCompilerError`, so a
-fixture that later becomes `error_compiler: true` keeps its last generated
-`sizes.json` forever — neither asserted nor rewritten by `test:update`. The
-harness could delete (or assert the absence of) `sizes.json` for error
-fixtures. Verify: add `sizes.json` to any `error_compiler` fixture and watch
-`npm run test:update` leave it untouched.
-
-## Emit the circular-reference error for mutually-referential `<const>` tags, not just self-references
-
-`packages/runtime-tags/src/translator/util/references.ts` › `trackReferencesForBinding` | 2026-07-20 | impact:low | effort:med
-
-`trackReferencesForBinding` throws `Tag variable circular references are not
-supported.` only when a tag variable references itself inside its own tag
-(`<const/x=x/>`). A mutual cycle (`<const/a=b/><const/b=a/>`) passes the check
-and compiles to code that fails at runtime; detecting it through the binding
-graph would surface the same clear compile error. Verify: compile
-`<const/a=b/><const/b=a/>` used as a value and observe no diagnostic.
-
-## Forward the translator cheatsheet through `createInteropTranslator` so the agent fix-guide fires for interop (Marko 5 and mixed 5/6) compiles
+## Forward `cheatsheet` through `createInteropTranslator` so the agent fix guide fires on interop compiles
 
 `packages/runtime-tags/src/translator/interop/index.ts` › `createInteropTranslator` | 2026-07-20 | impact:med | effort:low
 
-`createInteropTranslator` (`interop/index.ts:16-41`) builds the translator every Marko 5 and mixed 5/6 project loads, forwarding `version`, `preferAPI`, `transform`, `analyze`, `translate`, `tagDiscoveryDirs`, `taglibs`, and `getRuntimeEntryFiles` but omitting `cheatsheet`; `runtime-class/src/translator.js` destructures exactly those 8 keys, so `marko/translator` exposes no `cheatsheet` (verified: loading it via the compiler's `markoModules.require` yields `cheatsheet === undefined`). The compiler's agent fix-guide (`agent-fix-guide.js:40-46`) appends `Fix guide: READ <cheatsheet> before writing a fix.` only when `tryLoadTranslator(translator)?.cheatsheet` is a string, so coding-agent sessions on interop projects never receive it — including on Marko 6 tags-API files compiled through the interop, where the runtime-tags cheatsheet (`runtime-tags/src/translator/index.ts:23`) is exactly the migration aid intended. Forward a `cheatsheet` from `createInteropTranslator` and add it to the runtime-class re-export; the value must be an absolute path, because `try-load-translator.js:16-19` resolves it via `path.resolve(path.dirname(translatorModule), value)` and the runtime-class translator sits at `src/translator.js`, so `translate6`'s raw `'../../cheatsheet.md'` would resolve to a non-existent file (`packages/runtime-class` has no `cheatsheet.md`). Re-verify with `CLAUDECODE=1`: `appendAgentFixGuide(new Error('x'), 'marko/translator')` leaves the message untouched (no `Fix guide:` suffix), whereas the same call with `'@marko/runtime-tags/translator'` appends `READ packages/runtime-tags/cheatsheet.md`.
+`createInteropTranslator` returns 8 keys without `cheatsheet`, and `runtime-class/src/translator.js` re-exports exactly those, so `marko/translator` exposes none. `agent-fix-guide.js` appends `Fix guide: READ …` only when `tryLoadTranslator(translator)?.cheatsheet` is a string, so Marko 5 and mixed 5/6 sessions never see it — including tags-API files compiled through the interop, where the runtime-tags cheat sheet is exactly the migration aid wanted. Forward one and re-export it from runtime-class; `try-load-translator.js` resolves the value against the translator module's own directory, so reusing `translate6`'s `"../../cheatsheet.md"` misses (`packages/runtime-class` has no `cheatsheet.md`). Verify with `CLAUDECODE=1`: `appendAgentFixGuide(new Error("x"), "marko/translator").message` stays `"x"`, while `"@marko/runtime-tags/translator"` appends `READ packages/runtime-tags/cheatsheet.md`.
 
 ## Serialize `Blob` and `File`, including inside `FormData`
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeFormData` | 2026-07-23 | impact:med | effort:med
 
-`writeFormData` already rejects any non-string entry with an explicit "`File`/`Blob` entries aren't serializable yet" comment, and both types are equally unserializable as standalone values, so a resumed form that carries an upload cannot be represented at all. Both hold binary content that the existing `writeArrayBuffer`/`writeTypedArray` machinery can already encode, and both reconstruct from a constructor call (`new File([bytes], name, { type, lastModified })`), so the work is reading the bytes plus threading the async read through the boundary the way `writeReadableStream` does. Re-verify: serializing `new Blob(["hi"])` or a `FormData` holding a `File` drops the value, and the `writeFormData` comment marks the gap in source.
+Neither type has a case in `writeUnknownObject`, and `writeFormData` aborts on any non-string entry ("`File`/`Blob` entries aren't serializable yet"), so a resumed form carrying an upload cannot be represented at all. Both hold binary content the existing `writeArrayBuffer`/`writeTypedArray` path already encodes and both rebuild from a constructor call (`new File([bytes], name, { type, lastModified })`); the work is reading the bytes and threading the async read through the boundary the way `writeReadableStream` does. Verify: `serializer.test.ts`'s "aborts on File/Blob values instead of dropping them" pins today's behavior, and a bare `new Blob(["hi"])` hits `throwUnserializable`.
 
-## Serialize the remaining DOM built-ins reachable from browser code
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeUnknownObject` | 2026-07-23 | impact:low | effort:low
-
-`DOMException`, `AbortSignal`, and `Event` still fall through the constructor dispatch to `throwUnserializable`, each a one-case addition. They reach templates through request handling yet cannot cross to the browser, so a resumed value holding one is dropped. Each has a constructor form that round-trips its observable state (`new DOMException(message, name)`, `AbortSignal.abort(reason)` for an already-aborted signal, `new Event(type, { bubbles, cancelable, composed })`), but a live `AbortSignal` that has not yet aborted has no faithful representation — resume would need it wired to a fresh controller, so decide that semantics before adding it. Lower value than the rest of the dispatch table and only worth adding if a real template needs them. Re-verify: pass each through `Serializer#stringifyScopes` and observe the value is omitted from the payload, against `new URL("https://a.b")` as a supported control.
-
-## Make `Cannot assign to hoisted tag variable.` say what the rule is and link the tag-variable docs
+## Name the variable and the positional rule in `Cannot assign to hoisted tag variable.`
 
 `packages/runtime-tags/src/translator/util/references.ts` › `trackReferencesForBinding` | 2026-07-23 | impact:med | effort:low
 
-Writing a `<let>` from a handler that appears _above_ the `<let>` fails with the
-bare message `Cannot assign to hoisted tag variable.` (references.ts:524).
-"Hoisted" is compiler jargon (CONTEXT.md's _Hoist_ entry), the restriction is
-not stated anywhere in the language reference — website
-`docs/reference/language.md:664` only says tag variables are hoisted and
-readable anywhere — and the message names neither the variable nor the fix,
-which is simply to move the declaration above the assignment. `references.ts` is
-a cluster of nine user-facing compile errors (`:291`, `:306`, `:309`, `:495`,
-`:519`, `:524`, `:555`, `:584`, `:679`) and none of them follow the convention
-AGENTS.md documents and `core/if.ts` demonstrates — backticked names plus a
-markojs.com docs link; every `core/*.ts` tag file does. `Duplicate declaration
-"x"` (`:519`/`:306`) even uses `JSON.stringify` quotes where the house style is
-backticks. Direction: reword to name the variable and the positional rule (e.g.
-"`count` is assigned before its declaring tag; move `<let/count=…>` above this
-assignment.") and link
-`https://markojs.com/docs/reference/language#tag-variables`, and add the
-assignment-position rule to the Tag Variables docs section. This is distinct
-from the existing dx.md entry on `trackReferencesForBinding`, which asks for
-_detecting_ mutual `<const>` cycles rather than improving message text.
-Re-verify: compile `<button onClick() { x = 2
-}>b</button>\n<let/x=1/>\n<div>${x}</div>` and observe the jargon-only message;
-swapping the two lines compiles cleanly, confirming the rule is purely
-positional.
+Assigning a `<let>` from a handler that sits _above_ the `<let>` fails with that bare message: "hoisted" is compiler jargon and it names neither the variable nor the fix, which is simply to move the declaration above the assignment. It is one of nine user-facing errors in `references.ts`, none of which follow the backticked-name-plus-markojs.com-link convention `packages/runtime-tags/AGENTS.md` documents and `core/if.ts` demonstrates; `Duplicate declaration "x"` even uses `JSON.stringify` quotes where house style is backticks. Reword to name the variable and the positional rule and link `https://markojs.com/docs/reference/language#tag-variables`. Verify: compile `<button onClick() { x = 2 }>b</button>` above `<let/x=1/>` for the jargon-only message; swapping the two lines compiles cleanly.
 
-## Exercise `MountedTemplate.destroy()` and `.value` in the CSR fixture harness
-
-`packages/runtime-tags/src/__tests__/main.test.ts` › `csr` | 2026-07-23 | impact:med | effort:low
-
-The CSR half of the fixture harness mounts a template and then only ever calls
-`instance.update(input)` (main.test.ts:282); `instance.destroy()` and the
-`value` getter/setter returned by `dom/template.ts` › `mount` are never called
-anywhere under `src/__tests__`. So the entire client-side teardown path of the
-public mount API — `removeAndDestroyBranch`, `<lifecycle> onDestroy`, `$signal`
-abort, nested-branch destruction — has no fixture coverage at all, which is why
-the stranded-cleanup-effects defect above survives (`cleanup-*` fixtures only
-cover destroys driven from inside a render by `<if>`/`<for>`). Add a `Destroy`
-step control alongside the existing `Wait`/`Flush`/`Throws` controls in
-`TestConfig.steps` (and a matching `SetValue` for the tag-variable channel),
-have `runSteps` call `instance.destroy()`, and let the mutation tracker snapshot
-the resulting removal plus any console/`onDestroy` output; a couple of fixtures
-over `<lifecycle>`, `$signal`, and a nested `<for>` would lock the contract in.
-Re-verify: `rg -n "instance\.|\.destroy\(\)" packages/runtime-tags/src/__tests__
---glob '!fixtures/**'` returns only the single `instance.update(input)` line.
-
-## Add a unit test for the `Opt`/`Sorted` list algebra in `translator/util/optional.ts`
+## Unit-test the pure `Opt`/`Sorted` helpers in `translator/util/optional.ts`
 
 `packages/runtime-tags/src/translator/util/optional.ts` › `Sorted` | 2026-07-23 | impact:med | effort:low
 
-`util/optional.ts` is the hand-rolled sorted-list algebra that `AGENTS.md`
-describes as underpinning reference tracking, yet it has no direct test — the
-only coverage is indirect, through ~800 end-to-end fixture snapshots, which is
-exactly why `Sorted.isSuperset`'s off-by-one survived long enough to become
-load-bearing (see the existing bugs.md entry). The module is pure and
-dependency-free, and the repo already auto-discovers unit tests via
-`.mocharc.json`'s `packages/*/@(src|test)/**/*.test.@(js|ts)` spec with
-`common-helpers.test.ts` and `resolve-cursor-position.test.ts` as the precedent,
-so a new `src/__tests__/optional.test.ts` needs no config change. A short
-differential test comparing `Sorted.union/add/find/has/groupBy/isSuperset`,
-`addSorted`, `findSorted`, `findIndexSorted`, `filter`, `concat`, `push`,
-`fromIter`/`toIter` and `mapToString` against naive array reference
-implementations over randomized sorted inputs pins the contract, documents the
-`Opt` single-vs-array duality, and would let someone actually attempt the
-`isSuperset` fix with a safety net instead of a full snapshot audit. Re-verify
-the gap: `ls packages/runtime-tags/src/__tests__/*.test.ts` shows no
-optional/Sorted test, and `grep -rn "util/optional"
-packages/runtime-tags/src/__tests__` returns nothing.
+`util/optional.ts` is the sorted-list algebra `packages/runtime-tags/AGENTS.md` calls the basis of reference tracking, yet it has no direct test — coverage is only indirect, through fixture snapshots. The module is pure and dependency-free, and `.mocharc.json`'s `packages/*/@(src|test)/**/*.test.@(js|ts)` spec already picks up `src/__tests__/common-helpers.test.ts`, so a sibling `optional.test.ts` needs no config change. Pin `Sorted.add/union/find/has/findIndex/groupBy`, `addSorted`/`findSorted`/`findIndexSorted`, `filter`, `concat`, `push`, `fromIter`/`toIter` and `mapToString` against naive array references over randomized sorted input. `Sorted.isSuperset` must instead be pinned to its current behavior — `isSuperset([1,2,3],[1,2,3])` is `false` — because the entry "Fix `Sorted.isSuperset` arithmetic together with a proper-superset test in `isSupersetSources`" records that the wrong arithmetic is depended on; this test is the safety net that fix needs, so it should land first. Re-verify: `rg -l "util/optional" packages/runtime-tags/src/__tests__` returns nothing.
 
-## Prune only snapshots whose tests actually ran; `test:update` deletes snapshots for skipped/bailed tests
+## Prune only snapshots whose tests actually ran; `test:update` deletes snapshots for skipped or bailed tests
 
 `packages/runtime-tags/src/__tests__/utils/snap.ts` › `cleanupSnapshots` | 2026-07-23 | impact:med | effort:low
 
-The `after(cleanupSnapshots)` hook in `snap.ts` treats "not written during this
-run" as "stale": for every `__snapshots__` dir that received at least one write
-it `fs.rmSync`s every entry missing from `writtenFiles`. That is only correct
-when the whole fixture ran. Because mocha suite titles include the mode
-(`describe(entry)` → `describe(mode)` in `main.test.ts`), a natural narrowing
-like `pnpm run test:update -- --grep "runtime-tags/translator title-counter
-debug "` writes only the debug snapshots and then deletes `dom.bundle.js`,
-`html.bundle.js`, `render.md` and `writes.html` for that fixture; the same
-happens on a bailed update run, since `.mocharc.json` sets `bail: true` and
-mocha still runs root `after` hooks after aborting (verified), so a fixture
-whose `ssr` step throws mid-`test:update` loses the snapshots of every test that
-never got to run. This directly undercuts the repo invariant that
-`__snapshots__/**` is never deleted by hand, and the deletions are only visible
-in `git status`. Direction: record which fixture/mode combinations completed (or
-which snapshot basenames the run was responsible for) and prune only within
-those, instead of every entry of any touched dir. Re-verify: `pnpm run
-test:update -- --grep "runtime-tags/translator title-counter debug "` then `git
-status packages/runtime-tags/src/__tests__/fixtures/title-counter` — the
-optimize-mode snapshots show up as deletions.
+The `after(cleanupSnapshots)` hook `fs.rmSync`s every entry of any `__snapshots__` dir that got at least one write but is missing from `writtenFiles`, which is only correct when the whole fixture ran. Suite titles include the mode (`describe(entry)` → `describe(mode)` in `main.test.ts`), so `pnpm run test:update -- --grep "runtime-tags/translator title-counter debug "` writes the debug snapshots and then deletes `dom.bundle.js`, `html.bundle.js`, `render.md` and `writes.html`. A bailed run is the same: `.mocharc.json` sets `bail: true` and mocha's `runSuite` `done()` still runs root `afterAll` hooks after abort, so a fixture throwing mid-update loses every not-yet-run test's snapshot, visible only in `git status`. Direction: record which fixture/mode combinations completed and prune only the basenames that run owned. The sibling gate in the entry "Make the fixture `sizes.json` gate inert when the run is `--grep`-scoped" has the same shape but not the same fix — a bailed run carries no `--grep`, so that entry's scoped-run guard leaves this data loss open. Re-verify: run that grep, then `git status packages/runtime-tags/src/__tests__/fixtures/title-counter`.
 
-## Surface `<style>`/`<title>`/`<link>` mutations in the render log; today a dynamic `<style>` update snapshots as an empty step
+## Record `<style>`/`<title>`/`<link>` mutations in the render log; a dynamic `<style>` update snapshots as an empty step
 
 `packages/runtime-tags/src/__tests__/utils/get-node-info.ts` › `isIgnoredTag` | 2026-07-23 | impact:med | effort:med
 
-`isIgnoredTag` returns true for `T`, `LINK`, `TITLE`, `STYLE` and
-non-typed/module `SCRIPT`, and `formatMutationRecord` drops any record whose
-target (or characterData parent) is an ignored node, so no `<style>`, `<title>`
-or `<link>` change is ever representable in a `render*.md` snapshot — grepping
-all committed render snapshots finds zero `<style`/`<title` occurrences. The
-cost is concrete for the `<style>` core tag: `_style_rule_item`
-(`src/dom/dom.ts`) does non-trivial string surgery on the style element's
-`textContent` to splice a CSS custom property, yet the `style-tag-dynamic`
-fixture — whose entire purpose is a dynamic `${input.color}` in a `<style>` —
-snapshots its update step as the bare line `# Update \`{"color":"blue"}\``with
-no html block and no`## Change`, byte-identical to what a no-op client update
-would produce (only `style-tag-dynamic-injection`covers this path, and only via`assert`calls inside step functions, which the snapshot does not record). Since
-AGENTS.md tells reviewers to audit the mutation log for unexpected updates, this
-is a blind spot in the primary review artifact. Direction: narrow the ignore
-rule to Marko-emitted asset/resume nodes (the`T`placeholder, resume`<script>`s, injected `<link>`s) rather than the element type, or always emit
-style/title text changes as an `UPDATE:`line. Re-verify: read`fixtures/style-tag-dynamic/**snapshots**/render-csr.debug.md`and confirm the
-second step has no`## Change`even though`writes.debug.html` shows the custom
-property carrying the value.
+`isIgnoredTag` returns true for `T`, `LINK`, `TITLE`, `STYLE` and untyped/module `SCRIPT`, and `utils/track-mutations.ts` › `formatMutationRecord` drops any record whose target (or characterData parent) is ignored, so no committed `render*.md` contains a `<style`/`<title` change. `_style_rule_item` (`src/dom/dom.ts`) splices a CSS custom property into that `textContent`, yet `fixtures/style-tag-dynamic/__snapshots__/render-csr.debug.md` ends at the bare line ``# Update `{"color":"blue"}` `` — byte-identical to a no-op client update, with the path covered only by `assert` calls in `style-tag-dynamic-injection`'s steps. AGENTS.md tells reviewers to audit the mutation log, so this is a blind spot in the primary review artifact. Direction: ignore Marko-emitted asset/resume nodes (the `T` placeholder, resume `<script>`s, injected `<link>`s) rather than the element type, or always emit style/title text changes. Distinct from the `isMarkoComment` arm of the same predicate — "Stop the render-snapshot comment filter from swallowing real `<html-comment>` content", a self-contained regex swap — but both widen what `render*.md` records, so land them together for one committed-snapshot re-baseline instead of two. Re-verify: read that snapshot and confirm the second step has no `## Change`.
 
 ## Error on an empty `<for>` body instead of silently compiling the loop away
 
 `packages/runtime-tags/src/translator/core/for.ts` › `analyze` | 2026-07-23 | impact:low | effort:low
 
-When `startSection(tagBody)` returns undefined because the body is empty,
-`analyze` calls `dropNodes(getAllTagReferenceNodes(tag.node))` and returns
-(for.ts:154-159), so `<for|item| of=input.list/>` compiles to nothing at all —
-the `of=` expression is not even evaluated — with no diagnostic in any mode.
-Every other body-requiring core tag raises a code-frame error for the same
-mistake: `core/if.ts` › `assertHasBody`, `core/show.ts` › `assertHasBody`,
-`core/try.ts` › `analyze` (:74-80), and `core/await.ts` › `analyze` (:97) all
-throw "The [`<x>` tag](…) requires [body content](…)". A `<for>` body is the
-tag's only output, so an empty one is always an authoring mistake (a stray `/>`
-or an emptied body), and today it costs a debugging cycle where `<if>` gives an
-immediate caret. Add the same `assertHasBody` check to `<for>` before the
-`dropNodes` fast path, and add an `error-for-empty-body` fixture — the
-`error-for-*` family currently has ten cases and none of them is an empty body.
-Re-verify: compile `<div><for|x| of=input.list/></div>` and observe it succeeds
-with output `_html("<div></div>")`, versus `<div><if=input.list/></div>` which
-fails with the "requires body content" code frame.
+When `startSection(tagBody)` returns undefined, `analyze` calls `dropNodes(getAllTagReferenceNodes(tag.node))` and returns, so `<div><for|x| of=input.list/></div>` compiles to `_html("<div></div>")` — the `of=` expression is never evaluated — with no diagnostic in any mode. Every other body-requiring core tag raises a code frame for the same mistake: `core/if.ts` › `assertHasBody`, `core/show.ts` › `assertHasBody`, `core/try.ts` › `analyze`, `core/await.ts` › `analyze`. A `<for>` body is the tag's only output, so an empty one is always an authoring mistake, and today it costs a debugging cycle where `<if>` gives an immediate caret. Add the same check before the `dropNodes` fast path plus an `error-for-empty-body` fixture — the `error-for-*` family has ten cases and none is an empty body. Re-verify: `pnpm run compile -o html -d` that template succeeds, while `<div><if=input.list/></div>` fails.
 
 ## Fix the dead markojs.com links core tags hand to users: `/docs/syntax/` and synthesized `core-tag#<tagName>` anchors
 
 `packages/runtime-tags/src/translator/core/import.ts` › `autocomplete` | 2026-07-23 | impact:low | effort:low
 
-`<import>`'s completion entry sets `descriptionMoreURL:
-"https://markojs.com/docs/syntax/#importing-external-files"` (import.ts:20-22),
-and `core/static.ts:28`, `core/server.ts:28`, `core/client.ts:28` use the same
-`/docs/syntax/` base — a page that no longer exists (the website repo has no
-`docs/syntax*` markdown, its docs routes are generated from `docs/**/*.md` by
-`src/util/markodown.ts`, and `src/routes/docs/+handler.ts` only redirects bare
-`/docs` to getting-started), so the "[More Info]" link the language server
-renders in tag-name completion documentation
-(`packages/language-server/src/service/marko/util/get-tag-name-completion.ts`)
-404s. The live targets are `docs/reference/language.md` headings `### import`,
-`### static`, `### server and client` → `#import`, `#static`,
-`#server-and-client`. The same class of breakage exists in the shared assert
-helpers reached from `core/if.ts`:
-`packages/runtime-tags/src/translator/util/assert.ts` › `assertNoSpreadAttrs`
-(:8) and `assertNoBodyContent` (:38) build the anchor as `core-tag#${tagName}`,
-which is only correct when a tag's docs heading is its bare name — `<if=x
-...attrs>` errors with `core-tag#if` and `<else-if=y ...attrs>` with
-`core-tag#else-if` when the real heading id is `if--else`, and
-`<effect>`/`<attrs>` have no core-tag section at all. Replace the four
-`/docs/syntax/` URLs and give the assert helpers an explicit anchor argument (or
-a tag-name→anchor map) rather than interpolating the tag name; this is distinct
-from the existing unclear.md llms.txt entry, which is about the website's own
-index, not links emitted from runtime-tags. Re-verify: `grep -rn "docs/syntax"
-packages/runtime-tags/src` lists the four call sites while the website has no
-matching page, and compiling `<if=input.x ...input.attrs>a</if>` prints ``The
-[`<if>`](https://markojs.com/docs/reference/core-tag#if) tag does not support
-`...spread` attributes.``
+`import.ts` (both its error message and `descriptionMoreURL`), `static.ts`, `server.ts` and `client.ts` point at `https://markojs.com/docs/syntax/#…`, which now returns 404; the live targets are `docs/reference/language#import`, `#static` and `#server-and-client`. The same breakage lives in `packages/runtime-tags/src/translator/util/assert.ts` › `assertNoSpreadAttrs` and `assertNoBodyContent`, which build the anchor as `core-tag#${tagName}` — only correct when a tag's docs heading is its bare name. Compiling `<if=input.x ...input.attrs>a</if>` emits `core-tag#if` when the real anchor is `#if--else`, and `<else>`, `<else-if>`, `<effect>` and `<attrs>` (all callers of these helpers) have no anchor at all. Replace the `/docs/syntax/` URLs and give the assert helpers an explicit anchor argument or tag-name→anchor map instead of interpolating the tag name. Re-verify: `rg -n "docs/syntax" packages/runtime-tags/src` lists the call sites, and the `<if>` spread compile prints `core-tag#if`.
 
 ## Give `<show>` a `types` stub so its input is type-checked like every other core tag
 
-`packages/runtime-tags/src/translator/core/show.ts` › `default export (the `Tag` definition)` | 2026-07-23 | impact:low | effort:low
+`packages/runtime-tags/src/translator/core/show.ts` › `export default` | 2026-07-23 | impact:low | effort:low
 
-Every core tag that renders through the normal tag path declares `types:
-runtimeInfo.name + "/tags/<name>.d.marko"` — 14 of them (await, const, debug,
-define, effect, html-comment, html-script, html-style, id, let, lifecycle, log,
-script, try) with matching files in `packages/runtime-tags/tags/`. `<show>`, a
-documented first-class control-flow tag (`website/docs/reference/core-tag.md` ›
-`## <show>`), declares none and has no `tags/show.d.marko`. The other
-`types`-less entries in `core/index.ts` are all handled elsewhere:
-`if`/`for`/`return` are special-cased in `@marko/language-tools`' script
-extractor, `class`/`import`/`export`/`style`/`server`/`client`/`static` are
-parsed as statements in its `parser.ts`, and `attrs` is a migrate-only
-deprecation. `<show>` is the only renderable core tag with neither. In the
-extractor's `#writeTag`, the taglib def exists but `resolveTagFile(def) =
-def.types || def.template || def.renderer` is `undefined`, so `importPath` is
-undefined, the `if (!def || importPath)` block is skipped, and the tag falls
-through to `varShared("missingTag")` typed `DefaultRenderer = (): () =>
-<Input>(input: Input) => …` — a free generic with no contract. Consequently
-`<show=cond when=x>` and a `<show>` missing its value attribute both type-check
-clean and only fail later with `assertValidShow`'s "only supports the `value=`
-attribute" / "requires a `value=` attribute" compile errors, and there is no
-hover/type information for `value`. Add `tags/show.d.marko` (`export interface
-Input { value: unknown; content: Marko.Body }`, mirroring `tags/await.d.marko`)
-and point `core/show.ts` at it. Re-verify: `rg -n "types:"
-packages/runtime-tags/src/translator/core/*.ts` lists 14 files and not
-`show.ts`, and `ls packages/runtime-tags/tags` contains no `show.d.marko`.
+Fourteen core tags declare `types: runtimeInfo.name + "/tags/<name>.d.marko"` with matching files in `packages/runtime-tags/tags/`; `<show>`, a documented first-class control-flow tag, declares none and has no `tags/show.d.marko`. The other `types`-less entries in `core/index.ts` are covered elsewhere by `@marko/language-tools` (`if`/`for`/`return` in the script extractor, `class`/`import`/`export`/`style`/`server`/`client`/`static` parsed as statements, `attrs` migrate-only), leaving `<show>` the only renderable core tag with no contract, so the extractor falls through to the free-generic `missingTag` renderer. `<show=cond when=x>` and a `<show>` missing its value attribute therefore type-check clean and only fail later at `assertValidShow`, and `value` gets no hover type. Add `tags/show.d.marko` (`export interface Input { value: unknown; content: Marko.Body }`, mirroring `tags/await.d.marko`) and point `core/show.ts` at it. This is the missing-stub case of the same stub audit as "Declare the element-getter `return=` in the `html-comment` / `html-script` / `html-style` type stubs" and "Make `<let>`'s `value` optional in `tags/let.d.marko`; the valueless `<let/x/>` compiles but fails type-check", which are the wrong-stub cases — one review covers all three. Re-verify: `rg -n "types:" packages/runtime-tags/src/translator/core/*.ts` omits `show.ts` and `ls packages/runtime-tags/tags` has no `show.d.marko`.
 
-## Raise the unresolvable-tag-name error during analyze; at translate its `<let>`/`<const>` hint is silently lost and only the first bad tag is reported
+## Raise the unresolvable-tag-name error during analyze; at translate its `<let>`/`<const>` hint is lost and only the first bad tag reports
 
 `packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `tagNotFoundError` | 2026-07-23 | impact:med | effort:med
 
-`analyzeTagNameType` reclassifies a string tag name whose file cannot be
-resolved as `TagNameType.DynamicTag` (util/tag-name-type.ts, the `else if
-(!childFile)` branch), so `CustomTag.analyze.enter`'s `tagNotFoundError` never
-fires for a plain unknown tag; the error instead comes out of
-`getTagRelativePath` (custom-tag.ts:342) during `DynamicTag.translate.exit` —
-verified by wrapping `getTagRelativePath` and printing `file.___compileStage`,
-which prints `translate`. Two consequences. (1) `tagNotFoundError`'s best hint
-is order-dependent: `tag.scope.hasBinding(tagName)` (`:383`) reads a scope that
-translate has already been rewriting, so `<let/thing="hi"/>` followed by
-`<thing/>` loses the "Local variables must be in a dynamic tag unless they are
-PascalCase" message and instead prints the bogus ``Did you mean `<img>`?``
-(levenshtein distance 3 < 4); moving `<thing/>` above the `<let>` restores the
-correct hint, and `<const/panel=input.content/>` + `<panel/>` degrades to ``Did
-you mean `<label>`?``. Module bindings (`import thing from ...`) and
-`<for|widget|>` params survive translate and still get the right hint, so the
-failure is specific to same-scope tag variables — the most common way a user
-writes this mistake. (2) The whole `reportAnalyzeError`/`analyzeFailed`
-machinery in `visitors/tag/index.ts` exists so every bad tag reports at once,
-and a translate-stage throw bypasses it: a template with two unknown tags
-reports only the first, while two `<let/x=x/>` circular-reference errors report
-together. Fix direction: detect the unresolvable string-literal tag name in
-`DynamicTag.analyze.enter` (export `tagNotFoundError` from custom-tag.ts) so the
-diagnostic is produced while the scope is intact and batched with the rest.
-Re-verify: compile `<let/thing="hi"/>` + `<thing/>` and the same two lines
-swapped and compare the two error messages; compile a file with two unknown tags
-and count the reported errors.
+`analyzeTagNameType`'s `else if (!childFile)` branch (`util/tag-name-type.ts`) reclassifies an unresolvable string tag name as `TagNameType.DynamicTag`, so `CustomTag.analyze.enter` never throws and the error surfaces instead from `getTagRelativePath` during `DynamicTag.translate.exit`. That costs two things. `tagNotFoundError`'s `tag.scope.hasBinding(tagName)` hint reads a scope translate has already rewritten, so `<let/thing="hi"/>` then `<thing/>` prints ``Did you mean `<img>`?`` instead of the PascalCase/dynamic-tag hint the reversed order still prints, and `<const/panel=input.content/>` + `<panel/>` degrades to ``Did you mean `<label>`?``. And the `reportAnalyzeError`/`analyzeFailed` batching in `visitors/tag/index.ts` is bypassed: two unknown tags report one error, while two `<let/x=x/>` circular references report together. Direction: detect the unresolvable string-literal tag name in `DynamicTag.analyze.enter` (export `tagNotFoundError`) so the diagnostic is built while the scope is intact and batched. Re-verify: compile those two pairs and count reported errors.
 
-## Stop a `--grep`-scoped test run from rewriting `sizes.json` and pruning `__snapshots__`
+## Make the fixture `sizes.json` gate inert when the run is `--grep`-scoped
 
 `packages/runtime-tags/src/__tests__/main.test.ts` › the optimize `after()` sizes hook | 2026-07-23 | impact:med | effort:low
 
-Both generated-file gates in the fixture harness assume the whole fixture ran,
-so a narrower `--grep` reports a false failure and then destroys committed
-output. (1) `pnpm test -- --grep "runtime-tags/translator attr-class optimize
-html"` fails in `"after all" hook for "ssr"` with `AssertionError: sizes.json
-out of date for "attr-class" — run pnpm run test:update` (`main.test.ts:408`);
-nothing is stale — `stats.dom` is only filled by the `dom` test and `stats.html`
-only by the `ssr` test, both excluded by the grep, so `actual` is `{}`. (2)
-Following that message with the same grep is destructive: the hook then does
-`fs.writeFileSync(sizesFile, "{}\n")` (`main.test.ts:402-403`), and `snap`'s
-root `after` hook `cleanupSnapshots` (`utils/snap.ts:103-113`) deletes every
-entry of each visited `__snapshots__` directory that this run did not rewrite —
-so a run scoped to one mode erases the other mode's `dom.bundle.js` /
-`render.md` / `writes.html` — that prune half is the same defect as "Prune only
-snapshots whose tests actually ran", which owns the `snap.ts` anchor; fix them
-together rather than twice. Both are files AGENTS.md marks as generated and
-never to be hand-edited or deleted. Fix direction: make both gates inert when
-the run is scoped (mocha exposes `--grep`/`--fgrep` on its options;
-alternatively track that every `it` of the mode actually executed), and reword
-the sizes assertion to say the numbers are incomplete because the run was scoped
-rather than pointing at `test:update`. Re-verify: run the grep above and observe
-the false "out of date" failure; for the prune, with `UPDATE_EXPECTATIONS=1`
-call `snap` once against a scratch dir whose `__snapshots__` holds
-`dom.bundle.debug.js`, `dom.bundle.js` and `render.md`, rewriting only
-`dom.bundle.debug.js`, and list the directory after mocha's root hooks — only
-`dom.bundle.debug.js` remains.
+`stats.dom` is filled only by the `dom` test and `stats.html` only by the `ssr` test, yet the optimize `after()` hook always compares the whole `stats` object — so a run scoped to one mode asserts `{}` against a populated file and reports `sizes.json out of date for "attr-class" — run pnpm run test:update`. Following that advice with the same grep writes `{}\n` over a file AGENTS.md marks generated and never hand-editable. Skip the gate when mocha's options carry `--grep`/`--fgrep`, and say the numbers are incomplete because the run was scoped. The matching snapshot-prune defect is the entry "Prune only snapshots whose tests actually ran; `test:update` deletes snapshots for skipped or bailed tests", which owns the `utils/snap.ts` anchor; fix both together. The same hook's `!hasCompilerError` gate is a separate defect — see "Delete or assert the absence of `sizes.json` for `error_compiler` fixtures" — whose fix must sit outside the mode loop. Re-verify: `pnpm test -- --grep "runtime-tags/translator attr-class optimize html"` → false "out of date" failure.
 
-## Warn when a `<script>` effect returns a cleanup function — the return value is discarded
+## Warn when a `<script>` body returns a cleanup function — the value is discarded
 
-`packages/runtime-tags/src/translator/core/script.ts` › `default export › translate.exit` | 2026-07-23 | impact:med | effort:low
+`packages/runtime-tags/src/translator/core/script.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low
 
-The React `useEffect` habit compiles clean and silently leaks: `<script>` with
-`const id = setInterval(() => n++, 1000); return () => clearInterval(id);`
-becomes the effect statement `(() => { const id = setInterval(...); return () =>
-clearInterval(id); })()` (`core/script.ts:139`, the IIFE fallback taken because
-a top-level `return` blocks inlining), so the returned cleanup is dropped and
-the interval runs for the life of the page with no error, no warning and no
-`MARKO_DEBUG` complaint. Marko's actual cleanup channel is `$signal.onabort = ()
-=> clearInterval(id)` (documented in `packages/runtime-tags/cheatsheet.md`,
-"Client-side effects" section) or `<lifecycle onDestroy>`, and nothing in the
-compile output points there. Detection is already paid for: `translate.exit`
-calls `traverseContains(value.body, isReturnStatement)` at `core/script.ts:120`
-(predicate at `:179-193`, which already skips nested function bodies). Narrow
-that to a `return` whose argument is an arrow or function expression — a bare
-early-exit `return;` is legitimate and must stay silent — and emit
-`diagnosticWarn` naming `$signal.onabort`/`<lifecycle onDestroy>`. Re-verify:
-compile `<let/n=0/><script>const id = setInterval(() => n++, 1000); return () =>
-clearInterval(id);</script>` with `pnpm run compile -- -o dom -d file.marko` and
-observe the returned arrow sitting inside the emitted IIFE with an empty
-`meta.diagnostics`.
+The React `useEffect` habit compiles clean and leaks: `<script>const id = setInterval(() => n++, 1000); return () => clearInterval(id);</script>` becomes `_script(..., $scope => (() => { ... return () => clearInterval(id); })())` — the top-level `return` blocks inlining, so the IIFE fallback drops the cleanup and the interval outlives the component with no error, warning or `meta.diagnostics` entry. Marko's cleanup channel is `$signal.onabort` (`cheatsheet.md`, "Client-side effects") or `<lifecycle onDestroy>`, and nothing in the output points there. `translate.exit` already runs `traverseContains(value.body, isReturnStatement)`; narrow a variant of it to a `return` whose argument is a function or arrow — a bare `return;` must stay silent — and `diagnosticWarn` naming both APIs. Re-verify: `pnpm run compile -o dom -d file.marko` on that template and observe the returned arrow inside the emitted IIFE with empty diagnostics.
 
-## Diagnose a dropped `<style>` block when `resolveVirtualDependency` is not configured
+## Warn when a `<style>` block is dropped because `resolveVirtualDependency` is unset
 
 `packages/runtime-tags/src/translator/core/style.ts` › `getStyleImportPath` | 2026-07-23 | impact:low | effort:low
 
-`getStyleImportPath` returns `undefined` as soon as
-`file.markoOpts.resolveVirtualDependency` is unset (`core/style.ts:347-350`), so
-`node.extra.styleImportPath` stays falsy, `emitStyleImport` returns early
-(`:301-302`), and `translateHTML`/`translateDOM` just `tag.remove()` — the
-entire `<style>` block disappears from both targets with no error, warning or
-`meta.diagnostics` entry. This bites the repo's own documented iteration loop:
-`pnpm run compile` (`scripts/inspect-compiled-output.mts`) never sets the hook,
-so `<style>.a{color:red}</style><div class=a>hi</div>` compiles to output
-containing only the `<div>` and a contributor inspecting `<style>` codegen
-cannot tell whether the CSS was dropped by design or by their change; the same
-silent loss hits any hand-rolled `@marko/compiler` integration. The compiler
-already validates this exact option elsewhere
-(`packages/compiler/src/babel-plugin/index.js:47-50` throws "the
-`resolveVirtualDependency` option must be supplied when output is `hydrate`"),
-so a `diagnosticWarn` when a non-empty `<style>` body is discarded is consistent
-with existing behavior; independently, `scripts/inspect-compiled-output.mts`
-should pass a stub `resolveVirtualDependency` so inspected output shows the
-emitted style import. Re-verify: `pnpm run compile -- -o html -d file.marko` on
-that template and observe the emitted `_html("<div class=a>hi</div>")` with no
-style import and no diagnostic.
+`getStyleImportPath` returns `undefined` as soon as `file.markoOpts.resolveVirtualDependency` is missing, so `node.extra.styleImportPath` stays falsy, `emitStyleImport` returns early, and `translateHTML`/`translateDOM` just `tag.remove()` — the whole `<style>` block vanishes from both targets with no error, warning or `meta.diagnostics` entry, so any hand-rolled `@marko/compiler` integration silently loses its CSS. The compiler already hard-errors on the same missing option for `output: "hydrate"` (`packages/compiler/src/babel-plugin/index.js`), so a `diagnosticWarn` when a non-empty `<style>` body is discarded is consistent with existing behavior. (`scripts/inspect-compiled-output.mts` now supplies the hook, so `pnpm run compile` no longer hides the loss.) Re-verify: `compileFileSync` that template with no `resolveVirtualDependency` and observe output with no style import and `meta.diagnostics` `[]`.
 
-## Report a tag-variable diagnostic instead of Babel's "invalid left-hand side in function parameter list"
+## Replace Babel's "invalid left-hand side in function parameter list" for bad tag variables
 
 `packages/compiler/src/babel-utils/parse.js` › `parseVar` | 2026-07-23 | impact:low | effort:low
 
-A hyphenated tag variable — a common habit for anyone naming things like HTML —
-produces a diagnostic that leaks `parseVar`'s internal encoding and never
-mentions tag variables: `<div/my-el>hi</div>` and `<input/card-input>` both
-compile-fail with `Binding invalid left-hand side in function parameter list.`,
-caret on the variable. The cause is `parseVar`
-(`packages/compiler/src/babel-utils/parse.js:55-69`), which parses the
-tag-variable source as `(${str})=>{}` to reuse Babel's binding-pattern grammar
-and relays Babel's raw parameter-list message when that parse fails; the author
-wrote no function and no parameter list. This falls below the repo's own
-documented diagnostic standard (`packages/runtime-tags/AGENTS.md` › Translator:
-errors use backticked names plus a markojs.com docs link, `core/if.ts` as
-canonical style) — for contrast, `<let x=0>` produces a fully tailored message
-with a `<let>` docs link. It is also why `packages/runtime-tags/cheatsheet.md`'s
-DON'T table needs the row `<div/my-el>` / `<input/card-input>` → "valid JS
-identifier: `<div/myEl>`": the compiler cannot say it itself. Detect the
-parameter-list-family parse errors in `parseVar` and rethrow as e.g. "`my-el`
-is not a valid [tag
-variable](https://markojs.com/docs/reference/language#tag-variables); use a
-JavaScript identifier or destructuring pattern". Distinct from the existing
-dx.md entries on `parser.js` › `onError`/`onText`, which concern htmljs-parser
-tokenizer messages in concise mode, not Babel messages from the tag-variable
-wrapper. Re-verify: compile `<div/my-el>hi</div>` and observe `Binding invalid
-left-hand side in function parameter list.`
+`parseVar` parses a tag variable as `(${str})=>{}` to reuse Babel's binding-pattern grammar and relays Babel's raw message, so `<div/my-el>hi</div>` and `<input/card-input>` compile-fail with `Binding invalid left-hand side in function parameter list.` — naming a parameter list the author never wrote and never mentioning tag variables. That is below the repo's own standard (`packages/runtime-tags/AGENTS.md`: backticked names plus a markojs.com docs link); `<let x=0>` gets a fully tailored message. Detect the parameter-list family of parse errors in `parseVar` and rethrow as e.g. "`my-el` is not a valid [tag variable](https://markojs.com/docs/reference/language#tag-variables); use a JavaScript identifier or destructuring pattern". Distinct from the `parser.js` › `onError`/`onText` entries, which cover htmljs-parser messages. Re-verify: `pnpm run compile -o dom -d file.marko` on `<div/my-el>hi</div>` and observe the Babel message.
 
-## Make `pnpm run compile` tolerate the `--` that root AGENTS.md documents
+## Make `pnpm run compile` tolerate the `--` that AGENTS.md documents
 
 `scripts/inspect-compiled-output.mts` › `parseArgs` | 2026-07-23 | impact:med | effort:low
 
-Root `AGENTS.md`/`CLAUDE.md` call `pnpm run compile -- -o dom -d foo.marko` "the
-fastest way to inspect what the translator generates", but the documented form
-with `--` does not work: pnpm forwards the literal `--` to the script, and
-`scripts/inspect-compiled-output.mts` uses Node
-`parseArgs({allowPositionals:true})`, which treats everything after a bare `--`
-as positionals — so `-o` becomes a file path and it dies with `ENOENT ... open
-'<repo>/-o'`. Fix by having the script drop a leading `--` before parsing (or by
-correcting the two AGENTS.md invocations to omit it). The translator-resolution
-half of this — `Cannot find module '@marko/runtime-tags/translator'`, which used
-to force an explicit `-t <abs path>` — no longer reproduces; the no-`--` form
-resolves the default translator on its own. Re-verify from the repo root: `pnpm
-run compile -- -o dom -d /tmp/x.marko` → ENOENT on `-o`, while `pnpm run compile
--o dom -d /tmp/x.marko` succeeds and writes `/tmp/x.marko.js`.
+Root `AGENTS.md` (line 21; `CLAUDE.md` symlinks to it) and `packages/runtime-tags/AGENTS.md` (line 111) both call `run compile -- -o dom -d foo.marko` the fastest way to inspect translator output, but pnpm forwards the literal `--` and Node's `parseArgs({allowPositionals:true})` treats everything after a bare `--` as positionals, so `-o` becomes an input path and the script dies with `ENOENT ... open '<repo>/-o'`. Every contributor or agent following the docs hits this on the first inspect. Drop a leading `--` from the argv slice before `parseArgs`, or correct the two documented invocations. Re-verify from the repo root: `pnpm run compile -- -o dom -d /tmp/x.marko` → ENOENT on `-o`, while `pnpm run compile -o dom -d /tmp/x.marko` writes `/tmp/x.marko.js`.
 
-## Serialize boxed primitives
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeUnknownObject` | 2026-07-24 | impact:low | effort:low
-
-Boxed primitives (`Object(1)`, `Object("x")`, `Object(true)`) fall through the constructor dispatch to `throwUnserializable` and resume as nothing. This is a one-case addition with an obvious constructor form (`Object(value)`). `DataView`, previously recorded alongside them, was serialized in #3571 and is done. Re-verify: pass `Object(1)` through `Serializer#stringifyScopes` and observe the value is omitted from the payload, against `new URL("https://a.b")` as a supported control.
-
-## Unify `packages/runtime-class/src` on ESM so its module type can be declared
-
-`packages/runtime-class/package.json` › `files` | 2026-07-24 | impact:low | effort:high
-
-`packages/runtime-class` declares no `"type"`, and 79 ESM-syntax `.js` files sit under it alongside 140 CommonJS ones, so Node parses each ESM file as CommonJS, fails, and reparses it as ESM. This is the last typeless-package surface in the repo now that `packages/compiler` is unified — no current npm script trips the warning (the class translator entry `src/translator.js` is CommonJS, and mocha runs with `no-warnings`), so this is a latent cost rather than visible noise. It is harder than the compiler was: unlike `compiler`, this package publishes `src` (it is in `files`), so a `src/package.json` marker would ship to consumers and would need the same `dist` override the compiler build now applies via `scripts/write-dist-package.mjs`. Marko 5 is in maintenance, so weigh the churn before starting. Verify: `node -e "..."` walking `packages/runtime-class/src` for files matching `/^\s*(import|export)\s/m` reports 79.
-
-## Name the actual handler attribute in SSR's controllable assertion; `checkedChange`/`checkedValueChange`/`openChange` all report `valueChange`
+## Name the actual handler attribute in SSR's controllable assertion instead of hardcoding `valueChange`
 
 `packages/runtime-tags/src/html/attrs.ts` › `writeControlledScope` | 2026-07-27 | impact:low | effort:low
 
-All six typed SSR controllable helpers (`_attr_input_checked`, `_attr_input_checkedValue`, `_attr_details_or_dialog_open`, `_attr_select_value`, `_attr_input_value`, `_attr_textarea_value`) funnel into `writeControlledScope`, whose MARKO_DEBUG guard calls `assertHandlerIsFunction("valueChange", valueChange)` with a hardcoded name, so a non-function `checkedChange`, `checkedValueChange` or `openChange` throws an error naming an attribute the author never wrote and sends them looking at the wrong line. The DOM runtime gets this right — `dom/controllable.ts` passes the real name at each of its five `assertHandlerIsFunction` call sites — so the identical authoring mistake yields a correct message on the client and a misdirecting one on the server, which is the one an SSR-first render surfaces. `writeControlledScope` already receives the `ControlledType`, and that maps 1:1 onto the handler name (`InputChecked`→`checkedChange`, `InputCheckedValue`→`checkedValueChange`, `DetailsOrDialogOpen`→`openChange`, `InputValue`/`SelectValue`→`valueChange`, per `packages/runtime-tags/src/common/constants/controlled-type.ts`), so a debug-only lookup there — or threading the name in from each call site the way DOM does — fixes all six at once. Re-verify: `node -r ~ts -e 'const a=require("./packages/runtime-tags/src/html/attrs.ts");try{a._attr_input_checked(0,"#input/0",true,"oops")}catch(e){console.log(e.message)}'` from the repo root prints "The `valueChange` handler must be a function …" for a value that was really passed as `checkedChange`, while the same call against `src/dom/controllable.ts` reports `checkedChange`.
+All six typed SSR controllable helpers (`_attr_input_checked`, `_attr_input_checkedValue`, `_attr_details_or_dialog_open`, `_attr_select_value`, `_attr_input_value`, `_attr_textarea_value`) funnel into `writeControlledScope`, whose MARKO_DEBUG guard calls `assertHandlerIsFunction("valueChange", valueChange)`, so a non-function `checkedChange`, `checkedValueChange` or `openChange` throws naming an attribute the author never wrote. `dom/controllable.ts` passes the real name at all five of its call sites, so the identical authoring mistake reads correctly on the client and misdirects on the server — the one an SSR-first render surfaces. `writeControlledScope` already receives the `ControlledType`, which maps 1:1 onto the handler name (`common/constants/controlled-type.ts`), so derive it there under debug or thread the name in per call site. Re-verify: `_attr_input_checked(0, "#input/0", true, "oops")` must report `checkedChange`, not `valueChange`.
 
 ## Add `"./package.json"` to the source-mode `exports` map so it resolves the way the published map does
 
 `packages/runtime-tags/package.json` › `exports` | 2026-07-27 | impact:low | effort:low
 
-`packages/runtime-tags/package.json` declares `"./package.json": "./package.json"` only in `exports:override` — the map `scripts/pkg-override.js` swaps in at publish — so in the monorepo, and in any workspace linked against source, the subpath falls through the catch-all `"./*": "./src/*.ts"` and resolves to the nonexistent `src/package.json.ts`; it is the single key that differs between the two maps, and it has been override-only since the maps were introduced. Reading a dependency's own `package.json` to get its version or locate its root is routine for bundlers and dev tooling — `language-server` and `packages/runtime-class/bin/markoc.js` both do exactly that via `require.resolve("marko/package.json")`, which works only because `marko` ships no `exports` map at all — so this breaks in source mode while looking fine from npm. Sibling `@marko/compiler` lists `"./package"` and `"./package.json"` in both of its maps, so the omission reads as an oversight rather than policy. Fix by adding `"./package.json": "./package.json"` to `exports` alongside the existing `"./cheatsheet.md"` entry. Re-verify from the repo root: `node -e 'require.resolve("@marko/runtime-tags/package.json")'` throws `Cannot find module '<repo>/node_modules/@marko/runtime-tags/src/package.json.ts'`, while `node -e 'console.log(require.resolve("@marko/compiler/package.json"))'` prints `packages/compiler/package.json`.
+`"./package.json": "./package.json"` is declared only in `exports:override` — the map `scripts/pkg-override.js` swaps in at publish — so in the monorepo, and in any workspace linked against source, the subpath falls through the catch-all `"./*": "./src/*.ts"` to the nonexistent `src/package.json.ts`. Reading a dependency's own `package.json` for its version or root is routine for bundlers and dev tooling, so this breaks in source mode while looking fine from npm; sibling `@marko/compiler` lists both `"./package"` and `"./package.json"` in each of its maps, so the omission reads as an oversight. Add the key to `exports` beside the existing `"./cheatsheet.md"` entry. Re-verify from the repo root: `node -e 'require.resolve("@marko/runtime-tags/package.json")'` throws `Cannot find module '<repo>/node_modules/@marko/runtime-tags/src/package.json.ts'`.
 
 ## Reject unknown attribute tags on `<try>` — a `<@placholder>`/`<@cath>` typo compiles clean and silently drops the pending/error UI
 
 `packages/runtime-tags/src/translator/core/try.ts` › `analyze` | 2026-07-27 | impact:med | effort:low
 
-`<try>`'s `analyze` is strict about plain attributes — `assertNoAttributes(tag)` turns `<try foo=1>` into a hard "Tag does not support attributes" error — but it then calls `analyzeAttributeTags(tag)` with no name check, so any misspelled or invented attribute tag compiles clean even though `_try` in `packages/runtime-tags/src/html/writer.ts` and `packages/runtime-tags/src/dom/control-flow.ts` only ever reads `input.placeholder` and `input.catch`. The typo'd branch still emits a full `_content_resume` renderer into both the SSR and the client output and is then never read: `<@placholder>` means the pending UI silently never streams, and `<@cath|e|>` means a rejection escapes `render()` entirely instead of being caught — a page that dies with no diagnostic at any layer. `<await>` already produces a good error for exactly this mistake via `assertNoAttributeTags(tag, hint)`, and `<try>`'s own type stub `packages/runtime-tags/tags/try.d.marko` already declares the closed set (`content`/`placeholder`/`catch`), so the translator is the one layer that lets it through. Add a name check in `analyze` that throws for any attribute tag other than `@placeholder`/`@catch` (with a near-miss suggestion, in the style of the other core-tag code-frame errors), plus an `error-try-unknown-attr-tag` fixture — the error fixture family has `error-await-attr-tags` and `error-try-no-body` but nothing for this. Re-verify: `pnpm run compile -o html -d tmp.marko` on `<try><@cath|e|>caught ${e.message}</@cath><await|v|=Promise.reject(new Error("boom"))>${v}</await></try>` succeeds and emits a `cath:` key in the `_try` props object, and rendering that template rejects with `boom`, while the `<@catch|e|>` spelling renders "caught boom".
+`analyze` is strict about plain attributes via `assertNoAttributes(tag)` but then calls `analyzeAttributeTags(tag)` with no name check, while `_try` in `html/writer.ts` and `dom/control-flow.ts` reads only `input.placeholder` and `input.catch`. A misspelled `<@placholder>`/`<@cath|e|>` still emits a full `_content_resume` renderer into both outputs that is never read, so the pending UI never streams and a rejection escapes `render()` with no diagnostic at any layer. `<await>` already errors on exactly this via `assertNoAttributeTags(tag, hint)`, and `tags/try.d.marko` already declares the closed set, so the translator is the one layer letting it through. Add a name check throwing for anything but `@placeholder`/`@catch` (with a near-miss suggestion), plus an `error-try-unknown-attr-tag` fixture. Re-verify: `pnpm run compile -o html -d t.marko` on a `<try>` with `<@cath|e|>` still emits a `cath:` key into the `_try` props object.
 
 ## Validate the `load` import attribute even when `linkAssets` is not configured — a bogus trigger compiles clean today
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `analyze` | 2026-07-27 | impact:low | effort:low
 
-`analyze` bails out of all `load` handling with `if (!getMarkoOpts().linkAssets) { loadAttrPath.remove(); return; }` before `getLoadImportConfig` ever runs, so every diagnostic for the attribute — unknown trigger type, missing selector or media query, `render` combined with other triggers, unknown query params, non-default specifiers, an unresolvable `.marko` target — only fires in builds that configure `linkAssets`. That means `import Child from "<child>" with { load: "bogus-trigger" }` compiles completely clean under a plain `@marko/compiler` invocation — `@marko/vite` with `linked: false`, the repo's own `pnpm run compile`, unit-test setups, Lasso — and the typo surfaces only later, as a hard throw, in whichever asset-linked build first consumes the template, so a component library validated in a non-linked pipeline can ship a `load` string that breaks its consumers. The eager fallback itself is deliberate (CHANGELOG #3434, "compile lazy `with { load }` imports as normal eager tag imports when the `linkAssets` compiler option isn't configured ... instead of throwing"), but the trigger parse is pure string validation with no dependency on asset orchestration, so it should run unconditionally — parse and report first, then drop the attribute when `linkAssets` is absent — so a template either always errors or always compiles. The class-API translator has the same ordering (`packages/runtime-class/src/translator/util/load-import.js` › `analyzeLoadImport` returns on `markoOpts.hot || !markoOpts.linkAssets` before its `getLoadImportConfig` call), so a fix should cover both. Re-verify: compile a template containing `import Child from "<child>" with { load: "bogus-trigger" }` plus `<Child/>` with `compileFile` at `output: "html"` — it resolves with empty `meta.diagnostics` under default options, and throws `Unknown trigger type "bogus-trigger". Supported triggers are "visible", "idle", "media", and "on*".` once `linkAssets: { runtime, onAsset }` is added; `pnpm run compile -o html -d that.marko` likewise emits the `.js` with no complaint.
+`analyze` bails with `if (!getMarkoOpts().linkAssets) { loadAttrPath.remove(); return; }` before `getLoadImportConfig` runs, so every `load` diagnostic — unknown trigger type, missing selector or media query, unknown query params, non-default specifiers — fires only in asset-linked builds. `import Child from "<child>" with { load: "bogus-trigger" }` compiles clean under plain `@marko/compiler` (`pnpm run compile`, `@marko/vite` with `linked: false`), so a component library validated in a non-linked pipeline can ship a `load` string that hard-throws for its consumers. The eager fallback is deliberate (commit b384bc03), but the trigger parse is pure string validation: parse and report first, then drop the attribute. `runtime-class/src/translator/util/load-import.js` › `analyzeLoadImport` has the same ordering and needs the same fix. Re-verify: `pnpm run compile -o html -d that.marko` on the bogus-trigger template still emits the `.js` with no complaint.
 
 ## Union the Marko 5 and 6 `types` stubs in the interop taglib merge — `<await>` and `<script>` type-check against the Marko 5 API inside Tags-API files
 
 `packages/runtime-tags/src/translator/interop/index.ts` › `mergeTagDef` | 2026-07-27 | impact:med | effort:med
 
-`mergeTagDef` special-cases only the hook keys (`parse`/`migrate`/`transform`/`analyze`/`translate`) and falls through to `value5 ?? value6` for everything else, so wherever both core taglibs define a tag the Marko 5 `types` stub wins unconditionally — and `types` is the only key that actually diverges, for exactly `<await>` and `<script>`. `marko/translator` is the interop translator (`packages/runtime-class/src/translator.js` = `createInteropTranslator(classAPI)`) and is also `@marko/compiler`'s default (`packages/compiler/src/config.js`), so `@marko/language-tools` — which picks a tag's type file via `resolveTagFile(def) = def.types || def.template || def.renderer` — resolves those two tags to `marko/src/core-tags/core/await/index.d.marko` and `marko/src/core-tags/core/script.d.marko` even inside a Tags-API `tags/*.marko` file. Idiomatic `<await|v| value=promise>` still type-checks (the Marko 5 stub extracts as `api: "class"`, so `Marko._.contentFor` binds the body to `renderBody`, matching that stub's second union branch), but the editor now offers and silently accepts `<@then>`/`<@catch>`/`<@placeholder>`/`client-reorder`/`timeout` on `<await>` and every HTML script attribute on `<script>`, all of which the Marko 6 translator rejects with a hard compile error ("Tag does not support nested attribute tags…" / "The `<script>` tag does not support html attributes…"), and hovers describe the wrong tag entirely — precisely in the projects that are mid-migration. The taglib merge has no per-file API dispatch available, so the direction is interop-specific stubs whose `Input` unions both APIs, selected when both sides declare `types`, rather than silently preferring 5. This is a different defect from the entry `Give <show> a types stub so its input is type-checked like every other core tag`, which is about a core tag that declares no `types` at all. Re-verify: `node -r ~ts -e 'const {taglib}=require("@marko/compiler");const l=taglib.buildLookup("packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class","marko/translator");for(const n of ["await","script"])console.log(n,l.getTag(n).types);'` prints the two `marko/src/core-tags/...` paths instead of `@marko/runtime-tags/tags/await.d.marko` and `.../script.d.marko`.
+`mergeTagDef` special-cases only the hook keys and falls through to `value5 ?? value6`, so the Marko 5 `types` stub wins wherever both core taglibs declare one — today exactly `<await>` and `<script>`. Because `marko/translator` is the interop translator and `@marko/compiler`'s default, `@marko/language-tools` resolves those two to `marko/src/core-tags/core/await/index.d.marko` and `.../script.d.marko` even inside a Tags-API `tags/*.marko` file, so editors offer and silently accept `<@then>`/`<@catch>`/`client-reorder`/`timeout` and every html `<script>` attribute — all of which the Marko 6 translator rejects with a hard compile error — precisely in mid-migration projects. Direction: interop-specific stubs whose `Input` unions both APIs, selected when both sides declare `types`. Re-verify: `taglib.buildLookup(".../fixtures-interop/interop-basic-tags-to-class", "marko/translator").getTag("await").types` prints the Marko 5 path instead of `@marko/runtime-tags/tags/await.d.marko`.
 
 ## Stop the render-snapshot comment filter from swallowing real `<html-comment>` content; `<!--TODO: fix-->` is classified as a Marko marker
 
 `packages/runtime-tags/src/__tests__/utils/get-node-info.ts` › `isIgnoredNode` | 2026-07-27 | impact:med | effort:low
 
-`isMarkoComment` (reached through the exported `isIgnoredNode`) decides a comment is Marko-internal by shape, `/^[a-zA-Z$_]\w*[^\w\s]/`, which does catch resume markers like `M_*1 b` but also matches ordinary comment prose whose first word is followed by punctuation — `TODO: fix`, `wp:paragraph`, `count: 1`, `note-1`, `foo=bar` are all treated as internal while `hello world` is not. `cloneAndSanitize` (`src/__tests__/utils/track-mutations.ts`) then removes those nodes from the html block of every `render*.md`, so an `<html-comment>` carrying exactly the analytics/CMS-marker text the tag exists for is invisible in the primary review artifact; worse, the two halves of the snapshot contradict each other, because `formatMutationRecord` tests only `target.parentNode` for characterData records, so a fixture whose comment updates still emits `UPDATE: div > #comment "c: 0" => "c: 1"` in `## Change` for a node the html block never showed. Since AGENTS.md directs reviewers to audit the mutation log for unexpected changes, an `<html-comment>` regression on such content would pass unnoticed, and the committed `html-comment-counter` fixture escapes only by accident (its data starts with a digit, which `[a-zA-Z$_]` rejects). Direction: match the actual marker grammar instead of a generic shape — every marker `html/writer.ts` › `mark` emits is `commentPrefix` (runtime id + `_`) followed by a resume sigil, as the committed `writes.html` snapshots show (`M_*10 a`, `M_]10 a 11`, `M_[`) — or have the writer tag its markers so the tracker recognizes them by prefix. This is a different defect from the entry `Surface <style>/<title>/<link> mutations in the render log`, which is about the element-name list in `isIgnoredTag`, and from `Mutation-tracker jsdom workaround silently hides real text updates`, which drops the `## Change` line rather than the html node. Re-verify: `node -r ~ts -e 'const n=require("./packages/runtime-tags/src/__tests__/utils/get-node-info.ts");for(const d of ["TODO: fix","wp:paragraph","hello world","M_*1 b"])console.log(JSON.stringify(d),n.isIgnoredNode({nodeType:8,data:d}))'` prints true for `TODO: fix` and `wp:paragraph` and false for `hello world`.
+`isMarkoComment` (reached through the exported `isIgnoredNode`) decides a comment is internal by shape, `/^[a-zA-Z$_]\w*[^\w\s]/` — it catches resume markers like `M_*1 b` but also ordinary prose: `TODO: fix`, `wp:paragraph`, `count: 1`, `foo=bar` all match while `hello world` does not. `cloneAndSanitize` (`utils/track-mutations.ts`) then strips those nodes from the html block of every `render*.md`, so an `<html-comment>` carrying exactly the analytics/CMS marker text the tag exists for is invisible in the primary review artifact, while `formatMutationRecord` still logs `UPDATE: div > #comment "c: 0" => "c: 1"` because it only checks `target.parentNode` for characterData records. The committed `html-comment-counter` fixture escapes only because its data starts with a digit. Match the real marker grammar instead — `commentPrefix` plus a resume sigil, as `html/writer.ts` › `mark` emits. Distinct from the `isIgnoredTag` arm of the same predicate — "Record `<style>`/`<title>`/`<link>` mutations in the render log", which needs a different fix but shares the committed-snapshot re-baseline, so land the two together — and from "Mutation-tracker jsdom workaround silently hides real text updates in snapshots", which drops the `## Change` line rather than the html node. Re-verify: `isIgnoredNode({nodeType:8,data:"TODO: fix"})` returns true while `"hello world"` returns false.
 
 ## Format fixture console args with `util.inspect`: an `Error` snapshots as `ERROR {}` and a circular value crashes the harness
 
 `packages/runtime-tags/src/__tests__/utils/capture-console.ts` › `formatConsoleRecord` | 2026-07-27 | impact:low | effort:low
 
-`formatConsoleRecord` renders every console argument with `JSON.stringify`, which erases exactly the values a fixture would want to assert on: `console.error(new Error("boom"))` snapshots as `ERROR {}`, a DOM node as `LOG {}`, and `undefined`/a function/a symbol each collapse to a bare `LOG ` — so a `<try>`/`@catch` or `onError` fixture that logs the caught error records no information and would keep passing however the error changes. A circular argument is worse: the stringify throws inside `getStatusString` (`utils/track-mutations.ts`), so both the `ssr` and `csr` tests fail with `TypeError: Converting circular structure to JSON` over a stack that names only harness internals, never the template. No committed snapshot logs a non-primitive today, so the gap is latent, but it silently caps what a console-based fixture can assert and turns a self-referential value into a dead-end crash. Direction: format with `node:util.inspect` (depth-limited, `Error`- and DOM-aware), or at minimum special-case `Error` as `name: message` and wrap the stringify in a try/catch that falls back to `String(arg)`. Re-verify from the repo root: `node -r ~ts -e 'const {formatConsoleRecord}=require("./packages/runtime-tags/src/__tests__/utils/capture-console.ts"); console.log(formatConsoleRecord({type:"error",args:[new Error("boom")]})); const c={}; c.self=c; formatConsoleRecord({type:"log",args:[c]});'` prints `ERROR {}` and then throws.
+`formatConsoleRecord` renders every console argument with `JSON.stringify`, so `console.error(new Error("boom"))` snapshots as `ERROR {}` and `undefined`, a function, a symbol or a DOM node each collapse to a bare `"LOG "` — a `<try>`/`@catch` or `onError` fixture that logs the caught error records nothing and keeps passing however the error changes. A circular argument is worse: the throw escapes `getStatusString` (`utils/track-mutations.ts`), failing both the `ssr` and `csr` tests with `TypeError: Converting circular structure to JSON` over a stack naming only harness internals. No committed snapshot logs a non-primitive, so the gap is latent but caps what a console fixture can assert. Format with `node:util.inspect`, or at minimum special-case `Error` and wrap the stringify in a try/catch falling back to `String(arg)`. Re-verify: `formatConsoleRecord({type:"error",args:[new Error("boom")]})` returns `ERROR {}` and a self-referential arg throws.
 
-## Thread `reject_load` into the CSR half of the fixture harness; today it is silently inert and a CSR chunk-load-failure fixture passes with a successful load
+## Forward `rejectLoad` from `csr()` into `clientRunner` — `reject_load` is inert in CSR mode
 
 `packages/runtime-tags/src/__tests__/main.test.ts` › `csr` | 2026-07-27 | impact:med | effort:low
 
-`ssr()` builds its jsdom with `createBrowser(runner.assets, config.load_order, rejectLoad)`, but `csr()` calls the bare `createBrowser()` and reaches the client entry through `clientRunner` (`__tests__/utils/bundle.ts` › `createServerRunner`), which calls `importWithContext(csrFile, { browser: true }, ctx)` with no `rejectLoad` — so the `reject_load` TestConfig option is silently a no-op in CSR mode even though the CSR module graph does perform the dynamic `import("./v:child.marko.input_value.mjs")` that the option is meant to fail. That is not theoretical: a fixture carrying `reject_load: ["input_value"]` that renders client-side produces a snapshot where the lazy chunk loads fine and `<try>`'s `@catch` never fires, i.e. a green test asserting the opposite of what the fixture is named for; today only the easy-to-forget `skip_csr: true` on `fixtures/lazy-tag-input-chunk-load-error` hides that, and the client-only lazy-chunk-failure path has no coverage at all. Direction: forward `rejectLoad` from `csr()` through `clientRunner` into `importWithContext` (a single extra argument — with it the same fixture renders `<div id="error">simulated chunk load failure: ./v:child.marko.input_value.mjs</div>` under CSR), or throw at fixture setup when `reject_load` is set without `skip_csr`; while there, note that `load_order` is likewise SSR-only, but harmlessly so, since a CSR browser has no document module scripts to order (`fixtures/lazy-tag-nested-shared-reversed` sets it and still runs CSR). This is a different item from the entry "Exercise `MountedTemplate.destroy()` and `.value` in the CSR fixture harness", which is about missing teardown-API coverage rather than a config option that is wired into only one render path. Re-verify: copy `fixtures/lazy-tag-input-chunk-load-error`'s `template.marko` and `child.marko` into a new fixture whose `test.ts` keeps `reject_load: ["input_value"]` and `equivalent: false` but uses `skip_ssr: true` in place of `skip_csr: true`, run `pnpm test -- --grep "runtime-tags/translator <newFixture> " --no-bail`, and read the written `__snapshots__/csr.actual.md` — it ends with `<span id="child">1</span>`, never the `#error` div that the committed `lazy-tag-input-chunk-load-error/__snapshots__/render-ssr.debug.md` records for the same input.
+`ssr()` builds its jsdom with `createBrowser(runner.assets, config.load_order, rejectLoad)`, but `csr()` calls the bare `createBrowser()` and reaches the client entry through `createServerRunner`'s `clientRunner` (`__tests__/utils/bundle.ts`), which calls `importWithContext(csrFile, { browser: true }, ctx)` with no `rejectLoad` — so `reject_load` never fails the `import("./v:child.marko.input_value.mjs")` the CSR bundle actually performs. A fixture with `reject_load` and no `skip_csr` therefore snapshots a successful lazy load and a `@catch` that never fires; only `fixtures/lazy-tag-input-chunk-load-error`'s easy-to-forget `skip_csr: true` hides that today, and the client-only chunk-failure path has no coverage at all. Thread `rejectLoad` through `clientRunner` into `importWithContext`, or throw at fixture setup when `reject_load` is set without `skip_csr`. Re-verify: drop `skip_csr` from that fixture and read the written CSR snapshot — it ends with `<span id="child">1</span>`, never the `#error` div its `render-ssr.debug.md` records for the same input.
 
-## Validate `translator.tagDiscoveryDirs` in `buildLookup` — omitting it throws a bare `is not iterable`, and a string silently discovers no tags
+## Default and validate `translator.tagDiscoveryDirs` in `buildLookup`
 
 `packages/compiler/src/taglib/index.js` › `buildLookup` | 2026-07-27 | impact:low | effort:low
 
-`buildLookup` guards one member of the translator contract (`if (!translator || !Array.isArray(translator.taglibs)) throw "@marko/compiler: Invalid translator provided to buildLookup(dir, translator)"`) and defaults another (`translator.optionalTaglibs || []`), but hands `translator.tagDiscoveryDirs` straight to `finder.find`, whose `for (const tagDiscoveryDir of tagDiscoveryDirs)` (`packages/compiler/src/taglib/finder/index.js` › `find`) is the only thing standing behind it. Omitting the key throws an unprefixed `TypeError: tagDiscoveryDirs is not iterable` from inside the finder with no hint that the culprit is a translator export — compare dropping `translate`, which produces `@marko/compiler: translator must provide a translate visitor object` — and the natural typo `tagDiscoveryDirs: "tags"` is worse: a string is iterable, so it iterates the characters, discovers nothing, and only surfaces much later as a misdirecting `Unable to find entry point for custom tag <child>. Did you mean <meta>?`. Nothing type-checks it either, since `packages/compiler/config.d.ts` declares `translator?: any`, and both shipped translators declare the key (`packages/runtime-tags/src/translator/index.ts` → `["tags"]`, `packages/runtime-class/src/translator/index.js` → `["components"]`), so it is required in practice while `packages/compiler/AGENTS.md`'s "Translator contract" paragraph lists it in the same run as the genuinely optional `optionalTaglibs` / `preferAPI` / `cheatsheet`. Default it to `[]` next to the `optionalTaglibs` default and reject a non-array with the existing named `@marko/compiler:` error, then mark it required in AGENTS.md. Re-verify: `node -r ~ts -e 'const {taglib}=require("./packages/compiler/src/index.js");const t=require("./packages/runtime-tags/src/translator/index.ts");const d="packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced";for(const tdd of [["tags"],"tags",undefined]){taglib.clearCaches();try{console.log(JSON.stringify(tdd),"-> <child>:",!!taglib.buildLookup(d,{taglibs:t.taglibs,translate:t.translate,tagDiscoveryDirs:tdd}).getTag("child"))}catch(e){console.log(JSON.stringify(tdd),"->",e.constructor.name+": "+e.message)}}'` prints `<child>: true`, then `<child>: false`, then `TypeError: tagDiscoveryDirs is not iterable`.
+`buildLookup` validates `translator.taglibs` and defaults `translator.optionalTaglibs || []`, but hands `translator.tagDiscoveryDirs` straight to `finder.find`, whose `for (const tagDiscoveryDir of tagDiscoveryDirs)` is the only guard. Omitting the key throws an unprefixed `TypeError: tagDiscoveryDirs is not iterable` from inside the finder, and the natural typo `tagDiscoveryDirs: "tags"` is worse — a string iterates its characters, discovers nothing, and surfaces much later as a misdirecting `Unable to find entry point for custom tag <child>`. Nothing type-checks it (`config.d.ts` declares `translator?: any`) yet both shipped translators set it, so it is required in practice while `packages/compiler/AGENTS.md` lists it among the optional exports. Default it to `[]` beside the `optionalTaglibs` default, reject non-arrays with the existing `@marko/compiler:`-prefixed error, and mark it required in AGENTS.md. Re-verify: call `buildLookup` on `fixtures/assign-destructured-reduced` with `tagDiscoveryDirs` of `["tags"]`, `"tags"`, `undefined` — it prints `<child>: true`, `<child>: false`, then the TypeError.
 
-The asymmetry reads as accidental rather than deliberate, because every other export in AGENTS.md's optional list genuinely is optional: `transform`/`analyze` are `if`-guarded in `babel-plugin/index.js`, `getRuntimeEntryFiles` is guarded in `src/index.js`, and `optionalTaglibs` is defaulted on the very line above this one — while both genuinely required exports get a named `@marko/compiler:` error. Inline translator objects are a supported entry point rather than a test-only artifact (`util/agent-fix-guide.js` explicitly accommodates "inline objects (tests, embedders)"), so this is reachable by embedders, and `errorRecovery: true` does not downgrade the `TypeError` to a diagnostic.
-
-## Diagnose a cross-environment read of a `server`/`client` scriptlet binding — it compiles to a bare `var` with no warning
+## Diagnose cross-environment reads of a `server`/`client` scriptlet binding
 
 `packages/runtime-tags/src/translator/visitors/scriptlet.ts` › `translate.exit` | 2026-07-27 | impact:med | effort:med
 
-When a scriptlet's `target` does not match the output, `translate.exit` replaces it with bare `var` declarations of its outer binding identifiers, so every cross-environment read compiles clean and silently evaluates to `undefined` — no compile error, no MARKO_DEBUG warning. A template with `server function fmt(n) { return n + "!" }` and `<p>${fmt(input.n)}</p>` renders `<p>a!</p>` on the server but emits `var fmt;` plus `_text($scope["#text/0"], fmt(input_n))` for DOM, which throws `TypeError: fmt is not a function` as soon as the browser renders or updates; the mirror case, `client const only = "browser";` read from the template body, renders `<p></p>` on the server and `<p>browser</p>` on the client. The translator already has the exact binding names it is stubbing and the reference paths are available at analyze, so it can raise a code frame on the offending reference naming the binding and its declaring environment ("`fmt` is declared in a `server` statement and is not available on the client — use `static`, or move the use into a `server` statement"). Any diagnostic must exempt the deliberately guarded form: `src/__tests__/fixtures/server-client/template.marko` reads both `server_x` and `client_x` from a `static` statement behind `typeof server_x === "undefined"` and must keep compiling. Re-verify: `printf 'server function fmt(n) { return n + "!" }\n<p>${fmt(input.n)}</p>\n' > /tmp/t.marko && pnpm run compile -o dom -d /tmp/t.marko` exits 0 with no diagnostic and writes a module containing `var fmt;` next to `fmt(input_n)`.
+When a scriptlet's `target` does not match the output, `translate.exit` replaces it with bare `var` declarations of its outer binding identifiers, so every cross-environment read compiles clean and silently evaluates to `undefined` — no compile error, no MARKO_DEBUG warning. `server function fmt(n) { return n + "!" }` with `<p>${fmt(input.n)}</p>` renders fine on the server but emits `var fmt;` plus `_text($scope["#text/0"], fmt(input_n))` for DOM, throwing `fmt is not a function` on the first client render. The translator already has the binding names it stubs and the reference paths at analyze, so it can raise a code frame naming the binding and its declaring environment. Any diagnostic must exempt `src/__tests__/fixtures/server-client/template.marko`, which deliberately reads both bindings from a `static` statement behind `typeof server_x === "undefined"`. Re-verify: `pnpm run compile -o dom -d` on that two-line template exits 0 with no diagnostic and writes `var fmt;` next to `fmt(input_n)`.
+
+## Re-measure `test:parallel` before chasing further speedups
+
+`scripts/test-parallel.js` | 2026-07-11 | impact:med | effort:high
+
+The "CPU-bound, so packing and worker count can't help" conclusion rests on a profile that no longer describes the tooling: `@babel/register` is gone (Node strips types natively) and the `c8 report` pass was replaced by zcov in a2ac845475. Nothing has re-profiled a worker since. If a fresh profile still shows significant idle, the one identified win — pipelining the next fixture's `createServerRunner()` build one fixture ahead, gated on `MARKO_TEST_SLOTS` — remains blocked by `packages/runtime-tags/src/__tests__/utils/capture-console.ts`, which patches `globalThis.console` process-wide so a concurrent build's output lands in another test's capture window; scope that capture first. Re-verify by `--cpu-prof`-ing one worker of `node scripts/test-parallel.js`.
+
+## Document the exact-camelCase rule for native element event attributes
+
+`packages/runtime-tags/cheatsheet.md` › `Golden rules` (rule 5, Events) | 2026-07-18 | impact:low | effort:low
+
+`<input onKeydown(e) {}>` binds correctly at runtime — `isEventHandler` matches `/^on[A-Z-]/` and `getEventHandlerName` lowercases everything after "on" (`packages/runtime-tags/src/common/helpers.ts`), so `onKeydown` and `onKeyDown` are the same `keydown` listener — but the types accept only the exact camelCase spelling (`onKeyDown` at `packages/runtime-tags/tags-html.d.ts:5129`, with the `"on-keydown"` alias on :5130), so `@marko/type-check` rejects it with a bare TS2353 excess-property error that names no alternative and makes it look like the element supports no event handlers. The cheatsheet's only camelCase note (`// event attrs: exact camelCase`, :163) sits inside an `export interface Input` example, i.e. it is about declaring your own input, not about native elements, so an author who guesses `onKeydown` (or arrives from a case-insensitive HTML habit) has nothing to consult. Add one clause to rule 5 (Events): native event attrs must match the DOM camelCase name exactly — `onKeyDown`, `onMouseOver`, `onDblClick`, not `onKeydown` — even though the runtime itself is case-insensitive. Re-verify by running `mtc` over a template containing `<input onKeydown(e) {}>`.
+
+## Give a structural error for a stray close tag / unwrapped text on a concise line
+
+`packages/compiler/src/babel-plugin/parser.js` › `onError` | 2026-07-19 | impact:low | effort:med
+
+`onError` relays htmljs-parser's raw `part.message` into `buildCodeFrameError` with no post-classification, so a concise line of bare text plus a stray close tag reports a JS-tokenizer internal that never mentions tags: `hello</div>` → "Unterminated regular expression." at column 8, `Read more or/and less` → "Invalid attribute name.", `Click here</a> to continue` → "Attribute cannot contain type parameters unless it is a shorthand method". The identical mistake in HTML mode is diagnosed correctly (`<div>hi</span>` names the mismatched closing tag). Detect the concise `<identifier>`-scanned-as-tag followed by a `/`-started expression and remap it to a tag/text structural message before rethrowing. Distinct from "Emit a compile-time diagnostic when a space-separated `>` truncates an attribute-value expression" — that one is a silent truncation, this one a misleading message — but both want a post-classification layer in the same parser adapter. Re-verify by compiling those three one-line templates.
+
+## Emit a dev-mode diagnostic when a self-referential effect re-renders past a threshold
+
+`packages/runtime-tags/src/dom/signals.ts` › `_let` | 2026-07-19 | impact:low | effort:med
+
+A `<script>` effect that writes a `<let>` it transitively reads re-renders forever with no cycle or max-depth diagnostic. `<let/n=0/><div>${n}</div><script>{ n = n + 1 }</script>` compiles to a `_let("n/1", ...)` signal that invokes the `_script` effect, whose body calls the setter again: `_let`'s non-rendering branch fires `schedule()` + `queueRender` on every value change with no per-scope update counter, `_script` is a bare `queueEffect` with no dedupe, and `run()` in `dom/queue.ts` drains renders then effects with no depth tracking. Mounted in jsdom the effect runs ~124 times per second (the `queueMicrotask`->`requestAnimationFrame`->`MessageChannel` pacing in `dom/schedule.ts` yields ~2 passes per frame), `n` grows unbounded and the console stays silent; a terminating variant (`if (n < 3) n = n + 1`) settles at `n = 3`, showing each self-write is a full render+effect pass. Writing state from an effect is user error (derive with `<const>`), so the gap is the diagnostic React and Solid provide. Add a `MARKO_DEBUG`-only update-depth guard in `run()`/`queueRender` that throws after N self-perpetuating passes on the same scope+signal.
+
+## Attach the agent fix-guide to `errorRecovery` diagnostics, not just thrown errors
+
+`packages/compiler/src/index.js` › `buildResult` | 2026-07-19 | impact:med | effort:med
+
+`appendAgentFixGuide` runs only in the `compile`/`compileSync` catch blocks, and with `errorRecovery: true` — the mode editors and LSPs compile with — `buildResult` returns `meta.diagnostics` without throwing, so recovery-mode consumers only ever see the raw `diag.label`. Verified with `CLAUDECODE=1`: `compileSync("$ const x = ;", f, { errorRecovery: true })` yields diagnostics `["Unexpected token", "Scriptlets are not supported when using the tags api."]` with no `Fix guide:` anywhere in `meta`, while the same source thrown (recovery off) gets the pointer. Thread the guide onto the diagnostic label/meta in `buildResult`, behind the same `isCodingAgent()` gate so human editor UIs stay clean. See also "Key the agent fix-guide to the specific error instead of one generic cheatsheet pointer" — a separate message-quality defect on the same helper; neither fix implies the other. Re-verify with that `compileSync` call.
+
+## Fail loudly when a `document` global makes `@marko/compiler` disable module resolution
+
+`packages/compiler/modules.js` › `exports.resolve` | 2026-07-19 | impact:low | effort:low
+
+`modules.js` decides once, at first require, whether it is in a browser via `typeof document === "object"`, so a script that installs jsdom globals before requiring the compiler takes the browser branch and gets `exports.resolve`/`tryResolve`/`require === null` with `cwd === "/"` (verified with `node -e 'globalThis.document={}; require("packages/compiler/modules.js")'`). The next translator load then dies in `try-load-translator.js` as `TypeError: markoModules.resolve is not a function`, which names nothing about the DOM global, and the branch is cached for the module's lifetime. Throw a message naming the cause when `markoModules.resolve` is null, or document the compile-then-shim-then-import order for headless self-checks. Re-verify with that two-line node snippet.
+
+## Delete or assert the absence of `sizes.json` for `error_compiler` fixtures
+
+`packages/runtime-tags/src/__tests__/main.test.ts` › `hasCompilerError` sizes gate | 2026-07-20 | impact:low | effort:low
+
+The optimize `after()` that asserts or rewrites `sizes.json` is gated on `optimize && !hasCompilerError`, and `utils/snap.ts`'s stale-file sweep only cleans `__snapshots__/`, so a fixture that later gains `error_compiler: true` (or `skip_optimize`) keeps its last `sizes.json` forever, never asserted and never rewritten by `test:update`. No fixture is affected today. Have the harness delete the file (or assert its absence) for those fixtures, but outside the mode loop: `skip_optimize` skips the whole `optimize` describe (`main.test.ts:143-145`), so an `after()` registered inside it never runs. The entry "Make the fixture `sizes.json` gate inert when the run is `--grep`-scoped" reworks the same hook, so fix both in one pass. Verify: drop a `sizes.json` into any `error_compiler` fixture and watch `pnpm run test:update` leave it untouched.
+
+## Detect mutually-referential `<const>` cycles, not just self-references
+
+`packages/runtime-tags/src/translator/util/references.ts` › `trackReferencesForBinding` | 2026-07-20 | impact:low | effort:med
+
+`trackReferencesForBinding` throws `Tag variable circular references are not supported.` only when a reference's `MarkoAttribute` root is the binding's own tag, so `<const/a=b/><const/b=a/>` passes and compiles. The output then references an undeclared `$b_getter` (`const a = $b_getter;`) and dies with a ReferenceError at render time instead of a compile error. Detect the cycle through the binding graph and reuse the same diagnostic. Verify: `pnpm run compile -o html -d cycle.marko` on `<const/a=b/><const/b=a/><div>${a}${b}</div>` succeeds and emits `$b_getter`.
+
+## Serialize `DOMException`, `AbortSignal`, and `Event`
+
+`packages/runtime-tags/src/html/serializer.ts` › `writeUnknownObject` | 2026-07-23 | impact:low | effort:low
+
+All three fall past the constructor `switch` to `throwUnserializable`, so a resumed value holding one is dropped even though they reach templates through request handling. Each has a constructor form that round-trips its observable state (`new DOMException(message, name)`, `AbortSignal.abort(reason)`, `new Event(type, { bubbles, cancelable, composed })`), but a not-yet-aborted `AbortSignal` has no faithful representation — resume would have to wire it to a fresh controller, so settle that semantics before adding it. Worth the runtime bytes only if a real template needs them. See also the entry "Serialize boxed primitives" — the same `proto?.constructor` switch and the same re-verify recipe, so the two are worth batching into one PR, though these need `case globalThis.X:` guards. Verify: pass each through `Serializer#stringifyScopes` and watch it drop, against `new URL("https://a.b")` as a supported control.
+
+## Add a `Destroy` step to the CSR fixture harness
+
+`packages/runtime-tags/src/__tests__/main.test.ts` › `csr` | 2026-07-23 | impact:low | effort:low
+
+The CSR harness mounts a template and only ever calls `instance.update(input)`, so fixture snapshots never exercise teardown; `cleanup-*` fixtures only cover destroys driven from inside a render by `<if>`/`<for>`. `mounted-template.test.ts` now covers `destroy()`, `<lifecycle>` onDestroy, `$signal` abort, and the `value` getter/setter directly (4499fbaa3e), so what remains is snapshot breadth over nested-branch teardown. Add a `Destroy` step alongside `Wait`/`Flush`/`Throws` in `TestConfig.steps`, have `runSteps` call `instance.destroy()`, and let the mutation tracker snapshot the resulting removal. Verify: `rg -n "instance\." packages/runtime-tags/src/__tests__/main.test.ts` returns only `instance.update(input)`.
+
+## Serialize boxed primitives
+
+`packages/runtime-tags/src/html/serializer.ts` › `writeUnknownObject` | 2026-07-24 | impact:low | effort:low
+
+Boxed primitives (`Object(1)`, `Object("x")`, `Object(true)`) have no case in the `proto?.constructor` dispatch, so they fall through to `throwUnserializable` and resume as nothing. Adding them is a one-case change with an obvious emitted form (`Object(value)`); `DataView`, previously recorded alongside them, is done. Note the switch now carries the comment `// Boxed primitives (Object(1)) are deliberately unsupported.` (added with DataView support in ee882c82bb), so this needs a maintainer ruling before it is worth doing. See also the entry "Serialize `DOMException`, `AbortSignal`, and `Event`" — the same dispatch switch and the same re-verify recipe, so batch them, but that gap is gated only on demand and has no recorded stance to overturn. Re-verify: pass `Object(1)` through `Serializer#stringifyScopes` and observe the value omitted from the payload, against `new URL("https://a.b")` as a supported control.
+
+## Unify `packages/runtime-class/src` on ESM so its module type can be declared
+
+`packages/runtime-class/package.json` › `files` | 2026-07-24 | impact:low | effort:high
+
+`packages/runtime-class` declares no `"type"`, and 79 ESM-syntax `.js` files sit under `src` alongside 137 CommonJS ones, so Node parses each ESM file as CommonJS, fails, and reparses it as ESM. It is not silent: `pnpm run compile -t class` — the `-t class` form root `AGENTS.md` documents — prints `[MODULE_TYPELESS_PACKAGE_JSON] ... packages/runtime-class/src/translator/index.js ... incurs a performance overhead`. It is harder than `packages/compiler` was: that package fixed it with a `src/package.json` `{"type":"module"}` marker it never publishes, whereas `runtime-class` lists `src` in `files`, so the marker would ship and all 137 CJS files would have to convert. Marko 5 is in maintenance, so weigh the churn before starting. Re-verify: `pnpm run compile -t class -o dom -d /tmp/x.marko` and observe the warning.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -2,582 +2,272 @@
 
 Runtime speed and bundle size opportunities. Format and rules: [README.md](README.md).
 
-## Derive await/try branch scope owners without serialization
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `writeHTMLResumeStatements` | 2026-07-02 | impact:low | effort:high
-
-State-driven `<if>`/`<for>` branches now link their owner from resume markers instead of serializing it, but `<await>`/`<try>` branches still serialize `_: _scope_with_id(parentScopeId)`. Two blockers were verified: (1) their branch machinery can be tree-shaken out of resume bundles while closures into the content still fire (`await-tag` fixture: `_await_promise` is dropped, `branchesEnabled` stays off, so branch visits are never processed), and (2) reordered/out-of-order content pushes scope data and closure subscriptions a flush earlier than its markers, so a state update mid-stream can read the owner before it could be linked. Solving these likely means an explicit enable in the resume payload and deferring subscriptions to marker processing.
-
-## Serialize ConditionalRenderer only when the condition is stateful or has direct closures
-
-`packages/runtime-tags/src/html/writer.ts` › `writeBranchEnd` | 2026-07-02 | impact:low | effort:med
-
-Existing TODO in `_if`, but narrower than it reads: branch index 0 is already elided (`branchIndex || undefined`), and the `return <index>` statements are only appended to branches whose `kBranchSerializeReason` is truthy, so a conditional whose branches never serialize writes nothing. The remaining waste is an `else`/`else-if` branch (index > 0) serialized for a reason unrelated to branch swapping (e.g. hoist-through) under a condition that can never change and with no direct closures (`_if_closure` reads the index at `src/dom/signals.ts:245`, the `_if` signal at `src/dom/control-flow.ts:433`). Suppressing it needs another `_if` arg at every call site, which likely costs more compiled-output bytes than the rare wire bytes saved. Related but separate: `packages/runtime-tags/src/html/writer.ts:209` TODO about `_var` re-registering an already-registered return value.
-
-## Gate `<return valueChange>` serialization on parent mutation
-
-`packages/runtime-tags/src/translator/core/return.ts` › `analyze` | 2026-07-02 | impact:low | effort:high
-
-Existing TODO: `<return value=... valueChange=...>` force-serializes the `TagVariableChange` accessor even when no parent ever assigns the tag variable. Unlike the now-implemented `<let>` equivalent (gated on `binding.assignmentSections` in `core/let.ts`), this needs cross-template information: whether any parent mutates the tag variable is only known at the parent's compile (`mutatesTagVar` in `packages/runtime-tags/src/translator/util/known-tag.ts:147`), so the reason would have to flow through the param serialize reason group protocol rather than a local check.
-
 ## Avoid resume-registering native tag change handlers
 
 `packages/runtime-tags/src/translator/visitors/function.ts` › `canIgnoreRegister` | 2026-07-02 | impact:med | effort:high
 
-Existing TODO: plain `on*` event handlers on native tags skip registration, but controllable change handlers (`valueChange=`, `checkedChange=`, ...) always go through `_resume` registration, costing a registry id + registration statement in server output and a registry entry client-side for every controllable input. The registration is currently load-bearing, not incidental: the handler function itself is serialized as a `ControlledHandler` scope prop (`packages/runtime-tags/src/html/attrs.ts:430`) that the shared typed resume effects (`_attr_input_checked_script` and friends in `src/dom/controllable.ts`) read when the user interacts before any re-render, and serializing a function requires it to be registered. Removing the registration means restructuring controllable resume so a per-section registered effect rebuilds the handler closure from serialized state (the way `on*` handlers work) instead of one shared runtime effect per controllable type reading a serialized function. Touches the ~30 controllable fixtures; needs deliberate design, not a spot fix.
+`canIgnoreRegister` skips registration for plain `on*` handlers on native tags, but its `// TODO: all native tag functions should avoid registration but right now change handlers require it` still holds: every `valueChange=`/`checkedChange=` costs a registry id plus a registration statement in server output and a registry entry client-side. The registration is load-bearing today — the handler is serialized as a `ControlledHandler` scope prop (`html/attrs.ts`) that the shared typed resume effects (`_attr_input_checked_script` and friends in `dom/controllable.ts`) read on interaction before any re-render, and serializing a function requires registration. Removing it means restructuring controllable resume so a per-section registered effect rebuilds the handler closure from serialized state, the way `on*` handlers work; that touches the ~30 controllable fixtures. Re-verify: `pnpm run compile -o html -d` on `<let/v="a"/><input value:=v>` emits `_resume(_new_v => { v = _new_v; }, "<file>/valueChange", $scope0_id)`.
 
-## Extend marker-elision optimizations to await/try
+## Let a nested-section content passthrough use the slim `_dynamic_tag_content`
 
-`packages/runtime-tags/src/translator/core/await.ts` › `analyze` | 2026-07-02 | impact:low | effort:med
+`packages/runtime-tags/src/translator/util/binding-prop-tree.ts` › `isDirectContentBinding` | 2026-07-02 | impact:med | effort:med
 
-The `onlyChildInParent`/`singleChild` optimizations (reuse the parent element as the marker node, skip range boundary comments) are implemented for `for`/`if`/`show` but not `await`/`try`, which always create a `#text` marker binding (`createBinding("#text", BindingType.dom, section)` in both `await.ts` › `analyze` and `packages/runtime-tags/src/translator/core/try.ts` › `analyze`), and `_try` always emits BranchStart/BranchEnd comments (`packages/runtime-tags/src/html/writer.ts` › `_try`) even for static bodies. The analogous `<html-comment>` case is done: its "make the marker node the same as the comment node" TODO was resolved by `b3752c95fa` (empty comments are padded so the resume marker claims the comment node).
-
-## Specialize dynamic tags statically known to be renderers
-
-`packages/runtime-tags/src/translator/util/tag-name-type.ts` › `analyzeExpressionTagName` | 2026-07-02 | impact:med | effort:med
-
-Existing TODO: `<${input.component}/>` style dynamic tags always compile against the fully general `_dynamic_tag` runtime, which includes string-tag (native element) handling, attr normalization for both shapes, and `attrTags` merging. When analysis can prove the value is never a string (e.g. it only ever receives template imports), a slimmer helper skipping the native-element path could be emitted, and conversely an always-string value could compile like a native tag with a dynamic name. Measured in a mid-size app on marko 6.2.3: an UNCONDITIONAL body-only dynamic tag (`<${input.content}/>`, the documented slot-render pattern) is already free in the browser bundle — resume adopts the server DOM — but wrapping the same tag in `<if>` makes the branch client-re-creatable and pulls `_dynamic_tag` plus the dynamic-attrs/controllable machinery into the shared chunk: `dom.mjs` grew 11.4 → 16.9 kB (+5.5 kB raw, +1.9 kB gzip on every route). `<if=input.aside><${input.aside.content}/></if>` is the natural authoring of an optional slot, so this cliff is hit from idiomatic code; a body-only-typed value (`Marko.Body` / attr-tag `content`) under a conditional is exactly the "never a string" case above and would skip the tag-name dispatch and dynamic-attrs support entirely.
+`<${expr}/>` always builds the fully general `_dynamic_tag` signal (`visitors/tag/dynamic-tag.ts`), whose string-tag branch pulls `_attrs`, `_attrs_content`, `_attrs_script` and `controllableRenders` (`src/dom/control-flow.ts`) into the shared chunk. A slim `_dynamic_tag_content` already exists, emitted as an extra `directContentExport` a known parent calls instead, so `<${input.content}/>` lets the bundler shake the general signal out. But `isDirectContentBinding` requires `read.section === binding.section`, so the idiomatic optional slot `<if=input.aside><${input.aside.content}/></if>` — the read now lives in the `<if>` body section — gets no direct export and drags `_dynamic_tag` in. Relax the section check (the passthrough is still input-less and parameter-less; only the branch scope differs) so the direct export is emitted there too. Related but separate: the `TODO: Optimize for when we are certain that this is either always a string or always a custom tag` at `tag-name-type.ts:191` would cover the `<let>`-bound tag name case. Re-verify: compile that `<if>` template with `-o dom` and check for an `export const $input_aside_content_direct = _dynamic_tag_content(0)` beside the `_dynamic_tag` signal, as `<div><${input.content}/></div>` already produces.
 
 ## See through statically-shown `<show>` bodies in `getNodeContentType`
 
 `packages/runtime-tags/src/translator/util/sections.ts` › `getNodeContentType` | 2026-07-02 | impact:low | effort:low
 
-`getNodeContentType` classifies a core `<show>` tag as `ContentType.Dynamic`, so a placeholder next to a `<show>` always gets a `<!>` separator / Replace visit even when the `<show>` value is statically truthy and the body is spliced inline with no runtime boundary (`packages/runtime-tags/src/translator/core/show.ts:156`). Sibling-text analysis in `packages/runtime-tags/src/translator/visitors/placeholder.ts` now looks through `<show>` body edges for correctness; the converse refinement (returning the body's start/end content type for a static-display `<show>`, like the custom-tag case does via `tagSection.content`) would drop a few unnecessary separator bytes.
-
-## Parallel test workers oversubscribe cores via rolldown's thread pool
-
-`scripts/test-parallel.js` › `SLICED_FILES` | 2026-07-02 | impact:low | effort:med
-
-`npm run test:parallel` runs one mocha process per core, but each fixture bundle already drives rolldown's own multi-threaded build (`packages/runtime-tags/src/__tests__/utils/bundle.ts`), so even a serial run uses ~1.4 cores. On a 4-core box the whole suite lands at ~87s vs ~238s serial (2.7×), short of the ~4× the core count implies, because the workers contend for the same native threads. `RAYON_NUM_THREADS=1` in the worker env made no measurable difference, so rolldown isn't honoring it. If rolldown (or its native binding) exposes a per-build thread cap, pinning workers to 1 bundler thread each — so N workers ≈ N threads total — could recover much of the lost efficiency and let the runner scale closer to linearly on higher core counts.
+`getNodeContentType` returns `ContentType.Dynamic` for every core `<show>`, so a placeholder beside one is classified `SiblingText.Before` — a `<!>` in the client template plus a Replace visit — even when the display value is statically truthy and `<show>`'s translate exit splices the body inline with no runtime boundary. Compiling `<div><show=true><b/></show>${input.x}</div>` to dom gives `"<div><b></b><!></div>"` / walks `"Db%l"`, versus `"<div><b></b> </div>"` / `"Db l"` for the same markup without the `<show>`. Return the body's `startType`/`endType` for a static-display `<show>`, the way the custom-tag arm reads `tagSection.content[extraMember]`; `evaluate()` on the display attribute is cached, so it is safe to call here even before `<show>`'s own analyze has run. Re-verify with that dom compile.
 
 ## Skip child client wiring for constant-input instances of client-inert tags
 
 `packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `analyze.enter` | 2026-07-09 | impact:med | effort:high
 
-A custom-tag call site always emits the child's client wiring — `_child($scope[...])` plus one `$input_*($scope[...], value)` per attribute — even when every input is a compile-time constant and the instance sits in content that never re-renders. The child's input signals then run at hydration, so whatever they read must ship. Measured: a leaf icon tag (an existence check against a generated manifest, then an `<img>`) rendered twice with literal inputs on an otherwise-static route pulled its module, the manifest, and their chunk-mates — 2.6 kB raw / 1.2 kB gzip of client JS for a page with zero dynamic content; the workaround was hand-replacing the tag with a plain `<img>`. The cross-file channel needed already half-exists at this line: `childExtra.domExports?.setupEmpty` skips the child's setup call when the child template proved it a noop. Extending that shape — child analysis exporting "client behavior is a pure function of inputs (no own state/handlers)", call-site analysis proving all inputs constant — would let the translator emit nothing for the instance, making leaf display tags (icons, badges, chips: the most-instantiated tag category) free wherever they're statically used. Note the module-retention side of the same story: a shaken-to-nothing child import still survives if the child has any top-level side effect (`<style>` CSS import, `_script` resume registration, un-annotated `static` calls), so the wiring skip must drop the import too, not just the calls.
-
-## Emit caret-free controllable input value handling for statically non-text types
-
-`packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `getRelatedControllable` | 2026-07-09 | impact:low | effort:med
-
-`value:=` on a native input always binds the generic `_attr_input_value` helper, which drags `dom/controllable.ts`'s value path plus `dom/resolve-cursor-position.ts` (caret preservation across external value writes) into the bundle. Selection APIs don't apply to non-text input types — `selectionStart` is null and `setSelectionRange` throws on `type="number"` — yet an app whose only controllable is a number stepper still ships the caret machinery — measured at ~1.25 kB raw of controllable + cursor-position code in the shared runtime chunk for a single `value:clamp:=` on a statically-typed `type="number"` input. When the `type` attribute is a static literal outside the text family (text/search/tel/url/password/textarea), the translator could bind a caret-free variant of the value helper; a dynamic or missing `type` keeps the generic path.
-
-## Reserve a trailing id for the section-instances fallback accessor
-
-`packages/runtime-tags/src/translator/util/references.ts` › `getDebugNameAsIdentifier` | 2026-07-10 | impact:low | effort:med
-
-When a section has no `sectionAccessor`, `getSectionInstancesAccessor` falls back to `ClosureScopes + section.id` (optimized: `B3`). Both emit sites are explicit literals — the serialized key in `visitors/program/html.ts:118` and the renderer argument in `visitors/program/dom.ts:129` — so nothing derives the key at runtime, and it could instead be an id reserved after the parent section's binding ids (the `closureAccessorIds` pattern in the same file), dropping the letter for ~1 byte per serialized owner scope and per renderer. Only the `hoist-*-from-dynamic` fixtures exercise the fallback, so the win is small; note the `typeof accessor === "number"` branch in `getSectionInstancesAccessorLiteral` is currently unreachable (both paths concatenate strings) and would either become live or be removed by this change.
+A custom-tag call site always emits the child's client wiring even when every input is a compile-time literal, so the child's dom module ships and its input signals re-run on every client-created instance. Compiling `<div><Icon name="a"/><Icon name="a"/></div>` to dom against an `icon.marko` that only maps a `static const` manifest onto an `<img>` emits `_Icon($scope.a); _tag_input_name($scope.a, "a")` twice plus the `./icon.marko` imports, on a page with zero dynamic content. The cross-file channel half-exists beside `childExtra.domExports?.setupEmpty`: have child analysis also export a "no client-observable behavior" flag and let an all-constant call site emit nothing, dropping the import too — a top-level side effect (`<style>`, `_script` resume, un-annotated `static`) otherwise retains the module. Purity of the child's inputs is not that flag: `_tag_input_name`'s `_attr($scope["#img/0"], "src", ...)` is a pure function of a constant input yet is the only thing that sets `src` when the child is created on the client (it lands in the branch content setup inside an `<if>`), so the flag has to prove the child adds nothing to the cloned DOM — no DOM writes, handlers, effects, or resume registrations — unless the call site also folds the constant into a specialized template. Re-verify with that two-instance dom compile.
 
 ## Make the runtime analyzably pure so bundlers tree-shake it fully
 
 `packages/runtime-tags/src/html/serializer.ts` › `Generator` | 2026-07-11 | impact:high | effort:med
 
-Bundlers retain every runtime module body as a potential side effect, so unused runtime code survives tree-shaking; a plain fixture page bundle measured 16.1 kB minified where 2.7 kB is reachable. Two categories block purity analysis: the serializer's iterator-consumption patch mutates `Generator.prototype`/`AsyncGenerator.prototype` at import time (`serializer.ts:6-9`), and getter-hazard constructs (bare `globalThis`/built-in member reads, the serializer's well-known-value tables) execute at module top level. A verified fix: install the iterator patch lazily from the `Serializer` constructor — every render's `State` creates one at render start, before user code can consume a generator — and wrap the remaining hazardous initializers in `/* @__PURE__ */`-annotated function calls. With both done, a bare import of the whole runtime (html + dom) tree-shakes to zero bytes (rolldown probe), with no bundler configuration or package metadata involved. Expect fixture `sizes.json` churn that mixes real wins with accounting: side-effect-free modules that previously landed in a shared chunk (never counted by per-entry sizes) inline into the measured entry chunks.
+Two module-top-level side effects stop bundlers from dropping unused runtime code: `patchIteratorNext` mutates `Generator.prototype`/`AsyncGenerator.prototype` at import, and the `KNOWN_FUNCTIONS`/`KNOWN_OBJECTS` tables read `globalThis` members eagerly — nothing in `src` carries a `/* @__PURE__ */` annotation today. A plain fixture page bundle measures 16.1 kB minified against 2.7 kB reachable. Install the iterator patch from the `Serializer` constructor instead (`html/writer.ts`'s `State` builds one per render, before user code can consume a generator) and wrap the remaining hazardous initializers in `@__PURE__`-annotated calls. Re-verify with a rolldown probe: a bare import of `src/html.ts` plus `src/dom.ts` should tree-shake to zero bytes. Expect fixture `sizes.json` churn mixing real wins with chunk accounting.
 
 ## Split rarely-used dom machinery out of the eager runtime chunks
 
 `packages/runtime-tags/src/dom/queue.ts` › `_enable_catch` | 2026-07-11 | impact:med | effort:med
 
-A module is hosted in exactly one chunk, so machinery co-hosted with common helpers ships to every app that uses any of them. Three verified splits: (1) `_enable_catch` in the render queue imports `renderCatch` from `./control-flow` at module top level (`queue.ts:7`), so every stateful app's queue chunk hosts branch machinery — move catch/pending installation to a new `dom/catch.ts` (compiled output still calls `_enable_catch`) that installs its wrappers through an internal `enableCatchPending` hook on the queue, and move `setConditionalRenderer` to `dom/scope` (its dependency home; control-flow, spread, and catch all import it); note catch still pulls branch construction — `renderCatch` must swap in a newly rendered catch block — the win is dropping `dom/control-flow`'s loop, dynamic-tag, and spread imports. (2) The spread/`content`-attr machinery (`_attrs`/`_attrs_content` and helpers, `dom/dom.ts:169`) co-hosts with the plain write helpers — move it to a new `dom/spread.ts`. (3) `dom/controllable.ts` hosts all five control kinds in one module, so a page with one controllable pulls all five — split into `dom/controllable/` with one module per kind (input value, checked [checkedValue co-hosts, it calls checked], select, details/dialog open) over a shared delegation/change-detection core. Public exports stay unchanged and compiled output byte-identical (two bundle snapshots lose a bundler collision suffix, `_script$1` → `_script`).
+A module is hosted in exactly one chunk, so machinery co-hosted with common helpers ships to every app that uses any of them. Three splits: (1) `queue.ts` imports `renderCatch` from `./control-flow` at module top level, so every stateful app's queue chunk drags in branch machinery — move catch/pending installation to a new `dom/catch.ts` that installs its wrappers through an internal queue hook, and move `setConditionalRenderer` to `dom/scope`, its dependency home. (2) Move `_attrs`/`_attrs_content` and helpers out of `dom/dom.ts` into a new `dom/spread.ts`. (3) Split `dom/controllable.ts` into one module per control kind (input value, checked, select, details/dialog open) over a shared change-detection core. Re-verify public exports and compiled output are unchanged (two bundle snapshots lose a `_script$1` collision suffix) and diff fixture `sizes.json`.
 
 ## Ship the dom runtime dist as preserved modules for file-granular chunking
 
 `packages/runtime-tags/scripts/bundle.mts` | 2026-07-11 | impact:med | effort:low
 
-`dist` bundles the dom runtime into a single `dom.mjs`, so an application bundler hosts the whole runtime in the first chunk that needs any of it. Shipping preserved modules behind the `dom.mjs` re-export facade lets app bundlers chunk the runtime at file granularity (which is also what makes the hosting splits above land for published consumers, not just src-linked dev). Requires `scripts/sizes.mts` to classify the whole dist directory as runtime for the user/runtime split — the facade stops being the only runtime module id. Depends on the runtime being analyzably pure (previous entries) for the unused files to actually drop.
+`bundle.mts` writes the dom runtime as a single `dist/dom.mjs`, so an application bundler hosts the whole runtime in the first chunk that needs any of it. Emitting preserved modules behind a `dom.mjs` re-export facade lets app bundlers chunk the runtime at file granularity — which is what makes the module-hosting splits land for published consumers, not just src-linked dev. `scripts/sizes.mts` must then classify the whole dist directory as runtime, since `runtimePath` (the facade) stops being the only runtime module id. Depends on the runtime being analyzably pure for unused files to actually drop. Re-verify by bundling a fixture against the new dist and confirming unreferenced runtime files leave the entry chunk.
 
-## Skip per-reference scope channel tracking when a render uses no channels
+## Skip per-reference scope channel tracking when a render uses no ready channels
 
 `packages/runtime-tags/src/html/serializer.ts` › `trackScope` | 2026-07-13 | impact:med | effort:high
 
-Every scope written as a value emits `_(id)` after `trackScope` (`serializer.ts:660`) does a `refs.get` and either `trackChannel` or `newScopeReference`; this whole path exists only so `_(id)` emissions stay channel-aware for independently-lazy-loaded content. In a fully synchronous render `state.channel` is `undefined` on every flush and `trackChannel` short-circuits immediately (`serializer.ts:1670`), so the `refs.get`/Reference bookkeeping per scope reference is pure overhead — and scope references are the single most common object in real component trees (a scope-reference-heavy microbenchmark spends a measurable double-digit fraction of its time here). The naive guard "this flush has no channel" is unsafe: a scope first referenced in a channel-free flush can be referenced again in a later channel-gated flush, and the Reference's `channel` field (set at creation) feeds `trackChannel`'s parent-channel walk, so skipping creation in the first flush would change cross-channel dependency tracking. A safe version needs a serializer-lifetime "no channels have ever been used" signal (channels only arise from `stringifyScopes`' `channel` argument, driven by lazy/`ready`-gated content in `writer.ts`), gating the fast path on it and falling back the first time any channel appears.
-
-## Cut per-value Reference allocation in data-heavy serialization
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeReferenceOr` | 2026-07-13 | impact:med | effort:high
-
-Profiling a 464 KB data-heavy payload (product records: nested objects, arrays, long strings) — after the prototype-dispatch and char-code key-escaping fast paths already landed — shows the remaining cost is dominated by intrinsic per-value bookkeeping: ~12% GC, driven by a `new Reference` (`serializer.ts:307`) allocated in `writeReferenceOr` (`serializer.ts:608`) / `writeString` (`serializer.ts:723`) for every object, array, and >12-char string, plus ~12% in output `StringAdd` and ~8% across the `refs`/`REGISTRY`/`strs` Map probes. Most of those References back a value that is written once and never referenced again, so they are immediate garbage. A lazy scheme — record only the buffer position on first write, upgrade to a full Reference only on a second occurrence — would remove the bulk of the allocation, but is blocked by cross-flush dedup: a value first written in one flush and reused in a later one resolves through `assignId`'s parent/accessor walk (`serializer.ts:1868`), which needs pos+parent+accessor+flush retained from the first write (essentially the whole Reference). Splitting within-flush dedup (the common case, which only needs `pos` via `assignId`'s early return) from the cross-flush path would let the first write store a cheap position marker and allocate a Reference only when one is actually reused. Output-preserving, but a deep change to the reference model, not a spot fix.
+Every scope written as a value runs `trackScope` — a `state.refs` probe plus either `trackChannel` or a `new Reference` in `newScopeReference` — before emitting `_(id)`, bookkeeping that exists only to keep `_(id)` channel-aware for independently lazy-loaded content; outside ready-gated content it is pure overhead, since `trackChannel` returns on its first line whenever `ref.channel?.readyId` is falsy. Note the gate is `readyId`, not the channel itself: the html `State` is the root channel and `flushSerializer` passes it to `stringifyScopes` on every scope flush, so "this render passed no channel" is never true, and only `writeWaitReady`'s child SerializeState carries a `readyId`. A per-flush guard is also unsafe — a scope first seen in a readyId-free flush can be referenced from a later gated one, and its `Reference.channel` feeds `trackChannel`'s parent walk. So gate on a serializer-lifetime "no channel with a readyId has ever reached `stringifyScopes`" flag and fall back permanently once one does; the rest of the scope-ref bookkeeping is safe to skip, since `writeScopesRoot` re-creates the Reference on demand and scope refs short-circuit in `ensureId` so their `flush`/`pos` are never read. Re-verify with the cross-channel/lazy serializer tests plus a scope-reference-heavy benchmark.
 
 ## Consolidate each lazy template behind one load adapter
 
 `packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `translateDOM` | 2026-07-13 | impact:med | effort:med
 
-Lazy inputs and setup each create separate virtual modules, import records, promises, and generated loaders despite sharing one child implementation. Use one cached adapter per trigger/template while retaining fine-grained exports; measure increasing input counts plus shared, nested, error, and unmount cases.
+The `isLoad` branch emits a separate virtual module, dynamic import, and `_load_signal` loader per lazy input binding (`buildLoadSignalVirtualModule`), plus one more pair for setup (`buildLoadSetupVirtualModule`), even though every one resolves to the same child template; setup also allocates a fresh uid per tag while signals at least dedupe on trigger+file+export. The cost is runtime as well as bytes — each `_load_setup` (`packages/runtime-tags/src/dom/load.ts`) keeps its own `pending`/`renderer` and re-runs `_content(...)`. Use one cached adapter per trigger/template while retaining fine-grained exports so per-input chunking is not lost. Re-verify on the `lazy-tag-twice` fixture's dom snapshot, which shows two `_load_setup` uids for one child, then across increasing input counts plus shared, nested, error, and unmount cases.
 
 ## Let parameter reason groups select client registration anchors
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateHTML` | 2026-07-13 | impact:high | effort:high
 
-Parameter reason groups narrow HTML payload per known call site, but child DOM modules still install every optional `_resume` root. Export pure values plus group-keyed registration anchors so known callers retain only active behavior; stateful, circular, dynamic, or unknown callers conservatively retain all groups.
+Parameter reason groups (`contentSection.paramReasonGroups`, known-tag.ts:246-311) already narrow the HTML payload per known call site via `_set_serialize_reason`, but the child's DOM module emits every `_resume(registerId, fn)` as an unconditional top-level statement (`signals.ts` `writeRegisteredFns`, collected with no serialize-reason gate; `_resume` is intentionally not in `pureDOMFunctions`), so a caller that activates one group still retains the client behavior of all of them. Export pure values plus group-keyed registration anchors so known callers keep only active behavior, with stateful, circular, dynamic, and unknown callers conservatively retaining all groups. The anchor a caller emits must itself be a retained root: in an optimized page bundle every pure chain shakes away (see `fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.js`, which keeps only non-pure statements), and a register id resume cannot resolve is not a no-op — `dom/resume.ts` pushes the missing value and calls it. Re-verify on a fixture whose child has a group no caller activates: that group's registered functions should disappear from the dom bundle snapshot with html output and resume unchanged.
 
-## Couple dynamic-tag resume registration to the retained signal
+## Coalesce `queueAsyncRender`'s per-completion microtasks
 
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `enableDynamicTagResume` | 2026-07-13 | impact:med | effort:med
+`packages/runtime-tags/src/dom/queue.ts` › `queueAsyncRender` | 2026-07-13 | impact:low | effort:low
 
-`enableDynamicTagResume()` emits standalone non-pure `_resume_dynamic_tag()` beside an otherwise removable pure signal; `dynamic-tag-spread` consequently retains 6,128 minified / 2,523 Brotli bytes. Register through a retained `_dynamic_tag_resume(...)` shape so signal and native spread/event support shake together; keep controlled and lazy paths as positive tests.
+`queueAsyncRender()` ends in an unconditional `queueMicrotask(run)`, so N promise completions in one tick schedule N microtasks; the first `run()` drains every pending render and effect and the rest are empty passes that still allocate two arrays and bump `runId`. Streaming resume hits this directly — `dom/load.ts` and `_await_promise` in `dom/control-flow.ts` call it once per settled promise. Guard with a module-level scheduled bit cleared at the top of the flush, so work enqueued during the flush still schedules a fresh microtask. Re-verify: settle several `<await>`/lazy boundaries in one tick and assert `run` executes once.
 
-## Gate catch runtime enablement on retained boundary capability
-
-`packages/runtime-tags/src/translator/core/try.ts` › `translate.dom.exit` | 2026-07-13 | impact:med | effort:high
-
-Every `<try>` emits non-pure `_enable_catch()` even when no client boundary survives. Gate it on a retained capability covering descendant effects, ready work, renderers, and recreation—not only `_try`, because lazy resumed effects can throw without that signal. Concretely, moving `_enable_catch()` into the `/*@__PURE__*/ _try` constructor (`src/dom/control-flow.ts:344`) is the unsound naive form: a try boundary reconstructed from the resume payload (`_resume_branch`/resume comments) never runs the constructor, so a descendant lazy/async resumed effect that throws would find the queue's `runEffects`/`runRender` catch wrappers uninstalled (`src/dom/queue.ts:190`). The current top-level `_enable_catch()` statement runs unconditionally at module eval precisely to guarantee those wrappers exist before any resumed throw.
-
-## Coalesce async render microtasks
-
-`packages/runtime-tags/src/dom/queue.ts` › `queueAsyncRender` | 2026-07-13 | impact:med | effort:low
-
-`queueAsyncRender()` schedules one microtask per completion, so the first drains shared work and later callbacks perform empty runs and advance `runId`. Coalesce with a scheduled bit cleared immediately before flushing; test simultaneous completions and effects that enqueue more work.
-
-## Use lightweight cleanup links for internal closure subscriptions
-
-`packages/runtime-tags/src/dom/signals.ts` › `subscribeToScopeSet` | 2026-07-13 | impact:med | effort:high
-
-Each internal dynamic-closure subscription allocates an `AbortController`, listener, set entry, and closure. Store compact owner/set cleanup links destroyed directly with the scope, retaining `AbortController` only for public lifecycle APIs; validate large keyed-list reorder/destruction and owner swaps.
-
-## Index lazy ready work by channel and render
-
-`packages/runtime-tags/src/dom/resume.ts` › `ready` | 2026-07-13 | impact:med | effort:high
-
-`ready(id)` scans every render, then every globally ready id to a fixed point, and splices consumed prefixes. Index pending renders and reverse dependencies by ready id and use cursors; preserve late reordered gates and source-stream order.
-
-## Avoid scanning every embedded render after unrelated DOM mutations
-
-`packages/runtime-tags/src/dom/resume.ts` › `initEmbedded` | 2026-07-13 | impact:med | effort:med
-
-`initEmbedded()` checks every embedded anchor after every document child-list mutation, creating embedded-count × mutation-batch work. Process removed subtrees or group/schedule anchor checks while preserving move/reinsert, adoption, nested removal, and exactly-once destruction.
-
-## Propagate invoke-only inputs through local define tags after analysis
+## Propagate invoke-only inputs into same-program `<define>` tags
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `analyzeAttrs` | 2026-07-13 | impact:med | effort:high
 
-Invoke-only propagation skips same-program `<define>` props because reads are incomplete mid-analysis. A conservative post-analysis fixed point can make local handlers read persisted slots lazily, removing intersections, input updates, closure propagation, and owner state; compare with equivalent cross-file tags and cover recursion/aliases/hoists.
+`analyzeAttrs` sets `attrExtra.invokeOnly` only when `getRootSection(templateExportAttr.binding.section) !== getProgram().node.extra.section`, so a local `<define>` never gets the treatment an equivalent cross-file tag does — same-program prop trees are mid-analysis with incomplete reads. `<define/Btn|input|><button onClick=input.onClick>x</button></define>` with `<let/count=0/><Btn onClick=() => count++ />${count}` therefore folds `$Btn_content__input_onClick(...)` into the `$count` signal body, re-pushing the handler and re-running its `_on` script on every state update; the identical `tags/btn.marko` version hoists it into `$setup` alone. A conservative post-analysis fixed point would let local handlers read persisted slots lazily, dropping the intersection, input update, closure propagation and owner state. Re-verify: compile both shapes with `node -r ~ts scripts/inspect-compiled-output.mts -o dom -d` and diff the `$count` bodies.
 
-## Skip closest-branch writes for sections that cannot resume
+## Skip `_resume_branch` for sections with no serialize reason
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `writeHTMLResumeStatements` | 2026-07-13 | impact:low | effort:low
 
-`writeHTMLResumeStatements()` emits `_resume_branch(scopeId)` for some inert sections without a serialize reason (`html-style-injection` has no DOM bundle or scope payload). Omit or guard it with the finalized section reason while preserving empty referenced owners and ready-channel descendants.
+`resumeClosestBranch` ignores `sectionSerializeReason`, so an inert section emits `_resume_branch(scopeId)` with no accompanying `_scope(...)` write — wasted bytes, plus a `ClosestBranchId`-only scope nothing resumes when nested under a branch. Gate it on the finalized section reason while preserving empty referenced owners and ready-channel descendants. Re-verify: `fixtures/html-style-injection/__snapshots__/html.bundle.js` must stop emitting `_resume_branch($scope0_id)` for a template whose only state is an unserialized `<let>`.
 
-## Interop bridges a Class parent's `on-x` handler as a fresh closure each render
+## Cache the handler `addTagsEvents` binds for a Class parent's `on-x`
 
 `packages/runtime-class/src/runtime/helpers/dynamic-tag.js` › `addTagsEvents` | 2026-07-13 | impact:low | effort:low
 
-`addTagsEvents` calls `bindTagsEventHandler(component, handler, extraArgs)` to
-fold a Class parent's `on-x("method")` binding into the Tags child's `onX` input,
-allocating a **new** function every render (client path). The Tags child's input
-signal (`_const("input_onX", …)`) dirty-checks by identity, so every Class-parent
-re-render re-runs the child's event-attach signal (`_on(...)`) even though the
-target method is unchanged. `_on` is delegation-based so the re-attach itself is
-cheap, but the wasted signal re-execution is avoidable: cache the bound handler
-per `(component, methodName, extraArgs)` (string-method handlers are the common
-case and cache trivially) so the child sees a stable `onX` identity across
-renders.
+On the client path `addTagsEvents` calls `bindTagsEventHandler(component, handler, extraArgs)`, allocating a new closure per render for each `on-x("method")` binding folded into the Tags child's `onX` input. The child's input signal dirty-checks by identity (`_const` in `dom/signals.ts` compares with `!==`), so every Class-parent re-render re-executes the child's `_on` attach signal even though the target method is unchanged — the re-attach is cheap, the signal re-run is the waste. Cache the bound function per `(component, methodName, extraArgs)`; string-method handlers are the common case. Re-verify: two renders of a Class parent with `on-click("handle")` must hand the Tags child the same function reference.
 
-## `getClassHydrationMode` never memoizes its "no hydration" result
-
-`packages/runtime-class/src/translator/index.js` › `getClassHydrationMode` | 2026-07-13 | impact:low | effort:low
-
-`getClassHydrationMode` caches `meta.classHydration` only when it returns a
-truthy mode (SELF/DESCENDANT); the `undefined` (no-hydration) result is never
-stored, so `Object.hasOwn(meta, "classHydration")` stays false and every parent
-that references a shared inert child re-runs the full recursive descent over that
-child's subtree. In a wide/deep component graph this is repeated O(subtree) work
-per referencing parent. Memoizing the negative result (`meta.classHydration =
-undefined` with a presence sentinel, or a separate `visited`-scoped cache) makes
-it single-pass per file.
-
-## Compat resume runs the event resolver over every key of every boundary scope
+## Gate the compat resume's event-resolver loop and the process-wide patches
 
 `packages/runtime-tags/src/dom/compat.ts` › `compat.init` | 2026-07-13 | impact:low | effort:low
 
-The `SET_SCOPE_REGISTER_ID` resume iterates **all** enumerable keys of every
-compat boundary scope (including `$global`, `m5c`, `#Id`, `#StartNode`, …) and
-calls `classEventResolver` on each, even when the app has no bridged Class→Tags
-events. Related: `Component.prototype.___setCustomEvents` is patched on the
-prototype for **all** Class components (`tags-compat/runtime-dom.js:59`), so every
-component with custom events pays an extra `for…of` + `resolveRegistered` per
-event regardless of interop, and `compat.onFlush` permanently patches
-`Chunk.prototype.flushHTML` process-wide (`html/compat.ts:57`), taxing every pure
-Marko 6 chunk flush with a `writersByGlobal.get` miss once the class-compat
-module is loaded. Each is minor individually; worth gating the resolver loop on a
-"has bridged events" flag and scoping the patches.
+The `SET_SCOPE_REGISTER_ID` resume runs `classEventResolver` over every enumerable key of every compat boundary scope (`$global`, `m5c`, `#Id`, `#StartNode`, …), and `tags-compat/runtime-dom.js` installs that resolver unconditionally, so apps with no bridged Class→Tags events pay the loop anyway. Two related always-on costs: the same file patches `Component.prototype.___setCustomEvents` for every Class component, and `htmlCompat.onFlush` wraps `Chunk.prototype.flushHTML` process-wide, so once class-compat is loaded every pure Marko 6 flush runs an extra `chunk.render` plus a `writersByGlobal.get` miss. Gate the resolver loop on a "has bridged events" flag and scope both patches to interop renders. Re-verify: `rg -n "classEventResolver" packages/runtime-tags/src/dom/compat.ts` still shows the ungated `for…in`.
 
-## Document resume-payload cost of per-item custom tags and patterns to contain it
+## Document the resume-payload cost of per-item custom tags
 
 `packages/runtime-tags/cheatsheet.md` › `Golden rules` | 2026-07-18 | impact:med | effort:med
 
-A grid rendered as one small custom tag per cell (a 16x16 minesweeper board, parent `<let>` holding a 2D array of `{mine,revealed,flagged,adjacent}` cell objects, one `<mine-cell>` per cell) produces a production SSR page of 69.6kB where the `M._.r` resume payload is 44kB: the 256 serialized cell objects account for ~11kB, and the remaining ~130 bytes per tag instance is scope/binding bookkeeping — per-instance scope entries plus closure-subscriber sets serialized as `af:new Set([_(9),_(11),...])` with one `_(id)` per instance per closed-over parent `<let>` (an 8x8 board measures 18.5kB/11kB at the same ratio). The initial grid is also a pure function of input (every cell identical) yet fully serialized, since `<let>` has no way to declare a recomputable/lazy initial value. Some of this may be inherent to resumability, but neither `cheatsheet.md` nor any user-facing doc mentions resume-payload size as a design consideration or the mitigations (flat primitive state, rendering repeated leaf cells as plain elements in the parent instead of one custom tag each, deriving recomputable state with `<const>`); a short guidance section with this shape of numbers would steer grid/list-heavy apps away from an accidental 44kB-per-page tax, and the per-instance subscriber-set encoding may itself be compressible.
+No user-facing doc warns that one custom tag per grid/list cell dominates page weight. Measured with the repo's own optimize bundle (a `<let>` holding a 16x16 array of `{mine,revealed,flagged,adjacent}`, one `<mine-cell>` per cell, SSR): 45.8 kB page = 28.6 kB resume script + 11.7 kB of `<!--M…-->` marker comments; the n=8→n=16 slope is ~112 B of resume data plus ~46 B of markers per instance. Only ~11 kB of the payload is the 256 serialized cell objects; the rest is per-instance bookkeeping — one scope entry each (`{"#ClosestBranchId":N,e:_(N,"a0"),…}`, `"G"` in prod) plus, when the item body reads a parent `<let>`, one `_(id)` per instance in that binding's `ClosureScopes` set on the owner scope (`new Set([_(4),_(6),_(8)])`, see the `at-tags-for-loop-param-intersection-closure` snapshot). `<let>` also has no way to declare a recomputable/lazy initial value, so a grid that is a pure function of input is serialized in full. `cheatsheet.md` covers syntax only (`grep -in payload` returns nothing today) and `RESUMABILITY.md` is a contributor doc; a second addition to the same `Golden rules` list is pending in the entry "Cover `static` for module-level values and helpers in cheatsheet.md", so budget that file's space once. Add a short guidance block (flat primitive state, repeated leaf cells as plain elements in the parent, recomputable state via `<const>`), and separately consider compressing the per-instance scope-entry encoding.
 
 ## Inline single-consumer derived value signals, not only intersection-collapsed members
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `getSignal` | 2026-07-19 | impact:med | effort:med
 
-A derived value signal with a single downstream consumer still emits two module functions where one would do. `<for|item| of=input.items><li>${item.name}</li></for>` compiles (optimize, `-o dom`) to `const $for_content__item_name = ($scope, item_name) => _text($scope.a, item_name);` plus `const $for_content__$params = ($scope, $params2) => $for_content__item_name($scope, $params2[0]?.name);` — the value function is referenced exactly once. The same shape appears for a single-use `<const>` and even when the value feeds a child component. `esbuild --minify --bundle` keeps both functions (the value fn is a live binding), so this is real shipped size (~16-18B minified floor per binding, more with child consumers). `getSignalFn` (`signals.ts:607-619`) emits `value.signal.identifier(scope, value.value, …)` as a call for every downstream value unless `value.signal.inline` is set; `inline` is assigned only inside the `collapsedIntersectionSource` branch (`signals.ts:296-313`), gated on `member.reads.size === 1` and the member being one of the source signal's values. Standalone single-consumer derived bindings — `<for>` param members and single-use `<const>` — never enter that branch, so they always get a named function plus a one-shot call, even though the inlining machinery already exists. When a derived value signal has a single consumer within the same section and is not persisted/read cross-scope, inline its render body into the consumer signal. The correct gate is "single consumer call-site" (slightly broader than the intersection path's `reads.size===1`, e.g. `${item.name} - ${item.name}` has 2 reads but 1 consumer function and is still inlinable); keep standalone functions when the value has >1 consumer, is persisted (`forcePersist`/cross-scope), or has dynamic subscribers. Pervasive (every `<for>` and every single-use derived `<const>`), and "bundle size is a feature" here. Distinct from all existing perf/cleanup entries (the `known-tag.ts:675` invoke-only entry is about `<define>` props, not derived-value signal emission).
+`signal.inline` is set only inside `getSignal`'s `collapsedIntersectionSource` branch (gated on `member.reads.size === 1`), so a standalone derived value with a single consumer still emits a named module function plus a one-shot call from `getSignalFn`. `<for|item| of=input.items><li>${item.name}</li></for>` compiles (`-o dom`, optimize) to `$for_content__item_name` referenced exactly once by `$for_content__$params`; a single-use `<const>` gives the same shape, and minifiers do not cross-inline them (rolldown `minifySync` keeps both arrows), so it is shipped size on every `<for>`. Gate inlining on "one consumer call-site" (broader than `reads.size === 1`), keeping a standalone function when the value has >1 consumer, is persisted (`forcePersist`/cross-scope), or has dynamic subscribers. Re-verify: recompile that `<for>` and confirm the value body lands inside `$for_content__$params`.
 
-## Drop or warn on unused derived `<const>` bindings instead of emitting a live discarded computation
+## Drop unused derived `<const>` bindings instead of emitting a live discarded expression
 
 `packages/runtime-tags/src/translator/core/const.ts` › `analyze` | 2026-07-19 | impact:low | effort:low
 
-A derived `<const>` with zero readers still ships and re-runs its initializer on every update of its dependencies. For `<let/x=1><const/expensive=x.map(v => v * 2).join(",")>…` where `expensive` is never referenced, the `$x` let signal contains a discarded bare-expression statement `/* expensive */$scope.c.map(v => v * 2).join(",")`, recomputed on every `x` update; because the expression has method calls, `esbuild --minify --bundle` cannot drop it (a pure/literal unused const like `99;` minifies away, but any method-chain/impure-looking derived `<const>` survives). `core/const.ts` analyze (:82-88) always calls `setBindingDownstream(binding, valueExtra)` and `addSetupExpr(...)` when a non-aliased binding exists, with no check for whether the binding has any reads; `getSignalFn` (`signals.ts:620-628`) then emits the value expression as a bare statement (`withLeadingComment(value.value, …)`) whenever the derived signal has no render statements, retaining it for potential side effects. A `<const>`/`<let>` with no readers should be eliminated (no signal value emitted), or at minimum surface an "unused binding" diagnostic; a provably-pure initializer should never be emitted as a live statement. Niche (unused bindings are usually oversight and most are pure/minifiable) but genuinely non-recoverable for impure-looking exprs. Shares the emit locus with the single-consumer inlining entry above but is a distinct phenomenon (0 consumers → bare live expr, vs 1 consumer → redundant call).
+`analyze` calls `setBindingDownstream` + `addSetupExpr` for every non-aliased `<const>` binding without checking whether it has readers, and `translate.exit` still calls `addValue`, so a zero-reader binding survives `pruneBinding`. `<let/x=[1]><const/expensive=x.map(v => v * 2).join(",")>` with `expensive` unread compiles (`-o dom`) to `_let(1, $scope => /* expensive */$scope.b.map(v => v * 2).join(","))` — recomputed on every `x` update and unremovable by the minifier because the expression has calls (an unused `<const/pure=99>` does minify away). Skip value emission for a read-less binding, or at minimum surface an "unused binding" diagnostic. Shares the value-emission locus (`signals.ts` › `getSignalFn`) with "Inline single-consumer derived value signals, not only intersection-collapsed members", but is a distinct phenomenon: 0 consumers → bare live expr vs 1 consumer → redundant call. Re-verify: recompile that template and confirm the `/* expensive */` statement is gone.
 
-## Decompose the monolithic `isInteractive` gate into per-capability flags
-
-`packages/runtime-tags/src/translator/util/entry-builder.ts` › `visit` | 2026-07-19 | impact:high | effort:high
-
-`state.init` (ship the client init/hydration bootstrap) is flipped whenever `programExtra.isInteractive` is set, and `isInteractive` is force-set to `true` by six unrelated triggers: an event handler (`visitors/tag/native-tag.ts:225`), a `<script>` (`core/script.ts:84`), any function literal (`visitors/function.ts:203`), a scriptlet (`visitors/scriptlet.ts:31`), a dynamic tag (`visitors/tag/dynamic-tag.ts:150`), and `<lifecycle>` (`core/lifecycle.ts:60`). It is monotone and never refined, so a page that only delegates one click handler pulls the full effect/reactive-state bootstrap. Split it into narrower capability flags (event-delegation vs effects vs reactive-state) and gate the corresponding runtime bootstrap segments independently; a mis-classified capability is a resume failure, so default any unclassified trigger to the full path. Unlike whole-program register downgrades this fact is per-entry-local (no shared-module intersection hazard), but first verify `state.init`'s downstream is actually decomposable rather than one indivisible entrypoint.
-
-## Lower a never-reassigned `<let>` to `_const` and drop its `_resume_branch` disjunct
-
-`packages/runtime-tags/src/translator/core/let.ts` › `translate.exit` | 2026-07-19 | impact:low | effort:med
-
-`core/let.ts` calls `initValue(binding, true)` unconditionally, so a `<let>` whose `binding.assignmentSections` is empty (semantically a `<const>`) still lowers to the stateful `_let`/`_let_change` wrapper even though source analysis already routes it through `resolveDerivedSources`. Gate `isLet` on `!!binding.assignmentSections || hasValueChange` (after alias-root resolution) so it emits `_const`; under `isOptimize` `getScopeAccessorLiteral` ignores the `isLet` arg (`util/references.ts:1796`) so the scope slot is unchanged and resume stays aligned. This also removes the `BindingType.let` disjunct of the `resumeClosestBranch` OR at `util/signals.ts:1419`, so a section whose only branch-linking trigger was such a let stops emitting `_resume_branch` (a per-section SSR root in ~444 `html.bundle.js`) — sound only when `hasAbortSignal` and `referencedClosures` are also absent (combine with the "skip closest-branch writes" item above). Correctness gate: a two-way-bound `<let>` is mutated through a child `valueChange`/`constantViolation` in a different section, so confirm that path populates `assignmentSections` before the swap (and exclude `valueChange`/controllable lets) or a genuinely-mutated let ships `_const` and goes stale. Low aggregate impact — this is migration residue (a `<let>` that should be `<const>`, ~1/503 fixtures) — but a clean DOM+SSR root removal when it fires.
-
-## Demote state sources never written from client-reachable code
-
-`packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-19 | impact:low | effort:high
-
-`isStateSerializeReason` (`util/serialize-reasons.ts:167`) treats any binding whose sources contain `.state` as an unconditional serialize reason, and `references.ts:1016` deliberately adds reason `true` for every assigned binding with the comment "narrowing is a 0-byte no-op until a state-dropping pass exists". A `<let>` reassigned (`x=`/`x++`) only during synchronous render — never from an effect/handler/async/registered-fn, and not transitively reading any client-mutable binding — never needs its prior value on the client, so its state root could be dropped. Add a conservative client-immutability fixpoint in `finalizeReferences` (mutable if any assignment's enclosing function is a client-reachable effect/handler, or it transitively reads a client-mutable binding; default mutable on any alias/property-alias/spread/closure escape) and replace the `true` with the narrowed reason. Note the flagship "derived" shapes (`let total = items.reduce(...)`) are declaration initializers with no `assignmentSections` and already flow through `resolveDerivedSources`; the real target (render-only-reassigned-then-read lets) is a minority, largely-anti-pattern shape, so gate behind `isOptimize` and add render-reassigned-and-displayed / closure-read / derived-from-client-mutable-base stale-DOM fixtures before shipping.
-
-## Investigate the `_script` setup + handler double-registration for event handlers
+## Check whether the handler-setup `_script` registration is droppable
 
 `packages/runtime-tags/src/dom/signals.ts` › `_script` | 2026-07-19 | impact:med | effort:med
 
-`_script(id, fn)` fuses a `_resume(id, fn)` side effect with its returned effect-queuing closure and is absent from `pureDOMFunctions`; it is the dominant resume root, appearing in ~494/503 committed `dom.bundle.js` (more than `_content_resume` + `_var_resume` + `_hoist_resume` combined). A handler-only setup emits two registrations for one interactive handler: `basic-counter-const-event-handler/dom.bundle.js` ships both `_const(3, _script("a1", ($scope)=>_on($scope.a,"click",$scope.d)))` and a bare `_resume("a0", $increment)`. Determine whether the delegated-event resume path can reattach `_on` from the handler id (`a0`) alone, which would make the setup `_script` registration (`a1`) a droppable root repeated across hundreds of bundles; most `_script` registrations are legitimate (effects must re-run at resume), so any win is confined to the event-handler-setup subset. Splitting construction from registration here (as the registered-function path already does at `util/signals.ts:1111`) also creates the seam the "parameter reason groups select client registration anchors" item needs.
+`_script(id, fn)` fuses a `_resume(id, fn)` registration with the effect-queuing closure it returns, and is the dominant resume root: 547 of 559 committed `dom.bundle.js` snapshots contain it, versus 73 `_content_resume` + 26 `_var_resume` + 17 `_hoist_resume`; 141 contain both `_script(` and a bare `_resume(`. A `<const>` handler registers twice -- `basic-counter-const-event-handler/__snapshots__/dom.bundle.js` ships `_const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d)))` alongside `_resume("a0", $increment)`, and the resume payload carries both (`d: _(1, "a0")` plus `"a1 1"`). Determine whether the delegated-event resume path can reattach `_on` from the handler id alone -- `_on` (dom/event.ts) only sets `element["$click"] = handler` and delegates the type at the document, and the element accessor is already resumed via `_el_resume` -- which would make the setup registration droppable. If so, split construction from registration as `writeRegisteredFns` (`util/signals.ts:1109`) already does for registered fns; that seam is also what the 'parameter reason groups select client registration anchors' item needs. Most `_script` registrations are legitimate (effects must re-run at resume), so any win is confined to the event-handler-setup subset. Re-verify: `rg -l '_script\(' packages/runtime-tags/src/__tests__/fixtures/*/__snapshots__/dom.bundle.js | wc -l`.
 
-## Elide reactive closure subscription when the closed-over binding is provably immutable
+## Elide the closure wrapper when the closed-over binding never subscribes
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `getSignal` | 2026-07-19 | impact:med | effort:med
 
-A binding read across a section boundary builds a `_closure_get`/dynamic `_closure` (present in ~100 `dom.bundle.js`) that provides both scope access and a reactive subscription so the child re-renders when the parent value changes; the dynamic-closure case (`util/signals.ts:641`) also emits an extra `__closure` signal + `_closure` join per loop section. When the closed-over binding is client-immutable (a `<const>`, or a never-assigned `<let>` per the const-lowering item, whose sources are all immutable) the subscription can never fire and is dead registration. Degrade it to a one-time scope read and drop the subscription/dynamic-closure signal, reusing the client-immutability fixpoint; default to reactive on any assignment/alias/spread/closure escape. Verify-first: confirm a const-across-boundary fixture actually ships a redundant subscription rather than a plain scope read before implementing.
+`getSignal`'s cross-section branch always wraps the child render fn -- in `_if_closure`/`_for_closure` via `setClosureSignalBuilder` (core/if.ts, core/for.ts) or else in `_closure_get` -- even when the closed-over binding is client-immutable, i.e. `binding.sources` is undefined and the owner never pushes the signal. Compiling `<const/greeting="hi"/>` with `<if=input.show><div>${greeting}</div></if>` to DOM gives `_const(4)` with no downstream and `_if_closure(0, 0, fn)` used only as the `_if` content setup, which `_content` immediately unwraps (`setup._ || setup`, dom/renderer.ts) -- a dead closure plus a runtime import. The `_closure_get` form is worse: its returned signal has no `._`, so it becomes the setup itself and runs `subscribeToScopeSet` (`ownerScope[accessor] ||= new Set()`, `add`, `trackCleanup`) on every render into a set nothing iterates -- see committed `known-define-tag-empty-section-closure/__snapshots__/dom.bundle.js`, `_if(0, "<div> </div>", "D ", _closure_get(2, ...))` beside `const $count = _const(1)`. Emit the bare render fn when the binding has no sources, keeping the `underTryPlaceholder` resume registration when one is required; the dynamic `_closure` join the original entry also flagged needs no change, since it is already gated on `binding.sources`. Re-verify by compiling that `<if>` template with `-o dom`: `_if_closure` must disappear.
 
-## Cache the resolved lazy-module signal in `_load_signal` so the first post-load input update isn't deferred a tick
+## Cache the resolved lazy-module signal in `_load_signal`
 
 `packages/runtime-tags/src/dom/load.ts` › `_load_signal` | 2026-07-23 | impact:low | effort:low
 
-`_load_signal` keeps a closure `signal` for the resolved module's signal, but
-assigns it in exactly one place — inside the `pending.then((mod) =>
-queueAsyncRender(scope, (signal = mod._), value))` fallback (load.ts:180). The
-normal first-render path never goes through it: input values are collected into
-`scope[AccessorProp.Load]` and later applied by `insertLoaded` via
-`values.forEach((e) => e[LoadSignalValue.Signal]!._(branch,
-e[LoadSignalValue.Value]))` (load.ts:131-133), which writes the resolved signal
-onto the per-entry record and never back into the closure. So for every lazy
-tag, the first input update after its content is inserted still takes the async
-fallback — an extra promise tick plus a whole extra `queueAsyncRender` →
-`queueMicrotask(run)` queue drain outside the current render batch — and only
-the second update onward is applied synchronously. Fix: assign the closure once
-when `pending` is created (e.g. `pending.then((mod) => (signal ||= mod._), () =>
-0)` alongside `pending ||= load()`), leaving the `Load`-map branch's precedence
-unchanged. Re-verify: call `_load_signal(() => Promise.resolve({_: sig}))`
-against a scope with `[AccessorProp.Load]` set to a Map, replay `insertLoaded`'s
-flush (`Load = 0`, then `entry[LoadSignalValue.Signal]._(scope, value)`), then
-call the signal again — the value is missing immediately after the call and only
-appears after a microtask drain, while the call after that lands synchronously.
+The closure `signal` is assigned only in the `pending.then((mod) => queueAsyncRender(scope, (signal = mod._), value))` fallback; `insertLoaded` zeroes `branch[AccessorProp.Load]` and applies inputs through the per-entry record, never writing back into the closure. So the first input update after a lazy tag's content is inserted still takes the async arm — an extra promise tick plus a `queueMicrotask(run)` drain outside the current batch. Assign it once where `pending` is created (`pending.then((mod) => (signal ||= mod._), () => 0)`), keeping the `Load`-map arm first: between `Load = 0` and the `values.forEach` flush a synchronous write would be clobbered by the stale collected value. Re-verify: replay that flush against a scope, then call the signal — it must land without a microtask drain.
 
-## Dedupe/hoist serialize guards on the multi-param-section path in `getOrHoist`
+## Route multi-section serialize-guard disjuncts through the dedupe tracking
 
 `packages/runtime-tags/src/translator/util/serialize-guard.ts` › `getOrHoist` | 2026-07-23 | impact:low | effort:med
 
-`getOrHoist` (serialize-guard.ts:130) only performs guard dedup/hoisting on the
-`onlySection` branch: it looks the reason up in
-`TypeState.seenReasons`/`hoistedReasons`, and on the second occurrence pushes a
-`const $sg__x = _serialize_guard(...)` / `$si__x = _serialize_if(...)`
-declarator onto `getSectionReasonState(onlySection).declarators` and
-back-patches the first (pending) use. When `getOnlySection(reason.param)`
-returns `undefined` — a dynamic reason whose params live in two or more sections
-— the fallback loop (`for (const [paramsSection, params] of
-groupParamsBySection(reason.param))`) calls `buildGuardExpr` directly and never
-consults or updates that tracking, so both the composite OR and each per-section
-disjunct are re-emitted in full even when an identical single-section guard has
-already been hoisted to a variable that is lexically in scope. Concretely, the
-committed fixture `known-tag-args-spread` emits `(_serialize_if($scope0_reason,
-0) || _serialize_if($scope1_reason, 0)) && _subscribe(...)` on line 12 of
-`__snapshots__/html.bundle.js` while line 3 of the same function already
-declares `$si__input = _serialize_if($scope0_reason, 0)`; a two-level `<define>`
-nesting reproduces `_serialize_if($scope0_reason, 0)` three times and
-`_serialize_if($scope1_reason, 1)` twice inline alongside their hoisted
-`$si__input`/`$si__a`, plus the same two-disjunct composite twice. The fix is to
-route each disjunct through the same per-section tracking, looking up a
-synthesized `{ state: undefined, param: params }` in
-`getSectionReasonState(paramsSection)[isGuard ? "guard" : "if"]`
-(`compareSources` reduces to `compareReferences(param, param)` here because
-`getOrHoist` is only reached when `isReasonDynamic`, i.e. `state` is undefined),
-and optionally hoisting the composite too. Re-verify with `grep -Fn
-'_serialize_if($scope0_reason, 0)'
-packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js`
-— it must stop reporting both the hoisted declarator and a separate inline copy.
+`getOrHoist` dedupes and hoists only on its `onlySection` branch; when `getOnlySection(reason.param)` returns undefined the fallback loop over `groupParamsBySection(reason.param)` calls `buildGuardExpr` directly and never consults or updates `seenReasons`/`hoistedReasons`, so an identical single-section guard is re-emitted inline even though it is already hoisted and lexically in scope. In `known-tag-args-spread/__snapshots__/html.bundle.js` line 3 declares `$si__input = _serialize_if($scope0_reason, 0)` while line 12 still emits `(_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0))`. Look each disjunct up as a synthesized `{ state: undefined, param: params }` in `getSectionReasonState(paramsSection)[isGuard ? "guard" : "if"]`. Re-verify: `grep -Fn '_serialize_if($scope0_reason, 0)' packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js` must stop reporting both a declarator and an inline copy.
 
-## Stop registering tags→class compat scopes in `classIdToBranch`, which is never pruned
+## Prune `classIdToBranch` entries the tags→class direction never looks up
 
 `packages/runtime-tags/src/dom/compat.ts` › `classIdToBranch` | 2026-07-23 | impact:low | effort:low
 
-`classIdToBranch` is filled by the `SET_SCOPE_REGISTER_ID` resume handler in
-`compat.init` for every resumed scope carrying `m5c`, but its only `delete` is
-in `compat.render`, which runs exclusively for the class→tags direction (the
-`TagsCompat` renderer in
-`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js`). Scopes
-registered by the tags→class direction — written by
-`compat.writeSetScopeForComponent` in `html/compat.ts` and consumed on the
-client only through `scope.m5c` inside `renderAndMorph`, never through this map
-— are therefore inserted once and retained for the lifetime of the page, keeping
-the branch scope alive (and, after its first re-render, the attached
-`___marko5Component` and its `___rootNode` DOM fragment) even after the
-enclosing tags branch is destroyed. The two directions are distinguishable at
-registration time: the tags→class payload also carries `m5i` (`_scope(branchId,
-{ m5c, m5i })`) while the class→tags payload does not (`_scope(scopeId, { m5c:
-component.id })` in `html/compat.ts`'s `render`), so gating the
-`classIdToBranch.set` on `scope.m5i === undefined`, or deleting the entry when
-the branch is destroyed, removes the dead retention. This is distinct from the
-existing perf.md entry anchored at `dom/compat.ts › compat.init`, which concerns
-the `classEventResolver` for-in loop and the process-wide prototype patches.
-Re-verify: `rg -n "classIdToBranch" packages/runtime-tags/src/dom/compat.ts`
-shows exactly one `set` (in `init`) and one `delete` (in `render`), and
-`fixtures-interop/interop-basic-tags-to-class/__snapshots__/writes.debug.html`
-serialises `{ m5c: "_0", m5i: { count: 0 } }` — an id that no `compat.render`
-call ever looks up.
+`compat.init`'s `SET_SCOPE_REGISTER_ID` handler adds every resumed scope carrying `m5c` to the process-global `classIdToBranch`, but the only `delete` is in `compat.render`, which runs for the class→tags direction only; tags→class scopes (written by `writeSetScopeForComponent`, read on the client only as `scope.m5c` in `renderAndMorph`) are retained forever. They also outlive `initEmbedded`'s teardown, which drops `curRenders[renderId]` and releases the parallel `scopesByRender` record, leaving this map the last strong ref to a destroyed branch. Gate the `set` on `scope.m5i === undefined`, the key only the tags→class payload carries. Note the same handler retains every registered scope in `scopesByRender` for the render's lifetime, so top-level renders gain nothing. Distinct from "Compat resume runs the event resolver over every key of every boundary scope", which targets the other cost in this same handler and is worth fixing in one pass. Re-verify: `rg -n classIdToBranch packages/runtime-tags/src/dom/compat.ts` still shows one `set` (init) and one `delete` (render).
 
-## Coalesce the serializer flush per async completion instead of once per streamed chunk
+## Serialize once per flushed chunk instead of once per settled async
 
 `packages/runtime-tags/src/html/writer.ts` › `Boundary.flush` | 2026-07-23 | impact:med | effort:med
 
-`Boundary.flush()` runs `flushSerializer` unconditionally (writer.ts:1102), and
-`ServerRendered.#read`'s `onNext` in `html/template.ts` calls it on every
-`boundary.endAsync()` — i.e. once per settled `<await>` promise — even when the
-HTML write is deferred to the next `queueTick`. Each call appends its own
-`_=>[…]` closure to `state.resumes`, so N async completions landing in one
-streamed chunk emit N payload functions instead of one, and the run-length
-scope-id encoding in `writeScopesRoot` cannot span them. Serialization cannot
-simply be skipped, because `writePromise`/`writeReadableStream` call
-`boundary.startAsync()`, so serializing can raise `count` and a render must not
-be reported complete before it runs; a safe shape is `flush(write?)` that
-serializes only when `write` is true or `this.count === 0` (while `count > 0`
-the returned status is `FlushStatus.continue` regardless), with `#read` passing
-its existing `write` flag through. Re-verify: render N sibling `<await>`s that
-each serialize a `<let>` and count `_=>[` occurrences inside the emitted `M._.r`
-array — it should be 1, not N.
+`Boundary.flush()` runs `flushSerializer` on every call, and `ServerRendered.#read`'s `onNext` calls it on each `boundary.endAsync()` even when the HTML write is deferred to the next `queueTick`. Each call appends its own `_=>[…]` closure to `state.resumes`, so N awaits settling in one chunk emit N payloads and the delta scope-id encoding in `writeScopesRoot` cannot span them — see `fixtures/async-reorder-nested-batched-resolve/__snapshots__/writes.html`, where one chunk pushes `_ => [5,…], _ => [7,…]`. Serialization cannot simply be skipped, since the serializer itself calls `boundary.startAsync()`; take `flush(write?)` and serialize only when `write` or `this.count === 0`, with `#read` passing through its existing `write` flag. Re-verify: that snapshot should regenerate with a single `_ =>` closure per chunk.
 
-## Range-encode the consecutive branch ids packed into a single-node loop's BranchEnd marker
-
-`packages/runtime-tags/src/html/writer.ts` › `forBranches` | 2026-07-23 | impact:med | effort:med
-
-For a `singleNode` `<for>`, `forBranches` accumulates every branch scope id into
-one string (`flushBranchIds = " " + branchId + flushBranchIds`, writer.ts:509)
-that `writeBranchEnd` emits as a single
-`BranchEndSingleNode`/`BranchEndSingleNodeOnlyChildInParent` comment. Those ids
-are a constant-stride descending run whenever the loop body allocates a fixed
-number of scopes per item — the normal case for leaf rows — so the comment grows
-~4.5 bytes per row carrying no information. A run token (`start~end` or
-`start~end:stride`) with an explicit-id fallback would collapse it to a
-constant. The decoder is `packages/runtime-tags/src/dom/resume.ts`
-`createVisitBranches` (`while ((branchId = +lastToken))`, :208) reading
-space-separated tokens from `nextToken` (:297), and expansion must preserve
-iteration order because the single-node path walks `previousSibling` per branch
-and `endedBranches.reverse()` (:279) depends on it. Only the single-node marker
-variants (`|`, `}`) are affected; the `]`/`)` variants already spread one id per
-`BranchStart` comment. Re-verify: SSR `<let/n=2000/><button
-onClick(){n++}>add</button><ul><for|i| to=n><li>row</li></for></ul>` and compare
-the length of the single `<!--M_}…-->` comment against total page bytes before
-and after.
-
-## Mark class/style item writes pure so a single-consumer derived binding is not forced into a `_const` wrapper and scope slot
+## Mark class/style item writes pure so a single-consumer derived binding skips `_const`
 
 `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `translate.dom.enter` | 2026-07-23 | impact:med | effort:low
 
-The DOM `class`/`style` branch ends with `addStatement("render", tagSection,
-valueReferences, stmt, undefined, !!meta.dynamicItems)` (native-tag.ts:853-861),
-so the `isPure` argument is `true` only for the whole-value `_attr_class(node,
-value)` path and `false` for the split `_attr_class_item` / `_attr_class_items`
-/ `_attr_style_item(s)` path. A falsy `isPure` sets `signal.hasSideEffect`
-(`util/signals.ts:875-877`), which forces `signal.build` to wrap the value
-signal in `_const(accessor, fn)` instead of returning the plain function
-(`signals.ts:380-396`). Every other idempotent DOM write in the translator
-passes `true` — `_attr` (:897), `_attr_content` (:970), `_attr_nonce` (:737),
-`_text_content` (:1003), `_text`/`_html` in `visitors/placeholder.ts` — and the
-item helpers are just as idempotent (`element.classList.toggle(name, !!value)`
-and `element.style.setProperty(name, _to_text(value))`, dom/dom.ts:93-124). The
-cost lands on any derived binding whose only consumer is a class/style toggle,
-which is the idiomatic `class={ active: someConst }`: `<let/x=1/><const/y=x %
-2/><div class={ active: y }>` compiles (optimize, `-o dom`) to `const $y =
-_const(3, $scope => _attr_class_item($scope.a, "active", $scope.d))` — a
-`_const` import, a runtime dirty check and a scope slot — where the same const
-behind `data-active=y` compiles to `const $y = ($scope, y) => _attr($scope.a,
-"data-active", y)`. Intersection signals already set `hasSideEffect` at creation
-(`signals.ts:270-276`), so passing `true` unconditionally only affects the
-single-derived-binding case. Confirm the flag is not load-bearing (it was
-introduced with the `isPure` parameter in commit b2eb4e9925 "fix: optimize pure
-signals as plain functions"), then flip it and audit snapshots. Re-verify:
-compile the two templates above with `pnpm run compile -o dom` and diff the
-emitted `$y`.
+The DOM `class`/`style` branch passes `!!meta.dynamicItems` as `addStatement`'s `isPure`, so the split `_attr_class_item` / `_attr_style_item(s)` path is marked impure; that sets `signal.hasSideEffect` (`util/signals.ts`) and forces `signal.build` to emit `_const(accessor, fn)` plus a scope slot instead of a plain function. Those helpers are idempotent (`classList.toggle`, `style.setProperty`) and every other DOM write (`_attr`, `_attr_content`, `_text_content`) passes `true`. Confirmed with `-o dom`: `<let/x=1/><const/y=x % 2/><div class={ active: y }>` yields `const $y = _const(3, $scope => _attr_class_item($scope.a, "active", $scope.d))`, while `data-active=y` yields `const $y = ($scope, y) => _attr($scope.a, "data-active", y)`. Intersection signals already force `hasSideEffect` at creation, so passing `true` only affects the single-derived-binding case. Re-verify: flip the flag, recompile both templates, and audit the snapshot diff.
 
-## Elide the empty `$setup` export from the `_template` call so branches skip a no-op queued render
+## Pass `0` for an empty `$setup` in `_template`, and keep `setupEmpty` for dynamic tags
 
 `packages/runtime-tags/src/translator/visitors/program/dom.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low
 
-When a template's program section has no setup signal, `program/dom.ts` emits
-`export const $setup = () => {};` (:179-190) and still passes that identifier as
-the 4th argument of `_template` (:212-223). `_content` therefore stores a truthy
-`RendererProp.Setup` (`packages/runtime-tags/src/dom/renderer.ts:117`), so
-`setupBranch` (renderer.ts:76-81) does `queueRender(branch, emptyFn, -1)` for
-every branch built from that template — i.e. once per `<${dynamicTag}/>`
-instance via `createBranchWithTagNameOrRenderer` (`dom/control-flow.ts:996`) —
-and `mount` invokes it directly (`dom/template.ts:118`). The helper for exactly
-this already exists (`replaceNullishAndEmptyFunctionsWith0` in
-`util/signals.ts:806`, applied to child-section `_content` args but not to the
-program `_template` args), and `program/index.ts:78` carries the matching TODO
-"make any exports undefined if they are noops/empty". A related miss feeds it:
-`visitors/tag/dynamic-tag.ts:130` unconditionally calls `addSetupStatement`, so
-any template containing a dynamic tag loses `domExports.setupEmpty` and every
-parent emits `import { $setup as _child } from './child.marko'` plus
-`_child($scope.a)` even though translate produced an empty function. Re-verify:
-compile `<section class="wrap"><${input.content}/></section>` with `-o dom` and
-observe `export const $setup = () => {};` passed to `_template`, then compile a
-parent `<wrap><p>hi</p></wrap>` and observe `import { $setup as _wrap ... }` +
-`_wrap($scope.a);` in its `$setup`; a rolldown `minify:true` build keeps the
-empty arrow alive because it is a live `_template` argument. 19 committed
-`dom.bundle.js` snapshots contain a `$setup = () => {}`.
+With no program setup signal, `program/dom.ts` emits `export const $setup = () => {};` and still passes that identifier as `_template`'s 4th argument, so `_content` stores a truthy `RendererProp.Setup` and `setupBranch` queues `queueRender(branch, emptyFn, -1)` for every branch built from the template (and `mount` calls it directly). Child-section `_content` args already go through `replaceNullishAndEmptyFunctionsWith0`; the program `_template` args do not, and `program/index.ts` carries the matching TODO. Separately, `visitors/tag/dynamic-tag.ts` calls `addSetupStatement` unconditionally, so any template containing a dynamic tag loses `domExports.setupEmpty` and its parents still emit `import { $setup as _wrap }` + `_wrap($scope.a)` for a function translate left empty. Re-verify: compile `<section class="wrap"><${input.content}/></section>` and a parent that uses it with `-o dom`; 19 committed `dom.bundle.js` snapshots still contain `$setup = () => {}`.
 
-## Encode an all-same param-reason group set as a bitmask instead of a per-render object literal
+## Collapse an all-same `_set_serialize_reason` group object into a bare guard or bitmask
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateHTML` | 2026-07-23 | impact:low | effort:low
 
-`knownTagTranslateHTML` picks the `_set_serialize_reason` payload shape at
-known-tag.ts:239-300: `1` when nothing is dynamic or skipped, a bitmask when
-every present guard is the literal `1`, otherwise an object literal `{0: g0, 1:
-g1, ...}` (:297). The object branch is taken whenever any guard is a runtime
-expression, even when every group shares the _same_ expression — and the literal
-is allocated on every render of the call site, so inside a `<for>` that is one
-object per item. Because `_serialize_if`/`_serialize_guard`
-(`packages/runtime-tags/src/html/writer.ts:717-729`) treat `condition === 1` as
-"all groups" and a number as a bit-per-group mask, a shared 1|0 guard can be
-passed bare as `guard` when no group was skipped (`hasSkippedReasons === false`,
-the same gate the existing `t.numericLiteral(1)` branch uses), or as `<bitmask> *
-guard` otherwise — both allocation-free and shorter. "Contiguous from 0" is not
-the right gate: trailing skipped groups leave the present ones contiguous, yet a
-bare `1` guard would make `_serialize_if` report the skipped ones as
-serializable, so those need the bitmask form too.
-Soundness gate: only apply when the shared expression is known to be normalized
-to 1|0 (a `_serialize_guard(...)` call, an `||` chain of them, or a numeric
-literal), because `buildGuardExpr` (`util/serialize-guard.ts:179-199`) can also
-hand back a raw `$scopeN_reason` whose value may itself be a mask or object for
-a different group indexing. In the committed corpus 17 of 127
-`_set_serialize_reason` calls use the object form and 8 of those have identical
-values in every slot (4 contiguous, 4 with gaps). This is unrelated to the
-existing perf entry on the same symbol about client registration anchors.
-Re-verify:
-`packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js`
-emits `_set_serialize_reason({0: $sg__input_x, 1: $sg__input_x, 2:
-$sg__input_x})`; compiling a `<for|c| of=input.cards><card title=c.title
-body=c.body footer=c.footer/></for>` page with `-o html` puts the equivalent
-4-key literal inside the `_for_of` callback, i.e. one allocation per row.
+`knownTagTranslateHTML` falls back to an object literal `{0: g0, 1: g1, …}` whenever any group guard is a runtime expression, even when every group shares the same expression, and that literal is allocated on every render of the call site — one per row inside a `<for>`. Since `_serialize_if` treats `1` as "all groups" and a number as a bit-per-group mask, a shared 1|0 guard can be passed bare when `hasSkippedReasons` is false, or as `<bitmask> * guard` when groups were skipped. Gate it on the shared expression being normalized to 1|0 (a `_serialize_guard` call, an `||` chain of them, or a numeric literal), because `buildGuardExpr` can also hand back a raw `$scopeN_reason` whose value is itself a mask or object. Re-verify: `fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js` emits `_set_serialize_reason({0: $sg__input_x, 1: $sg__input_x, 2: $sg__input_x})`; across the committed html.bundle.js corpus 17 of 137 calls use the object form and 14 have identical values in every slot.
 
-## Memoize runtime-helper import resolution; every `callRuntime` re-scans the runtime import's specifier list
+## Memoize runtime-helper imports; every `callRuntime` rescans the import's specifier list
 
 `packages/runtime-tags/src/translator/util/runtime.ts` › `importRuntime` | 2026-07-23 | impact:med | effort:low
 
-`callRuntime(name, ...)` calls `importRuntime(name)` → `importNamed(getFile(),
-getRuntimePath(output), name)` for every single emitted helper reference, and
-`importNamed` (`packages/compiler/src/babel-utils/imports.js`) does
-`importDeclaration.get("specifiers")` — which re-`setContext`/`setScope`s a
-NodePath per specifier — followed by a linear `.find` over them; only after that
-miss does it create a new specifier. The results are overwhelmingly repeats:
-compiling the same 20-section page template for dom+html issues 691
-`importNamed` calls for just 33 distinct `(request, name)` pairs (95% repeats),
-and compiling the whole fixture corpus issues 21,885 calls with ~113k specifier
-comparisons. A `--cpu-prof` of 150 dom+html compiles of that page attributes
-5.80% of total inclusive time to `importNamed` (`callRuntime` 6.83%,
-`importRuntime` 5.93%), and the profile's top self-time entries are exactly the
-Babel NodePath machinery `path.get` drives (`isScopable` 4.22%, `setContext`
-3.25%, `getOrCreateCachedPaths` 3.01%, `setScope` 2.75%). Fix: keep a
-per-program `name → local identifier name` map (via `createProgramState`, so it
-is per-output and cannot leak the dom path into an html compile) and return
-`t.identifier(cached)` on a hit; the general version is a second-level `name →
-local` map inside `getImports` in the compiler, which also fixes
-`importDefault`/`importStar`. Re-verify by wrapping `importNamed` with such a
-memo before running the fixture corpus: output is byte-identical for all 2456
-compiles, and 400 dom+html compiles of
-`src/__tests__/fixtures/for-tag/template.marko` drop from 930ms to 876ms (min of
-7 alternating runs).
+Every emitted helper reference goes `callRuntime` → `importRuntime` → `importNamed`, and `importNamed` (`packages/compiler/src/babel-utils/imports.js`) does `importDeclaration.get("specifiers")` — rebuilding a NodePath per specifier (setContext/setScope) — plus a linear `.find` before it can reuse the existing local. The calls are almost all repeats: a 20-section page compiled for dom+html issues 830 `importNamed` calls for 28 distinct `(request, name)` pairs. Keep a per-program `name → local` map (via `createProgramState`, so a dom compile cannot leak its path into an html one) and return `t.identifier(cached)` on a hit; the general fix is a second-level `name → local` map inside `getImports`, which also covers `importDefault`/`importStar`. Re-verify: wrapping `importNamed` with such a memo keeps output byte-identical and cut 80 dom+html compiles of that page from ~2480 ms to ~2355 ms (best of 5).
 
-## Stop re-deriving each intersection's anchor binding inside the id-assignment loop in `finalizeReferences`
+## Reuse the `anchors` map for the intersection id loop in `finalizeReferences`
 
 `packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-23 | impact:low | effort:low
 
-In the final `forEachSection` pass of `finalizeReferences`
-(~references.ts:1278-1355) the id-assignment loop tests
-`intersections[intersectionIndex].filter(isOwnedBinding).at(-1) === binding`,
-allocating a filtered copy of the intersection on every iteration of the
-per-binding loop. That value is exactly what the `anchors` map built ~30 lines
-earlier already holds (`anchors` scans each intersection from the end for the
-first owned binding, i.e. the last owned element), so the whole condition
-reduces to `anchors.get(intersection) === binding` once `anchors` is hoisted out
-of the `if (intersections.length)` block that currently scopes it. As written
-the pass is O(ownBindings × intersectionLength) with one array allocation per
-owned binding: a synthetic section with ~802 own bindings and a single
-~800-member intersection (800 `<let>`s all read in one expression, compiled
-output shows one `_or(802, ...)`) does ~640k element visits and ~800 array
-allocations that a Map lookup replaces. Two smaller items in the same pass:
-`filter(bindings, isOwnedBinding)` is built twice (lines 1320 and 1350) and
-could be computed once, and the name-collision check at line 1016
-(`find(section.bindings, ({name}) => name === binding.name)`) is an O(bindings²)
-linear scan with a fresh closure per binding that a per-section `Set<string>` of
-names would make O(1). Re-verify by replacing the condition with
-`anchors.get(intersection) === binding` and running `pnpm run test:update`
-scoped to a fixture with intersections (e.g. `--grep "runtime-tags/translator
-for-tag "`): snapshots must be unchanged, since the two expressions are equal by
-construction on the sorted intersection arrays.
+The id-assignment loop tests `intersections[intersectionIndex].filter(isOwnedBinding).at(-1) === binding`, allocating a filtered array per owned binding, while the `anchors` map built ~30 lines above already holds each intersection's last owned binding; hoist `anchors` out of the `if (intersections.length)` block and the test becomes `anchors.get(intersection) === binding`. That removes an O(ownBindings × intersectionLength) walk (~640k element visits for 800 `<let>`s read in one expression). Same pass: `filter(bindings, isOwnedBinding)` is built twice and could be shared, and the name-collision check `find(section.bindings, ({ name }) => name === binding.name)` is an O(bindings²) scan a per-section `Set<string>` makes O(1). Re-verify: swap in the map lookup and run `pnpm run test:update -- --grep "runtime-tags/translator for-tag "` — snapshots must be unchanged, since the two expressions are equal by construction.
 
-## Defer `_resume_locals` scope serialization until the registered function is actually serialized
-
-`packages/runtime-tags/src/html/writer.ts` › `_resume_locals` | 2026-07-24 | impact:low | effort:med
-
-`_resume_locals` eagerly `writeScope`s a per-iteration scope holding attr-tag
-loop params referenced by a registered function, so those values ride the
-resume payload on every SSR render even when the child template never
-serializes the handler (eg it only renders some attribute tags). The
-serializer already tracks registered-value scopes lazily at reference time
-(`writeRegistered` › `trackScope` in `packages/runtime-tags/src/html/serializer.ts`);
-a channel that flushes a scope's props only once the registered value is
-written would drop the dead weight, but it is serializer surgery rather than
-a helper tweak. Re-verify: SSR a template whose attr-tag `<for>` handler is
-never spread onto a native tag and observe the `{foo}` scope still in the
-payload.
-
-## Decide the tag-variable `_var_resume` registration when the signal is written, not at translate exit
+## Decide the tag-variable `_var_resume` registration when the signal is final, not at translate exit
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateDOM` | 2026-07-27 | impact:med | effort:low
 
-`knownTagTranslateDOM` sets `source.register = !!getSerializeReason(tagSection, childScopeBinding) || !signalHasStatements(source)`, but it runs at the tag's translate exit — before the placeholders and scripts that read the tag variable have pushed their render statements onto that signal — so the `!signalHasStatements(source)` escape hatch (added in e917c2d to keep an empty signal's declaration from being elided, where the commit message calls the case "empty/unread") fires on signals that are non-empty by the time `writeSignals` builds them. That wraps the signal in an impure `_var_resume("…/var", …)` whose id the HTML output never writes, shipping a dead registry entry and pinning the declaration in the bundle: `pnpm run compile -o dom template.marko` on `<child/data/><div>${data}</div>` emits `const $data = _var_resume("…_0_data/var", ($scope, data) => _text($scope.c, data))` while `-o html` on the same template contains no `/var` id, and forcing `register` to the serialize reason alone drops the helper import plus call (and restores a top-level `const $get = /*@__PURE__*/_const(…)` in `return-value-registered`, which `_var_resume` currently makes unshakeable). Deleting the disjunct outright is wrong — a genuinely unread tag variable then loses its declaration while `_var($scope, 0, $data)` still references it — so move the emptiness half into `writeSignals`, where `signalHasStatements` is final, giving "keep the declaration" its own flag distinct from `register`; `visitors/tag/dynamic-tag.ts` still sets `tagVarSignal.register = true` unconditionally and needs the same gate (`dynamic-tag-var`'s `data1`). Re-verify from the repo root: `for d in packages/runtime-tags/src/__tests__/fixtures/*/__snapshots__; do a=$(grep -oh '"[^"]*/var"' "$d/dom.bundle.debug.js" 2>/dev/null | sort -u); b=$(grep -oh '"[^"]*/var"' "$d/html.bundle.debug.js" 2>/dev/null | sort -u); if [ "$a" != "$b" ]; then echo "$d"; fi; done` prints `custom-tag-var-expression`, `custom-tag-var-multiple`, `dynamic-tag-var`, `return-tag-no-state` and `return-value-registered` today, and should print nothing — every `/var` id registered in a DOM bundle must also be written by its sibling HTML bundle.
+`source.register = !!getSerializeReason(…) || !signalHasStatements(source)` runs at the tag's translate exit, before placeholders reading the tag variable push render statements onto that signal, so the "empty/unread" escape hatch from e917c2d fires on signals that are non-empty by the time `writeSignals` builds them. That ships a dead impure `_var_resume("…/var", …)` whose id the HTML never writes, pinning the declaration in the bundle: `-o dom -d` on `<child/data/><div>${data}</div>` emits it while `-o html` has no `/var` id. Deleting the disjunct is wrong — a genuinely unread var then loses the declaration `_var($scope, 0, $data)` references — so move the emptiness half into `writeSignals`, where `signalHasStatements` is final, behind a "keep the declaration" flag distinct from `register`; `visitors/tag/dynamic-tag.ts` sets `tagVarSignal.register = true` unconditionally and needs the same gate. Re-verify: diffing `grep -oh '"[^"]*/var"'` between each fixture's `dom.bundle.debug.js` and `html.bundle.debug.js` lists custom-tag-var-expression, custom-tag-var-multiple, dynamic-tag-var, return-tag-no-state and return-value-registered today, and should list nothing.
 
 ## Skip the `AbortController` when a section only uses `$signal` for cleanup
 
 `packages/runtime-tags/src/translator/visitors/referenced-identifier.ts` › `analyze` | 2026-07-29 | impact:med | effort:med
 
-`$signal` is the only DOM-side `AbortController` allocation left, and it is
-emitted from a single translator site whenever a template names `$signal` at
-all — so a section doing nothing but `$signal.onabort = fn` still allocates a
-controller AND its signal, then tears down through `ctrl.abort()`, which
-dispatches a real DOM event. That teardown is not cheap: when closure
-subscriptions used this same mechanism, native `abort` plus its JS wrapper
-measured ~21% of profiled self time on a keyed list torn down and rebuilt five
-times. Across the fixtures every single use is elidable — `$signal.onabort` x18,
-`$signal.aborted` x2, `$signal.addEventListener` x1, and not one bare reference —
-and `.onabort` is the idiom `cheatsheet.md` teaches, so this is the dominant
-shape rather than a fixture artifact.
+Naming `$signal` at all compiles to `$signal($scope, id)`, the last DOM-side `AbortController` allocation, and teardown runs `ctrl.abort()` — a real DOM event dispatch that measured ~21% of profiled self time when closure subscriptions used this path. Almost every use is elidable: recursively over `packages/runtime-tags/src/__tests__/fixtures`, `.onabort` dominates, and the one reference that escapes is `packages/runtime-tags/src/__tests__/mounted-template/lifecycle.marko` (`window.signal = $signal`), which must keep a real controller. `analyze` already allocates the per-expression `abortId`, so classify the parent there: `onabort` as an assignment LHS or `addEventListener` with a literal `"abort"` is cleanup-only, `aborted` needs only a boolean, anything else keeps a controller. When every reference for an id is cleanup-only, store the callback in the slot `AccessorProp.AbortControllers` already uses and have `$signalReset` (`packages/runtime-tags/src/dom/abort-signal.ts`) invoke it instead of aborting — still calling `trackCleanup(scope)`, or the callback is never enrolled with its branch and never fires. Re-verify: `pnpm run compile -o dom -d` on `<script>$signal.onabort = () => {}</script>` emits `_$signal($scope, 0).onabort = …`.
 
-`analyze` already visits each `$signal` identifier and allocates a per-expression
-`abortId`, which is the natural place to classify the parent: an `onabort`
-member as an assignment LHS, or `addEventListener` with a literal `"abort"`, is
-cleanup-only; an `aborted` member needs a boolean but no controller; ANYTHING
-else — a bare reference, an argument, a spread, an alias into a variable — must
-keep a real controller, since something else may hold that signal. When every
-reference for an `abortId` is cleanup-only, emit the callback into the slot
-`AccessorProp.AbortControllers` already uses and have `$signalReset`
-(`packages/runtime-tags/src/dom/abort-signal.ts`) invoke it instead of aborting,
-keeping the existing render-time deferral. Note the fixture counts are a biased
-sample: if real apps commonly pass `$signal` to `fetch`, the win narrows to the
-`<script>`-cleanup case, which is still the one that lands inside keyed lists.
-Re-verify: `pnpm run compile -- -o dom -d` on a template whose only signal use is
-`<script>$signal.onabort = () => {}</script>` emits
-`$signal($scope, 0).onabort = …`, and
-`grep -rhoE '\$signal[.a-zA-Z]*' packages/runtime-tags/src/__tests__/fixtures/*/template.marko | sort | uniq -c`
-lists no bare `$signal`.
+## Derive await/try branch scope owners without serializing `_`
+
+`packages/runtime-tags/src/translator/util/signals.ts` › `writeHTMLResumeStatements` | 2026-07-02 | impact:low | effort:high
+
+State-driven `<if>`/`<for>` branches link their owner from resume markers (`setSectionOwnerResumedByMarker`, called only from `core/if.ts` and `core/for.ts`), but `<await>`/`<try>` branches still serialize `_: _scope_with_id(parentScopeId)`. Two blockers remain: their branch machinery tree-shakes out of resume bundles while closures into the content still fire (the `await-tag` fixture's optimized `dom.bundle.js` drops `_await_promise`, so `enableBranches` never runs and `dom/resume.ts` only retains branch visits), and reordered content pushes scope data and closure subscriptions a flush earlier than its markers, so a mid-stream state update can read the owner before it could be linked. Solving both likely needs an explicit branches-enable flag in the resume payload plus deferring subscriptions to marker processing. Re-verify: `rg -n "_scope_with_id" packages/runtime-tags/src/__tests__/fixtures/await-tag/__snapshots__/html.bundle.js`.
+
+## Narrow the `_if` ConditionalRenderer TODO to the one case that still wastes bytes
+
+`packages/runtime-tags/src/html/writer.ts` › `_if` | 2026-07-02 | impact:low | effort:med
+
+The `// TODO: Write the renderer only for stateful conditions or direct closures.` in `_if` is narrower than it reads: branch index 0 is already elided (`branchIndex || undefined`) and `core/if.ts` appends `return <i>` only to branches whose `kBranchSerializeReason` is truthy, so a conditional whose branches never serialize writes nothing. The residue is an `else`/`else-if` branch (index > 0) serialized for a reason unrelated to branch swapping (e.g. hoist-through) under a condition that can never change and with no direct closures (`_if_closure` in `dom/signals.ts`, `_if` in `dom/control-flow.ts`). Suppressing it needs another `_if` argument at every call site, which likely costs more compiled-output bytes than the rare wire bytes saved. Re-verify: read the `AccessorPrefix.ConditionalRenderer` write in `html/writer.ts` › `_if` against the `t.returnStatement` guard in `core/if.ts`.
+
+## Gate `<return valueChange>` serialization on parent mutation
+
+`packages/runtime-tags/src/translator/core/return.ts` › `analyze` | 2026-07-02 | impact:low | effort:high
+
+`analyze` still carries `// TODO: this should be based on the parent actually mutating the tag variable.` above an unconditional `addSerializeReason(section, true, getAccessorProp().TagVariableChange)`, so `<return value=... valueChange=...>` force-serializes the change accessor even when no parent ever assigns the tag variable. The `<let>` equivalent is already gated on `binding.assignmentSections` (`core/let.ts`), but this one needs cross-template information: whether a parent mutates the tag variable is known only at the parent's compile (`mutatesTagVar` in `util/known-tag.ts`), so the reason has to flow through the param serialize-reason group protocol instead of a local check. Re-verify: `rg -n "TagVariableChange" packages/runtime-tags/src/translator/core/return.ts`.
+
+## Extend only-child marker elision to `<await>`/`<try>`
+
+`packages/runtime-tags/src/translator/core/await.ts` › `analyze` | 2026-07-02 | impact:low | effort:med
+
+`<await>` and `<try>` unconditionally create a `#text` marker binding (`createBinding("#text", BindingType.dom, section)` in `await.ts` › `analyze` and `core/try.ts` › `analyze`), so neither takes the `getOnlyChildParentTagName` / `getOptimizedOnlyChildNodeBinding` path that `for`/`if`/`show` use to reuse the parent element as the marker, and `_try` (`packages/runtime-tags/src/html/writer.ts`) always writes BranchStart/BranchEnd marks even for a static body. Compiled to dom, `<div><if=input.c><b>hi</b></if></div>` yields `"<div></div>"` with walks `" b"`, while `<div><try><b>hi</b></try></div>` yields `"<div><!></div>"` with `"D%l"` — an extra comment node and a Replace visit per instance. Route both tags through `util/is-only-child-in-parent` and gate the `_try` branch marks on a non-static body. Re-verify by rerunning that dom compile comparison.
+
+## Bind a caret-free input value helper for statically non-text `type`s
+
+`packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `getRelatedControllable` | 2026-07-09 | impact:low | effort:med
+
+A `type="number"` input still ships caret-preservation code that can never fire: `setInputValue` (`src/dom/controllable.ts`) calls `resolveCursorPosition` + `setSelectionRange`, and selection APIs only apply to text/search/url/tel/password and `<textarea>` (`selectionStart` is null elsewhere, so the runtime is already correct -- this is bytes only, roughly 0.5 kB raw for `resolve-cursor-position.ts` plus the two caret lines, not the ~1.25 kB the whole value path costs). `getInputValueMode` already evaluates a static `type` to pick `attribute`/`dynamic` mode and `getDOMControllableDefaultHelper` maps a mode onto `_attr_input_value_<mode>_default`, so a caret-free mode slots in there. Note both emitted helpers must be covered: one-way `value=` emits only `_attr_input_value_default`, but two-way `value:=` also emits `_attr_input_value_script`, whose post-handler `setInputValue` keeps `resolve-cursor-position` alive on its own -- a caret-free default helper without a caret-free script variant saves nothing for `value:=`. Opt out only for types where selection provably never applies (number, range, color, file, date/time family) rather than 'not in the text family', so `email` keeps the generic path, and weigh the split: a page with both a text and a number controllable ships both variants. Re-verify by compiling a `type="number"` `value:=` input and checking neither emitted helper reaches `resolve-cursor-position`.
+
+## Reserve a trailing id for the section-instances fallback accessor
+
+`packages/runtime-tags/src/translator/util/references.ts` › `getSectionInstancesAccessor` | 2026-07-10 | impact:low | effort:med
+
+When a section has no `sectionAccessor`, `getSectionInstancesAccessor` falls back to `getAccessorPrefix().ClosureScopes + section.id` (optimized: `"B3"`). Both emit sites are explicit literals — the serialized key in `visitors/program/html.ts` and the `_content`/`_content_resume` renderer argument in `visitors/program/dom.ts` — so nothing derives the key at run time, and it could instead be a bare id reserved after the parent section's binding ids, following the `closureAccessorIds` pattern in the same file, dropping the letter for ~1 byte per serialized owner scope and per renderer. Only four `hoist-*` fixtures exercise the fallback, so the win is small. Re-verify by grepping `packages/runtime-tags/src/__tests__/fixtures/*/__snapshots__/*.js` for `"B[0-9]+"`.
+
+## Cut per-value Reference allocation in data-heavy serialization
+
+`packages/runtime-tags/src/html/serializer.ts` › `writeReferenceOr` | 2026-07-13 | impact:med | effort:high
+
+With the prototype-dispatch and char-code key-escaping fast paths already landed, a 464 KB data payload (nested product records, arrays, long strings) is dominated by intrinsic bookkeeping: ~12% GC from the `new Reference` that `writeReferenceOr` and `writeString` (strings over `STRING_DEDUP_LENGTH`) allocate for every object, array, and long string. Each is retained by the `refs` WeakMap for as long as its value lives, even though most back a value that is written once and never referenced again. `assignId`'s early return needs only `ref.pos` when `ref.flush === state.flush`; only the cross-flush path needs parent/accessor. Any lazy scheme has to respect two constraints: the Reference is also the `parent` handed to every nested write (and what `isCircular`/`isAncestorMember` walk), so a container still needs an object identity at write time; and a later flush cannot patch an already-shipped buffer (`stringifyScopes` resets `state.buf`), so a position-only marker cannot be upgraded on reuse without parent+accessor -- dropping them would duplicate the value instead of deduping it, changing payload size and browser-side identity. So the realistic version is a slimmer per-value record (pos/parent/accessor) upgraded to a full Reference with id/assigns/calls/channel only on reuse -- a deep change to the reference model, not a spot fix. Re-verify with the serializer suite (especially cross-flush dedup) plus the benchmark's GC share.
+
+## Couple dynamic-tag resume registration to the retained signal
+
+`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `enableDynamicTagResume` | 2026-07-13 | impact:low | effort:high
+
+`enableDynamicTagResume()` pushes a bare top-level `_resume_dynamic_tag()` whenever a dynamic tag carries a spread or event/change handler, so it is an unconditional module side effect pinning `_resume`, `dynamicTagScript`, `_attrs_script` and `_on` and keeping the module in the graph, while the `_dynamic_tag(...)` signal beside it is `/*@__PURE__*/`; `<${input.as} onClick=input.onClick/>` compiles to a module whose only non-pure statement is this call. Do not charge `dynamic-tag-spread`'s retained bytes to it: that fixture's optimized `dom.bundle.js` also keeps `_enable_controllable()` (from the neighbouring `enableDynamicTagControllables`, which pulls all of `dom/controllable.ts`) and a non-pure `_content_resume(...)`, so removing this statement alone frees almost nothing there. Any fix must survive the resume-only case: for a page whose client work is entirely resume-driven every pure chain shakes away (that same snapshot retains no `_template` and no `$setup`), yet the server still writes the `d <scopeId>` effect from `html/dynamic-tag.ts` and `dom/resume.ts` invokes whatever `registeredValues[id]` holds — so a `/*@__PURE__*/ _dynamic_tag_resume(...)` hung off the signal is the unsound naive form. Same emitted shape as "Make `<try>`'s `_enable_catch()` shakable without breaking resumed boundaries" below, but a separate fix: the `pureDOMFunctions` comment in `translator/util/runtime.ts` is the one place that line gets drawn, and it already blesses registration-only calls like this one. Establish first whether any retained resume root can carry the registration; if none can, close this out.
+
+## Make `<try>`'s `_enable_catch()` shakable without breaking resumed boundaries
+
+`packages/runtime-tags/src/translator/core/try.ts` › `translate.dom.exit` | 2026-07-13 | impact:med | effort:high
+
+Every program containing a `<try>` gets a bare top-level `_enable_catch()` (guarded by `hasEnabledCatch`), a non-pure statement that survives even when the `/*@__PURE__*/ _try` signal beside it shakes away. Gating it needs a retained capability covering descendant effects, ready work, renderers and recreation — not just `_try`. The naive form, calling `_enable_catch()` from the `_try` constructor in `dom/control-flow.ts`, is unsound: a boundary rebuilt from the resume payload never runs that constructor, so a resumed lazy/async effect that throws finds `_enable_catch`'s `runEffects`/`runRender` wrappers (`dom/queue.ts`) uninstalled — the reason already recorded above `pureDOMFunctions` in `translator/util/runtime.ts`. "Couple dynamic-tag resume registration to the retained signal" above is that same emitted shape on the blessed side of that comment, a separate fix but with the same resume-only hazard to clear. Re-verify: a program whose `_try` signal is unreferenced drops `_enable_catch` from its dom bundle while `try-effects-async` still catches.
+
+## Index lazy ready work instead of rescanning every render
+
+`packages/runtime-tags/src/dom/resume.ts` › `ready` | 2026-07-13 | impact:med | effort:high
+
+`ready(id)` adds the id to `readyIds` and then runs `runResumeEffects` for every render in `curRenders`; each `render.m` re-runs `processResumes(render.r)` and loops the entire global `readyIds` set against `render.b` to a fixed point. Drained channels are left in `render.b` as empty arrays rather than deleted, and every `processResumes` ends with `resumes.splice(0, i)` even when `i === 0`, so with L lazy chunks arriving separately that is O(L²) channel scans plus a splice per pass, per render — and a fully resumed render pays it again on each later `ready()`. Index pending renders and reverse dependencies by ready id and advance cursors instead of splicing, preserving late reordered gates and source-stream order. Re-verify: the `lazy-tag-reorder-stream-order` and `lazy-tag-nested-shared-reversed` fixtures still pass.
+
+## Use the mutation records instead of rescanning every embedded anchor
+
+`packages/runtime-tags/src/dom/resume.ts` › `initEmbedded` | 2026-07-13 | impact:low | effort:med
+
+`initEmbedded()`'s `MutationObserver(...).observe(document, { childList: true, subtree: true })` callback ignores its records and iterates all of `embedRenders`, testing `anchor.isConnected` for every embedded render on every document-wide child-list batch. Once one embed exists, any page that mutates the DOM pays embedded-count × batch work. Inspect the records' `removedNodes` (or debounce the sweep) while preserving move/reinsert, adoption, nested removal, and exactly-once `destroyScope`. Re-verify: the `embed-removal` and `embed-counter` fixtures still destroy scopes exactly once.
+
+## Narrow the assignment serialize reason from `true` to a client-mutability fixpoint
+
+`packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-19 | impact:low | effort:high
+
+`finalizeReferences` calls `addOwnerSerializeReason(assignedSection, section, true)` for every assigned binding, with the in-source note "narrowing is a 0-byte no-op until a state-dropping pass exists" -- a no-op because `resolveBindingSources` gives any assigned `<let>` a `.state` source and `isStateSerializeReason` (`util/serialize-reasons.ts`) treats state as statically true. So a `<let>` reassigned only during synchronous render still roots its owner scope: `<let/total=0/>` + `<for|i| of=[1,2,3]><const/_x=[i].forEach(n => { total += n })/></for>` serializes `_: _scope_with_id($scope0_id)` per iteration even though the parent scope serializes `{}`. Replace the `true` with a conservative client-immutability fixpoint: mutable if an assignment's enclosing function is a client-reachable effect/handler/registered fn, or it transitively reads a client-mutable binding, defaulting mutable on alias, property-alias, spread, or closure escape. Note assignments must sit inside a function (`trackAssignment` throws otherwise), so the target is always a synchronously-invoked callback. Gate on `isOptimize` and add render-reassigned-then-displayed and closure-read stale-DOM fixtures. Re-verify: `rg -n 'narrowing is a 0-byte no-op' packages/runtime-tags/src/translator/util/references.ts`.
+
+## Range-encode the branch ids packed into a single-node loop's BranchEnd marker
+
+`packages/runtime-tags/src/html/writer.ts` › `forBranches` | 2026-07-23 | impact:med | effort:med
+
+For a `singleNode` `<for>`, `forBranches` builds one string (`flushBranchIds = " " + branchId + flushBranchIds`) that `writeBranchEnd` emits as a single `BranchEndSingleNode` (`|`/`}`) comment — e.g. `<!--M_}1 a 4 3 2-->` — so a loop body with a fixed scope count per item spends ~4.5 SSR bytes per row on a constant-stride descending run. A run token (`start~end[:stride]`) with an explicit-id fallback collapses it to a constant. The decoder is `createVisitBranches` in `dom/resume.ts` (`while ((branchId = +lastToken))`), and expansion must preserve order because the single-node path walks `previousSibling` and depends on `endedBranches.reverse()`; the `]`/`)` variants already spread one id per `BranchStart` and are unaffected. Weigh the decoder's client bytes first — the adjacent comment there budgets ~18 B brotli. Re-verify: SSR a 2000-row `<for>` and compare the `<!--M_}…-->` length before and after.
+
+## Flush a `_resume_locals` scope only once its registered function is serialized
+
+`packages/runtime-tags/src/html/writer.ts` › `_resume_locals` | 2026-07-24 | impact:low | effort:med
+
+`_resume_locals` calls `writeScope` eagerly, so the attr-tag loop params it captures set `flushScopes` and ride the resume payload on every SSR render even when the handler is never serialized. The reachable shape is a runtime-conditional consumer — parent `<my-menu><for|foo| of=[…]><@item onClick(ev){…}>` with a child that spreads `...item` only under `<if=input.enabled>` — where `_resume_locals(fn, id, {"foo/5": foo})` still runs per iteration and `flushSerializer` writes those props with `enabled` false (a statically unused handler is already elided). The serializer resolves registered-value scopes lazily (`writeRegistered` › `trackScope` in `packages/runtime-tags/src/html/serializer.ts`), so the fix is a channel that flushes a scope's props only when the registered value is written — serializer surgery, not a helper tweak. Re-verify: SSR that template with `enabled=false` and look for the `foo` scope in the payload.

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -2,218 +2,86 @@
 
 Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).
 
-## Document that text interpolation drops `NaN`/`0n` while attributes write them
+## Document the `Marko.Global` augmentation path so `$global` in tests is type-checked
 
-`packages/runtime-tags/src/html/content.ts` › `_to_text` | 2026-07-18 | impact:low | effort:low
+`packages/runtime-tags/index.d.ts` › `TemplateInput` | 2026-07-19 | impact:low | effort:low
 
-The same value coerces differently in text position and attribute position, and only the attribute rule is documented. Text uses `_to_text` = `val || val === 0 ? val + "" : ""` (`html/content.ts:10`, mirrored by `dom/dom.ts` for CSR), so `NaN` and `0n` are falsy and not `=== 0` and render as an empty string. Attributes use `_attr` → `isVoid` = `value == null || value === false` (`common/helpers.ts:137`), so `NaN`/`0n` are non-void and `nonVoidAttr` (`html/attrs.ts:442-455`) writes them — a `number` (including `NaN`) as `name=NaN` and a bigint `0n` as `name=0`. So `<div>${NaN} ${0n}</div>` renders empty text while `<div data-a=NaN data-b=0n/>` writes `data-a=NaN data-b=0`. The language reference at website `docs/reference/language.md:220-223` documents only the attribute rule and explicitly promises "`0`, `NaN`, and `""` will still be written", with no text-coercion note, so the two positions silently disagree for the non-zero falsy numerics. The text drop is intentional (the `content.ts:10` comment says `0n` is deliberately not special-cased for hot-path size), and even MARKO_DEBUG's `assertValidTextValue` (`common/errors.ts`) does not flag `NaN`/`0n`, so a blank price/quantity cell produced by bad numeric arithmetic is silent in dev too. Direction: add a text-coercion table near the dynamic-text section of the language reference and cross-link the attribute note at `:220-223`; optionally warn in DEBUG when a `NaN` `number` reaches a text position. Distinct from the existing `normalizeStrAttrValue` bugs.md entry, which concerns controlled-value selection, not text-vs-attribute rendering.
+`TemplateInput<Input> = Input & { $global?: Global }` is the only typed slot for `$global`, and both `html/template.ts` `render` and `dom/template.ts` `mount` destructure it - but `Marko.Global` carries `[x: PropertyKey]: unknown` (index.d.ts:16), so a render test or story can pass any shape and nothing checks it against the route `Context` the component reads. `Marko.Global` is an interface in `declare global`, so `declare global { namespace Marko { interface Global { data?: Run.Context } } }` does restore checking (verified: a wrong-typed member errors TS2322) - but only with OPTIONAL members; a required member makes `render({ $global: {} })` error TS2741 everywhere. Direction: document that merge in `index.d.ts` and the `## TypeScript` section of `cheatsheet.md` (which currently covers only Input/Body/AttrTag), including the optional-member caveat, so `@marko/run` can type route context. Context, unverifiable in this repo: Storybook has no slot at all - `Story<Input>.args` is `Input`, so `$global` gets smuggled through `args` and surfaces as a bogus control. Distinct from the separate finding on typing `@marko/run`'s `ctx.search` - same `Run.Context`, different surface, so fixing one does not cover the other. Re-verify: `rg -n 'PropertyKey' packages/runtime-tags/index.d.ts` still shows the open index signature at :16.
 
-The same `0n`/`NaN` drop also occurs on the **style-object** surface, where the consequence is more insidious than empty text: `stringifyStyleObject` returns `value || value === 0 ? name + ":" + value : ""` (`packages/runtime-tags/src/common/helpers.ts:77`; the in-file comment at :75-76 confirms `0n` is deliberately not special-cased for hot-path size), so `<div style={ width: input.v }>` renders `width:0` for `0` but drops the `width` declaration entirely for `0n` or `NaN` — a missing CSS declaration / silent layout shift rather than a visibly-empty text node. Reached via `_attr_style` → `toDelimitedString(value, ";", stringifyStyleObject)` in both `html/attrs.ts` and `dom/dom.ts`; no warning even under `MARKO_DEBUG`. Extend the coercion-table doc note to cover style objects, and/or warn in DEBUG when a `NaN` reaches a style value.
-
----
-
-## Document the client-only-init + localStorage-persist idiom (`<script>` effects run at dependency-init, not source order)
-
-`packages/runtime-tags/src/dom/signals.ts` › `_script` | 2026-07-18 | impact:med | effort:low
-
-The intuitive two-`<script>` pattern for restoring then persisting state through localStorage silently clobbers saved state. Given a restore script (`const s = localStorage.getItem('k'); if (s) board = JSON.parse(s)`, assign-only, first in source) followed by a persist script (`localStorage.setItem('k', JSON.stringify(board))`, which reads `board`, second in source), on mount the persist script runs before the restore script and writes the DEFAULT board to storage, destroying the previously-saved state; the restore then reads back the just-clobbered default, so state does not survive a reload — with no error or hydration-mismatch warning. This is correct fine-grained-reactivity behavior, not a bug: a state-reading `<script>` compiles as a downstream of its `<let>` signal, so `$setup` running `$board($scope, DEFAULT)` at the `<let>` position immediately queues the persist effect via `_script` → `queueEffect` (`dom/signals.ts:386-390`), while the assign-only restore script is a plain mount effect queued later at its own source position; `runEffects` (`dom/queue.ts`) runs them in queue order, so persist(read) precedes restore(assign). It is undocumented and surprising: no docs page mentions localStorage or `<script>` execution order, and `core-tag.md`'s `<script>` section (`:304`) says only that it runs "when the template has finished rendering", implying source order. The working idiom is `<lifecycle onMount(){ restore } onUpdate(){ persist } />` (onMount runs first with the pre-restore value, onUpdate persists after), but nothing points users there, and a `<let>` init expression cannot read localStorage because it also runs during SSR. Direction: a guide page on persisting state to localStorage recommending `<lifecycle>`, plus a note in the `<script>` reference that state reads run at dependency-init time; optionally a MARKO_DEBUG warning when a `<script>` both depends on state and writes storage before that state is initialized.
-
-## Provide or document a head-management primitive; nested `<title>`/`<meta>`/`<link>` render in `<body>` with no hoisting
-
-`packages/runtime-tags/src/html/writer.ts` › `_hoist` | 2026-07-19 | impact:med | effort:med
-
-A component nested under `<main>` that emits `<title>`, `<meta name=description>`, or `<link rel=canonical>` renders those tags inline in the `<body>`, not hoisted into `<head>` — producing an invalid document with duplicate `<title>`/`<meta>` elements and a canonical `<link>` stranded in the body where it is inert. Marko 6's HTML runtime writes tags in document/source order and has no head-relocation pass: the sole `_hoist`/`hoist` symbol in `html/writer.ts` (:180) is scope-reactivity plumbing (`_hoist_read_error`), unrelated to `<head>`. The only documented head idiom (`website/docs/reference/language.md:446-489`) is prop-drilling a `title` attribute up to the layout that owns the real `<head>`, which cannot express "this deeply nested widget sets the canonical/OG tag" and forces threading meta through every intermediate layer. Peer frameworks ship a component-scoped primitive (Svelte `<svelte:head>`, Next metadata API, SolidStart `@solidjs/meta`, Astro head slot). Either add such a primitive so a descendant can contribute to `<head>`, or document explicitly that Marko renders head tags in source order with no hoisting, that children must never emit `<head>` elements, and that dynamic/computed meta must be prop-drilled to (or passed via `$global`/`+meta.json` and read in) the root layout. Docs are low-effort; a real primitive is medium. Distinct from the run meta-union typing finding (that concerns typing heterogeneous `+meta.json` across sibling routes).
-
-## Document + type how to supply route `$global` when render-testing or writing a Storybook story
-
-`packages/runtime-tags/index.d.ts` › `TemplateInput` | 2026-07-19 | impact:med | effort:low
-
-A tag that reads `$global.url.pathname` / `$global.data.user` (how `@marko/run` threads its `Context`) can be render-tested with `render(Tag, { $global: { url, data } })` and it works — but nothing tells you so, and nothing checks the shape. `Marko.TemplateInput<Input> = Input & { $global?: Marko.Global }` (`index.d.ts:29-32`) is the typed slot, and `render`/`mount` pull it out (`html/template.ts:44-52`, `dom/template.ts:54-56`), but it is typed only as bare `Marko.Global` (`[x: PropertyKey]: unknown`, `index.d.ts:16`), so a test's `$global` is not checked against the real route `Context`. `@marko/testing-library`'s `RenderOptions` exposes only `container` and its README never mentions `$global`, so authors defensively write `render(Tag, {…} as any)` (the cast is unnecessary — `mtc` is clean without it). For Storybook there is no typed slot at all: `Story<Input>.args` is `Input`, so route context has to be smuggled as an untyped `args.$global` (which then also shows up as a bogus Storybook control). Testing-library docs (and `@marko/run` docs) should show `render(Tmpl, { $global })` as the way to provide route context, and ideally `@marko/run` should export a `Context`-shaped test type (or augment `Marko.Global`) so `$global` in a test is checked against the real `Context`; Storybook needs a documented, typed way to attach `$global` per story. The generated `.marko-run/routes.d.ts` defines a per-file `Run.Context` but never augments `Marko.Global`, so in-component and in-test `$global` are both untyped against the real context — the discoverability gap is pure docs. Distinct from the run `ctx.search` typing entry.
-
-## Consider renaming `signal`, which clashes with the ecosystem meaning
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `signals` | 2026-07-20 | impact:med | effort:high
-
-"Signal" in this codebase is a compiled setup/update program keyed by a binding or intersection — not a reactive value container, which is what most contributors will assume from other frameworks; alternatives if renamed: "effect program", "update unit", "work unit". Any rename is a broad churn (runtime helper names, `callRuntime` sites, snapshots), so it should ride a major refactor; until then the disclaimer in `packages/runtime-tags/CONTEXT.md` (Signal entry) is the mitigation. Re-verify by reading that entry.
-
-## Key (or document) the `getOnlyChildParentTagName` memo on `branchSize` — the argument is ignored on every call after the first
+## Make the `getOnlyChildParentTagName` memo order-independent — `branchSize` is ignored after the first call
 
 `packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts` › `getOnlyChildParentTagName` | 2026-07-23 | impact:low | effort:low
 
-`getOnlyChildParentTagName(tag, branchSize = 1)` memoizes its answer in
-`tag.node.extra[kOnlyChildInParent]` and returns the cached value before
-`branchSize` is ever consulted, so the parameter only has an effect on the very
-first call for a given tag node — and `node.extra` survives the
-analyze→translate node cloning, so "first call" spans phases. The whole
-`<if>`/`<else-if>`/`<else>` chain optimization depends on this: `core/if.ts`
-`IfTag.analyze` is the only caller that passes the real branch count
-(`getOptimizedOnlyChildNodeBinding(ifTag, ifTagSection, branches.length)`),
-while `core/if.ts:117`/`:167`/`:296` and `core/for.ts`/`core/show.ts` all call
-with the default `1` during translate and silently ride that cached answer. Any
-future caller that touches an `<if>` tag before `IfTag.analyze` (a new
-pre-analyze pass, a transform-phase visitor, a reordered core-tag registration)
-would poison the memo with `branchSize === 1`, and every multi-branch chain
-would quietly stop reusing its parent element as the marker node — an extra
-`<!>` in the template string, an extra walk char, and an extra `#text` DOM
-binding per chain, with no test naming the invariant. Either include
-`branchSize` in the memo key (or assert it matches the cached computation) or
-state the ordering contract in a comment on the function. Distinct from the
-existing perf.md entry "Extend marker-elision optimizations to
-await/try/html-comment", which is about adding the optimization elsewhere, not
-about this memo's key. Re-verify: compile
-`<div><if=input.x><p>a</p></if><else-if=input.y><i>c</i></else-if><else><b>b</b></else></div>`
-with `-o dom -d` and confirm the marker is `_if("#div/0", …)` with `$template
-=== "<div></div>"`; forcing `branchSize` to 1 turns it into `_if("#text/0", …)`
-with `$template === "<div><!></div>"`, which is what the sibling case
-`<div>z<if=input.x><p>a</p></if></div>` already produces.
+The cached `tag.node.extra[kOnlyChildInParent]` is returned before `branchSize` is read, so only the first call per node decides the answer — in practice `IfTag.analyze`, the sole caller passing `branches.length`, since `core/if.ts` translate, `core/for.ts` and `core/show.ts` pass the default `1` and ride the cache across the analyze→translate clone. Any new pass touching an `<if>` before `IfTag.analyze` poisons the memo with `1`, silently costing every multi-branch chain its parent-element marker (an extra `<!>`, walk char and `#text` binding). Nothing catches that: every multi-branch fixture snapshot uses `_if("#text/…")`. Pass the real branch count at the `core/if.ts` translate sites too — keying the memo on `branchSize` alone would break them, since they pass `1` — and add a chain-as-only-child fixture. Distinct from the won't-fix entry "Extend only-child marker elision to `<await>`/`<try>`", which spreads the optimization to more tags rather than fixing this memo's key. Re-verify: compile `<div><if=input.x><p>a</p></if><else-if=input.y><i>c</i></else-if><else><b>b</b></else></div>` with `-o dom -d`; today it yields `_if("#div/0", …)` with `$template === "<div></div>"`.
 
-## Explain the `doc` parameter's double duty in the debug walker runtime
+## Name the `doc`-becomes-runtime trick in the debug walker runtime
 
 `packages/runtime-tags/src/html/inlined-runtimes.debug.ts` › `WALKER_RUNTIME_CODE` | 2026-07-23 | impact:low | effort:low
 
-The whole point of the `.debug` half of the inlined-runtimes pair is that a
-human can read what the minified string does, but the walker's central trick is
-undocumented and reads as a bug. The default parameter `doc = document` is used
-for `doc.createTreeWalker(doc, 129)` and stored as the runtime's `d` field, and
-then the body immediately reassigns it: `doc = (self[runtimeId][renderId] = { …,
-d: doc, … })`. From that point `doc` is the runtime object, which is why `w()`
-calls `doc.x(...)` — a late-bound call so the reorder runtime's replacement of
-`runtime.x` (see `REORDER_RUNTIME_CODE`, which assigns `runtime.x`) is picked
-up, without re-indexing `self[runtimeId][renderId]` per node. A reader tracing
-`doc.x` naturally expects `document.x`. The reorder half already carries the
-precedent fix (`// repurpose "op" for callbacks ...carefully`); add the same
-one-line intent comment here, or — since only exported member names must match
-the minified file — give the debug version a separate `runtime` default
-parameter so `doc` keeps meaning the document. Re-verify: read
-`WALKER_RUNTIME_CODE` in inlined-runtimes.debug.ts and confirm `d: doc` is
-evaluated before the `doc = (...)` assignment, so `d` holds the document while
-every later `doc.` reference is the runtime object.
+The debug half of the pair exists to be readable, yet its central trick is unexplained and reads as a bug: `doc = document` builds the TreeWalker and is captured as the runtime's `d` field, then `doc = (self[runtimeId][renderId] = {…})` rebinds `doc` to the runtime object, which is why `w()`'s `doc.x(...)` is a late-bound call that picks up `REORDER_RUNTIME_CODE`'s `runtime.x` replacement. A reader tracing `doc.x` expects `document.x`. Add the one-line intent comment (the reorder half already sets the precedent) or give the debug version its own `runtime` parameter, since only exported member names must match `inlined-runtimes.ts`. Re-verify: confirm `d: doc` is evaluated before `doc` is reassigned, so `d` holds the document while every later `doc.` is the runtime.
 
-## Correct the two wrong file citations in AGENTS.md's Translator section — `util/assert.ts` and `util/known-tag.ts`
+## Fix the two wrong citations in the runtime-tags AGENTS.md Translator section
 
 `packages/runtime-tags/AGENTS.md` › `Translator` | 2026-07-23 | impact:low | effort:low
 
-The Translator section says "Validate early with `assertNoArgs` /
-`assertNoParams` / `assertNoSpreadAttrs` (`util/assert.ts`)", but
-`packages/runtime-tags/src/translator/util/assert.ts` exports only
-`assertNoSpreadAttrs`, `assertNoTagVarMutation`, and `assertNoBodyContent`.
-`assertNoArgs`/`assertNoParams` are defined in
-`packages/compiler/src/babel-utils/assert.js` and are imported by core tags from
-`@marko/compiler/babel-utils` (see `core/if.ts`, `core/debug.ts`,
-`core/return.ts`), alongside siblings the doc never names (`assertNoVar`,
-`assertNoAttributeTags`, `assertAllowedAttributes`, `diagnosticDeprecate`). So
-the one pointer an agent has for tag validation names two symbols that are not
-in the cited file and omits the two local helpers that are. Reword to "local
-helpers `assertNoSpreadAttrs`/`assertNoTagVarMutation`/`assertNoBodyContent`
-(`util/assert.ts`), plus
-`assertNoArgs`/`assertNoParams`/`assertNoVar`/`assertAllowedAttributes` from
-`@marko/compiler/babel-utils`". Re-verify: `grep -n '^export'
-packages/runtime-tags/src/translator/util/assert.ts` lists three names, none of
-them `assertNoArgs`/`assertNoParams`.
+The validation bullet credits `util/assert.ts` with `assertNoArgs`/`assertNoParams`, which it does not export (it has `assertNoSpreadAttrs`, `assertNoTagVarMutation`, `assertNoBodyContent`); those two plus `assertNoVar`/`assertAllowedAttributes` come from `@marko/compiler/babel-utils` (`packages/compiler/src/babel-utils/assert.js`), as `core/if.ts`, `core/debug.ts` and `core/return.ts` show. The next bullet says `util/known-tag.ts` "holds native HTML tag/attribute metadata"; it holds none — it exports `knownTagAnalyze`/`knownTagTranslateHTML`/`knownTagTranslateDOM`/`finalizeKnownTags` (custom and dynamic tag input contracts) and is imported only by `custom-tag.ts`, `dynamic-tag.ts` and `references.ts`, so an agent sent there for native-element work lands in the wrong subsystem. Reword both: split local from babel-utils assert helpers, and point native-element work at `visitors/tag/native-tag.ts` (plus `common/helpers.ts`, `util/is-non-html-text.ts`). Re-verify: `grep -n '^export' packages/runtime-tags/src/translator/util/assert.ts` and `rg -l 'known-tag' packages/runtime-tags/src`.
 
-The next bullet in the same section is wrong the same way: it ends "`util/known-tag.ts` holds native HTML tag/attribute metadata", but that file holds no native HTML metadata at all. It exports `knownTagAnalyze` / `knownTagTranslateHTML` / `knownTagTranslateDOM` / `finalizeKnownTags`, which model the input contract of a custom or dynamic tag whose renderer is statically known — child-scope bindings, `trackParamsReferences`, attribute-to-signal binding, param serialize-reason groups, attr-tag grouping — and its only importers are `visitors/tag/custom-tag.ts`, `visitors/tag/dynamic-tag.ts` and `util/references.ts`. `visitors/tag/native-tag.ts` never imports it, so an agent sent to `known-tag.ts` to change how a native element or attribute is handled lands in the wrong subsystem entirely; the real native-element knowledge lives in `visitors/tag/native-tag.ts` plus `common/helpers.ts` (`isEventHandler`, `getWrongAttrSuggestion`, `stringifyClassObject`), `util/is-non-html-text.ts` (`isTextOnlyNativeTag`), `common/constants/controlled-type.ts` and the taglib via `getTagDef`. Reword that clause to describe known custom/dynamic tag contracts (matching RESUMABILITY.md's "known-tag contracts" usage) and point native-element work at `visitors/tag/native-tag.ts`. Re-verify: `grep -n '^export function' packages/runtime-tags/src/translator/util/known-tag.ts` lists only the four `knownTag*`/`finalizeKnownTags` functions, and `grep -rl 'known-tag' packages/runtime-tags/src --include='*.ts'` returns `custom-tag.ts`, `dynamic-tag.ts` and `references.ts` — never `native-tag.ts`.
-
-## Document the fixture `diagnostics.md` snapshot and the missing `TestConfig` options in the Testing section
+## Document the `diagnostics.md` and error snapshots plus the missing `TestConfig` keys
 
 `packages/runtime-tags/AGENTS.md` › `Testing › Fixture anatomy` | 2026-07-23 | impact:med | effort:low
 
-The fixture-anatomy block lists four snapshot kinds (`dom.bundle`,
-`html.bundle`, `render`, `writes`) and a `TestConfig` summary, and both are out
-of date with `main.test.ts`. Missing entirely is the `diagnostics` test, which
-snapshots the html build's `meta.diagnostics` into
-`__snapshots__/diagnostics.md` (debug mode only, 19 fixtures have one today) and
-asserts it like any other snapshot — so a change that adds or removes a
-recoverable/deprecation diagnostic fails a test the docs never mention, and the
-AGENTS.md instruction to "read the generated snapshots as part of your change"
-never points at it. Also undocumented: the error snapshots
-`error-compile-{html,dom}[.debug].txt` and `{ssr,csr}.error[.debug].txt`, and
-the config options `error_dom`/`error_html` (used by 41 fixtures), `embedded`,
-`load_order`, `reject_load`, and `fix_guide`; the stated "~800 fixtures" is now
-910 directories. Add `diagnostics.md` and the error-snapshot filenames to the
-anatomy block and extend the `TestConfig` list. Re-verify: `find
-packages/runtime-tags/src/__tests__/fixtures -path '*__snapshots__*' -type f |
-sed 's#.*/##' | sort | uniq -c` shows `diagnostics.md`, `error-compile-*.txt`
-and `*.error*.txt` alongside the four documented kinds, and `TestConfig` in
-`main.test.ts` lists the extra keys.
+The anatomy block lists four snapshot kinds (`dom.bundle`, `html.bundle`, `render`, `writes`) but not `diagnostics.md` (debug-only `meta.diagnostics` snapshot, 19 fixtures today), `error-compile-{html,dom}[.debug].txt`, or `{ssr,csr}.error[.debug].txt` — so adding or dropping a recoverable/deprecation diagnostic fails a test the docs never name, and "read the generated snapshots" never points at it. The `TestConfig` summary also omits `error_dom`/`error_html` (41 fixtures), `embedded`, `load_order`, `reject_load` and `fix_guide`, and the stated "~800 fixtures" is 964 dirs. Add the missing snapshot kinds and config keys. Re-verify: `find packages/runtime-tags/src/__tests__/fixtures -path '*__snapshots__*' -type f | sed 's#.*/##' | sort -u` against the block, and `TestConfig` in `main.test.ts`.
 
-## Say "following siblings" — dynamic `<style>` values silently miss any target that is not a sibling of the tag
+## Say "following siblings" in the dynamic `<style>` placement warning
 
 `packages/runtime-tags/src/translator/core/style.ts` › `checkDynamicStylePlacement` | 2026-07-23 | impact:med | effort:low
 
-A dynamic `<style>` renders as `<style class=ID>.ID~*{--M_x:value}</style>`
-(`html/attrs.ts` › `_style_html`, mirrored by `dom/dom.ts` › `_style_shell`), so
-the custom properties reach only the _subsequent siblings_ of the `<style>`
-element and their descendants. Both the compile-time warning in
-`checkDynamicStylePlacement` ("only apply to elements rendered after it, so the
-content before this tag will not receive them") and the website reference
-(`website/docs/reference/core-tag.md`, "### Dynamic Values" NOTE: "Dynamic
-values only apply to elements rendered after the `<style>` tag") describe this
-as document order, which is wrong for anything outside the `<style>`'s own
-parent: the tag's parent element, and any element rendered later but in a
-shallower or different subtree, get nothing — with no diagnostic, because
-`checkDynamicStylePlacement` only scans `tag.getAllPrevSiblings()`. Authors hit
-this when scoping styles to a component root (`<div
-class=panel><style>.panel{--accent:${input.accent}}</style>…`) or when the
-`<style>` sits inside a header/wrapper while the styled element follows outside
-it. Direction: reword the warning label and the docs NOTE to "subsequent
-siblings of the `<style>` tag and their descendants", and consider extending
-`checkDynamicStylePlacement` to also warn when a dynamic `<style>` has no
-renderable following siblings at all (today the most-broken shape is the
-quietest). Re-verify: compile
-`<header><style>.badge{color:${input.c}}</style></header><span
-class="badge">New</span>` with `errorRecovery: true` — `meta.diagnostics` is
-empty and the emitted `_style_html(...)` sits inside `<header>`, so `.ID~*` can
-never match the `<span>`; moving the `<style>` after the `<span>` instead
-produces the existing "content before this tag" warning.
+A dynamic `<style>` renders as `.ID~*{--M_x:value}` (`html/attrs.ts` › `_style_html`, mirrored by `dom/dom.ts` › `_style_shell`), so the custom properties reach only the style element's _following siblings_ and their descendants — never its own parent or a different subtree. The warning's "only apply to elements rendered after it, so the content before this tag will not receive them" reads as document order, and `checkDynamicStylePlacement` only scans `getAllPrevSiblings()`, so `<div class=panel><style>.panel{--accent:${input.accent}}</style>…>` — where the styled element is the parent — is silent. Reword the label to "subsequent siblings of the `<style>` tag and their descendants". Re-verify: compile `<header><style>.badge{color:${input.c}}</style></header><span class=badge>New</span>` with `errorRecovery: true` — `meta.diagnostics` is empty and `_style_html` sits inside `<header>`.
 
-## Document `Scope[AccessorProp.Gen]`'s four states; one numeric slot means destroyed, resumed, this-run, and earlier-run
+## Document the four states of `Scope[AccessorProp.Gen]`
 
 `packages/runtime-tags/src/common/types.ts` › `Scope` | 2026-07-23 | impact:med | effort:low
 
-`Scope[AccessorProp.Gen]` (debug name `#Gen`, declared bare as
-`[AccessorProp.Gen]: number` in `common/types.ts:23`) is read four different
-ways across the DOM runtime with no comment on the declaration, no `accessor.ts`
-note, and no CONTEXT.md glossary entry: `0` means destroyed (`dom/scope.ts` ›
-`destroyNestedScopes` sets it; `dom/queue.ts` › `skipDestroyedRenders` and
-`_enable_catch` test `?.[Gen] !== 0`), `1` means resumed from SSR
-(`dom/resume.ts:135` in `initScope`, viable only because `queue.ts` starts
-`runId` at 2), `=== runId` means "created/rendered during the current run" and
-is the branch that decides whether `_let` assigns in place or schedules a render
-(`dom/signals.ts:39-49`), whether `_or` counts intersection arrivals or queues
-(`dom/signals.ts:103-121`), and whether `controllable.ts` reads the live DOM
-value or the bound one (nine sites, e.g. `:27`, `:193`, `:281`, `:442`), and `>
-0 && < runId` means "live scope from an earlier run" (`dom/signals.ts` ›
-`_for_closure` and `runLiveBranch`). RESUMABILITY.md mentions only "`runId` as
-the generation boundary (resumed scopes start at 1; normal client work at 2)"
-and never says `Gen` doubles as the destroyed flag, so a reader tracing why a
-`<let>` write does not re-render has to reconstruct the state machine from nine
-call sites. Add a **Generation** entry to CONTEXT.md's "DOM runtime" section and
-a two-line comment on the `Scope[AccessorProp.Gen]` member enumerating the four
-states (0 destroyed / 1 resumed / `runId` created this run / in-between live
-from a previous run). Re-verify: `rg -n "AccessorProp.Gen"
-packages/runtime-tags/src --glob '!**/__tests__/**'` lists the sites and shows
-no explanatory comment on any of them.
+`[AccessorProp.Gen]: number` is declared bare and read four ways: `0` destroyed (`dom/scope.ts` › `destroyNestedScopes`; tested by `queue.ts` › `skipDestroyedRenders`), `1` resumed from SSR (`dom/resume.ts` › `initScope`, viable only because `runId` starts at 2), `=== runId` created during this run (decides whether `_let`/`_or`/`controllable.ts` write in place or queue a render), and `> 0 && < runId` live from an earlier run (`_for_closure`, `runLiveBranch`). Nothing says so — no comment on the member, no CONTEXT.md glossary entry, and RESUMABILITY.md covers only the `runId` boundary — so tracing why a `<let>` write does not re-render means reconstructing the state machine from ~20 call sites. Add a two-line comment plus a **Generation** entry in CONTEXT.md's DOM runtime section. Re-verify: `rg -n "AccessorProp.Gen" packages/runtime-tags/src --glob '!**/__tests__/**'` lists the sites with no explanation on any.
 
-## Point the accessor-enum lockstep guidance at `src/common/constants/*[.debug].ts` — `accessor.ts` / `accessor.debug.ts` are now member-less barrels
+## Point the accessor-lockstep guidance at `src/common/constants/*[.debug].ts`
 
-`packages/runtime-tags/AGENTS.md` › `Runtime conventions › `.debug.ts` pairs` | 2026-07-27 | impact:low | effort:low
+`packages/runtime-tags/AGENTS.md` › `Runtime conventions` | 2026-07-27 | impact:low | effort:low
 
-The Runtime-conventions bullet says to "mirror any accessor enum change in `accessor.ts` **and** `accessor.debug.ts`", the Gotchas list repeats "keep `accessor.ts` / `accessor.debug.ts` in lockstep (same members, char vs. readable string values)", and CONTEXT.md's `Accessor` glossary entry calls them "the lockstep `accessor.ts` / `accessor.debug.ts` pair" — but since the `replace enums with top-level const module exports` refactor both files are barrels that only re-export namespaces as declaration-merged type/value aliases, and neither declares a single member. The members now live in seven `.debug`-paired modules under `src/common/constants/` (`accessor-prefix`, `accessor-prop`, `closure-signal-prop`, `keyed-scopes-prop`, `load-signal-value`, `pending-render-prop`, `renderer-prop`), and nothing checks the two halves of a pair against each other: each file's `Value` is `typeof import("./<itself>")`, all six consuming source files import the `.debug` half, and the one site that reads both (`translator/util/get-accessor-char.ts` › `getAccessorProp`) casts `as any` — so a member added to only one half type-checks clean and surfaces as `undefined` only in an optimize build. The same bullet's parenthetical "(the other pair is `html/inlined-runtimes[.debug].ts`)" implies two `.debug` pairs when there are nine, and the Layout table's `src/common/` row ("Types, accessor enums, helpers") never names `constants/`, so an agent following the docs literally opens `accessor.ts`, finds nothing resembling an enum, and either edits the barrel or patches one half of the real pair. Point both AGENTS.md mentions and the CONTEXT.md glossary entry at `src/common/constants/<name>[.debug].ts` as the edit site, state the pair count, and add `constants/` to the Layout row; a parity assertion over the seven pairs would make the lockstep rule enforced rather than documented. Re-verify: `grep -c '^export const' packages/runtime-tags/src/common/accessor.ts` prints `0` while the same command on `packages/runtime-tags/src/common/constants/accessor-prop.ts` prints `27`, and `find packages/runtime-tags/src -name '*.debug.ts' | wc -l` prints `9`.
+The `.debug.ts`-pairs bullet, the Gotchas line and CONTEXT.md's `Accessor` entry all say to keep `accessor.ts` / `accessor.debug.ts` in lockstep, but since the const-module refactor both files are member-less barrels; the members live in seven `.debug`-paired modules under `src/common/constants/`, and the Layout table's `src/common/` row never names `constants/`. Nothing enforces parity: each module's `Value` is `typeof import("./<itself>")` and `translator/util/get-accessor-char.ts` › `getAccessorProp` casts `as any`, so a member added to one half type-checks and surfaces as `undefined` only in an optimize build. Retarget the three mentions, fix "the other pair" (there are nine `.debug.ts` files), and consider a parity assertion over the seven pairs. Re-verify: `grep -c '^export const' packages/runtime-tags/src/common/accessor.ts` prints 0 while `constants/accessor-prop.ts` prints 28.
 
-## Document `static` for module-level values and helpers in cheatsheet.md — it is the fix the compiler's own diagnostics name, and the cheatsheet never mentions it
+## Cover `static` for module-level values and helpers in cheatsheet.md
 
 `packages/runtime-tags/cheatsheet.md` › `Golden rules` | 2026-07-27 | impact:med | effort:low
 
-`cheatsheet.md` — the LLM syntax reference shipped in the published package (`files` plus `exports["./cheatsheet.md"]` in `packages/runtime-tags/package.json`) — contains zero occurrences of `static`, even though `static` is a core tag (`src/translator/core/static.ts`) and is exactly what the compiler's own diagnostics tell authors to reach for: both `core/let.ts` and `core/const.ts` append "For a one time module level value, prefix a plain JavaScript statement with `static`." to their tag-variable errors. The gap is worst for module-level helpers, where no diagnostic names `static` at all: a template whose first line is `function fmt(n) { return n + "!" }` fails with the bogus ``Unable to find entry point for custom tag `<function>`. Did you mean `<section>`?``, and the `$ const y = ...` scriptlet an LLM otherwise reaches for hard-errors with "Scriptlets are not supported when using the tags api." (`src/translator/visitors/scriptlet.ts`) — also with no `static` hint. Meanwhile the cheatsheet's only adjacent guidance is the DON'T row `$ const y = x * 2;` → `<const/y=x * 2>`, which steers a never-changing value into a per-instance reactive binding: `<const/LIMIT=10>` emits an extra signal function `const $LIMIT = ($scope, LIMIT) => _text(…)` plus a `$LIMIT($scope, 10)` call in `$setup`, while `static const LIMIT = 10;` emits a plain module-scope `const` and inlines the read. Add a golden rule covering module-level values and helpers plus a DON'T row (`$ const CONFIG = {…}` or a bare `function helper() {}` at the template root → `static const CONFIG = {…}` / `static function helper() {}`); this is distinct from the perf.md entry "Document resume-payload cost of per-item custom tags and patterns to contain it", which is anchored to the same heading but is about resume-payload size. Re-verify: `grep -c static packages/runtime-tags/cheatsheet.md` prints `0`, and `printf 'function fmt(n) { return n + "!" }\n<p>${fmt(1)}</p>\n' > /tmp/r.marko && pnpm run compile -o dom -d /tmp/r.marko` fails with the `<function>` custom-tag error, while the same file with `static ` prefixed onto that first line compiles.
+The shipped LLM syntax reference contains zero occurrences of `static`, though it is a core tag (`translator/core/static.ts`) and the exact fix `core/let.ts` and `core/const.ts` name in their tag-variable errors. Module-level helpers are worse: a template starting with `function fmt(n) { … }` fails with ``Unable to find entry point for custom tag `<function>` `` and no diagnostic mentions `static`. The only adjacent guidance, the DON'T row `$ const y = x * 2;` → `<const/y=x * 2>`, steers never-changing values into per-instance signals — `<const/LIMIT=10>` emits a `$LIMIT` signal plus a `$setup` call where `static const LIMIT = 10;` emits a module-scope const. Add a golden rule plus a DON'T row for module-level values and helpers. Distinct from the entry "Document the resume-payload cost of per-item custom tags", which is anchored to the same heading but is about resume-payload size; both additions land in the same `Golden rules` list. Re-verify: `grep -c static packages/runtime-tags/cheatsheet.md` prints 0, and the `function fmt` template fails to compile until `static` is prefixed.
 
-## Mark the five `@marko/compiler` config options that only the Marko 5 translator implements
+## Mark the five `@marko/compiler` options only the Marko 5 translator implements
 
 `packages/compiler/src/config.js` › `config (default export)` | 2026-07-27 | impact:med | effort:low
 
-`config.js` documents `writeVersionComment`, `ignoreUnrecognizedTags`, `hydrateInit`, `hot` and `meta` as plain compiler options with no qualifier, but the only code that reads any of them is the Marko 5 translator (`packages/runtime-class/src/translator/index.js:417,444`, `tag/custom-tag.js:66`, `tag/native-tag.js:16`, `tag/index.js:54`, `util/add-dependencies.js:74`, `util/load-import.js:31`); grepping the five names across `packages/runtime-tags/src` hits only two `__tests__` files, and their reference docs live in `packages/runtime-class/docs/compiler.md`. Under `@marko/runtime-tags/translator` all five are silently inert: toggling `writeVersionComment`, `hot` or `meta` produces byte-identical `code`, `hydrateInit` likewise at `output: "hydrate"`, and `ignoreUnrecognizedTags: true` still hard-fails `<unknown-thing/>` with ``Unable to find entry point for custom tag `<unknown-thing>` `` — every one of which changes Marko 5 output. Since Marko 6 is the primary runtime, someone reading `config.js` to pick options cannot tell which still apply, and setting an inert one yields no diagnostic; `config.d.ts` currently flags only `meta` (`@deprecated`) and the deprecated `output: "hydrate"`, so the other four read as current API. Add a "Marko 5 (class API) translator only" line to each of those five JSDoc blocks in `config.js` and to the matching `config.d.ts` fields, following the note already carried on `output`. Re-verify from the repo root: `node -r ~ts -e` a script that calls `compileSync("<div>hi</div>\n", f, {translator, output:"html", cache:new Map(), [opt]:true/false})` for each of `writeVersionComment`/`hot`/`meta` — the two `code` strings are equal under `@marko/runtime-tags/translator` and differ under `marko/translator` — and `compileSync("<unknown-thing/>\n", f, {translator, output:"html", cache:new Map(), ignoreUnrecognizedTags:true})` throws under the former while the latter returns a result.
+`writeVersionComment`, `ignoreUnrecognizedTags`, `hydrateInit`, `hot` and `meta` are documented as plain compiler options, but the only readers are in the Marko 5 translator (`packages/runtime-class/src/translator/index.js`, `tag/{custom-tag,native-tag,index}.js`, `util/{add-dependencies,load-import}.js`). Under `@marko/runtime-tags/translator` all five are inert with no diagnostic: toggling `writeVersionComment`/`hot`/`meta` yields byte-identical `code`, `hydrateInit` likewise at `output: "hydrate"`, and `ignoreUnrecognizedTags: true` still hard-fails `<unknown-thing/>`. Since Marko 6 is primary and `config.d.ts` flags only `meta`, the other four read as current API. Add a "Marko 5 (class API) translator only" line to each JSDoc block in `config.js` and to the matching `config.d.ts` fields, following the note already on `output`. Re-verify: `compileSync("<div>hi</div>", f, {translator, output:"html", cache:new Map(), [opt]:true|false})` gives equal `code` under the tags translator and differing `code` under `marko/translator`.
 
-## Correct the compiler AGENTS.md stage bullet — migrate runs no translator visitor and analyze runs no taglib visitors
+## Fix the compiler AGENTS.md stage bullet: no `translator.migrate`, no taglib visitors in analyze
 
-`packages/compiler/AGENTS.md` › `Map › `src/babel-plugin/`` | 2026-07-27 | impact:low | effort:low
+`packages/compiler/AGENTS.md` › `Map` | 2026-07-27 | impact:low | effort:low
 
-The `src/babel-plugin/` bullet says "Stages: `parse → migrate → transform → analyze` … Each stage merges visitors from taglibs + the translator", but only `transform` and the later `translate` merge both. `getMarkoFile` builds `rootMigrators` from taglib migrators plus the compiler's own `migrate` visitor and never reads a `translator.migrate` — the string appears nowhere in `packages/compiler/src`, and neither `@marko/runtime-tags/translator` nor `marko/translator` exports one — while the analyze stage runs `traverseAll(file, translator.analyze)` with no taglib list at all; `loadTaglibFromProps` accepts only `migrate`/`migrator`, `transform`/`transformer` and `translate` at taglib level, so a taglib `analyze` prop is not ignored but a hard load error ("Invalid option: analyze"). The bullet also contradicts the Translator-contract section directly below it, which lists no `migrate` export, leaving an agent extending the pipeline to hunt for a translator `migrate` hook that cannot exist or to write a taglib analyze visitor that fails to load. Reword it per stage: migrate = taglib migrators + the compiler's `migrate`; transform = taglib transformers + the compiler's `transform` + optional `translator.transform`; analyze = `translator.analyze` only; translate = taglib `translate` hooks (skipped for `output: "hydrate"`) + `translator.translate`. Re-verify: `node -r ~ts -e 'const {compileSync}=require("@marko/compiler");const log=[];const mk=(n)=>({Program:{enter(p){log.push(n+"@"+p.hub.file.___compileStage)}}});compileSync("<div>hi</div>",process.cwd()+"/probe.marko",{cache:new Map(),translator:{taglibs:[["/probe/marko.json",{migrate:mk("taglib.migrate"),transform:mk("taglib.transform"),translate:mk("taglib.translate")}]],tagDiscoveryDirs:[],optionalTaglibs:[],migrate:mk("translator.migrate"),transform:mk("translator.transform"),analyze:mk("translator.analyze"),translate:mk("translator.translate")}});console.log("FIRED "+log.join(" "))'` prints `FIRED taglib.migrate@migrate taglib.transform@transform translator.transform@transform translator.analyze@analyze taglib.translate@translate translator.translate@translate` — `translator.migrate` never fires and no taglib visitor runs during analyze.
+The `src/babel-plugin/` bullet says "Each stage merges visitors from taglibs + the translator", but only `transform` and `translate` do. `getMarkoFile` builds `rootMigrators` from taglib migrators plus the compiler's own `migrate` and never reads `translator.migrate` (no translator exports one, matching the Translator-contract section right below); analyze runs `traverseAll(file, translator.analyze)` alone, and a taglib-level `analyze` prop is a hard load error, "Invalid option: analyze". Reword per stage: migrate = taglib migrators + compiler `migrate`; transform = taglib transformers + compiler `transform` + optional `translator.transform`; analyze = `translator.analyze` only; translate = taglib `translate` (skipped for `output: "hydrate"`) + `translator.translate`. Re-verify with `compileSync` and an inline translator whose every hook logs `p.hub.file.___compileStage`: `translator.migrate` never fires and no taglib visitor runs during analyze.
+
+## Warn under `MARKO_DEBUG` when `NaN`/`0n` vanish from text and style values
+
+`packages/runtime-tags/src/html/content.ts` › `_to_text` | 2026-07-18 | impact:low | effort:low
+
+Text and style-object values use `val || val === 0`, so `NaN` and `0n` render as nothing (`_to_text`/`_escape` in `html/content.ts`, `_to_text` in `dom/dom.ts`, `stringifyStyleObject` in `common/helpers.ts`), while attributes skip only `null`/`undefined`/`false` (`isVoid` → `nonVoidAttr`) and write `data-a=NaN`, `data-b=0`. A stray `NaN` therefore blanks a text node or drops an entire `width:` declaration with no signal: `assertValidTextValue` rejects only symbols and objects, so `MARKO_DEBUG` is silent too. Direction: warn in `MARKO_DEBUG` when `NaN` reaches a text or style value, alongside the existing camelCase-key warn in `stringifyStyleObject`. Distinct from the controlled-value selection path, where `normalizeStrAttrValue` (`html/attrs.ts`) already mirrors the DOM for `NaN`/`0n` — the drop survives only in text and style positions. The coercion-table half of this entry has been ported to the markojs.com website repo, which documents the drop rules for text and `style=`. Re-verify: `rg -n "val \|\| val === 0|value \|\| value === 0" packages/runtime-tags/src` beside `isVoid` in `common/helpers.ts`.
+
+## Add a head-contribution primitive, or state that nested `<title>`/`<meta>`/`<link>` never hoist
+
+`packages/runtime-tags/src/html/assets.ts` › `_flush_head` | 2026-07-19 | impact:med | effort:med
+
+The HTML runtime writes in source order with no head-relocation pass, so a component under `<main>` that emits `<title>`, `<meta name=description>` or `<link rel=canonical>` renders them in the body — duplicate titles and an inert canonical link. The only head hook is `_flush_head`, written at a literal `</head>` by native-tag.ts:719 when `linkAssets` is on; it flushes assets already collected and cannot pick up tags written later. (`_hoist` in html/writer.ts is scope-resume plumbing, not head hoisting.) The only answer today is prop-drilling meta up to the layout that owns `<head>` — unrelated to the `@marko/run` `+meta.json` finding, which is about typing heterogeneous meta across sibling routes, not where head tags land. Direction: a descendant-contributes-to-head primitive (cf. `<svelte:head>`, `@solidjs/meta`), or — since the website docs live in the separate markojs.com repo — at minimum an explicit no-hoisting note in `packages/runtime-tags/cheatsheet.md`. Re-verify: `pnpm run compile -o html -d` on `<html><head><title>Layout</title></head><body><main><title>Nested</title></main></body></html>` emits both titles in source order.
+
+## Consider renaming translator "signal", which clashes with the ecosystem meaning
+
+`packages/runtime-tags/src/translator/util/signals.ts` › `getSignal` | 2026-07-20 | impact:med | effort:high
+
+A `Signal` here is a compiled setup/update program keyed by setup, a binding, or an intersection — not a reactive value container, which is what contributors arriving from other frameworks assume. A rename ("update unit", "effect program") churns runtime helper names, every `callRuntime` site and every snapshot, so it can only ride a major refactor. Until then the `packages/runtime-tags/CONTEXT.md` Signal entry ("_Avoid_: observable, reactive value") is the mitigation. Re-verify: read that entry.


### PR DESCRIPTION
Every one of the 213 entries was re-checked against current source: the cited symbol still exists, the claimed mechanism still holds, and it wasn't already fixed. Descriptions are rewritten to the house 2–6 sentence format, which halves the backlog (47k → 24k words) without losing a repro or a path.

Five entries are deleted as verified stale or wrong. Six move out to the repos that actually own the fix (htmljs-parser, language-server, testing-library, website), with the marko-side remainder kept here where the work genuinely splits. Everything else stays in its category file — 205 entries.

No true duplicates existed. Cross-references between related entries are restored and made reciprocal — the shortening had dropped 17 of them.

---

**Review pass.** All 11 CodeRabbit comments were checked against the source and answered inline. Six led to entry edits — two padded code spans, a search recipe that used a symbol that never existed, a false-positive caveat on the `>` heuristic (every Marko attribute value is an expression, so "restrict to expression attributes" excludes nothing), a handler-parameter correction, and a soundness precondition on the inert-child perf entry. Five were rejected with evidence; the rest of the pass also cleared six older malformed code spans the linter surfaced.