### PR TITLE
refactor(runtime-class): stop passing a state to the zero-arg compat toJSON

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -14,12 +14,6 @@ After `host = rootNode.startNode`, `renderAndMorph` calls `domCompat.setScopeNod
 
 The test's only two event-handler assertions are commented out (and call a long-gone `helpers.attrs`), and the title is wrong: `_attrs` (`src/html/attrs.ts`) does not strip `on*` names, it collects them into `events` and registers them via `_scope(scopeId, { [AccessorPrefix.EventAttributes + nodeAccessor]: events })`. They cannot simply be uncommented — outside a render `_scope` reads `$chunk.boundary` and throws. Either delete the dead comments and retitle to what the test actually checks (invalid attribute names, and `content` on a non-`<meta>` tag), or drive `_attrs` inside an active writer boundary and assert the handler lands on the scope. Re-verify: `node -r ~ts -e 'require("./packages/runtime-tags/src/html/attrs.ts")._attrs({onClick(){}},"a",0,"")'` throws `TypeError: Cannot read properties of undefined (reading 'boundary')`.
 
-## Drop the ignored `state` argument from the two `htmlCompat.toJSON` call sites
-
-`packages/runtime-tags/src/html/compat.ts` › `compat.toJSON` | 2026-07-23 | impact:low | effort:low
-
-`compat.toJSON()` takes no parameters, yet both call sites in `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` still pass a `State`: `htmlCompat.toJSON(htmlCompat.ensureState(out.global))` and `htmlCompat.toJSON(state)`. The parameter disappeared in 9e043c0724 ("refactor: unify scope serialization and concurrent resume") but the untyped JS callers were never updated, so the code reads as though the returned `toJSON` were bound to one render's `State` when it is not. Keep the `ensureState` calls — they seed `$global.runtimeId`/`renderId` and memoise the `State` — as standalone statements, call `toJSON()` with no argument, and drop the then-unused `const state` local. Re-verify: `rg -n "htmlCompat\.toJSON\(" packages/runtime-class` shows two callers passing an argument while `compat.toJSON` is declared `toJSON()`.
-
 ## Extract one helper for the `attrTag`/`attrTags` merge duplicated in `known-tag.ts`
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `translateAttrTag` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
@@ -93,9 +93,8 @@ exports.p = function (htmlCompat) {
 
     return (input, out) => {
       if (!tagsRenderer && renderBody) {
-        renderBody.toJSON = htmlCompat.toJSON(
-          htmlCompat.ensureState(out.global),
-        );
+        htmlCompat.ensureState(out.global);
+        renderBody.toJSON = htmlCompat.toJSON();
       }
       TagsCompat(
         args
@@ -173,7 +172,7 @@ exports.p = function (htmlCompat) {
     return (input, ...args) => {
       // tags to class
       const $global = htmlCompat.$global();
-      const state = htmlCompat.ensureState($global);
+      htmlCompat.ensureState($global);
       const out = defaultCreateOut($global);
       const branchId = htmlCompat.nextScopeId();
       let forceBoundary = boundaryModeByRenderer.get(tag);
@@ -192,7 +191,7 @@ exports.p = function (htmlCompat) {
               value,
             ]);
             forceBoundary = true;
-            value.toJSON = htmlCompat.toJSON(state);
+            value.toJSON = htmlCompat.toJSON();
           } else {
             input[key === "content" ? "renderBody" : key] = value;
           }


### PR DESCRIPTION
`9e043c0724` changed `compat.toJSON(state: State)` to `toJSON()`, but the two callers in `tags-compat/runtime-html.js` kept passing a `State`. That file is untyped JS, so nothing caught it, and the code reads as though the returned `toJSON` were bound to one render's state when it is not — the closure captures nothing and resolves the scope through the ambient chunk.

`ensureState` is not a pure getter (it memoises `$global[K_TAGS_API_STATE]` and seeds `runtimeId`/`renderId`), so both calls are kept: one is lifted out of the argument position into the statement before, and the other stays as a bare call with its now-unused local dropped. Evaluation order is unchanged.

Safe against version skew: `runtime-class` requires `@marko/runtime-tags@^6.3.26`, and the parameter was already gone in 6.1.4 — the 6.3.26 tag declares `toJSON()`. Passing an extra argument to a zero-parameter function that never reads `arguments` is inert, so this is a no-op that makes the source say what already happens.

Resolves the corresponding `agent-feedback/cleanup.md` entry.