### PR TITLE
refactor(runtime-tags): stop exporting internal loop-key helpers from the html entry

### DIFF
--- a/.changeset/brave-jars-tap.md
+++ b/.changeset/brave-jars-tap.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Stop exporting the internal `forOfBy`, `forInBy` and `forStepBy` loop-key helpers from the html runtime entry. Generated code has not referenced them since loop keying moved into the runtime.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -14,12 +14,6 @@ After `host = rootNode.startNode`, `renderAndMorph` calls `domCompat.setScopeNod
 
 `trackDomVarReferences` opens by throwing "Tag variables on native elements cannot be destructured." for a non-identifier `tag.node.var`, but both call sites already reject one with a better, docs-linked message: `visitors/tag/native-tag.ts` throws at the top of the same `analyze.enter` that later calls it, and `core/html-comment.ts` throws its `<html-comment>` variant before its call. The branch is dead, and it is the only place in the package that says "native elements" instead of CONTEXT.md's "native tag". Drop it, keeping the non-null cast, so the one live message is the linked one. Re-verify: compiling `<div/{a}/>` reports the native-tag.ts wording with the docs link, and `rg -n "cannot be destructured" packages/runtime-tags/src --glob '!**/__snapshots__/**'` shows one message per owner.
 
-## Stop re-exporting `forOfBy`/`forInBy`/`forStepBy` from the html runtime entry
-
-`packages/runtime-tags/src/html.ts` › `export { … } from "./html/for"` | 2026-07-23 | impact:low | effort:low
-
-`src/html.ts` re-exports seven names from `./html/for`, but codegen emits only four — `translator/core/for.ts` › `forTypeToRuntime` maps the `<for>` kinds to `forOf`/`forIn`/`forTo`/`forUntil`, which is also all `dom.ts` re-exports from `./common/for`. `forOfBy`, `forInBy` and `forStepBy` are internal helpers that `html/writer.ts` imports straight from `./for`; no `callRuntime`/`importRuntime` call site names them. Since `HTMLRuntimeHelpers = keyof typeof import("../../html")` (`translator/util/runtime.ts`), exporting them makes `callRuntime("forOfBy", …)` type-check even though codegen never emits it. Drop the three names from the export block. Re-verify: `rg -n "forOfBy|forInBy|forStepBy" packages/` hits only `src/html/for.ts` and `src/html/writer.ts`, and a `<for by=…>` fixture still renders.
-
 ## Retitle the `_attrs` test or give its event-handler routing real coverage
 
 `packages/runtime-tags/src/__tests__/html-attrs.test.ts` › `it("should strip event handlers, invalid attribute names and content")` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -39,15 +39,7 @@ export {
   _unescaped,
 } from "./html/content";
 export { _content, _content_resume, _dynamic_tag } from "./html/dynamic-tag";
-export {
-  forIn,
-  forInBy,
-  forOf,
-  forOfBy,
-  forStepBy,
-  forTo,
-  forUntil,
-} from "./html/for";
+export { forIn, forOf, forTo, forUntil } from "./html/for";
 export { _template } from "./html/template";
 export {
   _attr_content,


### PR DESCRIPTION
`src/html.ts` re-exported `forOfBy`, `forInBy` and `forStepBy`, but codegen has not emitted them since `15db9a79de` ("move for tag serialization logic into html runtime") deleted those arms from `forTypeToRuntime` — it now emits only `forOf`/`forIn`/`forTo`/`forUntil`. They were added by `c7bcf4b363` when the translator did emit them, and were simply left behind. `html/writer.ts` still uses them, importing straight from `./for`.

This is worth more than a dead-export removal: `HTMLRuntimeHelpers = keyof typeof import("../../html")` is what types `callRuntime`/`importRuntime`, so every extra name in the entry widens that union. `callRuntime("forOfBy", …)` type-checked before this change and is now `TS2820: Type '"forOfBy"' is not assignable … Did you mean '"forOf"'?` — the type actually guards codegen.

No output or bundle-size change. Resolves the corresponding `agent-feedback/cleanup.md` entry.