### PR TITLE
feat(runtime-tags): persisted class and style attribute patches (experimental)

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<div><p>content</p><span class=base>badge</span></div>";
+const $walks = " D b l";
+const $setup = () => {};
+const $input_theme = ($scope, input_theme) => _attr_class($scope["#div/0"], input_theme);
+const $input_accent = ($scope, input_accent) => {
+	_attr_style($scope["#p/1"], input_accent);
+	_attr_style($scope["#span/2"], [input_accent, { margin: 0 }]);
+};
+const $input_on = /*@__PURE__*/ _const("input_on", ($scope) => _attr_class_item($scope["#span/2"], "compact", $scope.input_on));
+const $input = ($scope, input) => {
+	$input_theme($scope, input.theme);
+	$input_accent($scope, input.accent);
+	$input_on($scope, input.on);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
-    > 1 | <div class=input.class>content</div>
-        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
-    > 1 | <div class=input.class>content</div>
-        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
-    > 1 | <div class=input.class>content</div>
-        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/error-compile-html.txt
@@ -1,5 +1,0 @@
-
-    at packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko:1:6
-    > 1 | <div class=input.class>content</div>
-        |      ^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
-      2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_patch_attr_class($scope0_id, "#div/0", input.theme)}${_attr_class(input.theme)}><p${_patch_attr_style($scope0_id, "#p/1", input.accent)}${_attr_style(input.accent)}>content</p>${_el_resume($scope0_id, "#p/1")}<span${_patch_attr_class($scope0_id, "#span/2", {
+		base: true,
+		compact: input.on
+	})} class=${input.on ? "\"base compact\"" : "base"}${_patch_attr_style($scope0_id, "#span/2", [input.accent, { margin: 0 }])}${_attr_style([input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "#span/2")}</div>${_el_resume($scope0_id, "#div/0")}`);
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div${_patch_attr_class($scope0_id, "a", input.theme)}${_attr_class(input.theme)}><p${_patch_attr_style($scope0_id, "b", input.accent)}${_attr_style(input.accent)}>content</p>${_el_resume($scope0_id, "b")}<span${_patch_attr_class($scope0_id, "c", {
+		base: true,
+		compact: input.on
+	})} class=${input.on ? "\"base compact\"" : "base"}${_patch_attr_style($scope0_id, "c", [input.accent, { margin: 0 }])}${_attr_style([input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "c")}</div>${_el_resume($scope0_id, "a")}`);
+	$scope0_reason && writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/patches.debug.js
@@ -1,0 +1,23 @@
+// PATCH
+{
+  "PatchAttr:#div/0 class": "dark compact",
+  "PatchAttr:#p/1 style": "color:red",
+  "PatchAttr:#span/2 class": "base compact",
+  "PatchAttr:#span/2 style": "color:red;margin:0"
+}
+
+// PATCH
+{
+  "PatchAttr:#div/0 class": "dark",
+  "PatchAttr:#p/1 style": 0,
+  "PatchAttr:#span/2 class": "base",
+  "PatchAttr:#span/2 style": "margin:0"
+}
+
+// PATCH
+{
+  "PatchAttr:#div/0 class": 0,
+  "PatchAttr:#p/1 style": "color:blue",
+  "PatchAttr:#span/2 class": "base compact",
+  "PatchAttr:#span/2 style": "color:blue;margin:0"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/patches.js
@@ -1,0 +1,23 @@
+// PATCH
+{
+  "aa class": "dark compact",
+  "ab style": "color:red",
+  "ac class": "base compact",
+  "ac style": "color:red;margin:0"
+}
+
+// PATCH
+{
+  "aa class": "dark",
+  "ab style": 0,
+  "ac class": "base",
+  "ac style": "margin:0"
+}
+
+// PATCH
+{
+  "aa class": 0,
+  "ab style": "color:blue",
+  "ac class": "base compact",
+  "ac style": "color:blue;margin:0"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/render.debug.md
@@ -1,0 +1,89 @@
+# Render `{"theme":"light","accent":{"color":"red"},"on":true}`
+```html
+<div
+  class="light"
+>
+  <p
+    style="color:red"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:red;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+
+# Update `{"theme":["dark",{"compact":true}],"accent":{"color":"red"},"on":true}`
+```html
+<div
+  class="dark compact"
+>
+  <p
+    style="color:red"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:red;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .dark.compact[class] "light" => "dark compact"
+```
+
+# Update `{"theme":["dark",{"compact":false}],"on":false}`
+```html
+<div
+  class="dark"
+>
+  <p>
+    content
+  </p>
+  <span
+    class="base"
+    style="margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .dark[class] "dark compact" => "dark"
+UPDATE: .dark > p[style] "color:red" => null
+UPDATE: .base[class] "base compact" => "base"
+UPDATE: .base[style] "color:red;margin:0" => "margin:0"
+```
+
+# Update `{"accent":"color:blue","on":true}`
+```html
+<div>
+  <p
+    style="color:blue"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:blue;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: div[class] "dark" => null
+UPDATE: div > p[style] null => "color:blue"
+UPDATE: .base.compact[class] "base" => "base compact"
+UPDATE: .base.compact[style] "margin:0" => "color:blue;margin:0"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/render.md
@@ -1,0 +1,89 @@
+# Render `{"theme":"light","accent":{"color":"red"},"on":true}`
+```html
+<div
+  class="light"
+>
+  <p
+    style="color:red"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:red;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+
+# Update `{"theme":["dark",{"compact":true}],"accent":{"color":"red"},"on":true}`
+```html
+<div
+  class="dark compact"
+>
+  <p
+    style="color:red"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:red;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .dark.compact[class] "light" => "dark compact"
+```
+
+# Update `{"theme":["dark",{"compact":false}],"on":false}`
+```html
+<div
+  class="dark"
+>
+  <p>
+    content
+  </p>
+  <span
+    class="base"
+    style="margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: .dark[class] "dark compact" => "dark"
+UPDATE: .dark > p[style] "color:red" => null
+UPDATE: .base[class] "base compact" => "base"
+UPDATE: .base[style] "color:red;margin:0" => "margin:0"
+```
+
+# Update `{"accent":"color:blue","on":true}`
+```html
+<div>
+  <p
+    style="color:blue"
+  >
+    content
+  </p>
+  <span
+    class="base compact"
+    style="color:blue;margin:0"
+  >
+    badge
+  </span>
+</div>
+```
+## Change
+```
+UPDATE: div[class] "dark" => null
+UPDATE: div > p[style] null => "color:blue"
+UPDATE: .base.compact[class] "base" => "base compact"
+UPDATE: .base.compact[style] "margin:0" => "color:blue;margin:0"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/writes.debug.html
@@ -1,0 +1,8 @@
+<div class=light>
+  <p style=color:red>content</p><!--M_*1 #p/1--><span class="base compact"
+    style=color:red;margin:0>badge</span><!--M_*1 #span/2-->
+</div><!--M_*1 #div/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<div class=light>
+  <p style=color:red>content</p><!--M_*1 b--><span class="base compact"
+    style=color:red;margin:0>badge</span><!--M_*1 c-->
+</div><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2128,
+      "brotli": 1081
+    }
+  },
+  "html": {
+    "min": 436,
+    "brotli": 268
+  },
+  "patch": {
+    "min": 280,
+    "brotli": 96
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/template.marko
@@ -1,1 +1,4 @@
-<div class=input.class>content</div>
+<div class=input.theme>
+  <p style=input.accent>content</p>
+  <span class={ base: true, compact: input.on } style=[input.accent, { margin: 0 }]>badge</span>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/test.ts
@@ -1,6 +1,13 @@
 import type { TestConfig } from "../../main.test";
 
+// Server-only class/style values normalize on the server and patch as
+// plain attr entries, including removal when the value normalizes empty.
 export const config: TestConfig = {
-  error_compiler: true,
   persisted: true,
+  steps: [
+    { theme: "light", accent: { color: "red" }, on: true },
+    { theme: ["dark", { compact: true }], accent: { color: "red" }, on: true },
+    { theme: ["dark", { compact: false }], accent: undefined, on: false },
+    { theme: undefined, accent: "color:blue", on: true },
+  ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,32 @@
+// template.marko
+const $template = "<main><button>+</button><span>parity</span><!></main>";
+const $walks = "D b b%l";
+const $if_content__input_tone = /*@__PURE__*/ _if_closure("#text/2", 0, ($scope) => _attr_class($scope["#em/0"], $scope._.input_tone));
+const $if_content__setup = $if_content__input_tone;
+const $input_tone__OR__count = /*@__PURE__*/ _fill_join("__tests__/template.marko0", "input_tone", /*@__PURE__*/ _or(8, ($scope) => _attr_class($scope["#button/0"], [
+	"btn",
+	$scope.input_tone,
+	$scope.count % 2 && "odd"
+])));
+const $count = /*@__PURE__*/ _let("count/7", ($scope) => {
+	_attr_class($scope["#span/1"], $scope.count % 2 ? "odd" : "even");
+	$input_tone__OR__count($scope);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_tone = /*@__PURE__*/ _fill_const("__tests__/template.marko0", "input_tone", ($scope) => {
+	$input_tone__OR__count($scope);
+	$if_content__input_tone($scope);
+});
+const $if = /*@__PURE__*/ _if("#text/2", "<em>note</em>", " ", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_tone($scope, input.tone);
+	$input_show($scope, input.show);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const $input_tone__OR__count = /*@__PURE__*/ _fill_join("a0", 5, /*@__PURE__*/ _or(8, ($scope) => _attr_class($scope.a, [
+	"btn",
+	$scope.f,
+	$scope.h % 2 && "odd"
+])));
+const $count = /*@__PURE__*/ _let(7, ($scope) => {
+	_attr_class($scope.b, $scope.h % 2 ? "odd" : "even");
+	$input_tone__OR__count($scope);
+});
+const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.h + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+_renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.marko_1_shell; ;<em>note</em>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 2);
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><button${_attr_class([
+		"btn",
+		input.tone,
+		count % 2 && "odd"
+	])}>+</button>${_el_resume($scope0_id, "#button/0")}<span class=${count % 2 ? "odd" : "even"}>parity</span>${_el_resume($scope0_id, "#span/1")}`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html(`<em${_patch_attr_class($scope1_id, "#em/0", input.tone)}${_attr_class(input.tone)}>note</em>${_el_resume($scope1_id, "#em/0")}`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "8:4");
+			return 0;
+		}
+	}, $scope0_id, "#text/2", _serialize_guard($scope0_reason, 0), $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
+	_html("</main>");
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason ? writeScope($scope0_id, {
+		input_tone: input.tone,
+		count
+	}, "__tests__/template.marko", 0, {
+		input_tone: ["input.tone"],
+		count: "1:6"
+	}) : _patch_value($scope0_id, "__tests__/template.marko0", input.tone);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
@@ -1,0 +1,27 @@
+// template.marko
+_renderer_shells({ a0: ",`a0; ;<em>note</em>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 2);
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><button${_attr_class([
+		"btn",
+		input.tone,
+		count % 2 && "odd"
+	])}>+</button>${_el_resume($scope0_id, "a")}<span class=${count % 2 ? "odd" : "even"}>parity</span>${_el_resume($scope0_id, "b")}`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html(`<em${_patch_attr_class($scope1_id, "a", input.tone)}${_attr_class(input.tone)}>note</em>${_el_resume($scope1_id, "a")}`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+			return 0;
+		}
+	}, $scope0_id, "c", _serialize_guard($scope0_reason, 0), $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
+	_html("</main>");
+	_script($scope0_id, "a1");
+	$scope0_reason ? writeScope($scope0_id, {
+		f: input.tone,
+		h: count
+	}) : _patch_value($scope0_id, "a0", input.tone);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko_1_shell; ;<em>note</em>`, {
+  "PatchBranch:#text/2": [{
+    "PatchAttr:#em/0 class": "warn"
+  }, "packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko_1_shell"],
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko0": "warn"
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+// PATCH
+[`a0; ;<em>note</em>`, {
+  bc: [{
+    "aa class": "warn"
+  }, "a0"],
+  va0: "warn"
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/render.debug.md
@@ -1,0 +1,104 @@
+# Render `{"tone":"info","show":true}`
+```html
+<main>
+  <button
+    class="btn info"
+  >
+    +
+  </button>
+  <span
+    class="even"
+  >
+    parity
+  </span>
+  <em
+    class="info"
+  >
+    note
+  </em>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <button
+    class="btn info odd"
+  >
+    +
+  </button>
+  <span
+    class="odd"
+  >
+    parity
+  </span>
+  <em
+    class="info"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: main > span[class] "even" => "odd"
+UPDATE: .btn.info.odd[class] "btn info" => "btn info odd"
+```
+
+# Update `{"tone":"warn","show":true}`
+```html
+<main>
+  <button
+    class="btn warn odd"
+  >
+    +
+  </button>
+  <span
+    class="odd"
+  >
+    parity
+  </span>
+  <em
+    class="warn"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: main > em[class] "info" => "warn"
+UPDATE: .btn.warn.odd[class] "btn info odd" => "btn warn odd"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <button
+    class="btn warn"
+  >
+    +
+  </button>
+  <span
+    class="even"
+  >
+    parity
+  </span>
+  <em
+    class="warn"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: .even[class] "odd" => "even"
+UPDATE: .btn.warn[class] "btn warn odd" => "btn warn"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/render.md
@@ -1,0 +1,104 @@
+# Render `{"tone":"info","show":true}`
+```html
+<main>
+  <button
+    class="btn info"
+  >
+    +
+  </button>
+  <span
+    class="even"
+  >
+    parity
+  </span>
+  <em
+    class="info"
+  >
+    note
+  </em>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <button
+    class="btn info odd"
+  >
+    +
+  </button>
+  <span
+    class="odd"
+  >
+    parity
+  </span>
+  <em
+    class="info"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: main > span[class] "even" => "odd"
+UPDATE: .btn.info.odd[class] "btn info" => "btn info odd"
+```
+
+# Update `{"tone":"warn","show":true}`
+```html
+<main>
+  <button
+    class="btn warn odd"
+  >
+    +
+  </button>
+  <span
+    class="odd"
+  >
+    parity
+  </span>
+  <em
+    class="warn"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: main > em[class] "info" => "warn"
+UPDATE: .btn.warn.odd[class] "btn info odd" => "btn warn odd"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <button
+    class="btn warn"
+  >
+    +
+  </button>
+  <span
+    class="even"
+  >
+    parity
+  </span>
+  <em
+    class="warn"
+  >
+    note
+  </em>
+</main>
+```
+## Change
+```
+UPDATE: .even[class] "odd" => "even"
+UPDATE: .btn.warn[class] "btn warn odd" => "btn warn"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<main><button class="btn info">+</button><!--M_*1 #button/0--><span
+    class=even>parity</span><!--M_*1 #span/1--><!--M_[--><em
+    class=info>note</em><!--M_*2 #em/0--><!--M_]1 #text/2 2--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      input_tone: "info",
+      count: 0
+    }, {
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/writes.html
@@ -1,0 +1,13 @@
+<main><button class="btn info">+</button><!--M_*1 a--><span
+    class=even>parity</span><!--M_*1 b--><!--M_[--><em
+    class=info>note</em><!--M_*2 a--><!--M_]1 c 2--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    f: "info",
+    h: 0
+  }, {
+    _: _(1)
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8103,
+      "brotli": 3592
+    }
+  },
+  "html": {
+    "min": 492,
+    "brotli": 306
+  },
+  "patch": {
+    "min": 66,
+    "brotli": 70
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/template.marko
@@ -1,0 +1,11 @@
+<let/count=0/>
+<main>
+  <button
+    class=["btn", input.tone, count % 2 && "odd"]
+    onClick() { count++ }
+  >+</button>
+  <span class=count % 2 ? "odd" : "even">parity</span>
+  <if=input.show>
+    <em class=input.tone>note</em>
+  </if>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/test.ts
@@ -1,0 +1,17 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A class mixing a server tone with client state never captures (the fill
+// recomputes both), pure-state classes stay client-owned, branch captures pair.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { tone: "info", show: true },
+    click,
+    { tone: "warn", show: true },
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/template.marko:1:8
     > 1 | <input ...input.attrs>
-        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/template.marko:1:8
     > 1 | <input ...input.attrs>
-        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/template.marko:1:8
     > 1 | <input ...input.attrs>
-        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-spread/template.marko:1:8
     > 1 | <input ...input.attrs>
-        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |        ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-dom.debug.txt
@@ -1,2 +1,2 @@
-Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
     at packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-dom.txt
@@ -1,2 +1,2 @@
-Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
     at packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-html.debug.txt
@@ -1,2 +1,2 @@
-Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
     at packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/__snapshots__/error-compile-html.txt
@@ -1,2 +1,2 @@
-Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
     at packages/runtime-tags/src/__tests__/fixtures/persisted-script-alias/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
     > 1 | <a href="/static" ...input.attrs>${input.label}</a>
-        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
     > 1 | <a href="/static" ...input.attrs>${input.label}</a>
-        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
     > 1 | <a href="/static" ...input.attrs>${input.label}</a>
-        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/template.marko:1:19
     > 1 | <a href="/static" ...input.attrs>${input.label}</a>
-        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.
+        |                   ^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
       2 |

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -66,6 +66,8 @@ export {
   _id,
   _if,
   _patch_attr,
+  _patch_attr_class,
+  _patch_attr_style,
   _patch_bind,
   _patch_control,
   _patch_child,

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -8,6 +8,9 @@ import {
   isPromise,
   normalizeAttrValue,
   normalizeDynamicRenderer,
+  stringifyClassObject,
+  stringifyStyleObject,
+  toDelimitedString,
 } from "../common/helpers";
 /* eslint-disable @typescript-eslint/no-this-alias */
 import { concat, forEach, type Opt, push } from "../common/opt";
@@ -303,6 +306,34 @@ export function _patch_attr(
   }
 
   return "";
+}
+
+// Class/style normalize on the server into the same string the dom helper
+// writes, so the client applies them as plain attr entries.
+export function _patch_attr_class(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+) {
+  return _patch_attr(
+    scopeId,
+    accessor,
+    "class",
+    toDelimitedString(value, " ", stringifyClassObject) || undefined,
+  );
+}
+
+export function _patch_attr_style(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+) {
+  return _patch_attr(
+    scopeId,
+    accessor,
+    "style",
+    toDelimitedString(value, ";", stringifyStyleObject) || undefined,
+  );
 }
 
 // Links a child scope into its parent's entry: immediately when already

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -287,7 +287,7 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
       node,
       detail
         ? `Persisted templates cannot patch this faithfully yet: ${detail}.`
-        : "Persisted templates currently support only escaped dynamic text and plain dynamic attributes in native HTML.",
+        : "Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.",
     );
   };
   program.traverse({
@@ -441,8 +441,6 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
                 // `content=` mounts structural content the patch wire has no
                 // entry for, so a dynamic one cannot apply faithfully.
                 attr.name === "content" ||
-                attr.name === "class" ||
-                attr.name === "style" ||
                 // Option state couples to the parent select's selection;
                 // a lone attribute write cannot re-sync it.
                 (tagName === "option" &&

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -638,6 +638,32 @@ export default {
           }
         }
 
+        // An attribute fed by client state never captures directly: the
+        // client owns part of its value and recomputes it instead.
+        const capturesPatchAttr = (name: string, value: t.Expression) => {
+          if (!(isPersisted() && isPatchCaptureSection(tagSection))) {
+            return false;
+          }
+          const attrSources = getSerializeSourcesForExpr(value.extra || {});
+          if (!attrSources?.state) return true;
+          if (attrSources.global) {
+            throw tag.buildCodeFrameError(
+              `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
+            );
+          }
+          if (
+            tagSection.isBranch &&
+            !constructRendersReads(
+              tagSection,
+              value.extra?.referencedBindings as Opt<Binding>,
+            )
+          ) {
+            // A state-fed attribute never captures; see placeholder.
+            recordConstructBlocker(tagSection, "state-fed attribute");
+          }
+          return false;
+        };
+
         for (const attr of staticAttrs) {
           const { name, value } = attr;
           const { confident, computed } = value.extra || {};
@@ -655,6 +681,14 @@ export default {
               if (confident) {
                 write`${getHTMLRuntime()[helper](computed)}`;
               } else {
+                if (capturesPatchAttr(name, value)) {
+                  write`${callRuntime(
+                    `_patch_attr_${name as "class" | "style"}`,
+                    getScopeIdIdentifier(tagSection),
+                    getScopeAccessorLiteral(nodeBinding!),
+                    value,
+                  )}`;
+                }
                 write`${factorAttrConditional(
                   buildAttrExpression(
                     value,
@@ -679,33 +713,7 @@ export default {
               } else if (isEventHandler(name)) {
                 addHTMLEffectCall(tagSection, valueReferences);
               } else {
-                const attrSources =
-                  isPersisted() && isPatchCaptureSection(tagSection)
-                    ? getSerializeSourcesForExpr(value.extra || {})
-                    : undefined;
-                if (attrSources?.state && attrSources.global) {
-                  throw tag.buildCodeFrameError(
-                    `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
-                  );
-                }
-                if (
-                  attrSources?.state &&
-                  tagSection.isBranch &&
-                  !constructRendersReads(
-                    tagSection,
-                    value.extra?.referencedBindings as Opt<Binding>,
-                  )
-                ) {
-                  // A state-fed attribute never captures; see placeholder.
-                  recordConstructBlocker(tagSection, "state-fed attribute");
-                }
-                // An attribute fed by client state never captures directly: the
-                // client owns part of its value and recomputes it instead.
-                if (
-                  isPersisted() &&
-                  isPatchCaptureSection(tagSection) &&
-                  !attrSources?.state
-                ) {
+                if (capturesPatchAttr(name, value)) {
                   write`${callRuntime(
                     "_patch_attr",
                     getScopeIdIdentifier(tagSection),
@@ -1006,6 +1014,37 @@ export default {
           }
         }
 
+        // The dom compile shares the capture gating (errors and construct
+        // blockers must match the html output) and imports the feature:
+        // an interactive page receives assets transitively through its dom
+        // program, so the analyze-phase asset import alone cannot load it.
+        const capturesPatchAttr = (name: string, value: t.Expression) => {
+          if (!(isPersisted() && isPatchCaptureSection(tagSection))) {
+            return false;
+          }
+          const attrSources = getSerializeSourcesForExpr(value.extra || {});
+          if (!attrSources?.state) {
+            importRuntimeFeature("patch-attr");
+            return true;
+          }
+          if (attrSources.global) {
+            throw tag.buildCodeFrameError(
+              `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
+            );
+          }
+          if (
+            tagSection.isBranch &&
+            !constructRendersReads(
+              tagSection,
+              value.extra?.referencedBindings as Opt<Binding>,
+            )
+          ) {
+            // A state-fed attribute never captures; see placeholder.
+            recordConstructBlocker(tagSection, "state-fed attribute");
+          }
+          return false;
+        };
+
         for (const attr of staticAttrs) {
           const { name, value } = attr;
           const { confident } = value.extra || {};
@@ -1016,6 +1055,7 @@ export default {
             case "style": {
               const helper = `_attr_${name}` as const;
               if (!confident) {
+                capturesPatchAttr(name, value);
                 const nodeExpr = createScopeReadExpression(nodeBinding!);
                 const meta: DelimitedAttrMeta = {
                   staticItems: undefined,
@@ -1096,35 +1136,7 @@ export default {
                   ),
                 );
               } else {
-                const attrSources =
-                  isPersisted() && isPatchCaptureSection(tagSection)
-                    ? getSerializeSourcesForExpr(value.extra || {})
-                    : undefined;
-                if (attrSources?.state && attrSources.global) {
-                  throw tag.buildCodeFrameError(
-                    `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
-                  );
-                }
-                if (
-                  attrSources?.state &&
-                  tagSection.isBranch &&
-                  !constructRendersReads(
-                    tagSection,
-                    value.extra?.referencedBindings as Opt<Binding>,
-                  )
-                ) {
-                  // A state-fed attribute never captures; see placeholder.
-                  recordConstructBlocker(tagSection, "state-fed attribute");
-                }
-                if (
-                  isPersisted() &&
-                  isPatchCaptureSection(tagSection) &&
-                  !attrSources?.state
-                ) {
-                  // An interactive page receives assets transitively through
-                  // its dom program, so the feature import rides both outputs.
-                  importRuntimeFeature("patch-attr");
-                }
+                capturesPatchAttr(name, value);
                 addStatement(
                   "render",
                   tagSection,


### PR DESCRIPTION
Lifts the class/style rejection (feature-completion tier 1). The server pre-normalizes values with the same shared helpers the dom writer uses (`toDelimitedString` + `stringify*Object`) via `_patch_attr_class`/`_patch_attr_style` composing over `_patch_attr`, so patches carry plain `a` entries with the existing `0` removal sentinel and the client needs no new machinery (the prototype's client-side name dispatch is deliberately not ported). State-mixing values keep the fill path — the whole-attr read classifies the server member, so object/array/item shapes recompute with both contributions. The persisted attr gating is factored into one `capturesPatchAttr` helper per output, which also fixed a dual-registration gap the new interactive fixture caught: the dom compile now emits `importRuntimeFeature("patch-attr")` for class/style captures (interactive pages load assets transitively through their dom program).

Fixtures: `persisted-class-attribute` flipped positive (string/array/object-toggle shapes, style object/array, removal both ways), new `persisted-class-intersection` (mixed fill + pure-state class + branch capture). Grok 4.5 (high) adversarial review: SHIP — exhaustive normalization-parity matrix, removal, state-gating, and parity all verified; its coverage findings drove the extra fixture shapes. Non-persisted output unchanged.