### PR TITLE
fix(compiler): name the concise form when a statement tag is written in html mode

### DIFF
--- a/.changeset/statement-tag-html-mode-error.md
+++ b/.changeset/statement-tag-html-mode-error.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Replace the parser's "reserved and cannot be used as an HTML tag" error for a statement tag written in html mode with one that names the concise form, and point `<export/value>` at `<return>`.

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -350,6 +350,15 @@ export function parseMarko(file) {
             parseType = TagType.text;
           }
         }
+
+        // Otherwise this reaches htmljs-parser's "reserved and cannot be used
+        // as an HTML tag", which names neither the concise form nor `<return>`.
+        if (parseType === TagType.statement && code[part.start - 1] === "<") {
+          throw file.buildCodeFrameError(
+            tagName,
+            statementTagInHTMLModeError(literalTagName, code, part.end),
+          );
+        }
       }
 
       enterTag(node);
@@ -705,4 +714,28 @@ function templateElement(value, tail) {
     raw: value,
     cooked: value,
   });
+}
+
+const tagVarAfterNameReg = /^\/([A-Za-z_$][\w$]*)/;
+const statementTagExample = {
+  class: "class { … }",
+  client: 'client console.log("…")',
+  export: "export const value = …",
+  import: 'import Tag from "<tag>"',
+  server: 'server console.log("…")',
+  static: "static const value = …",
+};
+function statementTagInHTMLModeError(tagName, code, nameEnd) {
+  // `<export/value>` is what an author reaches for to publish a value to the
+  // parent, and `<export>` is not that feature at all.
+  if (tagName === "export") {
+    const tagVar = tagVarAfterNameReg.exec(code.slice(nameEnd))?.[1];
+    if (tagVar) {
+      return `The \`export\` statement does not support a tag variable. To publish a value to the parent template, use a \`<return>\` tag instead — \`<return=${tagVar}>\` — and the parent names it with its own tag variable on this template's tag.`;
+    }
+  }
+
+  return `\`${tagName}\` is a statement, not an html tag: write it at the root of the template without angle brackets, eg \`${
+    statementTagExample[tagName] || `${tagName} …`
+  }\`.`;
 }

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/cjs-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/generated-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/html-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/vdom-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-export-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <export x from "y"/>
-        |    ^^^^^^ The "export" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `export` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `export const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/cjs-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/generated-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/html-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/vdom-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-import-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <import x from "y"/>
-        |    ^^^^^^ The "import" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `import` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `import Tag from "<tag>"`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/cjs-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/generated-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/html-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/htmlProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/hydrate-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/vdom-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-static-tag-root-only/snapshots/vdomProduction-error-expected.txt
@@ -2,5 +2,5 @@ CompileError:
     at __tests__/template.marko:2:4
       1 | <div>
     > 2 |   <static { console.log(x) }/>
-        |    ^^^^^^ The "static" tag is reserved and cannot be used as an HTML tag.
+        |    ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
       3 | </div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko:2:2
+      1 | <let/expanded=false>
+    > 2 | <export/expanded>
+        |  ^^^^^^ The `export` statement does not support a tag variable. To publish a value to the parent template, use a `<return>` tag instead — `<return=expanded>` — and the parent names it with its own tag variable on this template's tag.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko:2:2
+      1 | <let/expanded=false>
+    > 2 | <export/expanded>
+        |  ^^^^^^ The `export` statement does not support a tag variable. To publish a value to the parent template, use a `<return>` tag instead — `<return=expanded>` — and the parent names it with its own tag variable on this template's tag.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko:2:2
+      1 | <let/expanded=false>
+    > 2 | <export/expanded>
+        |  ^^^^^^ The `export` statement does not support a tag variable. To publish a value to the parent template, use a `<return>` tag instead — `<return=expanded>` — and the parent names it with its own tag variable on this template's tag.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko:2:2
+      1 | <let/expanded=false>
+    > 2 | <export/expanded>
+        |  ^^^^^^ The `export` statement does not support a tag variable. To publish a value to the parent template, use a `<return>` tag instead — `<return=expanded>` — and the parent names it with its own tag variable on this template's tag.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/template.marko
@@ -1,0 +1,2 @@
+<let/expanded=false>
+<export/expanded>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-export-tag-var/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko:1:2
+    > 1 | <static const answer = 42>
+        |  ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
+      2 | <div>${answer}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko:1:2
+    > 1 | <static const answer = 42>
+        |  ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
+      2 | <div>${answer}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko:1:2
+    > 1 | <static const answer = 42>
+        |  ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
+      2 | <div>${answer}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko:1:2
+    > 1 | <static const answer = 42>
+        |  ^^^^^^ `static` is a statement, not an html tag: write it at the root of the template without angle brackets, eg `static const value = …`.
+      2 | <div>${answer}</div>
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/template.marko
@@ -1,0 +1,2 @@
+<static const answer = 42>
+<div>${answer}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-statement-tag-in-html-mode/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};


### PR DESCRIPTION
`<static const x = 1>`, `<import x from "y"/>` and friends already fail to compile — with htmljs-parser's "reserved and cannot be used as an HTML tag", which names neither the concise statement form nor, for `<export/value>`, the tag that actually publishes a value to the parent. This replaces that message; no template's compile status changes.
