### PR TITLE
refactor(runtime-tags): drop the write-only signal reference fields

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -14,12 +14,6 @@ After `host = rootNode.startNode`, `renderAndMorph` calls `domCompat.setScopeNod
 
 `trackDomVarReferences` opens by throwing "Tag variables on native elements cannot be destructured." for a non-identifier `tag.node.var`, but both call sites already reject one with a better, docs-linked message: `visitors/tag/native-tag.ts` throws at the top of the same `analyze.enter` that later calls it, and `core/html-comment.ts` throws its `<html-comment>` variant before its call. The branch is dead, and it is the only place in the package that says "native elements" instead of CONTEXT.md's "native tag". Drop it, keeping the non-null cast, so the one live message is the linked one. Re-verify: compiling `<div/{a}/>` reports the native-tag.ts wording with the docs link, and `rg -n "cannot be destructured" packages/runtime-tags/src --glob '!**/__snapshots__/**'` shows one message per owner.
 
-## Drop the write-only `renderReferencedBindings`/`effectReferencedBindings` signal fields
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `addRenderReferences` | 2026-07-23 | impact:low | effort:low
-
-`Signal.renderReferencedBindings` and `Signal.effectReferencedBindings` are declared, initialized in `getSignal`, and written by `addRenderReferences`/`addEffectReferences`, but nothing in the workspace reads them. Every `addStatement` and `addValue` therefore pays a `bindingUtil.union` — `unionSortedRepeatable` in `util/optional.ts`, which allocates a fresh array per call — to build state that is discarded. Deleting the two fields also makes `addStatement`'s `usedReferences` parameter dead, so its call sites can drop it. Re-verify: `rg -n "renderReferencedBindings|effectReferencedBindings" packages/` returns only the declaration, the two `getSignal` initializers, and the two assignment helpers in `signals.ts`, with no reader.
-
 ## Stop re-exporting `forOfBy`/`forInBy`/`forStepBy` from the html runtime entry
 
 `packages/runtime-tags/src/html.ts` › `export { … } from "./html/for"` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -251,7 +251,6 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
           getScopeAccessorLiteral(binding),
         ),
       ),
-      undefined,
       true,
     );
 
@@ -269,7 +268,6 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
             value,
           ),
         ),
-        undefined,
         !valueRef,
       );
     });

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -879,7 +879,6 @@ function writeParamsToSignals(
               arg,
             ]),
           ),
-          undefined,
           true,
         );
       }
@@ -966,7 +965,6 @@ function applyAttrObject(
         translatedProps,
       ]),
     ),
-    undefined,
     true,
   );
 }
@@ -1256,7 +1254,6 @@ function writeAttrsToSignals(
               ],
             ),
           ),
-          undefined,
           true,
         );
       }
@@ -1318,7 +1315,6 @@ function writeAttrsToSignals(
           attr.value, // TODO: use spreadBinding property alias after we optimize `in`
         ]),
       ),
-      undefined,
       true,
     );
   }
@@ -1344,7 +1340,6 @@ function writeAttrsToSignals(
             createScopeReadExpression(propBinding, info.tagSection),
           ]),
         ),
-        undefined,
         true,
       );
     }
@@ -1426,7 +1421,6 @@ function writeAttrsToSignals(
             ],
           ),
         ),
-        undefined,
         true,
       );
     }
@@ -1472,7 +1466,6 @@ function writeAttrsToSignals(
             ],
           ),
         ),
-        undefined,
         true,
       );
     }

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -19,7 +19,6 @@ import {
   type AssignedBindingExtra,
   type Binding,
   BindingType,
-  bindingUtil,
   collapsedIntersectionSource,
   getCanonicalBinding,
   getClosureAccessorId,
@@ -81,9 +80,7 @@ export interface Signal {
   }>;
   intersection: Opt<Signal>;
   render: t.Statement[];
-  renderReferencedBindings: ReferencedBindings;
   effect: t.Statement[];
-  effectReferencedBindings: ReferencedBindings;
   hasHTMLEffect: boolean;
   hasSideEffect: boolean;
   forcePersist: boolean;
@@ -262,9 +259,7 @@ export function getSignal(
         values: [],
         intersection: undefined,
         render: [],
-        renderReferencedBindings: undefined,
         effect: [],
-        effectReferencedBindings: undefined,
         hasHTMLEffect: false,
         build: undefined,
         export: !!exportName,
@@ -850,12 +845,10 @@ export function addStatement(
   targetSection: Section,
   referencedBindings: ReferencedBindings,
   statement: t.Statement | t.Statement[],
-  usedReferences?: ReferencedBindings[] | false,
   isPure?: boolean,
 ): void {
   const signal = getSignal(targetSection, referencedBindings);
   const statements = (signal[type] ??= []);
-  const add = type === "effect" ? addEffectReferences : addRenderReferences;
 
   if (Array.isArray(statement)) {
     statements.push(...statement);
@@ -863,39 +856,9 @@ export function addStatement(
     statements.push(statement);
   }
 
-  if (usedReferences !== false) {
-    if (usedReferences) {
-      for (const ref of usedReferences) {
-        add(signal, ref);
-      }
-    } else {
-      add(signal, referencedBindings);
-    }
-  }
-
   if (!isPure || type === "effect") {
     signal.hasSideEffect = true;
   }
-}
-
-function addEffectReferences(
-  signal: Signal,
-  referencedBindings: ReferencedBindings,
-) {
-  signal.effectReferencedBindings = bindingUtil.union(
-    signal.effectReferencedBindings,
-    referencedBindings,
-  );
-}
-
-function addRenderReferences(
-  signal: Signal,
-  referencedBindings: ReferencedBindings,
-) {
-  signal.renderReferencedBindings = bindingUtil.union(
-    signal.renderReferencedBindings,
-    referencedBindings,
-  );
 }
 
 export function addValue(
@@ -905,7 +868,6 @@ export function addValue(
   value: t.Expression,
 ) {
   const parentSignal = getSignal(targetSection, referencedBindings);
-  addRenderReferences(parentSignal, referencedBindings);
   parentSignal.values.push({
     signal,
     value,

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -190,7 +190,6 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
                 getScopeAccessorLiteral(nodeBinding!),
               ),
         ),
-        undefined,
         true,
       );
     }

--- a/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
+++ b/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
@@ -123,7 +123,6 @@ export default {
                   t.numericLiteral(exprId),
                 ]),
               ),
-              false,
             );
           }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -836,7 +836,6 @@ export default {
                 getScopeAccessorLiteral(nodeBinding!),
               ),
             ),
-            undefined,
             true,
           );
         }
@@ -953,7 +952,6 @@ export default {
                     tagSection,
                     valueReferences,
                     stmt,
-                    undefined,
                     !!meta.dynamicItems,
                   );
                 }
@@ -991,7 +989,6 @@ export default {
                       value,
                     ),
                   ),
-                  undefined,
                   true,
                 );
               }
@@ -1056,7 +1053,6 @@ export default {
             t.expressionStatement(
               callRuntime("_attrs_script", scopeIdentifier, visitAccessor),
             ),
-            false,
           );
         }
 
@@ -1073,7 +1069,6 @@ export default {
                 staticContentAttr.value,
               ),
             ),
-            undefined,
             true,
           );
         }
@@ -1099,7 +1094,6 @@ export default {
                     textLiteral,
                   ),
                 ),
-                undefined,
                 true,
               );
             }


### PR DESCRIPTION
`Signal.renderReferencedBindings` and `Signal.effectReferencedBindings` fed `createScopeReadPattern`, which emitted a bulk destructure at the top of a signal body (`let { a, b } = $scope`) so the statements could use the destructured locals.

`2bed9ef7d7` ("fix: consistently read latest value from let tags", #2920) replaced that strategy: destructuring snapshots values at signal entry, so a `<let>` reassigned partway through kept reading a stale local. Bindings are now read at each point of use through `createScopeReadExpression` instead, and that PR deleted `createScopeReadPattern` along with every read of these two fields — but left the writers behind.

So since then both fields have been declared, initialized in `getSignal` and written by `addRenderReferences`/`addEffectReferences` with no reader, meaning every `addStatement` and `addValue` paid a `bindingUtil.union` (a fresh array per call) to build state that was discarded.

Removing them makes `addStatement`'s `usedReferences` parameter dead too, so it and the argument at its 17 call sites go with it. Two of those passed `false` rather than `undefined`; dropping the parameter would have silently slid that `false` into the `isPure` slot, which is why they were removed explicitly rather than left to shift.

No generated output changes — the full suite passes with no snapshot or size churn, which is itself the evidence nothing consumed these.

Resolves the corresponding `agent-feedback/cleanup.md` entry.