### PR TITLE
refactor(runtime-tags): share branch-tag wiring between if and for

### DIFF
--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -8,8 +8,13 @@ import {
 
 import { WalkCode } from "../../common/types";
 import { assertNoSpreadAttrs } from "../util/assert";
+import {
+  getBranchSectionAccessor,
+  initBranchSection,
+  resumeOwnerByMarkerWhenStatic,
+} from "../util/branch-tag";
 import { detectForSelector, getForSelectorKey } from "../util/for-selector";
-import { getAccessorPrefix, getAccessorProp } from "../util/get-accessor-char";
+import { getAccessorProp } from "../util/get-accessor-char";
 import { getKnownAttrValues } from "../util/get-known-attr-values";
 import { getParentTag } from "../util/get-parent-tag";
 import {
@@ -43,15 +48,12 @@ import { getSerializeGuard } from "../util/serialize-guard";
 import {
   addSerializeExpr,
   getSerializeReason,
-  isStateSerializeReason,
-  isStaticSerializeReason,
 } from "../util/serialize-reasons";
 import {
   addValue,
   getSignal,
   replaceNullishAndEmptyFunctionsWith0,
   setClosureSignalBuilder,
-  setSectionOwnerResumedByMarker,
   writeHTMLResumeStatements,
 } from "../util/signals";
 import * as structure from "../util/structure";
@@ -179,13 +181,11 @@ export default {
         onFinalizeReferences(() => detectForSelector(bodySection, keyBinding));
       }
     }
-    bodySection.sectionAccessor = {
-      binding: nodeBinding,
-      prefix: getAccessorPrefix().BranchScopes,
-    };
-
-    bodySection.upstreamExpression = tagExtra;
-    bodySection.isBranch = true;
+    initBranchSection(
+      bodySection,
+      tagExtra,
+      getBranchSectionAccessor(nodeBinding),
+    );
 
     if (!isAttrTag && !getOnlyChildParentTagName(tag)) {
       structure.visit(tag, WalkCode.Replace);
@@ -236,19 +236,12 @@ export default {
           nodeBinding,
         );
 
-        const statefulSerializeReason = getSerializeReason(
+        resumeOwnerByMarkerWhenStatic(
           tagSection,
+          bodySection,
+          nodeBinding,
           kStatefulReason,
         );
-        if (
-          isStateSerializeReason(statefulSerializeReason) &&
-          isStaticSerializeReason(branchSerializeReason) &&
-          isStaticSerializeReason(markerSerializeReason)
-        ) {
-          // Each branch id rides a resume marker with the parent scope id, and the
-          // stateful loop keeps the branch-visiting signal, so link owner at resume.
-          setSectionOwnerResumedByMarker(bodySection);
-        }
 
         writer.flushInto(tag);
         writeHTMLResumeStatements(tagBody);

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -9,7 +9,11 @@ import {
 import { WalkCode } from "../../common/types";
 import { assertNoSpreadAttrs } from "../util/assert";
 import { bodyToRawTextLiteral, kRawText } from "../util/body-to-text-literal";
-import { getAccessorPrefix } from "../util/get-accessor-char";
+import {
+  getBranchSectionAccessor,
+  initBranchSection,
+  resumeOwnerByMarkerWhenStatic,
+} from "../util/branch-tag";
 import { getParentTag } from "../util/get-parent-tag";
 import { getTagName } from "../util/get-tag-name";
 import { isConditionTag, isCoreTagName } from "../util/is-core-tag";
@@ -43,8 +47,6 @@ import {
 import {
   addSerializeExpr,
   getSerializeReason,
-  isStateSerializeReason,
-  isStaticSerializeReason,
   type SerializeReasons,
 } from "../util/serialize-reasons";
 import {
@@ -52,7 +54,6 @@ import {
   getSignal,
   replaceNullishAndEmptyFunctionsWith0,
   setClosureSignalBuilder,
-  setSectionOwnerResumedByMarker,
   writeHTMLResumeStatements,
 } from "../util/signals";
 import * as structure from "../util/structure";
@@ -90,17 +91,12 @@ export const IfTag = {
         ifTagSection,
         branches.length,
       );
-      const sectionAccessor: Section["sectionAccessor"] = {
-        binding: nodeBinding,
-        prefix: getAccessorPrefix().BranchScopes,
-      };
+      const sectionAccessor = getBranchSectionAccessor(nodeBinding);
       // TODO: remove all branches if none have body content.
 
       for (const [branchTag, branchBodySection] of branches) {
         if (branchBodySection) {
-          branchBodySection.isBranch = true;
-          branchBodySection.upstreamExpression = ifTagExtra;
-          branchBodySection.sectionAccessor = sectionAccessor;
+          initBranchSection(branchBodySection, ifTagExtra, sectionAccessor);
         }
 
         if (branchTag.node.attributes.length) {
@@ -135,24 +131,12 @@ export const IfTag = {
         if (bodySection) {
           const [[ifTag]] = getBranches(tag);
           const ifTagSection = getSection(ifTag);
-          if (
-            isStateSerializeReason(
-              getSerializeReason(ifTagSection, kStatefulReason),
-            ) &&
-            isStaticSerializeReason(
-              getSerializeReason(bodySection, kBranchSerializeReason),
-            ) &&
-            isStaticSerializeReason(
-              getSerializeReason(
-                ifTagSection,
-                getOptimizedOnlyChildNodeBinding(ifTag, ifTagSection),
-              ),
-            )
-          ) {
-            // The branch id rides the always-rendered resume marker and the
-            // state driven condition keeps the signal, so the owner resumes.
-            setSectionOwnerResumedByMarker(bodySection);
-          }
+          resumeOwnerByMarkerWhenStatic(
+            ifTagSection,
+            bodySection,
+            getOptimizedOnlyChildNodeBinding(ifTag, ifTagSection),
+            kStatefulReason,
+          );
           writer.flushInto(tag);
           writeHTMLResumeStatements(tagBody);
         }

--- a/packages/runtime-tags/src/translator/util/branch-tag.ts
+++ b/packages/runtime-tags/src/translator/util/branch-tag.ts
@@ -1,0 +1,51 @@
+import { getAccessorPrefix } from "./get-accessor-char";
+import { type Binding, kBranchSerializeReason } from "./references";
+import type { Section } from "./sections";
+import {
+  getSerializeReason,
+  isStateSerializeReason,
+  isStaticSerializeReason,
+} from "./serialize-reasons";
+import { setSectionOwnerResumedByMarker } from "./signals";
+
+// Shared wiring for branch-owning tags (`<if>`/`<for>`): every branch body
+// hangs off its owner through the same accessor and reason rules, so the
+// two tags cannot drift apart one copy at a time.
+export function getBranchSectionAccessor(
+  nodeBinding: Binding,
+): NonNullable<Section["sectionAccessor"]> {
+  return {
+    binding: nodeBinding,
+    prefix: getAccessorPrefix().BranchScopes,
+  };
+}
+
+export function initBranchSection(
+  bodySection: Section,
+  upstreamExpression: Section["upstreamExpression"],
+  sectionAccessor: Section["sectionAccessor"],
+) {
+  bodySection.isBranch = true;
+  bodySection.upstreamExpression = upstreamExpression;
+  bodySection.sectionAccessor = sectionAccessor;
+}
+
+// The branch id rides the always-rendered resume marker and the state
+// driven selection keeps the branch-visiting signal, so the owner links at
+// resume instead of serializing.
+export function resumeOwnerByMarkerWhenStatic(
+  tagSection: Section,
+  bodySection: Section,
+  nodeBinding: Binding,
+  statefulReasonKey: symbol,
+) {
+  if (
+    isStateSerializeReason(getSerializeReason(tagSection, statefulReasonKey)) &&
+    isStaticSerializeReason(
+      getSerializeReason(bodySection, kBranchSerializeReason),
+    ) &&
+    isStaticSerializeReason(getSerializeReason(tagSection, nodeBinding))
+  ) {
+    setSectionOwnerResumedByMarker(bodySection);
+  }
+}


### PR DESCRIPTION
Extracts the branch-section wiring `<if>` and `<for>` each hand-rolled — the sectionAccessor/isBranch/upstream init and the owner-resumed-by-marker reason check — into one `util/branch-tag.ts`. Behavior-preserving (no snapshot changes); motivated by the persisted-pages work, where a reason-wiring gap existed in one tag's copy but not the other's.