### PR TITLE
feat(runtime-tags): add persisted attribute patches (experimental)

### DIFF
--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 26464,
-        "brotli": 9828
+        "brotli": 9800
       }
     },
     {
@@ -49,11 +49,11 @@
       },
       "runtime": {
         "min": 6509,
-        "brotli": 2885
+        "brotli": 2870
       },
       "total": {
         "min": 7154,
-        "brotli": 3249
+        "brotli": 3234
       }
     },
     {
@@ -64,11 +64,11 @@
       },
       "runtime": {
         "min": 2888,
-        "brotli": 1400
+        "brotli": 1392
       },
       "total": {
         "min": 3003,
-        "brotli": 1501
+        "brotli": 1493
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,5 +1,5 @@
-// size: 6509 (min) 2885 (brotli)
-//#region packages/runtime-tags/dist/dom-T0gUuD2H.mjs
+// size: 6509 (min) 2870 (brotli)
+//#region packages/runtime-tags/dist/dom-BYuonLyu.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   branchesEnabled,
   rendering,
@@ -190,6 +190,9 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   });
 function isNotVoid(value) {
   return value != null && value !== !1;
+}
+function normalizeAttrValue(value) {
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function withBranches(runtime) {
   return ((branchesEnabled = 1), runtime);
@@ -477,9 +480,6 @@ function setAttribute(element, name, value) {
 function _text(node, value) {
   let normalizedValue = _to_text(value);
   node.data !== normalizedValue && (node.data = normalizedValue);
-}
-function normalizeAttrValue(value) {
-  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function removeChildNodes(startNode, endNode) {
   let stop = endNode.nextSibling;

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,5 +1,5 @@
-// size: 2888 (min) 1400 (brotli)
-//#region packages/runtime-tags/dist/dom-T0gUuD2H.mjs
+// size: 2888 (min) 1392 (brotli)
+//#region packages/runtime-tags/dist/dom-BYuonLyu.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,
@@ -21,6 +21,9 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   readyIds;
 function isNotVoid(value) {
   return value != null && value !== !1;
+}
+function normalizeAttrValue(value) {
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function queueRender(scope, signal, signalKey, value, scopeKey = scope.L) {
   let render;
@@ -260,9 +263,6 @@ function setAttribute(element, name, value) {
 function _text(node, value) {
   let normalizedValue = _to_text(value);
   node.data !== normalizedValue && (node.data = normalizedValue);
-}
-function normalizeAttrValue(value) {
-  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function insertChildNodes(parentNode, referenceNode, startNode, endNode) {
   if (parentNode.isConnected)

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,5 +1,5 @@
 // size: 4038 (min) 1804 (brotli)
-//#region packages/runtime-tags/dist/dom-T0gUuD2H.mjs
+//#region packages/runtime-tags/dist/dom-BYuonLyu.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,5 +1,5 @@
 // size: 2683 (min) 1319 (brotli)
-//#region packages/runtime-tags/dist/dom-T0gUuD2H.mjs
+//#region packages/runtime-tags/dist/dom-BYuonLyu.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,5 +1,5 @@
-// size: 26464 (min) 9828 (brotli)
-//#region packages/runtime-tags/dist/dom-T0gUuD2H.mjs
+// size: 26464 (min) 9800 (brotli)
+//#region packages/runtime-tags/dist/dom-BYuonLyu.mjs
 let unsafeStyleAttrReg = /[\\;]/g,
   replaceUnsafeStyleAttr = (c) => (c === ";" ? "\\3B " : "\\\\"),
   toDelimitedString = function toDelimitedString(val, delimiter, stringify) {
@@ -390,6 +390,9 @@ function normalizeDynamicRenderer(value) {
     let normalized = value.content || value.default || value;
     if ("a" in normalized) return normalized;
   }
+}
+function normalizeAttrValue(value) {
+  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function withBranches(runtime) {
   return ((branchesEnabled = 1), runtime);
@@ -1320,9 +1323,6 @@ function _html(scope, value, accessor) {
 function normalizeClientRender(value) {
   let renderer = normalizeDynamicRenderer(value);
   if (renderer && renderer.a) return renderer;
-}
-function normalizeAttrValue(value) {
-  if (isNotVoid(value)) return value === !0 ? "" : value + "";
 }
 function _lifecycle(scope, thisObj, index = 0) {
   let accessor = "K" + index,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62522,
-        "brotli": 19347
+        "brotli": 19272
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63762,
-        "brotli": 19863
+        "min": 63760,
+        "brotli": 19810
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63644,
-        "brotli": 19813
+        "brotli": 19807
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62522,
-        "brotli": 19347
+        "brotli": 19272
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63801,
-        "brotli": 19904
+        "min": 63799,
+        "brotli": 19883
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62420,
-        "brotli": 19277
+        "brotli": 19274
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62461,
-        "brotli": 19258
+        "brotli": 19266
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63748,
-        "brotli": 19833
+        "min": 63747,
+        "brotli": 19809
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63867,
-        "brotli": 19882
+        "min": 63866,
+        "brotli": 19872
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62573,
-        "brotli": 19361
+        "brotli": 19304
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64057,
-        "brotli": 19983
+        "min": 64059,
+        "brotli": 19991
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65330,
-        "brotli": 20283
+        "min": 65327,
+        "brotli": 20309
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63693,
-        "brotli": 19822
+        "brotli": 19821
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63975,
-        "brotli": 19948
+        "min": 63974,
+        "brotli": 19946
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63762,
-        "brotli": 19837
+        "min": 63760,
+        "brotli": 19863
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62824,
-        "brotli": 19456
+        "min": 62827,
+        "brotli": 19475
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62496,
-        "brotli": 19315
+        "min": 62499,
+        "brotli": 19313
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64198,
-        "brotli": 19991
+        "min": 64199,
+        "brotli": 20021
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63374,
-        "brotli": 19676
+        "brotli": 19670
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63868,
-        "brotli": 19872
+        "brotli": 19870
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63474,
-        "brotli": 19735
+        "min": 63475,
+        "brotli": 19719
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62881,
-        "brotli": 19485
+        "brotli": 19489
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64562,
-        "brotli": 20201
+        "min": 64559,
+        "brotli": 20224
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8859,
-        "brotli": 3861
+        "brotli": 3855
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9899,
-        "brotli": 4303
+        "brotli": 4309
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2849,
-      "brotli": 1421
+      "brotli": 1428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2734,
-      "brotli": 1378
+      "brotli": 1385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2842,
-      "brotli": 1425
+      "brotli": 1433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9432,
-        "brotli": 4098
+        "brotli": 4101
       },
       "files": {
         "tags/child.marko": 432,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3099,
-      "brotli": 1535
+      "brotli": 1542
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7416,
-      "brotli": 3368
+      "brotli": 3374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 3720,
-        "brotli": 1807
+        "brotli": 1806
       },
       "files": {
         "tags/counter.marko": 449,

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4602,
-        "brotli": 2154
+        "brotli": 2148
       },
       "files": {
         "tags/FancyButton.marko": 238,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4339,
-      "brotli": 2020
+      "brotli": 2031
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4220,
-      "brotli": 1963
+      "brotli": 1971
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 10980,
-        "brotli": 4782
+        "brotli": 4777
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2728,
-      "brotli": 1373
+      "brotli": 1374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7304,
-        "brotli": 2994
+        "brotli": 3002
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7365,
-      "brotli": 3040
+      "brotli": 3035
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4291,
-      "brotli": 1954
+      "brotli": 1953
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4666,
-      "brotli": 2061
+      "brotli": 2071
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7561,
-        "brotli": 3076
+        "brotli": 3081
       },
       "files": {
         "tags/radio.marko": 280,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4428,
-      "brotli": 2013
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7564,
-        "brotli": 3077
+        "brotli": 3079
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4428,
-      "brotli": 2013
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4675,
-        "brotli": 2132
+        "brotli": 2130
       },
       "files": {
         "tags/my-details.marko": 257,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4910,
-      "brotli": 2247
+      "brotli": 2240
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 6347,
-        "brotli": 2765
+        "brotli": 2762
       },
       "files": {
         "tags/my-dialog.marko": 264,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8399,
-      "brotli": 3663
+      "brotli": 3652
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 14188,
-      "brotli": 5541
+      "brotli": 5538
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13746,
-      "brotli": 5340
+      "min": 13744,
+      "brotli": 5334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 13620,
-      "brotli": 5288
+      "brotli": 5287
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4132,
-        "brotli": 1921
+        "brotli": 1927
       },
       "files": {
         "tags/custom-input.marko": 496,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4148,
-        "brotli": 1924
+        "brotli": 1933
       },
       "files": {
         "tags/my-input.marko": 507,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3862,
-      "brotli": 1819
+      "brotli": 1835
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7283,
-        "brotli": 2985
+        "brotli": 2992
       },
       "files": {
         "tags/my-input.marko": 256,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3834,
-      "brotli": 1811
+      "brotli": 1820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7321,
-      "brotli": 3023
+      "brotli": 3019
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 6208,
-      "brotli": 2694
+      "brotli": 2700
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7337,
-      "brotli": 3020
+      "brotli": 3024
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4428,
-      "brotli": 2013
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13904,
-      "brotli": 5392
+      "min": 13902,
+      "brotli": 5396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4526,
-      "brotli": 2019
+      "brotli": 2014
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 9136,
-      "brotli": 3962
+      "brotli": 3968
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4433,
-      "brotli": 1987
+      "brotli": 1984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 9359,
-      "brotli": 4054
+      "brotli": 4049
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8993,
-        "brotli": 3688
+        "brotli": 3684
       },
       "files": {
         "tags/my-select.marko": 266,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4110,
-      "brotli": 1847
+      "brotli": 1843
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4110,
-      "brotli": 1847
+      "brotli": 1843
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4414,
-      "brotli": 1973
+      "brotli": 1974
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4211,
-      "brotli": 1893
+      "brotli": 1891
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 5615,
-        "brotli": 2480
+        "brotli": 2476
       },
       "files": {
         "tags/my-textarea.marko": 262,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3834,
-      "brotli": 1811
+      "brotli": 1820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8989,
-        "brotli": 3904
+        "brotli": 3905
       },
       "files": {
         "tags/custom-tag.marko": 618,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8975,
-        "brotli": 3903
+        "brotli": 3905
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8903,
-        "brotli": 3872
+        "brotli": 3876
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8805,
-        "brotli": 3808
+        "brotli": 3819
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8748,
-      "brotli": 3794
+      "brotli": 3798
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8635,
-      "brotli": 3748
+      "brotli": 3753
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9542,
-        "brotli": 4091
+        "brotli": 4102
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9622,
-        "brotli": 4114
+        "brotli": 4121
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9435,
-        "brotli": 4052
+        "brotli": 4060
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9458,
-        "brotli": 4062
+        "brotli": 4066
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14521,
-        "brotli": 5632
+        "min": 14519,
+        "brotli": 5636
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 13598,
-        "brotli": 5293
+        "brotli": 5294
       },
       "files": {
         "tags/my-tag.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8500,
-      "brotli": 3313
+      "brotli": 3319
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8629,
-      "brotli": 3683
+      "brotli": 3677
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9380,
-        "brotli": 4052
+        "brotli": 4053
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9480,
-        "brotli": 4065
+        "brotli": 4067
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8602,
-      "brotli": 3724
+      "brotli": 3723
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 8500,
-      "brotli": 3313
+      "brotli": 3319
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8864,
-        "brotli": 3828
+        "brotli": 3824
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-node-only-child-in-parent/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7076,
-      "brotli": 3237
+      "brotli": 3233
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-single-text-node-with-text-before/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7070,
-      "brotli": 3239
+      "brotli": 3235
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9245,
-        "brotli": 3955
+        "brotli": 3954
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 10005,
-        "brotli": 4232
+        "brotli": 4245
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9054,
-        "brotli": 3872
+        "brotli": 3879
       },
       "files": {
         "tags/child.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 6386,
-      "brotli": 2900
+      "brotli": 2905
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 6375,
-      "brotli": 2890
+      "brotli": 2896
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2941,
-      "brotli": 1463
+      "brotli": 1469
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9508,
-        "brotli": 4074
+        "brotli": 4080
       },
       "files": {
         "tags/handlers.marko": 431,

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3289,
-      "brotli": 1616
+      "brotli": 1624
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3295,
-      "brotli": 1624
+      "brotli": 1620
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7212,
-      "brotli": 2986
+      "brotli": 2976
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7293,
-        "brotli": 2988
+        "brotli": 2992
       },
       "files": {
         "tags/my-input.marko": 371,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -14,7 +14,7 @@
     },
     "shared": {
       "min": 11091,
-      "brotli": 4783
+      "brotli": 4789
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -14,7 +14,7 @@
     },
     "shared": {
       "min": 10972,
-      "brotli": 4723
+      "brotli": 4734
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -14,7 +14,7 @@
     },
     "shared": {
       "min": 10749,
-      "brotli": 4637
+      "brotli": 4643
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -14,7 +14,7 @@
     },
     "shared": {
       "min": 10807,
-      "brotli": 4689
+      "brotli": 4695
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4081,
-      "brotli": 1916
+      "brotli": 1927
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9399,
-      "brotli": 4042
+      "min": 9398,
+      "brotli": 4047
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4317,
-      "brotli": 2017
+      "brotli": 2004
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 9910,
-      "brotli": 4313
+      "brotli": 4324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9031,
-        "brotli": 3916
+        "brotli": 3920
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4094,
-        "brotli": 1934
+        "brotli": 1929
       },
       "files": {
         "tags/my-img.marko": 233,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
+    > 1 | <div class=input.class>content</div>
+        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
+    > 1 | <div class=input.class>content</div>
+        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
+    > 1 | <div class=input.class>content</div>
+        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
+    > 1 | <div class=input.class>content</div>
+        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko
@@ -1,0 +1,1 @@
+<div class=input.class>content</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/test.ts
@@ -1,0 +1,6 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko:1:8
+    > 1 | <input value=input.value>
+        |        ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko:1:8
+    > 1 | <input value=input.value>
+        |        ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko:1:8
+    > 1 | <input value=input.value>
+        |        ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko:1:8
+    > 1 | <input value=input.value>
+        |        ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/template.marko
@@ -1,0 +1,1 @@
+<input value=input.value>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/test.ts
@@ -1,0 +1,6 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+const $template = "<a> </a>";
+const $walks = " D l";
+const $setup = () => {};
+const $input_href = ($scope, input_href) => _attr($scope["#a/0"], "href", input_href);
+const $input_title = ($scope, input_title) => _attr($scope["#a/0"], "title", input_title);
+const $input_hidden = ($scope, input_hidden) => _attr($scope["#a/0"], "hidden", input_hidden);
+const $input_label = ($scope, input_label) => _text($scope["#text/1"], input_label);
+const $input = ($scope, input) => {
+	$input_href($scope, input.href);
+	$input_title($scope, input.title);
+	$input_hidden($scope, input.hidden);
+	$input_label($scope, input.label);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko:1:4
-    > 1 | <a href=input.href>${input.label}</a>
-        |    ^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko:1:4
-    > 1 | <a href=input.href>${input.label}</a>
-        |    ^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko:1:4
-    > 1 | <a href=input.href>${input.label}</a>
-        |    ^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/error-compile-html.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko:1:4
-    > 1 | <a href=input.href>${input.label}</a>
-        |    ^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<a${_patch_attr($scope0_id, "#a/0", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope0_id, "#a/0", "title", input.title)}${_attr("title", input.title)}${_patch_attr($scope0_id, "#a/0", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope0_id, "#text/1", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "#text/1")}</a>${_el_resume($scope0_id, "#a/0")}`);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<a${_patch_attr($scope0_id, "a", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope0_id, "a", "title", input.title)}${_attr("title", input.title)}${_patch_attr($scope0_id, "a", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope0_id, "b", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "b")}</a>${_el_resume($scope0_id, "a")}`);
+	writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+M._.r=[_=>[1,{"PatchAttr:#a/0 href":"/second","PatchAttr:#a/0 title":0,"PatchAttr:#a/0 hidden":"","PatchText:#text/1":"Second"}]]
+
+
+// PATCH
+
+M._.r=[_=>[1,{"PatchAttr:#a/0 href":"/third","PatchAttr:#a/0 title":"0","PatchAttr:#a/0 hidden":0,"PatchText:#text/1":"Third"}]]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+M._.r=[_=>[1,{"Qa href":"/second","Qa title":0,"Qa hidden":"",Pb:"Second"}]]
+
+
+// PATCH
+
+M._.r=[_=>[1,{"Qa href":"/third","Qa title":"0","Qa hidden":0,Pb:"Third"}]]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/render.debug.md
@@ -1,0 +1,43 @@
+# Render `{"href":"/first","label":"First","title":"one"}`
+```html
+<a
+  href="/first"
+  title="one"
+>
+  First
+</a>
+```
+
+# Update `{"href":"/second","label":"Second","hidden":true}`
+```html
+<a
+  hidden=""
+  href="/second"
+>
+  Second
+</a>
+```
+## Change
+```
+UPDATE: a[href] "/first" => "/second"
+UPDATE: a[title] "one" => null
+UPDATE: a[hidden] null => ""
+UPDATE: a::text "First" => "Second"
+```
+
+# Update `{"href":"/third","label":"Third","title":0}`
+```html
+<a
+  href="/third"
+  title="0"
+>
+  Third
+</a>
+```
+## Change
+```
+UPDATE: a[href] "/second" => "/third"
+UPDATE: a[title] null => "0"
+UPDATE: a[hidden] "" => null
+UPDATE: a::text "Second" => "Third"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/render.md
@@ -1,0 +1,43 @@
+# Render `{"href":"/first","label":"First","title":"one"}`
+```html
+<a
+  href="/first"
+  title="one"
+>
+  First
+</a>
+```
+
+# Update `{"href":"/second","label":"Second","hidden":true}`
+```html
+<a
+  hidden=""
+  href="/second"
+>
+  Second
+</a>
+```
+## Change
+```
+UPDATE: a[href] "/first" => "/second"
+UPDATE: a[title] "one" => null
+UPDATE: a[hidden] null => ""
+UPDATE: a::text "First" => "Second"
+```
+
+# Update `{"href":"/third","label":"Third","title":0}`
+```html
+<a
+  href="/third"
+  title="0"
+>
+  Third
+</a>
+```
+## Change
+```
+UPDATE: a[href] "/second" => "/third"
+UPDATE: a[title] null => "0"
+UPDATE: a[hidden] "" => null
+UPDATE: a::text "Second" => "Third"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/writes.debug.html
@@ -1,0 +1,5 @@
+<a href=/first title=one>First<!--M_*1 #text/1--></a><!--M_*1 #a/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/writes.html
@@ -1,0 +1,5 @@
+<a href=/first title=one>First<!--M_*1 b--></a><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2152,
+      "brotli": 1059
+    }
+  },
+  "html": {
+    "min": 340,
+    "brotli": 238
+  },
+  "patch": {
+    "min": 153,
+    "brotli": 102
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/template.marko
@@ -1,1 +1,1 @@
-<a href=input.href>${input.label}</a>
+<a href=input.href title=input.title hidden=input.hidden>${input.label}</a>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/test.ts
@@ -1,7 +1,10 @@
 import type { TestConfig } from "../../main.test";
 
 export const config: TestConfig = {
-  error_compiler: true,
   persisted: true,
-  steps: [{ href: "/first", label: "First" }],
+  steps: [
+    { href: "/first", label: "First", title: "one" },
+    { href: "/second", label: "Second", hidden: true },
+    { href: "/third", label: "Third", title: 0 },
+  ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-dom.debug.txt
@@ -3,7 +3,7 @@
       1 | <div class="wrap">
       2 |   <h1>Hello ${input.name}</h1>
     > 3 |   <if=input.show>
-        |   ^ Persisted templates currently support only escaped dynamic text in native HTML.
+        |   ^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
       4 |     <p>shown</p>
       5 |   </if>
       6 |   <for|item| of=input.items>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-dom.txt
@@ -3,7 +3,7 @@
       1 | <div class="wrap">
       2 |   <h1>Hello ${input.name}</h1>
     > 3 |   <if=input.show>
-        |   ^ Persisted templates currently support only escaped dynamic text in native HTML.
+        |   ^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
       4 |     <p>shown</p>
       5 |   </if>
       6 |   <for|item| of=input.items>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-html.debug.txt
@@ -3,7 +3,7 @@
       1 | <div class="wrap">
       2 |   <h1>Hello ${input.name}</h1>
     > 3 |   <if=input.show>
-        |   ^ Persisted templates currently support only escaped dynamic text in native HTML.
+        |   ^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
       4 |     <p>shown</p>
       5 |   </if>
       6 |   <for|item| of=input.items>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/error-compile-html.txt
@@ -3,7 +3,7 @@
       1 | <div class="wrap">
       2 |   <h1>Hello ${input.name}</h1>
     > 3 |   <if=input.show>
-        |   ^ Persisted templates currently support only escaped dynamic text in native HTML.
+        |   ^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
       4 |     <p>shown</p>
       5 |   </if>
       6 |   <for|item| of=input.items>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
+    > 1 | <a href="/static" ...input.attrs>${input.label}</a>
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
+    > 1 | <a href="/static" ...input.attrs>${input.label}</a>
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
+    > 1 | <a href="/static" ...input.attrs>${input.label}</a>
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.txt
@@ -1,0 +1,5 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
+    > 1 | <a href="/static" ...input.attrs>${input.label}</a>
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko
@@ -1,0 +1,1 @@
+<a href="/static" ...input.attrs>${input.label}</a>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/test.ts
@@ -1,0 +1,6 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2758,
-      "brotli": 1388
+      "brotli": 1396
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4203,
-      "brotli": 1889
+      "brotli": 1888
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4077,
-      "brotli": 1868
+      "brotli": 1867
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7252,
-      "brotli": 2979
+      "brotli": 2980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4474,
-      "brotli": 2060
+      "brotli": 2063
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14903,
-        "brotli": 5945
+        "min": 14902,
+        "brotli": 5926
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 6967,
-        "brotli": 2713
+        "brotli": 2704
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 8938,
-        "brotli": 3878
+        "brotli": 3875
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 6262,
-      "brotli": 2859
+      "brotli": 2853
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 9842,
-        "brotli": 4183
+        "brotli": 4189
       },
       "files": {
         "tags/a/index.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 9294,
-      "brotli": 4025
+      "brotli": 4027
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3418,
-      "brotli": 1661
+      "brotli": 1668
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3130,
-      "brotli": 1556
+      "brotli": 1562
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3733,
-      "brotli": 1762
+      "brotli": 1779
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3249,
-      "brotli": 1609
+      "brotli": 1616
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7502,
-      "brotli": 3313
+      "brotli": 3321
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 2732,
-      "brotli": 1372
+      "brotli": 1380
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4327,
-      "brotli": 1974
+      "brotli": 1978
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3510,
-      "brotli": 1666
+      "brotli": 1665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4321,
-      "brotli": 1967
+      "brotli": 1975
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3911,
-      "brotli": 1842
+      "brotli": 1856
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4280,
-      "brotli": 1925
+      "brotli": 1924
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4286,
-      "brotli": 1936
+      "brotli": 1928
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3953,
-      "brotli": 1852
+      "brotli": 1866
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 9062,
-      "brotli": 3932
+      "brotli": 3941
     }
   },
   "html": {

--- a/packages/runtime-tags/src/common/constants/accessor-prefix.debug.ts
+++ b/packages/runtime-tags/src/common/constants/accessor-prefix.debug.ts
@@ -10,6 +10,7 @@ export const DynamicHTMLLastChild = "DynamicHTMLLastChild:";
 export const EventAttributes = "EventAttributes:";
 export const KeyedScopes = "KeyedScopes:";
 export const Lifecycle = "Lifecycle:";
+export const PatchAttr = "PatchAttr:";
 export const PatchText = "PatchText:";
 export const Promise = "Promise:";
 export const TagVariableChange = "TagVariableChange:";

--- a/packages/runtime-tags/src/common/constants/accessor-prefix.ts
+++ b/packages/runtime-tags/src/common/constants/accessor-prefix.ts
@@ -10,6 +10,7 @@ export const DynamicHTMLLastChild = "H";
 export const EventAttributes = "I";
 export const KeyedScopes = "O";
 export const Lifecycle = "K";
+export const PatchAttr = "Q";
 export const PatchText = "P";
 export const Promise = "L";
 export const TagVariableChange = "M";

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -206,6 +206,12 @@ export function normalizeDynamicRenderer<Renderer>(
 export const decodeAccessor = (num: number): string =>
   (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36);
 
+export function normalizeAttrValue(value: unknown) {
+  if (isNotVoid(value)) {
+    return value === true ? "" : value + "";
+  }
+}
+
 // Branch (control flow) support latch. A `let` written only by
 // `withBranches` folds away with it, dropping guarded branch handling from
 // bundles without branches; an object property would defeat that analysis.

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -1,5 +1,5 @@
 import { assertHandlerIsFunction } from "../common/errors";
-import { isNotVoid } from "../common/helpers";
+import { isNotVoid, normalizeAttrValue } from "../common/helpers";
 import {
   type Accessor,
   AccessorPrefix,
@@ -7,7 +7,7 @@ import {
   ControlledType,
   type Scope,
 } from "../common/types";
-import { _attr, normalizeAttrValue } from "./dom";
+import { _attr } from "./dom";
 import { delegate } from "./event";
 import { pendingEffects, run, runId } from "./queue";
 import { resolveCursorPosition } from "./resolve-cursor-position";

--- a/packages/runtime-tags/src/dom/dom.ts
+++ b/packages/runtime-tags/src/dom/dom.ts
@@ -8,7 +8,7 @@ import {
   escapeStyleValue,
   getEventHandlerName,
   isEventHandler,
-  isNotVoid,
+  normalizeAttrValue,
   normalizeDynamicRenderer,
   stringifyClassObject,
   stringifyStyleObject,
@@ -46,7 +46,7 @@ export function _attr(element: Element, name: string, value: unknown) {
   setAttribute(element, name, normalizeAttrValue(value));
 }
 
-function setAttribute(
+export function setAttribute(
   element: Element,
   name: string,
   value: string | undefined,
@@ -371,12 +371,6 @@ function normalizeClientRender(value: any) {
         `Invalid \`content\` attribute. Received ${typeof value}`,
       );
     }
-  }
-}
-
-export function normalizeAttrValue(value: unknown) {
-  if (isNotVoid(value)) {
-    return value === true ? "" : value + "";
   }
 }
 

--- a/packages/runtime-tags/src/dom/patch-attr.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-attr.feat.ts
@@ -1,0 +1,14 @@
+import { type Accessor, AccessorPrefix } from "../common/types";
+import { setAttribute } from "./dom";
+import { patchers } from "./resume";
+
+patchers[AccessorPrefix.PatchAttr] = (scope, key, value) => {
+  const sep = key.indexOf(" ");
+  setAttribute(
+    scope[
+      key.slice(AccessorPrefix.PatchAttr.length, sep) as Accessor
+    ] as Element,
+    key.slice(sep + 1),
+    value === 0 ? undefined : (value as string),
+  );
+};

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -64,6 +64,7 @@ export {
   _html,
   _id,
   _if,
+  _patch_attr,
   _patch_text,
   _peek_scope_id,
   _resume,

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -4,7 +4,11 @@ import {
   assertValidLoopKey,
 } from "../common/errors";
 import { forIn, forOf, forTo, forUntil } from "../common/for";
-import { isPromise, normalizeDynamicRenderer } from "../common/helpers";
+import {
+  isPromise,
+  normalizeAttrValue,
+  normalizeDynamicRenderer,
+} from "../common/helpers";
 /* eslint-disable @typescript-eslint/no-this-alias */
 import { concat, forEach, type Opt, push } from "../common/opt";
 import {
@@ -210,6 +214,27 @@ export function _el_resume(
   const { state } = $chunk.boundary;
   state.needsMainRuntime = true;
   return state.mark(ResumeSymbol.Node, scopeId + " " + accessor);
+}
+
+export function _patch_attr(
+  scopeId: number,
+  accessor: Accessor,
+  name: string,
+  value: unknown,
+) {
+  const { state } = $chunk.boundary;
+  if (state.writesPatches) {
+    writeScope(scopeId, {
+      // `0` is the removal sentinel: normalized values are always strings and
+      // the serializer drops `undefined` members entirely.
+      [AccessorPrefix.PatchAttr + accessor + " " + name]:
+        normalizeAttrValue(value) ?? 0,
+    });
+  } else {
+    $chunk.needsWalk = true;
+  }
+
+  return "";
 }
 
 export function _patch_text(

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -62,7 +62,7 @@ export default {
     if (isNonHTMLText(placeholder)) {
       if (isPersisted() && !evaluate(placeholder.node.value).confident) {
         throw placeholder.buildCodeFrameError(
-          "Persisted templates currently support only escaped dynamic text in native HTML.",
+          "Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.",
         );
       }
       return;

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -8,6 +8,7 @@ import {
   usedSharedUid,
 } from "../../util/generate-uid";
 import { getDeclaredBindingExpression } from "../../util/get-declared-binding-expression";
+import { isEventOrChangeHandler } from "../../util/is-event-or-change-handler";
 import isStatic from "../../util/is-static";
 import { getMarkoOpts, isPersisted } from "../../util/marko-config";
 import { writeModuleRegistrations } from "../../util/module-registrations";
@@ -41,6 +42,7 @@ import { toObjectProperty } from "../../util/to-property-name";
 import { traverseReplace } from "../../util/traverse";
 import type { TemplateVisitor } from "../../util/visitors";
 import { flushInto } from "../../util/writer";
+import { controllableFeatureFor } from "../tag/native-tag";
 
 export function getTemplateContentName() {
   return getSharedUid("content");
@@ -206,13 +208,6 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
   let unsupported: t.Node | undefined;
   t.traverseFast(program.node, (node) => {
     switch (node.type) {
-      case "MarkoAttribute":
-      case "MarkoSpreadAttribute":
-        if (!evaluate(node.value).confident) {
-          unsupported = node;
-          return t.traverseFast.stop;
-        }
-        break;
       case "MarkoPlaceholder":
         if (!node.escape) {
           unsupported = node;
@@ -223,9 +218,9 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
         unsupported = node;
         return t.traverseFast.stop;
       case "MarkoTag": {
+        const tagName = t.isStringLiteral(node.name) && node.name.value;
         const tagDef =
-          t.isStringLiteral(node.name) &&
-          getTagDefForTagName(program.hub.file, node.name.value);
+          tagName && getTagDefForTagName(program.hub.file, tagName);
         if (
           !(
             tagDef &&
@@ -237,6 +232,24 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
           unsupported = node;
           return t.traverseFast.stop;
         }
+        // A tag that may become controllable keeps all of its dynamic
+        // attributes unsupported until patching understands controlled state.
+        const controllable = !!controllableFeatureFor(tagName as string);
+        for (const attr of node.attributes) {
+          if (
+            attr.type === "MarkoSpreadAttribute"
+              ? !evaluate(attr.value).confident
+              : !evaluate(attr.value).confident &&
+                (controllable ||
+                  isEventOrChangeHandler(attr.name) ||
+                  attr.name === "class" ||
+                  attr.name === "style" ||
+                  (tagName === "option" && attr.name === "value"))
+          ) {
+            unsupported = attr;
+            return t.traverseFast.stop;
+          }
+        }
         break;
       }
     }
@@ -244,7 +257,7 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
   if (unsupported) {
     throw program.hub.buildError(
       unsupported,
-      "Persisted templates currently support only escaped dynamic text in native HTML.",
+      "Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.",
     );
   }
 }

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -18,6 +18,7 @@ import {
   toDelimitedString,
 } from "../../../common/helpers";
 import { WalkCode } from "../../../common/types";
+import { addAssetImport } from "../../util/asset-imports";
 import { bodyToTextLiteral } from "../../util/body-to-text-literal";
 import evaluate from "../../util/evaluate";
 import { generateUidIdentifier } from "../../util/generate-uid";
@@ -26,7 +27,11 @@ import { getTagName } from "../../util/get-tag-name";
 import { isControlFlowTag } from "../../util/is-core-tag";
 import { isEventOrChangeHandler } from "../../util/is-event-or-change-handler";
 import { isTextOnlyNativeTag } from "../../util/is-non-html-text";
-import { getMarkoOpts, isOutputHTML } from "../../util/marko-config";
+import {
+  getMarkoOpts,
+  isOutputHTML,
+  isPersisted,
+} from "../../util/marko-config";
 import normalizeStringExpression from "../../util/normalize-string-expression";
 import { includes, type Opt, push } from "../../util/optional";
 import {
@@ -42,6 +47,7 @@ import {
   callRuntime,
   type DOMRuntimeFeature,
   getHTMLRuntime,
+  getRuntimePath,
   importRuntime,
   importRuntimeFeature,
 } from "../../util/runtime";
@@ -54,6 +60,7 @@ import {
 import { getSerializeGuard } from "../../util/serialize-guard";
 import {
   addSerializeExpr,
+  addSerializeReason,
   getSerializeReason,
 } from "../../util/serialize-reasons";
 import { addSetupExpr, addSetupStatement } from "../../util/setup-statements";
@@ -264,6 +271,14 @@ export default {
 
         if (hasEventHandlers) {
           getProgram().node.extra.isInteractive = true;
+        }
+
+        if (isPersisted() && hasDynamicAttributes && !tagSection.parent) {
+          addSerializeReason(tagSection, true, nodeBinding);
+          addAssetImport(
+            tag.hub.file,
+            `${getRuntimePath("dom")}/patch-attr.feat`,
+          );
         }
 
         if (spreadReferenceNodes) {
@@ -538,6 +553,15 @@ export default {
               } else if (isEventHandler(name)) {
                 addHTMLEffectCall(tagSection, valueReferences);
               } else {
+                if (isPersisted() && !tagSection.parent) {
+                  write`${callRuntime(
+                    "_patch_attr",
+                    getScopeIdIdentifier(tagSection),
+                    getScopeAccessorLiteral(nodeBinding!),
+                    t.stringLiteral(name),
+                    value,
+                  )}`;
+                }
                 write`${factorAttrConditional(
                   buildAttrExpression(
                     value,


### PR DESCRIPTION
Adds the second persisted vertical slice: dynamic attribute patching. A new `PatchAttr` wire prefix carries server-normalized attribute values (`0` as the removal sentinel, since a patch resends current values and the serializer drops `undefined`), applied client-side by a four-line `patch-attr.feat` module through dom's `setAttribute`. Compile-time rejection is narrowed to allow plain dynamic attributes on native tags while spread, event/change handlers, `class`/`style`, `<option value>`, and controllable tags remain errors — matching the prototype's ownership boundaries. `persisted-dynamic-attribute` becomes the first positive attribute fixture (change/boolean/removal), with new rejection fixtures for controllable, class, and spread cases.