### PR TITLE
feat(runtime-tags): catch two silent Marko 6 template mistakes

### DIFF
--- a/.changeset/tag-var-missing-return.md
+++ b/.changeset/tag-var-missing-return.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": minor
+---
+
+Error when a tag variable is declared on a custom tag whose template has no `<return>`, instead of silently binding it to `undefined`.

--- a/.changeset/warn-truncated-attr-value.md
+++ b/.changeset/warn-truncated-attr-value.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Warn when a bare `>` or a TypeScript type argument in an attribute value silently ends the tag, leaving a truncated value and the rest of the line as body text.

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,33 @@
+// tags/tree/index.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
+const $if_content__input_depth = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $input_depth($scope["#childScope/0"], $scope._.input_depth - 1));
+const $if_content__setup = ($scope) => {
+	$if_content__input_depth._($scope);
+	_var($scope, "#childScope/0", $if_content__nested);
+};
+const $if_content__nested = _var_resume("__tests__/tags/tree/index.marko_1_nested/var", ($scope, nested) => _text($scope["#text/2"], nested));
+const $if = /*@__PURE__*/ _if("#text/0", /*@__PURE__*/ ((_w0) => `<!>${_w0}<div>nested <!></div>`)($template$1), /*@__PURE__*/ ((_w0) => `b0${_w0}&Db%l`)("b%c"), $if_content__setup);
+const $input_depth = /*@__PURE__*/ _const("input_depth", ($scope) => {
+	_return($scope, $scope.input_depth);
+	$if($scope, $scope.input_depth ? 0 : 1);
+	$if_content__input_depth($scope);
+});
+const $input = ($scope, input) => $input_depth($scope, input.depth);
+var tree_default = /*@__PURE__*/ _template("__tests__/tags/tree/index.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>inc</button>${_w0}<div>total <!></div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b0${_w0}&Db%l`)("b%c");
+const $n = /*@__PURE__*/ _let("n/4", ($scope) => $input_depth($scope["#childScope/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + 1);
+}));
+function $setup($scope) {
+	_var($scope, "#childScope/1", $total);
+	$n($scope, 2);
+	$setup__script($scope);
+}
+const $total = _var_resume("__tests__/template.marko_0_total/var", ($scope, total) => _text($scope["#text/3"], total));
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/dom.bundle.js
@@ -1,0 +1,22 @@
+// tags/tree/index.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $if_content__input_depth = /*@__PURE__*/ _if_closure(0, 0, ($scope) => $input_depth($scope.a, $scope._.d - 1));
+const $if_content__setup = ($scope) => {
+	$if_content__input_depth._($scope);
+	_var($scope, 0, $if_content__nested);
+};
+const $if_content__nested = _var_resume("b0", ($scope, nested) => _text($scope.c, nested));
+const $if = /*@__PURE__*/ _if(0, /*@__PURE__*/ ((_w0) => `<!>${_w0}<div>nested <!></div>`)($template), /*@__PURE__*/ ((_w0) => `b0${_w0}&Db%l`)("b%c"), $if_content__setup);
+const $input_depth = /*@__PURE__*/ _const(3, ($scope) => {
+	_return($scope, $scope.d);
+	$if($scope, $scope.d ? 0 : 1);
+	$if_content__input_depth($scope);
+});
+
+// template.marko
+const $n = /*@__PURE__*/ _let(4, ($scope) => $input_depth($scope.b, $scope.e));
+const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, $scope.e + 1);
+}));
+const $total = _var_resume("a0", ($scope, total) => _text($scope.d, total));

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,43 @@
+// tags/tree/index.marko
+const $content = (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_depth = _serialize_guard($scope0_reason, 0), $si__input_depth = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_if(() => {
+		if (input.depth) {
+			const $scope1_id = _scope_id();
+			const $childScope = _peek_scope_id();
+			_set_serialize_reason($sg__input_depth);
+			let nested = $content({ depth: input.depth - 1 });
+			_var($scope1_id, "#scopeOffset/1", $childScope, "__tests__/tags/tree/index.marko_1_nested/var");
+			_html(`<div>nested ${_escape(nested)}</div>`);
+			$si__input_depth && writeScope($scope1_id, {
+				_: _scope_with_id($scope0_id),
+				"#childScope/0": _existing_scope($childScope)
+			}, "__tests__/tags/tree/index.marko", "1:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/0", $sg__input_depth, $sg__input_depth, $sg__input_depth);
+	const $return = input.depth;
+	$si__input_depth && writeScope($scope0_id, { input_depth: input.depth }, "__tests__/tags/tree/index.marko", 0, { input_depth: ["input.depth"] });
+	return $return;
+};
+var tree_default = _template("__tests__/tags/tree/index.marko", $content);
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 2;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}`);
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(1);
+	let total = tree_default({ depth: n });
+	_var($scope0_id, "#scopeOffset/2", $childScope, "__tests__/template.marko_0_total/var");
+	_html(`<div>total <!>${_escape(total)}${_el_resume($scope0_id, "#text/3")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		n,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/__snapshots__/html.bundle.js
@@ -1,0 +1,43 @@
+// tags/tree/index.marko
+const $content = (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_depth = _serialize_guard($scope0_reason, 0), $si__input_depth = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_if(() => {
+		if (input.depth) {
+			const $scope1_id = _scope_id();
+			const $childScope = _peek_scope_id();
+			_set_serialize_reason($sg__input_depth);
+			let nested = $content({ depth: input.depth - 1 });
+			_var($scope1_id, "b", $childScope, "b0");
+			_html(`<div>nested ${_escape(nested)}</div>`);
+			$si__input_depth && writeScope($scope1_id, {
+				_: _scope_with_id($scope0_id),
+				a: _existing_scope($childScope)
+			});
+			return 0;
+		}
+	}, $scope0_id, "a", $sg__input_depth, $sg__input_depth, $sg__input_depth);
+	const $return = input.depth;
+	$si__input_depth && writeScope($scope0_id, { d: input.depth });
+	return $return;
+};
+var tree_default = _template("b", $content);
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 2;
+	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}`);
+	const $childScope = _peek_scope_id();
+	_set_serialize_reason(1);
+	let total = tree_default({ depth: n });
+	_var($scope0_id, "c", $childScope, "a0");
+	_html(`<div>total <!>${_escape(total)}${_el_resume($scope0_id, "d")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		e: n,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/sizes.json
@@ -1,0 +1,14 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6603,
+        "brotli": 3000
+      },
+      "files": {
+        "tags/tree/index.marko": 759,
+        "template.marko": 312
+      }
+    }
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/tags/tree/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/tags/tree/index.marko
@@ -1,0 +1,5 @@
+<if=input.depth>
+  <tree/nested depth=input.depth - 1/>
+  <div>nested ${nested}</div>
+</if>
+<return=input.depth>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/template.marko
@@ -1,0 +1,4 @@
+<let/n=2>
+<button onClick() { n++ }>inc</button>
+<tree/total depth=n/>
+<div>total ${total}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-recursive/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+// A recursive tag is loaded mid-analyze, so its `<return>` may not have been
+// walked when the recursive call site is checked; the compiler must not decide
+// from that partial state that `nested` is always undefined.
+export const config: TestConfig = {
+  skip_ssr: true,
+  skip_csr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko:1:17
+    > 1 | <toggle-section/notifications title="Notifications"/>
+        |                 ^^^^^^^^^^^^^ `<toggle-section>` never returns a value, so this [tag variable](https://markojs.com/docs/reference/language#tag-variables) is always `undefined`. Add a [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) at the top level of `./tags/toggle-section.marko` (eg `<return=value>`) to publish one, then read it as `notifications`, not `notifications()` — read at or below its own tag, a custom tag's tag variable IS the returned value, not a getter; [native tag](https://markojs.com/docs/reference/native-tag) variables like `<div/el>` are. If `<toggle-section>` has no value to publish, remove the `/notifications` tag variable instead.
+      2 | <div>${notifications().expanded}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko:1:17
+    > 1 | <toggle-section/notifications title="Notifications"/>
+        |                 ^^^^^^^^^^^^^ `<toggle-section>` never returns a value, so this [tag variable](https://markojs.com/docs/reference/language#tag-variables) is always `undefined`. Add a [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) at the top level of `./tags/toggle-section.marko` (eg `<return=value>`) to publish one, then read it as `notifications`, not `notifications()` — read at or below its own tag, a custom tag's tag variable IS the returned value, not a getter; [native tag](https://markojs.com/docs/reference/native-tag) variables like `<div/el>` are. If `<toggle-section>` has no value to publish, remove the `/notifications` tag variable instead.
+      2 | <div>${notifications().expanded}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko:1:17
+    > 1 | <toggle-section/notifications title="Notifications"/>
+        |                 ^^^^^^^^^^^^^ `<toggle-section>` never returns a value, so this [tag variable](https://markojs.com/docs/reference/language#tag-variables) is always `undefined`. Add a [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) at the top level of `./tags/toggle-section.marko` (eg `<return=value>`) to publish one, then read it as `notifications`, not `notifications()` — read at or below its own tag, a custom tag's tag variable IS the returned value, not a getter; [native tag](https://markojs.com/docs/reference/native-tag) variables like `<div/el>` are. If `<toggle-section>` has no value to publish, remove the `/notifications` tag variable instead.
+      2 | <div>${notifications().expanded}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko:1:17
+    > 1 | <toggle-section/notifications title="Notifications"/>
+        |                 ^^^^^^^^^^^^^ `<toggle-section>` never returns a value, so this [tag variable](https://markojs.com/docs/reference/language#tag-variables) is always `undefined`. Add a [`<return>` tag](https://markojs.com/docs/reference/core-tag#return) at the top level of `./tags/toggle-section.marko` (eg `<return=value>`) to publish one, then read it as `notifications`, not `notifications()` — read at or below its own tag, a custom tag's tag variable IS the returned value, not a getter; [native tag](https://markojs.com/docs/reference/native-tag) variables like `<div/el>` are. If `<toggle-section>` has no value to publish, remove the `/notifications` tag variable instead.
+      2 | <div>${notifications().expanded}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/tags/toggle-section.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/tags/toggle-section.marko
@@ -1,0 +1,2 @@
+<let/expanded=false>
+<button onClick() { expanded = !expanded }>${input.title}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/template.marko
@@ -1,0 +1,2 @@
+<toggle-section/notifications title="Notifications"/>
+<div>${notifications().expanded}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-var-no-return/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/diagnostics.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/diagnostics.md
@@ -1,0 +1,3 @@
+# Diagnostics
+
+- `template.marko` warning: A `>` ended this tag, so this value is just `count` and the rest of the line became body text. If a comparison was meant, wrap it in parentheses: `disabled=(count >= …)`.

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+const $template = "<button>=8 onClick() { count++ }>More</button>";
+const $walks = " b";
+const $count = /*@__PURE__*/ _let("count/1", ($scope) => _attr($scope["#button/0"], "disabled", $scope.count));
+function $setup($scope) {
+	$count($scope, 2);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 2;
+	_html(`<button${_attr("disabled", count)}>=8 onClick() { count++ }>More</button>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<button${_attr("disabled", 2)}>=8 onClick() { count++ }>More</button>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/render.debug.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<button
+  disabled="2"
+>
+  =8 onClick() { count++ }&gt;More
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/render.md
@@ -1,0 +1,8 @@
+# Render
+```html
+<button
+  disabled="2"
+>
+  =8 onClick() { count++ }&gt;More
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+<button disabled=2>=8 onClick() { count++ }>More</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+<button disabled=2>=8 onClick() { count++ }>More</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 373,
+      "brotli": 250
+    }
+  },
+  "html": {
+    "min": 57,
+    "brotli": 54
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/template.marko
@@ -1,0 +1,2 @@
+<let/count=2>
+<button disabled=count>=8 onClick() { count++ }>More</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-gt-closes-tag/test.ts
@@ -1,0 +1,4 @@
+import type { TestConfig } from "../../main.test";
+
+// Compiles clean; the point of the fixture is the diagnostic it emits.
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/diagnostics.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/diagnostics.md
@@ -1,0 +1,3 @@
+# Diagnostics
+
+- `template.marko` warning: The `>` in `<Date>` ended this tag, so this value is `new Set<Date` and `()` became body text. Wrap a value that contains type arguments in parentheses: `=(new Set<Date>())`.

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+const $template = "()><div> </div>";
+const $walks = "bD l";
+const $s = /*@__PURE__*/ _let("s/1", ($scope) => _text($scope["#text/0"], String($scope.s)));
+function $setup($scope) {
+	$s($scope, new Set() < Date);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,8 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let s = new Set() < Date;
+	_html(`()><div>${_escape(String(s))}</div>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`()><div>${_escape(String(/* @__PURE__ */ new Set() < Date))}</div>`);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/render.debug.md
@@ -1,0 +1,7 @@
+# Render
+```html
+()&gt;
+<div>
+  true
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/render.md
@@ -1,0 +1,7 @@
+# Render
+```html
+()&gt;
+<div>
+  true
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+()><div>true</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+()><div>true</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 373,
+      "brotli": 250
+    }
+  },
+  "html": {
+    "min": 18,
+    "brotli": 22
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/template.marko
@@ -1,0 +1,2 @@
+<let/s=new Set<Date>()>
+<div>${String(s)}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-attr-value-type-args-close-tag/test.ts
@@ -1,0 +1,4 @@
+import type { TestConfig } from "../../main.test";
+
+// Compiles clean; the point of the fixture is the diagnostic it emits.
+export const config: TestConfig = {};

--- a/packages/runtime-tags/src/translator/util/truncated-attr-value.ts
+++ b/packages/runtime-tags/src/translator/util/truncated-attr-value.ts
@@ -1,0 +1,65 @@
+import { types as t } from "@marko/compiler";
+import { diagnosticWarn } from "@marko/compiler/babel-utils";
+
+// A top level `>` ends the open tag even mid expression, so an unenclosed
+// attribute value truncates there and the rest of the line is read as body
+// text. Both halves stay well formed, so only the source shape gives it away —
+// and the same shape can be exactly what the author meant, hence a warning.
+const enclosedAttrValueReg = /^[("'`]/;
+const comparisonRHSReg = /=[ \t]*[\w$([{"'`!+~-]/y;
+const typeArgsBodyReg = /^[\w$.,[\]|](?:[\w$.,[\]| \t]*[\w$.,[\]|])?$/;
+const tsTypeKeywordReg =
+  /^(?:any|bigint|boolean|never|number|object|string|symbol|undefined|unknown|void)$/;
+
+export function warnOnTruncatedAttrValue(tag: t.NodePath<t.MarkoTag>) {
+  const { attributes } = tag.node;
+  const attr = attributes[attributes.length - 1];
+  if (!t.isMarkoAttribute(attr) || !attr.value) return;
+
+  const { code } = tag.hub.file;
+  const start = attr.value.start!;
+  const end = attr.value.end!;
+  const value = code.slice(start, end);
+  if (enclosedAttrValueReg.test(value)) return;
+
+  // Only a `>` directly after the value can have cut it short.
+  let gt = end;
+  while (code[gt] === " " || code[gt] === "\t") gt++;
+  if (code[gt] !== ">") return;
+
+  // `new Set<string>()` leaves an orphan call behind; `count<MAX>(warning)` is
+  // a whole comparison with body text, so only the empty call is worth naming.
+  const openIndex = value.lastIndexOf("<");
+  if (~openIndex && code.startsWith("()", gt + 1)) {
+    const args = value.slice(openIndex + 1);
+    if (isTypeArgsBody(args)) {
+      diagnosticWarn(tag, {
+        label: `The \`>\` in \`<${args}>\` ended this tag, so this value is \`${value}\` and \`()\` became body text. Wrap a value that contains type arguments in parentheses: \`=(${value}>())\`.`,
+        loc: attr.loc ?? undefined,
+      });
+      return;
+    }
+  }
+
+  comparisonRHSReg.lastIndex = gt + 1;
+  if (comparisonRHSReg.test(code)) {
+    diagnosticWarn(tag, {
+      label: `A \`>\` ended this tag, so this value is just \`${value}\` and the rest of the line became body text. If a comparison was meant, wrap it in parentheses: \`${
+        attr.default ? "" : attr.name
+      }=(${value} >= …)\`.`,
+      loc: attr.loc ?? undefined,
+    });
+  }
+}
+
+// Type arguments name types, so `Set<string>` and `Box<Item>` are type
+// arguments while `a<b` stays an ordinary comparison.
+function isTypeArgsBody(src: string) {
+  if (!typeArgsBodyReg.test(src)) return false;
+  for (const name of src.split(/[^\w$]+/)) {
+    if (name && (/^[A-Z]/.test(name) || tsTypeKeywordReg.test(name))) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -129,6 +129,15 @@ export default {
   },
   translate: {
     enter(tag) {
+      // A recursive child is loaded mid-analyze, so "this template has no
+      // `<return>`" is only a settled fact once every analyze has finished.
+      if (tag.node.var) {
+        const childFile = loadFileForTag(tag)!;
+        if (!childFile.ast.program.extra.section!.returnValueExpr) {
+          throw missingReturnValueError(tag, childFile);
+        }
+      }
+
       if (isOutputHTML()) {
         writer.flushBefore(tag);
       }
@@ -417,6 +426,49 @@ function tagNotFoundError(tag: t.NodePath<t.MarkoTag>) {
     .get("name")
     .buildCodeFrameError(
       `Unable to find entry point for [custom tag](https://markojs.com/docs/reference/custom-tag#relative-custom-tags) \`<${tagName}>\`.${didYouMean}`,
+    );
+}
+
+// A tag variable is filled in by the child template's `<return>` tag and by
+// nothing else, so a child with no `<return>` leaves it `undefined` at every
+// render. That compiles clean today and only shows up as `undefined is not a
+// function` (or a value that never updates) once the page renders, so name both
+// halves of the fix: add the `<return>`, and stop calling the tag variable.
+// Reading it as a function is the common wrong guess because native tag
+// variables (`<div/el>`), and hoisted reads, really are getter functions.
+function missingReturnValueError(
+  tag: t.NodePath<t.MarkoTag>,
+  childFile: t.BabelFile,
+) {
+  const tagVar = tag.node.var!;
+  const { name } = tag.node;
+  const tagName =
+    getTagName(tag) ?? (name.type === "Identifier" ? name.name : undefined);
+  const childRequest = resolveRelativePath(
+    tag.hub.file,
+    childFile.opts.filename!,
+  );
+  // A computed tag name has nothing readable to quote, so the resolved template
+  // is the clearer subject.
+  const subject = tagName ? `\`<${tagName}>\`` : `\`${childRequest}\``;
+  const where = tagName
+    ? `the top level of \`${childRequest}\``
+    : "its top level";
+  const readIt =
+    tagVar.type === "Identifier"
+      ? `read it as \`${tagVar.name}\`, not \`${tagVar.name}()\``
+      : "read it directly, without calling it";
+  const dropIt =
+    tagVar.type === "Identifier"
+      ? `remove the \`/${tagVar.name}\` tag variable`
+      : "remove the tag variable";
+  return tag
+    .get("var")
+    .buildCodeFrameError(
+      `${subject} never returns a value, so this [tag variable](https://markojs.com/docs/reference/language#tag-variables) is always \`undefined\`. ` +
+        `Add a [\`<return>\` tag](https://markojs.com/docs/reference/core-tag#return) at ${where} (eg \`<return=value>\`) to publish one, ` +
+        `then ${readIt} — read at or below its own tag, a custom tag's tag variable IS the returned value, not a getter; [native tag](https://markojs.com/docs/reference/native-tag) variables like \`<div/el>\` are. ` +
+        `If ${subject} has no value to publish, ${dropIt} instead.`,
     );
 }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/index.ts
@@ -4,6 +4,7 @@ import { getTagDef, type Plugin } from "@marko/compiler/babel-utils";
 import { reportAnalyzeError } from "../../util/analyze-errors";
 import * as hooks from "../../util/plugin-hooks";
 import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
+import { warnOnTruncatedAttrValue } from "../../util/truncated-attr-value";
 import type { TemplateVisitor } from "../../util/visitors";
 import AttributeTag from "./attribute-tag";
 import CustomTag from "./custom-tag";
@@ -19,6 +20,8 @@ declare module "@marko/compiler/dist/types" {
 export default {
   analyze: {
     enter(tag) {
+      warnOnTruncatedAttrValue(tag);
+
       // Collect analyze failures as diagnostics instead of aborting on the first,
       // so all mistakes report together; skip the subtree to limit cascading errors.
       try {


### PR DESCRIPTION
Two shapes that compile clean today and fail only at render.

**A tag variable on a custom tag whose template has no `<return>`** is `undefined` at every render — now an error. Raised at `translate` rather than `analyze`, so a mutually recursive child (loaded mid-analyze) cannot change the outcome by compile order.

**A bare `>` or a TypeScript type argument in an unenclosed attribute value** ends the tag: the value truncates there and the rest of the line becomes body text. The same source shape can be exactly what the author meant — `<if=count<MAX>(warning)</if>` is correct code — so this warns via `meta.diagnostics` instead of erroring, and the type-argument case only fires when the leftover is an orphan `()`.

Both live in the runtime-tags translator; `@marko/compiler` is byte-identical to `main`, so nothing reaches the Marko 5 path.

Rewritten after review found the earlier parser-level version fired on Marko 5 templates, crashed with a `TypeError` on mutually recursive tags depending on compile order, and rejected valid comparisons. The statement-tag message rewrite that was also in this branch landed separately in #3728.

Checks: 10,351 passing / 0 failing; lint clean; swept 3,219 templates and the only warnings emitted anywhere are this PR's two fixtures.