### PR TITLE
chore(sizes): strip content hashes from region banners in size snapshots

### DIFF
--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,5 +1,5 @@
 // size: 6509 (min) 2885 (brotli)
-//#region packages/runtime-tags/dist/dom-Cj4HQ7T_.mjs
+//#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   branchesEnabled,
   rendering,

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,5 +1,5 @@
 // size: 2888 (min) 1400 (brotli)
-//#region packages/runtime-tags/dist/dom-Cj4HQ7T_.mjs
+//#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,5 +1,5 @@
 // size: 4038 (min) 1804 (brotli)
-//#region packages/runtime-tags/dist/dom-Cj4HQ7T_.mjs
+//#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,5 +1,5 @@
 // size: 2683 (min) 1319 (brotli)
-//#region packages/runtime-tags/dist/dom-Cj4HQ7T_.mjs
+//#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
   runId = 2,

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,5 +1,5 @@
 // size: 26012 (min) 9658 (brotli)
-//#region packages/runtime-tags/dist/dom-Cj4HQ7T_.mjs
+//#region packages/runtime-tags/dist/dom.mjs
 let unsafeStyleAttrReg = /[\\;]/g,
   replaceUnsafeStyleAttr = (c) => (c === ";" ? "\\3B " : "\\\\"),
   toDelimitedString = function toDelimitedString(val, delimiter, stringify) {

--- a/scripts/sizes.mts
+++ b/scripts/sizes.mts
@@ -307,9 +307,15 @@ function brotli(src: string): Promise<Buffer> {
 }
 
 function stripModuleCode(code: string) {
-  return code.replace(
-    /\s*(?:export\s*\{[^}]+\}|import\s*.*\s*from\s*['"][^'"]+['"]);?\s*/gm,
-    "",
+  return (
+    code
+      // Drop content hashes from dist chunk names in region banners so runtime
+      // edits don't churn every snapshot.
+      .replace(/^(\/\/#region .*?)-[\w-]{8}(\.[cm]?js)$/gm, "$1$2")
+      .replace(
+        /\s*(?:export\s*\{[^}]+\}|import\s*.*\s*from\s*['"][^'"]+['"]);?\s*/gm,
+        "",
+      )
   );
 }
 


### PR DESCRIPTION
The `.sizes/*.js` snapshots embed the runtime's dist chunk filenames in their `//#region` banners, so any runtime edit changes the content hash and churns every snapshot. Normalize the hash out when writing snapshots; this regenerates them once with no size changes.