### PR TITLE
fix(runtime-tags): persisted construct wiring binds live scopes (experimental)

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/test.ts
@@ -1,6 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 export const config: TestConfig = {
+  skip_parity: true,
   steps: [{}],
   equivalent: false,
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+const $template = "<main><h1> </h1><!><button>+</button></main>";
+const $walks = "E l%b l";
+const $if_content2__count = /*@__PURE__*/ _closure_get("count", ($scope) => _text($scope["#text/0"], $scope._._.count), ($scope) => $scope._._);
+const $if_content2__setup = $if_content2__count;
+const $if_content__if = /*@__PURE__*/ _if("#text/0", "<span>Seen <!></span>", "Db%", $if_content2__setup);
+const $if_content__input_inner = /*@__PURE__*/ _if_closure("#text/1", 0, ($scope) => $if_content__if($scope, $scope._.input_inner ? 0 : 1));
+const $if_content__setup = $if_content__input_inner;
+const $count__closure = /*@__PURE__*/ _closure($if_content2__count);
+const $count = /*@__PURE__*/ _let("count/8", $count__closure);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $if = /*@__PURE__*/ _if("#text/1", "<p>promo</p><!><!>", "b%", $if_content__setup);
+const $input_outer = ($scope, input_outer) => $if($scope, input_outer ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_outer($scope, input.outer);
+	$input_inner($scope, input.inner);
+};
+const $input_inner = /*@__PURE__*/ _const("input_inner", $if_content__input_inner);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $if_content2__count = /*@__PURE__*/ _closure_get(10, ($scope) => _text($scope.a, $scope._._.i), ($scope) => $scope._._);
+const $count = /*@__PURE__*/ _let(8, /* @__PURE__ */ _closure($if_content2__count));
+const $setup__script = _script("a2", ($scope) => _on($scope.c, "click", function() {
+	$count($scope, $scope.i + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+_renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.marko_1_shell;b%;<p>promo</p><!><!>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_inner = _serialize_guard($scope0_reason, 2), $sg__input_outer = _serialize_guard($scope0_reason, 1);
+	const $scope0_id = _scope_id();
+	const $count__closures = new Set();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_if(() => {
+		if (input.outer) {
+			const $scope1_id = _scope_id();
+			_html("<p>promo</p>");
+			_if(() => {
+				if (input.inner) {
+					const $scope2_id = _scope_id();
+					_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope2_id, "#text/0")}</span>`);
+					_subscribe($count__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "6:6"));
+					return 0;
+				}
+			}, $scope1_id, "#text/0", $sg__input_inner, $sg__input_inner, $sg__input_inner, void 0, void 0, [0]);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:4");
+			return 0;
+		}
+	}, $scope0_id, "#text/1", _serialize_guard($scope0_reason, 0), $sg__input_outer, $sg__input_outer, void 0, void 0, ["__tests__/template.marko_1_shell"]);
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/2")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		input_inner: input.inner,
+		count,
+		"ClosureScopes:count": $count__closures
+	}, "__tests__/template.marko", 0, {
+		input_inner: ["input.inner"],
+		count: "1:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
@@ -1,0 +1,33 @@
+// template.marko
+_renderer_shells({ a0: ",`a0;b%;<p>promo</p><!><!>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_inner = _serialize_guard($scope0_reason, 2), $sg__input_outer = _serialize_guard($scope0_reason, 1);
+	const $scope0_id = _scope_id();
+	const $count__closures = /* @__PURE__ */ new Set();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_if(() => {
+		if (input.outer) {
+			const $scope1_id = _scope_id();
+			_html("<p>promo</p>");
+			_if(() => {
+				if (input.inner) {
+					const $scope2_id = _scope_id();
+					_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope2_id, "a")}</span>`);
+					_subscribe($count__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }));
+					return 0;
+				}
+			}, $scope1_id, "a", $sg__input_inner, $sg__input_inner, $sg__input_inner, void 0, void 0, [0]);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+			return 0;
+		}
+	}, $scope0_id, "b", _serialize_guard($scope0_reason, 0), $sg__input_outer, $sg__input_outer, void 0, void 0, ["a0"]);
+	_html(`<button>+</button>${_el_resume($scope0_id, "c")}</main>`);
+	_script($scope0_id, "a2");
+	$scope0_reason && writeScope($scope0_id, {
+		h: input.inner,
+		i: count,
+		k: $count__closures
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko_1_shell;b%;<p>promo</p><!><!>`,{"PatchText:#text/0":"Store!","PatchBranch:#text/1":[{"PatchBranch:#text/0":0},"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko_1_shell"]}]
+
+
+// PATCH
+
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko_1_shell;b%;<p>promo</p><!><!>`,{"PatchText:#text/0":"Store!","PatchBranch:#text/1":[{"PatchBranch:#text/0":1},"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko_1_shell"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+[`a0;b%;<p>promo</p><!><!>`,{ta:"Store!",bb:[{ba:0},"a0"]}]
+
+
+// PATCH
+
+[`a0;b%;<p>promo</p><!><!>`,{ta:"Store!",bb:[{ba:1},"a0"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/render.debug.md
@@ -1,0 +1,54 @@
+# Render `{"title":"Store","outer":true,"inner":false}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","outer":true,"inner":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update `{"title":"Store!","outer":true,"inner":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+```
+
+## Patch rejected (navigate)

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/render.md
@@ -1,0 +1,54 @@
+# Render `{"title":"Store","outer":true,"inner":false}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","outer":true,"inner":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update `{"title":"Store!","outer":true,"inner":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    promo
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+```
+
+## Patch rejected (navigate)

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1><!--M_[-->
+  <p>promo</p>
+  <!--M_[--><!--M_]2 #text/0--><!--M_]1 #text/1 2--><button>+</button><!--M_*1 #button/2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      input_inner: !1,
+      count: 0,
+      "ClosureScopes:count": new Set
+    }, {
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/writes.html
@@ -1,0 +1,16 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1><!--M_[-->
+  <p>promo</p>
+  <!--M_[--><!--M_]2 a--><!--M_]1 b 2--><button>+</button><!--M_*1 c-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    h: !1,
+    i: 0,
+    k: new Set
+  }, {
+    _: _(1)
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7409,
+      "brotli": 3360
+    }
+  },
+  "html": {
+    "min": 463,
+    "brotli": 305
+  },
+  "patch": {
+    "min": 120,
+    "brotli": 73
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/template.marko
@@ -1,0 +1,11 @@
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <if=input.outer>
+    <p>promo</p>
+    <if=input.inner>
+      <span>Seen ${count}</span>
+    </if>
+  </if>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+// Root state read two branch levels deep is a dynamic closure the INIT
+// cannot render yet: the inner shell drops, pairing still patches, and
+// diverging to the inner branch rejects the patch (a document navigation).
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { title: "Store", outer: true, inner: false },
+    { title: "Store!", outer: true, inner: false },
+    { title: "Store!", outer: true, inner: true },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7264,
-      "brotli": 3291
+      "min": 7408,
+      "brotli": 3331
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6900,
-      "brotli": 3145
+      "min": 6989,
+      "brotli": 3163
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,29 @@
+// template.marko
+const $template = "<main><h1> </h1><p>Last <!></p><!></main>";
+const $walks = "E lDb%l%l";
+const $if_content__count = /*@__PURE__*/ _fill_let_change("__tests__/template.marko0", "count/2", ($scope) => _text($scope["#text/0"], $scope.count));
+const $if_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
+	$if_content__count($scope, $scope.count + 1);
+}));
+const $if_content__setup = ($scope) => {
+	$if_content__count($scope, 0, $valueChange($scope));
+	$if_content__setup__script($scope);
+};
+const $last = /*@__PURE__*/ _let("last/7", ($scope) => _text($scope["#text/1"], $scope.last));
+function $setup($scope) {
+	$last($scope, 0);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $if = /*@__PURE__*/ _if("#text/2", "<span>Seen <!></span><button>+</button>", "Db%l ", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_show($scope, input.show);
+};
+function $valueChange($scope) {
+	return function(next) {
+		$last($scope._, next);
+	};
+}
+_resume("__tests__/template.marko_1/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $if_content__count = /*@__PURE__*/ _fill_let_change("a0", 2, ($scope) => _text($scope.a, $scope.c));
+const $if_content__setup__script = _script("a2", ($scope) => _on($scope.b, "click", function() {
+	$if_content__count($scope, $scope.c + 1);
+}));
+const $last = /*@__PURE__*/ _let(7, ($scope) => _text($scope.b, $scope.h));
+function $valueChange($scope) {
+	return function(next) {
+		$last($scope._, next);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,31 @@
+// template.marko
+_renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.marko_1_shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "#text/0")}</span><button>+</button>${_el_resume($scope1_id, "#button/1")}`);
+			_script($scope1_id, "__tests__/template.marko_1");
+			_patch_value($scope1_id, "__tests__/template.marko0", count, 1);
+			_patch_bind($scope1_id, "TagVariableChange:count", _resume(function(next) {
+				last = next;
+			}, "__tests__/template.marko_1/valueChange", $scope1_id) || void 0);
+			writeScope($scope1_id, {
+				count,
+				_: _scope_with_id($scope0_id),
+				"TagVariableChange:count": _resume(function(next) {
+					last = next;
+				}, "__tests__/template.marko_1/valueChange", $scope1_id) || void 0
+			}, "__tests__/template.marko", "5:4", { count: "6:10" });
+			return 0;
+		}
+	}, $scope0_id, "#text/2", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
@@ -1,0 +1,31 @@
+// template.marko
+_renderer_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "a")}</span><button>+</button>${_el_resume($scope1_id, "b")}`);
+			_script($scope1_id, "a2");
+			_patch_value($scope1_id, "a0", count, 1);
+			_patch_bind($scope1_id, "d", _resume(function(next) {
+				last = next;
+			}, "a0", $scope1_id) || void 0);
+			writeScope($scope1_id, {
+				c: count,
+				_: _scope_with_id($scope0_id),
+				d: _resume(function(next) {
+					last = next;
+				}, "a0", $scope1_id) || void 0
+			});
+			return 0;
+		}
+	}, $scope0_id, "c", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["a1"]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+{"PatchText:#text/0":"Store!","PatchBranch:#text/2":0}
+
+
+// PATCH
+
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1_shell packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`,{"PatchText:#text/0":"Store!","PatchBranch:#text/2":[{"PatchFresh:":{"PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko0":0,"PatchBind:TagVariableChange:count":"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1/valueChange"}},"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1_shell"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+{ta:"Store!",bc:0}
+
+
+// PATCH
+
+[`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`,{ta:"Store!",bc:[{f:{va0:0,dd:"a0"}},"a1"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/render.debug.md
@@ -1,0 +1,89 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+INSERT: main > p + :is(span, button)
+UPDATE: main > span::text@5 "" => "0"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 1
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@5 "0" => "1"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/render.md
@@ -1,0 +1,89 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+INSERT: main > p + :is(span, button)
+UPDATE: main > span::text@5 "" => "0"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 1
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@5 "0" => "1"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <p>Last <!>0<!--M_*1 #text/1--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 #text/0--></span><button>+</button><!--M_*2 #button/1--><!--M_]1 #text/2 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      count: 0,
+      _: _(1),
+      "TagVariableChange:count": _(2,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko_1 2"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <p>Last <!>0<!--M_*1 b--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 a--></span><button>+</button><!--M_*2 b--><!--M_]1 c 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    c: 0,
+    _: _(1),
+    d: _(2, "a0")
+  }], "a2 2"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7472,
+      "brotli": 3348
+    }
+  },
+  "html": {
+    "min": 487,
+    "brotli": 309
+  },
+  "patch": {
+    "min": 119,
+    "brotli": 119
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/template.marko
@@ -1,0 +1,10 @@
+<let/last=0/>
+<main>
+  <h1>${input.title}</h1>
+  <p>Last ${last}</p>
+  <if=input.show>
+    <let/count=0 valueChange(next) { last = next }/>
+    <span>Seen ${count}</span>
+    <button onClick() { count++ }>+</button>
+  </if>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/test.ts
@@ -1,0 +1,19 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A scope-capturing change handler (it assigns a root let) rides the
+// fresh seed as a scope-bound reference: after a construct it must reach
+// the LIVE scopes, not the wire stash it arrived on.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { title: "Store", show: true },
+    { title: "Store!", show: false },
+    { title: "Store!", show: true },
+    click,
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+const $template = "<main><h1> </h1><p>Last <!></p><!></main>";
+const $walks = "E lDb%l%l";
+const $if_content__count = /*@__PURE__*/ _fill_let_change("__tests__/template.marko0", "count/2", ($scope) => _text($scope["#text/0"], $scope.count));
+const $if_content__handler = /*@__PURE__*/ _if_closure("#text/2", 0, ($scope) => $if_content__count($scope, 0, $scope._.handler));
+const $if_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
+	$if_content__count($scope, $scope.count + 1);
+}));
+const $if_content__setup = ($scope) => {
+	$if_content__handler._($scope);
+	$if_content__setup__script($scope);
+};
+const $last = /*@__PURE__*/ _let("last/7", ($scope) => _text($scope["#text/1"], $scope.last));
+const $handler2 = /*@__PURE__*/ _let("handler/8");
+function $setup($scope) {
+	$last($scope, 0);
+	$handler2($scope, $handler($scope));
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $if = /*@__PURE__*/ _if("#text/2", "<span>Seen <!></span><button>+</button>", "Db%l ", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_show($scope, input.show);
+};
+function $handler($scope) {
+	return (next) => {
+		$last($scope, next);
+	};
+}
+_resume("__tests__/template.marko_0/handler", $handler);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $if_content__count = /*@__PURE__*/ _fill_let_change("a0", 2, ($scope) => _text($scope.a, $scope.c));
+const $if_content__setup__script = _script("a2", ($scope) => _on($scope.b, "click", function() {
+	$if_content__count($scope, $scope.c + 1);
+}));
+const $last = /*@__PURE__*/ _let(7, ($scope) => _text($scope.b, $scope.h));
+function $handler($scope) {
+	return (next) => {
+		$last($scope, next);
+	};
+}
+_resume("a0", $handler);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,28 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	let handler = _resume((next) => {
+		last = next;
+	}, "__tests__/template.marko_0/handler", $scope0_id);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "#text/0")}</span><button>+</button>${_el_resume($scope1_id, "#button/1")}`);
+			_script($scope1_id, "__tests__/template.marko_1");
+			_patch_value($scope1_id, "__tests__/template.marko0", count, 1);
+			_patch_bind($scope1_id, "TagVariableChange:count", handler || void 0);
+			writeScope($scope1_id, {
+				count,
+				"TagVariableChange:count": handler || void 0
+			}, "__tests__/template.marko", "6:4", { count: "7:10" });
+			return 0;
+		}
+	}, $scope0_id, "#text/2", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, [0]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, { handler }, "__tests__/template.marko", 0, { handler: "2:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
@@ -1,0 +1,28 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	let handler = _resume((next) => {
+		last = next;
+	}, "a0", $scope0_id);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "a")}</span><button>+</button>${_el_resume($scope1_id, "b")}`);
+			_script($scope1_id, "a2");
+			_patch_value($scope1_id, "a0", count, 1);
+			_patch_bind($scope1_id, "d", handler || void 0);
+			writeScope($scope1_id, {
+				c: count,
+				d: handler || void 0
+			});
+			return 0;
+		}
+	}, $scope0_id, "c", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, [0]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, { i: handler });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/patches.debug.js
@@ -1,0 +1,12 @@
+{"PatchText:#text/0":"Store!","PatchBranch:#text/2":[{"PatchFresh:":{"PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko0":0,"PatchWrite:TagVariableChange:count":_._["packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko_0/handler"]}}]}
+
+
+// PATCH
+
+{"PatchText:#text/0":"Store!","PatchBranch:#text/2":0}
+
+
+// PATCH
+
+{"PatchText:#text/0":"Store!","PatchBranch:#text/2":[{"PatchFresh:":{"PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko0":0,"PatchWrite:TagVariableChange:count":_._["packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko_0/handler"]}}]}
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/patches.js
@@ -1,0 +1,12 @@
+{ta:"Store!",bc:[{f:{va0:0,wd:_._.a0}}]}
+
+
+// PATCH
+
+{ta:"Store!",bc:0}
+
+
+// PATCH
+
+{ta:"Store!",bc:[{f:{va0:0,wd:_._.a0}}]}
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/render.debug.md
@@ -1,0 +1,75 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+```
+
+## Patch rejected (navigate)

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/render.md
@@ -1,0 +1,75 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+```
+
+## Patch rejected (navigate)

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/writes.debug.html
@@ -1,0 +1,19 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <p>Last <!>0<!--M_*1 #text/1--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 #text/0--></span><button>+</button><!--M_*2 #button/1--><!--M_]1 #text/2 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      handler: _.a = _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko_0/handler"
+        )
+    }, {
+      count: 0,
+      "TagVariableChange:count": _.a
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko_1 2"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/writes.html
@@ -1,0 +1,15 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <p>Last <!>0<!--M_*1 b--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 a--></span><button>+</button><!--M_*2 b--><!--M_]1 c 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    i: _.a = _(1, "a0")
+  }, {
+    c: 0,
+    d: _.a
+  }], "a2 2"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7462,
+      "brotli": 3343
+    }
+  },
+  "html": {
+    "min": 492,
+    "brotli": 313
+  },
+  "patch": {
+    "min": 101,
+    "brotli": 56
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/template.marko
@@ -1,0 +1,11 @@
+<let/last=0/>
+<let/handler=(next: number) => { last = next }/>
+<main>
+  <h1>${input.title}</h1>
+  <p>Last ${last}</p>
+  <if=input.show>
+    <let/count=0 valueChange=handler/>
+    <span>Seen ${count}</span>
+    <button onClick() { count++ }>+</button>
+  </if>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+// A change handler from ANOTHER section would bind its factory to the
+// wrong scope on construct, so the shell drops: pairing still patches,
+// and diverging to the branch rejects (a document navigation).
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { title: "Store", show: true },
+    { title: "Store!", show: true },
+    { title: "Store!", show: false },
+    { title: "Store!", show: true },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+const $template = "<main><h1> </h1><p>Last <!></p><!></main>";
+const $walks = "E lDb%l%l";
+const $if_content__count = /*@__PURE__*/ _fill_let_change("__tests__/template.marko0", "count/3", ($scope) => _text($scope["#text/0"], $scope.count));
+const $if_content__handler = /*@__PURE__*/ _let("handler/2", ($scope) => $if_content__count($scope, 0, $scope.handler));
+const $if_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/1"], "click", function() {
+	$if_content__count($scope, $scope.count + 1);
+}));
+const $if_content__setup = ($scope) => {
+	$if_content__handler($scope, $handler($scope));
+	$if_content__setup__script($scope);
+};
+const $last = /*@__PURE__*/ _let("last/7", ($scope) => _text($scope["#text/1"], $scope.last));
+function $setup($scope) {
+	$last($scope, 0);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $if = /*@__PURE__*/ _if("#text/2", "<span>Seen <!></span><button>+</button>", "Db%l ", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_show($scope, input.show);
+};
+function $handler($scope) {
+	return (next) => {
+		$last($scope._, next);
+	};
+}
+_resume("__tests__/template.marko_1/handler", $handler);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $if_content__count = /*@__PURE__*/ _fill_let_change("a0", 3, ($scope) => _text($scope.a, $scope.d));
+const $if_content__setup__script = _script("a2", ($scope) => _on($scope.b, "click", function() {
+	$if_content__count($scope, $scope.d + 1);
+}));
+const $last = /*@__PURE__*/ _let(7, ($scope) => _text($scope.b, $scope.h));
+function $handler($scope) {
+	return (next) => {
+		$last($scope._, next);
+	};
+}
+_resume("a0", $handler);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+_renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.marko_1_shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let handler = _resume((next) => {
+				last = next;
+			}, "__tests__/template.marko_1/handler", $scope1_id);
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "#text/0")}</span><button>+</button>${_el_resume($scope1_id, "#button/1")}`);
+			_script($scope1_id, "__tests__/template.marko_1");
+			_patch_value($scope1_id, "__tests__/template.marko0", count, 1);
+			_patch_bind($scope1_id, "TagVariableChange:count", handler || void 0);
+			writeScope($scope1_id, {
+				count,
+				_: _scope_with_id($scope0_id),
+				"TagVariableChange:count": handler || void 0
+			}, "__tests__/template.marko", "5:4", { count: "7:10" });
+			return 0;
+		}
+	}, $scope0_id, "#text/2", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+_renderer_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	let last = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			let handler = _resume((next) => {
+				last = next;
+			}, "a0", $scope1_id);
+			let count = 0;
+			_html(`<span>Seen <!>${_escape(count)}${_el_resume($scope1_id, "a")}</span><button>+</button>${_el_resume($scope1_id, "b")}`);
+			_script($scope1_id, "a2");
+			_patch_value($scope1_id, "a0", count, 1);
+			_patch_bind($scope1_id, "e", handler || void 0);
+			writeScope($scope1_id, {
+				d: count,
+				_: _scope_with_id($scope0_id),
+				e: handler || void 0
+			});
+			return 0;
+		}
+	}, $scope0_id, "c", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["a1"]);
+	_html("</main>");
+	$scope0_reason && writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+{"PatchText:#text/0":"Store!","PatchBranch:#text/2":0}
+
+
+// PATCH
+
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1_shell packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`,{"PatchText:#text/0":"Store!","PatchBranch:#text/2":[{"PatchFresh:":{"PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko0":0,"PatchBind:TagVariableChange:count":"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1/handler"}},"packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1_shell"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+{ta:"Store!",bc:0}
+
+
+// PATCH
+
+[`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`,{ta:"Store!",bc:[{f:{va0:0,de:"a0"}},"a1"]}]
+

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/render.debug.md
@@ -1,0 +1,84 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+INSERT: main > p + :is(span, button)
+UPDATE: main > span::text@5 "" => "0"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 1
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@5 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/render.md
@@ -1,0 +1,84 @@
+# Render `{"title":"Store","show":true}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update `{"title":"Store!","show":false}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+REMOVE: main > p + span
+REMOVE: main > p + button
+```
+
+# Update `{"title":"Store!","show":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 0
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store!" => "Store!"
+INSERT: main > p + :is(span, button)
+UPDATE: main > span::text@5 "" => "0"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Last 1
+  </p>
+  <span>
+    Seen 0
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@5 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <p>Last <!>0<!--M_*1 #text/1--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 #text/0--></span><button>+</button><!--M_*2 #button/1--><!--M_]1 #text/2 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      count: 0,
+      _: _(1),
+      "TagVariableChange:count": _(2,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1/handler"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko_1 2"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <p>Last <!>0<!--M_*1 b--></p><!--M_[--><span>Seen <!>
+      0<!--M_*2 a--></span><button>+</button><!--M_*2 b--><!--M_]1 c 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    d: 0,
+    _: _(1),
+    e: _(2, "a0")
+  }], "a2 2"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 7464,
+      "brotli": 3346
+    }
+  },
+  "html": {
+    "min": 487,
+    "brotli": 309
+  },
+  "patch": {
+    "min": 119,
+    "brotli": 119
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/template.marko
@@ -1,0 +1,11 @@
+<let/last=0/>
+<main>
+  <h1>${input.title}</h1>
+  <p>Last ${last}</p>
+  <if=input.show>
+    <let/handler=(next: number) => { last = next }/>
+    <let/count=0 valueChange=handler/>
+    <span>Seen ${count}</span>
+    <button onClick() { count++ }>+</button>
+  </if>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/test.ts
@@ -1,0 +1,18 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A capturing change handler reached through an identifier (not inline):
+// boundness is decided on the rendered value, so the construct still
+// binds it to the live scope.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { title: "Store", show: true },
+    { title: "Store!", show: false },
+    { title: "Store!", show: true },
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
@@ -11,9 +11,9 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 			_html(`<p>Seen <!>${_escape(count)}${_el_resume($scope1_id, "#text/0")}</p><button>+</button>${_el_resume($scope1_id, "#button/1")}`);
 			_script($scope1_id, "__tests__/template.marko_1");
 			_patch_value($scope1_id, "__tests__/template.marko0", count, 1);
-			_patch_write($scope1_id, "TagVariableChange:count", _resume(function(next) {
+			_patch_bind($scope1_id, "TagVariableChange:count", _resume(function(next) {
 				document.querySelector("main").dataset.attempt = String(next);
-			}, "__tests__/template.marko_1/valueChange") || void 0, 1);
+			}, "__tests__/template.marko_1/valueChange") || void 0);
 			writeScope($scope1_id, {
 				count,
 				"TagVariableChange:count": _resume(function(next) {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
@@ -11,9 +11,9 @@ var template_default = _template_persisted("a", (input) => {
 			_html(`<p>Seen <!>${_escape(count)}${_el_resume($scope1_id, "a")}</p><button>+</button>${_el_resume($scope1_id, "b")}`);
 			_script($scope1_id, "a2");
 			_patch_value($scope1_id, "a0", count, 1);
-			_patch_write($scope1_id, "d", _resume(function(next) {
+			_patch_bind($scope1_id, "d", _resume(function(next) {
 				document.querySelector("main").dataset.attempt = String(next);
-			}, "a0") || void 0, 1);
+			}, "a0") || void 0);
 			writeScope($scope1_id, {
 				c: count,
 				d: _resume(function(next) {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/render.debug.md
@@ -97,7 +97,27 @@ UPDATE: main > h1::text "Store!" => "Store!"
 INSERT: main > h1 + :is(p, button)
 UPDATE: main > p::text@5 "" => "0"
 ```
-## Console
+
+# Update
+```js
+document.querySelector("button").click();
 ```
-ERROR {}
+```html
+<main
+  data-attempt="1"
+>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Seen 0
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-attempt] "1" => "1"
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/render.md
@@ -97,3 +97,27 @@ UPDATE: main > h1::text "Store!" => "Store!"
 INSERT: main > h1 + :is(p, button)
 UPDATE: main > p::text@5 "" => "0"
 ```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main
+  data-attempt="1"
+>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Seen 0
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-attempt] "1" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7327,
-      "brotli": 3304
+      "min": 7471,
+      "brotli": 3344
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7444,
-      "brotli": 3344
+      "min": 7588,
+      "brotli": 3385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7184,
-      "brotli": 3230
+      "min": 7328,
+      "brotli": 3272
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7101,
-      "brotli": 3223
+      "min": 7245,
+      "brotli": 3268
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6663,
-      "brotli": 3057
+      "min": 6752,
+      "brotli": 3088
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3442,
-      "brotli": 1692
+      "min": 3627,
+      "brotli": 1763
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3570,
-        "brotli": 1742
+        "min": 3755,
+        "brotli": 1816
       },
       "files": {
         "tags/price-card.marko": 369,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3723,
-        "brotli": 1769
+        "min": 3908,
+        "brotli": 1840
       },
       "files": {
         "tags/price-card.marko": 369,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2750,
-      "brotli": 1374
+      "min": 2837,
+      "brotli": 1398
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/test.ts
@@ -1,8 +1,9 @@
 import type { TestConfig } from "../../main.test";
 
 // Server-driven `<if>` and unkeyed `<for>` in one persisted template: items
-// pair positionally; the static branch has no walks, so it ships shell-less
-// and diverging back to it rejects the patch (a document navigation).
+// pair positionally, and the walk-less static branch round-trips through
+// its bare shell id (staying shown pairs by selection; a re-show after
+// hiding constructs it).
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3431,
-      "brotli": 1695
+      "min": 3616,
+      "brotli": 1766
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8936,
-      "brotli": 4054
+      "min": 9082,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8936,
-      "brotli": 4054
+      "min": 9082,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8936,
-      "brotli": 4054
+      "min": 9082,
+      "brotli": 4103
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2570,
-      "brotli": 1285
+      "min": 2657,
+      "brotli": 1307
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2570,
-      "brotli": 1286
+      "min": 2657,
+      "brotli": 1309
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -57,6 +57,8 @@ export type TestConfig = {
   error_dom?: boolean;
   error_html?: boolean;
   skip_optimize?: boolean;
+  /** Debug intentionally logs a dev-only diagnostic the optimized build cannot. */
+  skip_parity?: boolean;
   skip_dom?: boolean;
   skip_html?: boolean;
   skip_csr?: boolean;
@@ -375,10 +377,14 @@ function testFixtures(interop?: true) {
                     const frames: string[] = [];
                     for await (const frame of template.renderPatch(input)) {
                       frames.push(frame);
-                      applied = applyPatch(frame) && applied;
+                      // A production caller navigates on the first failed
+                      // frame; later frames must not mutate further.
+                      if (!(applied = applyPatch(frame))) break;
                     }
                     patches.push(frames.join(""));
                     tracker.logUpdate(input);
+                    if (!applied)
+                      tracker.logStatus("## Patch rejected (navigate)");
                     return applied;
                   }
                 : undefined,
@@ -499,6 +505,30 @@ function testFixtures(interop?: true) {
                 config.error_dom,
                 "csr",
               ));
+        });
+      }
+
+      // A diverging render log means tree shaking or debug-only assertions
+      // changed behavior (silently, since each mode snapshots separately).
+      // An `after` hook: it must observe the snapshots THIS run wrote.
+      if (!config.skip_optimize && !config.skip_parity) {
+        after(function parity() {
+          const snapshotsDir = resolve("__snapshots__");
+          for (const name of fs.existsSync(snapshotsDir)
+            ? fs.readdirSync(snapshotsDir)
+            : []) {
+            if (name.startsWith("render") && !name.includes(".debug.")) {
+              const debugName = name.replace(/\.md$/, ".debug.md");
+              const debugFile = path.join(snapshotsDir, debugName);
+              if (fs.existsSync(debugFile)) {
+                assert.strictEqual(
+                  fs.readFileSync(path.join(snapshotsDir, name), "utf8"),
+                  fs.readFileSync(debugFile, "utf8"),
+                  `${name} diverges from ${debugName}`,
+                );
+              }
+            }
+          }
         });
       }
     });

--- a/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
+++ b/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
@@ -63,6 +63,9 @@ export default function createMutationTracker(browser: {
       this.logUpdate(input);
       hasRendered = true;
     },
+    logStatus(status: string) {
+      logs.push(status);
+    },
     logUpdate(update?: unknown) {
       const pending = observer.takeRecords();
       if (pending.length) {

--- a/packages/runtime-tags/src/common/constants/patch-key.debug.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.debug.ts
@@ -1,4 +1,5 @@
 export const Attr = "PatchAttr:";
+export const Bind = "PatchBind:";
 export const Branch = "PatchBranch:";
 export const Child = "PatchChild:";
 export const Effect = "PatchEffect:";

--- a/packages/runtime-tags/src/common/constants/patch-key.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.ts
@@ -1,6 +1,7 @@
 // Patch wire entry kinds — a namespace of their own: `patchers` dispatch is
 // patch-only, so these never meet live scope accessor prefixes.
 export const Attr = "a";
+export const Bind = "d";
 export const Branch = "b";
 export const Child = "c";
 export const Effect = "e";

--- a/packages/runtime-tags/src/dom/patch-effect.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-effect.feat.ts
@@ -1,5 +1,6 @@
 import type { Accessor, Scope } from "../common/types";
 import { AccessorProp, PatchKey } from "../common/types";
+import { kStamps } from "./patch-value.feat";
 import { queueEffect, runId } from "./queue";
 import { getRegisteredWithScope, patchers } from "./resume";
 
@@ -8,19 +9,9 @@ type Stamped = Scope & {
   [kSeen]?: Record<string, number>;
 };
 
-// Change stamps bump per accessor on write; each effect scope remembers the
-// last stamp it acted on, so effects re-run exactly when their read changed
-// (the hydrated value is stamp 0).
-const kStamps = Symbol();
+// Each effect scope remembers the last stamp it acted on, so effects
+// re-run exactly when their read changed (the hydrated value is stamp 0).
 const kSeen = Symbol();
-
-patchers[PatchKey.Write] = (scope: Stamped, key, value) => {
-  const accessor = key.slice(PatchKey.Write.length) as Accessor;
-  if (scope[accessor] !== value || !(accessor in scope)) {
-    scope[accessor] = value;
-    (scope[kStamps] ??= {})[accessor] = -~scope[kStamps]![accessor];
-  }
-};
 
 // Key: the effect's register id. Entry: its space-joined read accessors,
 // with an owner-hop count suffixed when the values live up the scope chain

--- a/packages/runtime-tags/src/dom/patch-value.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-value.feat.ts
@@ -1,7 +1,31 @@
+import type { Accessor, Scope } from "../common/types";
 import { PatchKey } from "../common/types";
-import { patchers } from "./resume";
+import { getRegisteredWithScope, patchers } from "./resume";
 import { patchFills } from "./signals";
 
 // A miss is a fill whose intersection was tree-shaken: nothing to update.
 patchers[PatchKey.Value] = (scope, key, value) =>
   patchFills[key.slice(PatchKey.Value.length)]?.(scope, value);
+
+// Plain patched writes; change stamps bump per accessor so `patch-effect`
+// re-runs readers exactly when their read changed.
+export const kStamps = Symbol();
+
+type Stamped = Scope & { [kStamps]?: Record<Accessor, number> };
+
+patchers[PatchKey.Write] = (scope: Stamped, key, value) => {
+  const accessor = key.slice(PatchKey.Write.length) as Accessor;
+  if (scope[accessor] !== value || !(accessor in scope)) {
+    scope[accessor] = value;
+    (scope[kStamps] ??= {})[accessor] = -~scope[kStamps]![accessor];
+  }
+};
+
+// Construct wiring shipped as a register id: resolve it bound to the LIVE
+// scope being constructed (a factory receives the scope).
+patchers[PatchKey.Bind] = (scope, key, id) => {
+  scope[key.slice(PatchKey.Bind.length) as Accessor] = getRegisteredWithScope(
+    id as string,
+    scope,
+  );
+};

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -66,6 +66,7 @@ export {
   _id,
   _if,
   _patch_attr,
+  _patch_bind,
   _patch_child,
   _patch_effect,
   _patch_text,

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -34,6 +34,7 @@ import {
 import {
   K_SCOPE_ID,
   quote,
+  getRegistered,
   register as serializerRegister,
   type ScopeFlush,
   Serializer,
@@ -204,6 +205,11 @@ export function _resume<T extends WeakKey>(
   id: string,
   scopeId?: number,
 ): T {
+  // Patch renders drop scope refs, so boundness is remembered separately:
+  // `_patch_bind` re-binds SAME-scope registrations against the live scope.
+  if (scopeId !== undefined && $chunk.boundary.state.writesPatches) {
+    ($chunk.boundary.state.patchBoundIds ??= new Map()).set(id, scopeId);
+  }
   return serializerRegister(
     id,
     val,
@@ -358,10 +364,29 @@ export function _patch_value(
   return "";
 }
 
-// A patched scope write for effect-read values: no client registration —
-// the wire drives the accessor, and `_patch_effect` entries re-run readers.
-// Fresh writes nest under `f` for freshly constructed scopes only; they
-// apply AFTER the seeds, so a controllable seed cannot clobber its handler.
+// Fresh construct wiring: a value registered against THIS scope ships its
+// id to bind against the constructed live scope; anything else writes.
+export function _patch_bind(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+) {
+  const { state } = $chunk.boundary;
+  if (state.writesPatches) {
+    const registered = !!value && getRegistered(value as WeakKey);
+    const partial = patchPartial(state, scopeId);
+    const fresh = (partial[PatchKey.Fresh] ??= {}) as Record<string, unknown>;
+    if (registered && state.patchBoundIds?.get(registered.id) === scopeId) {
+      fresh[PatchKey.Bind + accessor] = registered.id;
+    } else {
+      fresh[PatchKey.Write + accessor] = value;
+    }
+  }
+  return "";
+}
+
+// A patched scope write: fresh entries nest under `f` AFTER the seeds, so
+// a controllable seed cannot clobber its handler.
 export function _patch_write(
   scopeId: number,
   accessor: Accessor,
@@ -1253,6 +1278,7 @@ export class State implements SerializeState {
   declare writesPatches?: boolean;
   declare rootScopeId?: number;
   declare patchPartials?: Record<number, Record<string, unknown>>;
+  declare patchBoundIds?: Map<string, number>;
   declare patchPending?: Record<number, [parentScopeId: number, key: string]>;
   declare patchFlushed?: 1;
   declare patchDeferred?: 1;

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -67,6 +67,7 @@ import {
   isSameReason,
   type SerializeReason,
 } from "./serialize-reasons";
+import { dropSectionShell } from "./shell";
 import { simplifyFunction } from "./simplify-fn";
 import { createSectionState } from "./state";
 import { toFirstExpressionOrBlock } from "./to-first-expression-or-block";
@@ -1555,14 +1556,25 @@ export function writeHTMLResumeStatements(
       );
       const change = getSerializedAccessors(section).get(changeAccessor);
       if (change) {
+        // A handler read from another section's binding would bind its
+        // factory to the wrong scope on construct, so the shell drops.
+        const changeFn =
+          change.expression.type === "LogicalExpression"
+            ? change.expression.left
+            : change.expression;
+        const changeRead = changeFn.extra?.read;
+        if (changeRead && changeRead.binding.section !== section) {
+          dropSectionShell(section);
+        }
+        // The runtime decides bind-vs-write on the rendered value, so any
+        // section-local handler expression shape wires.
         body.push(
           t.expressionStatement(
             callRuntime(
-              "_patch_write",
+              "_patch_bind",
               scopeIdIdentifier,
               t.stringLiteral(changeAccessor),
               t.cloneNode(change.expression, true),
-              t.numericLiteral(1),
             ),
           ),
         );


### PR DESCRIPTION
Fixes a masked bug in the merged construct-wiring stage and hardens the harness so its class cannot recur.

The fresh change-handler write dispatched to a patcher living in `patch-effect.feat`, which templates without effect reads never import — the construct threw, the patch rejected, and the harness's silent break left snapshots indistinguishable from success. The `w` patcher (with its stamps) now lives in `patch-value.feat` (patch-effect imports it). Underneath that, scope-capturing change handlers were still no-ops after a construct: patches cannot use the page serializer's scope-bound form (`PatchState.scopeRef()` is undefined), so the bare registry reference resolved the unbound factory. They now ship a `d` (Bind) entry — the register id, resolved via `getRegisteredWithScope(id, scope)` against the live constructed scope; non-capturing handlers keep the plain write.

Harness: debug and optimize render logs must now be identical (`skip_parity` opts out dev-only diagnostics; one fixture suite-wide), and rejected patches print `## Patch rejected (navigate)` in snapshots — which revealed no fixture exercised runtime rejection at all. `persisted-branch-let-change-accept` proves live-scope binding, `persisted-branch-closure-deep` pins the depth-2 fail-closed boundary, and `persisted-input-branches`' stale rejection comment is corrected.